### PR TITLE
#174, Add the Accept header to all requests

### DIFF
--- a/pkg/optimization/optimization.go
+++ b/pkg/optimization/optimization.go
@@ -13,6 +13,8 @@ import (
 // GenerateNewRequest is make http.Cilent
 func GenerateNewRequest(url, payload string, options model.Options) *http.Request {
 	req, _ := http.NewRequest("GET", url, nil)
+	// Add the Accept header like browsers do.
+	req.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9")
 	if options.Data != "" {
 		d := []byte(payload)
 		req, _ = http.NewRequest("POST", url, bytes.NewBuffer(d))


### PR DESCRIPTION
Created the PR as discussed in the issue I've opened.
Note that in this way we are **always** adding the Accept header, and I didn't handle the edge case that someone wants to use their own Accept header.
We can handle it by comparing the header value from the options, but since you haven't done it for the `Content-Type` header as well, I thought that we can skip this complication.

BTW, is it only possible to add one header using `-H` or am I missing something here? I saw it while debugging my change.

My change was tested with and wo the `-H` flag.

Please review and merge.