### PR TITLE
update docker tag to golang:1.15.2-alpine3.12

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:1.15
+FROM golang:1.15.2-alpine3.12
 
 WORKDIR /go/src/app
 COPY . .


### PR DESCRIPTION
The current dockerfile when built comes out to a big 839MB.
I suggest building with alpine instead and it reduces the image to 300MB.

Change line 1 of `dalfox/Dockerfile` to:
```
FROM golang:1.15.2-alpine3.12
```

Unless there are some hard glibc dependencies, I don't see why not. I've tested it and it seems to work fine. 
