### PR TITLE
Add HAR file writing support (#439)

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,7 +17,9 @@ require (
 	github.com/stretchr/testify v1.8.1
 	github.com/swaggo/echo-swagger v1.3.5
 	github.com/swaggo/swag v1.8.9
+	github.com/tidwall/sjson v1.2.5
 	github.com/tylerb/graceful v1.2.15
+	golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4
 	golang.org/x/term v0.0.0-20210927222741-03fcf44c2211
 )
 
@@ -48,6 +50,9 @@ require (
 	github.com/pmezard/go-difflib v1.0.0 // indirect
 	github.com/spf13/pflag v1.0.5 // indirect
 	github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a // indirect
+	github.com/tidwall/gjson v1.14.2 // indirect
+	github.com/tidwall/match v1.1.1 // indirect
+	github.com/tidwall/pretty v1.2.0 // indirect
 	github.com/valyala/bytebufferpool v1.0.0 // indirect
 	github.com/valyala/fasttemplate v1.2.1 // indirect
 	golang.org/x/crypto v0.0.0-20220411220226-7b82a4e95df4 // indirect

--- a/go.sum
+++ b/go.sum
@@ -133,6 +133,14 @@ github.com/swaggo/files v0.0.0-20220728132757-551d4a08d97a/go.mod h1:lKJPbtWzJ9J
 github.com/swaggo/swag v1.8.1/go.mod h1:ugemnJsPZm/kRwFUnzBlbHRd0JY9zE1M4F+uy2pAaPQ=
 github.com/swaggo/swag v1.8.9 h1:kHtaBe/Ob9AZzAANfcn5c6RyCke9gG9QpH0jky0I/sA=
 github.com/swaggo/swag v1.8.9/go.mod h1:ezQVUUhly8dludpVk+/PuwJWvLLanB13ygV5Pr9enSk=
+github.com/tidwall/gjson v1.14.2 h1:6BBkirS0rAHjumnjHF6qgy5d2YAJ1TLIaFE2lzfOLqo=
+github.com/tidwall/gjson v1.14.2/go.mod h1:/wbyibRr2FHMks5tjHJ5F8dMZh3AcwJEMf5vlfC0lxk=
+github.com/tidwall/match v1.1.1 h1:+Ho715JplO36QYgwN9PGYNhgZvoUSc9X2c80KVTi+GA=
+github.com/tidwall/match v1.1.1/go.mod h1:eRSPERbgtNPcGhD8UCthc6PmLEQXEWd3PRB5JTxsfmM=
+github.com/tidwall/pretty v1.2.0 h1:RWIZEg2iJ8/g6fDDYzMpobmaoGh5OLl4AXtGUGPcqCs=
+github.com/tidwall/pretty v1.2.0/go.mod h1:ITEVvHYasfjBbM0u2Pg8T2nJnzm8xPwvNhhsoaGGjNU=
+github.com/tidwall/sjson v1.2.5 h1:kLy8mja+1c9jlljvWTlSazM7cKDRfJuR/bOJhcY5NcY=
+github.com/tidwall/sjson v1.2.5/go.mod h1:Fvgq9kS/6ociJEDnK0Fk1cpYF4FIW6ZF7LAe+6jwd28=
 github.com/tylerb/graceful v1.2.15 h1:B0x01Y8fsJpogzZTkDg6BDi6eMf03s01lEKGdrv83oA=
 github.com/tylerb/graceful v1.2.15/go.mod h1:LPYTbOYmUTdabwRt0TGhLllQ0MUNbs0Y5q1WXJOI9II=
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
@@ -167,6 +175,7 @@ golang.org/x/net v0.0.0-20220722155237-a158d28d115b h1:PxfKdU9lEEDYjdIzOtC4qFWgk
 golang.org/x/net v0.0.0-20220722155237-a158d28d115b/go.mod h1:XRhObCWvk6IyKnWLug+ECip1KBveYUHfp+8e9klMJ9c=
 golang.org/x/sync v0.0.0-20190423024810-112230192c58/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sync v0.0.0-20210220032951-036812b2e83c/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
+golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4 h1:uVc8UZUe6tr40fFVnUP5Oj+veunVezqYl9z7DYw9xzw=
 golang.org/x/sync v0.0.0-20220722155255-886fb9371eb4/go.mod h1:RxMgew5VJxzue5/jJTE5uejpjVlOe/izrB70Jof72aM=
 golang.org/x/sys v0.0.0-20190215142949-d0b11bdaac8a/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=
 golang.org/x/sys v0.0.0-20190222072716-a9d3bda3a223/go.mod h1:STP8DvDyc/dI5b8T5hshtkjS+E42TnysNCUPdjciGhY=

--- a/pkg/har/client_tracer.go
+++ b/pkg/har/client_tracer.go
@@ -1,0 +1,79 @@
+package har
+
+import (
+	"crypto/tls"
+	"net/http/httptrace"
+	"time"
+)
+
+func newClientTracer() (*clientTracer, *httptrace.ClientTrace) {
+	ct1 := &clientTracer{
+		startAt: time.Now(),
+	}
+
+	ct2 := &httptrace.ClientTrace{
+		GetConn:              ct1.GetConn,
+		GotConn:              ct1.GotConn,
+		PutIdleConn:          nil,
+		GotFirstResponseByte: ct1.GotFirstResponseByte,
+		Got100Continue:       nil,
+		Got1xxResponse:       nil,
+		DNSStart:             ct1.DNSStart,
+		DNSDone:              ct1.DNSDone,
+		ConnectStart:         nil,
+		ConnectDone:          nil,
+		TLSHandshakeStart:    ct1.TLSHandshakeStart,
+		TLSHandshakeDone:     ct1.TLSHandshakeDone,
+		WroteHeaderField:     nil,
+		WroteHeaders:         nil,
+		Wait100Continue:      nil,
+		WroteRequest:         ct1.WroteRequest,
+	}
+
+	return ct1, ct2
+}
+
+type clientTracer struct {
+	startAt           time.Time
+	connStart         time.Time
+	connObtained      time.Time
+	firstResponseByte time.Time
+	dnsStart          time.Time
+	dnsEnd            time.Time
+	tlsHandshakeStart time.Time
+	tlsHandshakeEnd   time.Time
+	writeRequest      time.Time
+	endAt             time.Time
+}
+
+func (ct *clientTracer) GetConn(hostPort string) {
+	ct.connStart = time.Now()
+}
+
+func (ct *clientTracer) GotConn(info httptrace.GotConnInfo) {
+	ct.connObtained = time.Now()
+}
+
+func (ct *clientTracer) GotFirstResponseByte() {
+	ct.firstResponseByte = time.Now()
+}
+
+func (ct *clientTracer) DNSStart(info httptrace.DNSStartInfo) {
+	ct.dnsStart = time.Now()
+}
+
+func (ct *clientTracer) DNSDone(info httptrace.DNSDoneInfo) {
+	ct.dnsEnd = time.Now()
+}
+
+func (ct *clientTracer) TLSHandshakeStart() {
+	ct.tlsHandshakeStart = time.Now()
+}
+
+func (ct *clientTracer) TLSHandshakeDone(tls.ConnectionState, error) {
+	ct.tlsHandshakeEnd = time.Now()
+}
+
+func (ct *clientTracer) WroteRequest(info httptrace.WroteRequestInfo) {
+	ct.writeRequest = time.Now()
+}

--- a/pkg/har/har_test.go
+++ b/pkg/har/har_test.go
@@ -1,0 +1,120 @@
+package har_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"github.com/hahwul/dalfox/v2/pkg/har"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"github.com/tidwall/sjson"
+	"golang.org/x/sync/errgroup"
+	"net/http"
+	"testing"
+)
+
+var creator = &har.Creator{Name: "dalfox tests", Version: "0.0"}
+
+func TestSingleRequest(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	hw, err := har.NewWriter(buf, creator)
+	require.NoError(t, err)
+
+	rt := har.NewRoundTripper(nil, hw, nil)
+	c := &http.Client{Transport: rt}
+
+	resp, err := c.Get("https://example.com")
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+	assert.Equal(t, 200, resp.StatusCode)
+
+	err = hw.Close()
+	require.NoError(t, err)
+
+	assert.True(t, json.Valid(buf.Bytes()), "HAR file is not valid json")
+}
+
+func TestMultipleRequests(t *testing.T) {
+	buf := &bytes.Buffer{}
+
+	hw, err := har.NewWriter(buf, creator)
+	require.NoError(t, err)
+
+	rt := har.NewRoundTripper(nil, hw, nil)
+	c := &http.Client{Transport: rt}
+
+	g, _ := errgroup.WithContext(context.Background())
+	for idx := 0; idx < 5; idx++ {
+		g.Go(func() error {
+			resp, err := c.Get("https://example.com")
+			require.NoError(t, err)
+			assert.NotNil(t, resp)
+			assert.Equal(t, 200, resp.StatusCode)
+			return nil
+		})
+	}
+
+	err = g.Wait()
+	require.NoError(t, err)
+
+	err = hw.Close()
+	require.NoError(t, err)
+
+	harfile := har.File{}
+	err = json.Unmarshal(buf.Bytes(), &harfile)
+	require.NoError(t, err)
+
+	assert.Len(t, harfile.Log.Entries, 5)
+}
+
+func TestRewrite(t *testing.T) {
+	buf := &bytes.Buffer{}
+	ctx := context.Background()
+
+	hw, err := har.NewWriter(buf, creator)
+	require.NoError(t, err)
+
+	rt := har.NewRoundTripper(nil, hw, func(request *http.Request, response *http.Response, entry json.RawMessage) json.RawMessage {
+		messageID := har.MessageIDFromRequest(request)
+		entry, _ = sjson.SetBytes(entry, "_messageId", messageID)
+		return entry
+	})
+	require.NoError(t, err)
+
+	c := &http.Client{Transport: rt}
+
+	req, _ := http.NewRequestWithContext(ctx, "GET", "https://example.com", nil)
+	req = har.AddMessageIDToRequest(req)
+	firstMessageID := har.MessageIDFromRequest(req)
+
+	resp, err := c.Do(req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	req, _ = http.NewRequestWithContext(ctx, "GET", "https://example.com/?a=b&c=d", nil)
+	req = har.AddMessageIDToRequest(req)
+	secondMessageID := har.MessageIDFromRequest(req)
+
+	resp, err = c.Do(req)
+	require.NoError(t, err)
+	assert.NotNil(t, resp)
+
+	err = hw.Close()
+	require.NoError(t, err)
+
+	// assert valid HAR files
+	harfile := har.File{}
+	err = json.Unmarshal(buf.Bytes(), &harfile)
+	require.NoError(t, err)
+
+	anything := map[string]interface{}{}
+	err = json.Unmarshal(buf.Bytes(), &anything)
+	require.NoError(t, err)
+
+	entries := anything["log"].(map[string]interface{})["entries"].([]interface{})
+	assert.Len(t, entries, 2)
+
+	assert.EqualValues(t, firstMessageID, entries[0].(map[string]interface{})["_messageId"])
+	assert.EqualValues(t, secondMessageID, entries[1].(map[string]interface{})["_messageId"])
+}

--- a/pkg/har/message_id.go
+++ b/pkg/har/message_id.go
@@ -1,0 +1,31 @@
+package har
+
+import (
+	"context"
+	"net/http"
+	"sync/atomic"
+)
+
+var nextMessageID int64
+
+// NewMessageID returns an incrementing message ID. It is used for
+// correlating Dalfox PoCs with entries in a HAR file.
+func NewMessageID() int64 {
+	return atomic.AddInt64(&nextMessageID, 1)
+}
+
+type ctxkeyType int
+
+const ctxkey ctxkeyType = iota
+
+// MessageIDFromRequest returns the message ID associated with a *http.Request
+func MessageIDFromRequest(req *http.Request) int64 {
+	return req.Context().Value(ctxkey).(int64)
+}
+
+// AddMessageIDToRequest returns a new *http.Request with a message ID associated to it
+func AddMessageIDToRequest(req *http.Request) *http.Request {
+	messageID := NewMessageID()
+	ctx := context.WithValue(req.Context(), ctxkey, messageID)
+	return req.WithContext(ctx)
+}

--- a/pkg/har/round_tripper.go
+++ b/pkg/har/round_tripper.go
@@ -1,0 +1,276 @@
+// Package har implements HAR file output support for Dalfox
+package har
+
+import (
+	"bytes"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"io"
+	"mime"
+	"net/http"
+	"net/http/httptrace"
+	"strings"
+	"time"
+)
+
+var _ http.RoundTripper = (*RoundTripper)(nil)
+
+// forked from from https://github.com/vvakame/go-harlog/blob/master/types.go
+
+// RoundTripper implements the http.RoundTripper interface. Requests and
+// responses are written to HAR archives.
+type RoundTripper struct {
+	inner   http.RoundTripper
+	writer  *Writer
+	rewrite func(request *http.Request, response *http.Response, entry json.RawMessage) json.RawMessage
+}
+
+// NewRoundTripper creates a new RoundTripper. A RoundTripper is
+// safe for concurrent use by multiple goroutines.
+func NewRoundTripper(roundTripper http.RoundTripper, writer *Writer, rewrite func(request *http.Request, response *http.Response, entry json.RawMessage) json.RawMessage) *RoundTripper {
+	if roundTripper == nil {
+		roundTripper = http.DefaultTransport
+	}
+
+	if rewrite == nil {
+		rewrite = func(request *http.Request, response *http.Response, entry json.RawMessage) json.RawMessage {
+			return entry
+		}
+	}
+
+	return &RoundTripper{
+		inner:   roundTripper,
+		writer:  writer,
+		rewrite: rewrite,
+	}
+}
+
+// RoundTrip satisfies the http.RoundTripper interface
+func (rt *RoundTripper) RoundTrip(request *http.Request) (response *http.Response, err error) {
+	entry := &Entry{}
+	err = rt.preRoundTrip(request, entry)
+	if err != nil {
+		return
+	}
+
+	trace, clientTrace := newClientTracer()
+	request = request.WithContext(httptrace.WithClientTrace(request.Context(), clientTrace))
+
+	response, err = rt.inner.RoundTrip(request)
+	if err != nil {
+		return
+	}
+
+	err = rt.postRoundTrip(response, entry, trace)
+	if err != nil {
+		return
+	}
+
+	err = rt.writeEntry(request, response, entry)
+	if err != nil {
+		return
+	}
+
+	return
+}
+
+func (rt *RoundTripper) writeEntry(request *http.Request, response *http.Response, entry *Entry) error {
+	entryJSON, _ := json.Marshal(entry)
+
+	entryJSON = rt.rewrite(request, response, entryJSON)
+	if entryJSON == nil {
+		return nil
+	}
+
+	return rt.writer.writeEntry(entryJSON)
+}
+
+func (rt *RoundTripper) preRoundTrip(r *http.Request, entry *Entry) error {
+	bodySize := -1
+	var postData *PostData
+	if r.Body != nil {
+		reqBody, err := r.GetBody()
+		if err != nil {
+			return fmt.Errorf("getting body: %w", err)
+		}
+
+		reqBodyBytes, err := io.ReadAll(reqBody)
+		if err != nil {
+			return fmt.Errorf("reading request body: %w", err)
+		}
+
+		bodySize = len(reqBodyBytes)
+
+		mimeType := r.Header.Get("Content-Type")
+		postData = &PostData{
+			MimeType: mimeType,
+			Params:   []*Param{},
+			Text:     string(reqBodyBytes),
+		}
+
+		mediaType, _, err := mime.ParseMediaType(mimeType)
+		if err != nil {
+			return fmt.Errorf("parsing request Content-Type: %w", err)
+		}
+
+		switch mediaType {
+		case "application/x-www-form-urlencoded":
+			err = r.ParseForm()
+			if err != nil {
+				return fmt.Errorf("parsing urlencoded form in request body: %w", err)
+			}
+			r.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes))
+
+			for k, v := range r.PostForm {
+				for _, s := range v {
+					postData.Params = append(postData.Params, &Param{
+						Name:  k,
+						Value: s,
+					})
+				}
+			}
+
+		case "multipart/form-data":
+			err = r.ParseMultipartForm(10 * 1024 * 1024)
+			if err != nil {
+				return fmt.Errorf("parsing multipart form in request body: %w", err)
+			}
+			r.Body = io.NopCloser(bytes.NewBuffer(reqBodyBytes))
+
+			for k, v := range r.MultipartForm.Value {
+				for _, s := range v {
+					postData.Params = append(postData.Params, &Param{
+						Name:  k,
+						Value: s,
+					})
+				}
+			}
+			for k, v := range r.MultipartForm.File {
+				for _, s := range v {
+					postData.Params = append(postData.Params, &Param{
+						Name:        k,
+						FileName:    s.Filename,
+						ContentType: s.Header.Get("Content-Type"),
+					})
+				}
+			}
+		}
+	}
+
+	entry.Request = &Request{
+		Method:      r.Method,
+		URL:         r.URL.String(),
+		HTTPVersion: r.Proto,
+		Cookies:     toHARCookies(r.Cookies()),
+		Headers:     toHARNVP(r.Header),
+		QueryString: toHARNVP(r.URL.Query()),
+		PostData:    postData,
+		HeadersSize: -1, // TODO
+		BodySize:    bodySize,
+	}
+
+	return nil
+}
+
+func (rt *RoundTripper) postRoundTrip(resp *http.Response, entry *Entry, trace *clientTracer) error {
+	defer resp.Body.Close()
+	respBodyBytes, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return err
+	}
+
+	resp.Body = io.NopCloser(bytes.NewBuffer(respBodyBytes))
+
+	mimeType := resp.Header.Get("Content-Type")
+	mediaType, _, err := mime.ParseMediaType(mimeType)
+	if err != nil {
+		return fmt.Errorf("parsing response Content-Type: %w", err)
+	}
+
+	var text string
+	var encoding string
+	switch {
+	case strings.HasPrefix(mediaType, "text/"):
+		text = string(respBodyBytes)
+	default:
+		text = base64.StdEncoding.EncodeToString(respBodyBytes)
+		encoding = "base64"
+	}
+
+	entry.Response = &Response{
+		Status:      resp.StatusCode,
+		StatusText:  resp.Status,
+		HTTPVersion: resp.Proto,
+		Cookies:     toHARCookies(resp.Cookies()),
+		Headers:     toHARNVP(resp.Header),
+		RedirectURL: resp.Header.Get("Location"),
+		HeadersSize: -1,
+		BodySize:    resp.ContentLength,
+		Content: &Content{
+			Size:        resp.ContentLength, // TODO 圧縮されている場合のフォロー
+			Compression: 0,
+			MimeType:    mimeType,
+			Text:        text,
+			Encoding:    encoding,
+		},
+	}
+
+	// TODO: these timings are suspect. the `connect` timing includes the TLS negotiation time (it shouldn't)
+	trace.endAt = time.Now()
+	entry.StartedDateTime = Time(trace.startAt)
+	entry.Time = Duration(trace.endAt.Sub(trace.startAt))
+	entry.Timings = &Timings{
+		Blocked: Duration(trace.connStart.Sub(trace.startAt)),
+		DNS:     -1,
+		Connect: -1,
+		Send:    Duration(trace.writeRequest.Sub(trace.connObtained)),
+		Wait:    Duration(trace.firstResponseByte.Sub(trace.writeRequest)),
+		Receive: Duration(trace.endAt.Sub(trace.firstResponseByte)),
+		SSL:     -1,
+	}
+	if !trace.dnsStart.IsZero() {
+		entry.Timings.DNS = Duration(trace.dnsEnd.Sub(trace.dnsStart))
+	}
+	if !trace.connStart.IsZero() {
+		entry.Timings.Connect = Duration(trace.connObtained.Sub(trace.connStart))
+	}
+	if !trace.tlsHandshakeStart.IsZero() {
+		entry.Timings.SSL = Duration(trace.tlsHandshakeEnd.Sub(trace.tlsHandshakeStart))
+	}
+
+	return nil
+}
+
+func toHARCookies(cookies []*http.Cookie) []*Cookie {
+	harCookies := make([]*Cookie, 0, len(cookies))
+
+	for _, cookie := range cookies {
+		harCookies = append(harCookies, &Cookie{
+			Name:     cookie.Name,
+			Value:    cookie.Value,
+			Path:     cookie.Path,
+			Domain:   cookie.Domain,
+			Expires:  Time(cookie.Expires),
+			HTTPOnly: cookie.HttpOnly,
+			Secure:   cookie.Secure,
+		})
+	}
+
+	return harCookies
+}
+
+func toHARNVP(vs map[string][]string) []*NVP {
+	nvps := make([]*NVP, 0, len(vs))
+
+	for k, v := range vs {
+		for _, s := range v {
+			nvps = append(nvps, &NVP{
+				Name:  k,
+				Value: s,
+			})
+		}
+	}
+
+	return nvps
+}

--- a/pkg/har/types.go
+++ b/pkg/har/types.go
@@ -1,0 +1,339 @@
+package har
+
+import (
+	"encoding/json"
+	"time"
+)
+
+// copied from https://github.com/vvakame/go-harlog/blob/master/types.go
+
+// from https://w3c.github.io/web-performance/specs/HAR/Overview.html
+
+var _ json.Marshaler = Time{}
+var _ json.Unmarshaler = (*Time)(nil)
+var _ json.Marshaler = Duration(0)
+var _ json.Unmarshaler = (*Duration)(nil)
+
+// Time provides ISO 8601 format JSON data.
+type Time time.Time
+
+// MarshalJSON to ISO 8601 format from time.Time.
+func (t Time) MarshalJSON() ([]byte, error) {
+	if time.Time(t).IsZero() {
+		return []byte(`null`), nil
+	}
+
+	v := time.Time(t).Format(time.RFC3339)
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON from ISO 8601 format to time.Time.
+func (t *Time) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	v, err := time.Parse(`"`+time.RFC3339+`"`, string(data))
+	if err != nil {
+		return err
+	}
+	vt := Time(v)
+	*t = vt
+	return nil
+}
+
+// Duration provides milliseconds order JSON format.
+type Duration time.Duration
+
+// MarshalJSON to milliseconds order number format from time.Duration.
+func (d Duration) MarshalJSON() ([]byte, error) {
+	if d == -1 {
+		return []byte("-1"), nil
+	}
+	v := float64(d) / float64(time.Millisecond)
+	return json.Marshal(v)
+}
+
+// UnmarshalJSON from milliseconds order number format to time.Duration.
+func (d *Duration) UnmarshalJSON(data []byte) error {
+	if string(data) == "null" {
+		return nil
+	}
+
+	var v float64
+	err := json.Unmarshal(data, &v)
+	if err != nil {
+		return err
+	}
+
+	*d = Duration(v * float64(time.Millisecond))
+
+	return nil
+}
+
+// File represents the top-level JSON object in a HAR file
+// The HAR format is based on JSON, as described in RFC 4627.
+type File struct {
+	Log *Log `json:"log"`
+}
+
+// Log represents the root of the exported data. This object MUST
+// be present and its name MUST be "log". The object contains the
+// following name/value pairs:
+type Log struct {
+	// Required. Version number of the format.
+	Version string `json:"version"`
+	// Required. An object of type creator that contains the name and version information of the log creator application.
+	Creator *Creator `json:"creator"`
+	// Optional. An object of type browser that contains the name and version information of the user agent.
+	Browser *Browser `json:"browser,omitempty"`
+	// Optional. An array of objects of type page, each representing one exported (tracked) page. Leave out this field if the application does not support grouping by pages.
+	Pages []*Page `json:"pages,omitempty"`
+	// Required. An array of objects of type entry, each representing one exported (tracked) HTTP request.
+	Entries []*Entry `json:"entries"`
+	// Optional. A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Creator is ...
+// This object contains information about the log creator application and contains the following name/value pairs:
+type Creator struct {
+	// Required. The name of the application that created the log.
+	Name string `json:"name"`
+	// Required. The version number of the application that created the log.
+	Version string `json:"version"`
+	// Optional. A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Browser is ...
+// This object contains information about the browser that created the log and contains the following name/value pairs:
+type Browser struct {
+	// Required. The name of the browser that created the log.
+	Name string `json:"name"`
+	// Required. The version number of the browser that created the log.
+	Version string `json:"version"`
+	// Optional. A comment provided by the user or the browser.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Page is ...
+// This object represents list of exported pages.
+type Page struct {
+	// Date and time stamp for the beginning of the page load (ISO 8601 - YYYY-MM-DDThh:mm:ss.sTZD, e.g. 2009-07-24T19:20:30.45+01:00).
+	StartedDateTime Time `json:"startedDateTime"`
+	// Unique identifier of a page within the . Entries use it to refer the parent page.
+	ID string `json:"id"`
+	// Page title.
+	Title string `json:"title"`
+	// Detailed timing info about page load.
+	PageTiming *PageTiming `json:"pageTimings,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// PageTiming is ...
+// This object describes timings for various events (states) fired during the page load. All times are specified in milliseconds. If a time info is not available appropriate field is set to -1.
+type PageTiming struct {
+	// Content of the page loaded. Number of milliseconds since page load started (page.startedDateTime). Use -1 if the timing does not apply to the current request.
+	OnContentLoad Duration `json:"onContentLoad,omitempty"`
+	// Page is loaded (onLoad event fired). Number of milliseconds since page load started (page.startedDateTime). Use -1 if the timing does not apply to the current request.
+	OnLoad Duration `json:"onLoad,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Entry is ...
+// This object represents an array with all exported HTTP requests. Sorting entries by startedDateTime (starting from the oldest) is preferred way how to export data since it can make importing faster. However the reader application should always make sure the array is sorted (if required for the import).
+type Entry struct {
+	// Reference to the parent page. Leave out this field if the application does not support grouping by pages.
+	Pageref string `json:"pageref,omitempty"`
+	// Date and time stamp of the request start (ISO 8601 - YYYY-MM-DDThh:mm:ss.sTZD).
+	StartedDateTime Time `json:"startedDateTime"`
+	// Total elapsed time of the request in milliseconds. This is the sum of all timings available in the timings object (i.e. not including -1 values) .
+	Time Duration `json:"time"`
+	// Detailed info about the request.
+	Request *Request `json:"request"`
+	// Detailed info about the response.
+	Response *Response `json:"response"`
+	// Info about cache usage.
+	Cache *Cache `json:"cache"`
+	// Detailed timing info about request/response round trip.
+	Timings *Timings `json:"timings"`
+	// IP address of the server that was connected (result of DNS resolution).
+	ServerIPAddress string `json:"serverIPAddress,omitempty"`
+	// Unique ID of the parent TCP/IP connection, can be the client port number. Note that a port number doesn't have to be unique identifier in cases where the port is shared for more connections. If the port isn't available for the application, any other unique connection ID can be used instead (e.g. connection index). Leave out this field if the application doesn't support this info.
+	Connection string `json:"connection,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Request is ...
+// This object contains detailed info about performed request.
+type Request struct {
+	// Request method (GET, POST, ...).
+	Method string `json:"method"`
+	// Absolute URL of the request (fragments are not included).
+	URL string `json:"url"`
+	// Request HTTP Version.
+	HTTPVersion string `json:"httpVersion"`
+	// List of cookie objects.
+	Cookies []*Cookie `json:"cookies"`
+	// List of header objects.
+	Headers []*NVP `json:"headers"`
+	// List of query parameter objects.
+	QueryString []*NVP `json:"queryString"`
+	// Posted data info.
+	PostData *PostData `json:"postData,omitempty"`
+	// Total number of bytes from the start of the HTTP request message until (and including) the double CRLF before the body. Set to -1 if the info is not available.
+	HeadersSize int `json:"headersSize"`
+	// Size of the request body (POST data payload) in bytes. Set to -1 if the info is not available.
+	BodySize int `json:"bodySize"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Response is ...
+// This object contains detailed info about the response.
+type Response struct {
+	// Response status.
+	Status int `json:"status"`
+	// Response status description.
+	StatusText string `json:"statusText"`
+	// Response HTTP Version.
+	HTTPVersion string `json:"httpVersion"`
+	// List of cookie objects.
+	Cookies []*Cookie `json:"cookies"`
+	// List of header objects.
+	Headers []*NVP `json:"headers"`
+	// Details about the response body.
+	Content *Content `json:"content"`
+	// Redirection target URL from the Location response header.
+	RedirectURL string `json:"redirectURL"`
+	// Total number of bytes from the start of the HTTP response message until (and including) the double CRLF before the body. Set to -1 if the info is not available.
+	HeadersSize int `json:"headersSize"`
+	// Size of the received response body in bytes. Set to zero in case of responses coming from the cache (304). Set to -1 if the info is not available.
+	BodySize int64 `json:"bodySize"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Cookie is ...
+// This object contains list of all cookies (used in <request> and <response> objects).
+type Cookie struct {
+	// The name of the cookie.
+	Name string `json:"name"`
+	// The cookie value.
+	Value string `json:"value"`
+	// The path pertaining to the cookie.
+	Path string `json:"path,omitempty"`
+	// The host of the cookie.
+	Domain string `json:"domain,omitempty"`
+	// Cookie expiration time. (ISO 8601 - YYYY-MM-DDThh:mm:ss.sTZD, e.g. 2009-07-24T19:20:30.123+02:00).
+	Expires Time `json:"expires,omitempty"`
+	// Set to true if the cookie is HTTP only, false otherwise.
+	HTTPOnly bool `json:"httpOnly,omitempty"`
+	// True if the cookie was transmitted over ssl, false otherwise.
+	Secure bool `json:"secure,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// NVP is name-value pairs.
+type NVP struct {
+	Name    string `json:"name"`
+	Value   string `json:"value"`
+	Comment string `json:"comment,omitempty"`
+}
+
+// PostData is ...
+// This object describes posted data, if any (embedded in <request> object).
+type PostData struct {
+	// Mime type of posted data.
+	MimeType string `json:"mimeType"`
+	// List of posted parameters (in case of URL encoded parameters).
+	Params []*Param `json:"params"`
+	// Plain text posted data
+	Text string `json:"text"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Param is ...
+// List of posted parameters, if any (embedded in <postData> object).
+type Param struct {
+	// name of a posted parameter.
+	Name string `json:"name"`
+	// value of a posted parameter or content of a posted file.
+	Value string `json:"value,omitempty"`
+	// name of a posted file.
+	FileName string `json:"fileName,omitempty"`
+	// content type of a posted file.
+	ContentType string `json:"contentType,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Content is ...
+// This object describes details about response content (embedded in <response> object).
+type Content struct {
+	// Length of the returned content in bytes. Should be equal to response.bodySize if there is no compression and bigger when the content has been compressed.
+	Size int64 `json:"size"`
+	// Number of bytes saved. Leave out this field if the information is not available.
+	Compression int64 `json:"compression,omitempty"`
+	// MIME type of the response text (value of the Content-Type response header). The charset attribute of the MIME type is included (if available).
+	MimeType string `json:"mimeType"`
+	// Response body sent from the server or loaded from the browser cache. This field is populated with textual content only. The text field is either HTTP decoded text or a encoded (e.g. "base64") representation of the response body. Leave out this field if the information is not available.
+	Text string `json:"text,omitempty"`
+	// Encoding used for response text field e.g "base64". Leave out this field if the text field is HTTP decoded (decompressed & unchunked), than trans-coded from its original character set into UTF-8.
+	Encoding string `json:"encoding,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Cache is ...
+// This objects contains info about a request coming from browser cache.
+type Cache struct {
+	// State of a cache entry before the request. Leave out this field if the information is not available.
+	BeforeRequest *CacheInfo `json:"beforeRequest,omitempty"`
+	// State of a cache entry after the request. Leave out this field if the information is not available.
+	AfterRequest *CacheInfo `json:"afterRequest,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// CacheInfo is ...
+// Both beforeRequest and afterRequest object share the following structure.
+type CacheInfo struct {
+	// Expiration time of the cache entry.
+	Expires string `json:"expires,omitempty"`
+	// The last time the cache entry was opened.
+	LastAccess string `json:"lastAccess"`
+	// Etag
+	ETag string `json:"etag"`
+	// The number of times the cache entry has been opened.
+	HitCount int `json:"hitCount"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}
+
+// Timings is ...
+// This object describes various phases within request-response round trip. All times are specified in milliseconds.
+type Timings struct {
+	// Time spent in a queue waiting for a network connection. Use -1 if the timing does not apply to the current request.
+	Blocked Duration `json:"blocked,omitempty"`
+	// DNS resolution time. The time required to resolve a host name. Use -1 if the timing does not apply to the current request.
+	DNS Duration `json:"dns,omitempty"`
+	// Time required to create TCP connection. Use -1 if the timing does not apply to the current request.
+	Connect Duration `json:"connect,omitempty"`
+	// Time required to send HTTP request to the server.
+	Send Duration `json:"send"`
+	// Waiting for a response from the server.
+	Wait Duration `json:"wait"`
+	// Time required to read entire response from the server (or cache).
+	Receive Duration `json:"receive"`
+	// Time required for SSL/TLS negotiation. If this field is defined then the time is also included in the connect field (to ensure backward compatibility with HAR 1.1). Use -1 if the timing does not apply to the current request.
+	SSL Duration `json:"ssl,omitempty"`
+	// A comment provided by the user or the application.
+	Comment string `json:"comment,omitempty"`
+}

--- a/pkg/har/writer.go
+++ b/pkg/har/writer.go
@@ -1,0 +1,90 @@
+package har
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"sync"
+)
+
+// Writer represents a single HAR archive. Writer is
+// safe for concurrent use by multiple goroutines. It contains
+// an internal mutex to serialize writes to the underlying writer.
+type Writer struct {
+	first  bool
+	closed bool
+	mut    sync.Mutex
+	writer io.Writer
+}
+
+// NewWriter creates a new writer ready for usage by RoundTripper. It
+// returns an error if it is unable to write the start of the HAR file.
+func NewWriter(writer io.Writer, creator *Creator) (*Writer, error) {
+	var err error
+	creatorJSON, _ := json.Marshal(creator)
+
+	_, err = writer.Write([]byte(`{"log":{"version":"1.2","creator":`))
+	if err != nil {
+		return nil, fmt.Errorf("writing preamble: %w", err)
+	}
+
+	_, err = writer.Write(creatorJSON)
+	if err != nil {
+		return nil, fmt.Errorf("writing preamble: %w", err)
+	}
+
+	_, err = writer.Write([]byte(`,"entries":[` + "\n"))
+	if err != nil {
+		return nil, fmt.Errorf("writing preamble: %w", err)
+	}
+
+	return &Writer{
+		first:  true,
+		writer: writer,
+	}, nil
+}
+
+func (w *Writer) writeEntry(entry json.RawMessage) error {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+
+	if w.closed {
+		return fmt.Errorf("HarWriter already closed")
+	}
+
+	if !w.first {
+		_, err := w.writer.Write([]byte(",\n"))
+		if err != nil {
+			return fmt.Errorf("writing har entry: %w", err)
+		}
+	}
+
+	w.first = false
+
+	_, err := w.writer.Write(entry)
+	if err != nil {
+		return fmt.Errorf("writing har entry: %w", err)
+	}
+
+	return nil
+}
+
+// Close finalizes the JSON written to the underlying writer.
+// Close must be called to ensure the HAR file is valid. Writer
+// must not be used after Close is called.
+func (w *Writer) Close() error {
+	w.mut.Lock()
+	defer w.mut.Unlock()
+
+	if w.closed {
+		return fmt.Errorf("HarWriter already closed")
+	}
+
+	w.closed = true
+	_, err := w.writer.Write([]byte("\n]}}"))
+	if err != nil {
+		return fmt.Errorf("closing har writer: %w", err)
+	}
+
+	return nil
+}

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -1,6 +1,7 @@
 package model
 
 import (
+	"github.com/hahwul/dalfox/v2/pkg/har"
 	"sync"
 	t "time"
 
@@ -61,6 +62,7 @@ type Options struct {
 	SpinnerObject     *s.Spinner
 	AuroraObject      a.Aurora
 	StartTime         t.Time
+	HarWriter         *har.Writer
 	PathReflection    map[int]string
 	RemotePayloads    string
 	RemoteWordlists   string

--- a/pkg/model/result.go
+++ b/pkg/model/result.go
@@ -16,6 +16,7 @@ type PoC struct {
 	Evidence   string `json:"evidence"`
 	CWE        string `json:"cwe"`
 	Severity   string `json:"severity"`
+	MessageID  int64  `json:"message_id,omitempty"`
 }
 
 // Result is struct for library and cli application

--- a/pkg/optimization/optimization.go
+++ b/pkg/optimization/optimization.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"github.com/hahwul/dalfox/v2/pkg/har"
 	"html/template"
 	"net/http"
 	"net/url"
@@ -16,12 +17,14 @@ import (
 // GenerateNewRequest is make http.Cilent
 func GenerateNewRequest(url, body string, options model.Options) *http.Request {
 	req, _ := http.NewRequest("GET", url, nil)
+	req = har.AddMessageIDToRequest(req)
 	// Add the Accept header like browsers do.
 	req.Header.Add("Accept", "text/html,application/xhtml+xml,application/xml;q=0.9,image/avif,image/webp,image/apng,*/*;q=0.8,application/signed-exchange;v=b3;q=0.9")
 
 	if options.Data != "" {
 		d := []byte(body)
 		req, _ = http.NewRequest("POST", url, bytes.NewBuffer(d))
+		req = har.AddMessageIDToRequest(req)
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
 
@@ -64,7 +67,7 @@ func GenerateNewRequest(url, body string, options model.Options) *http.Request {
 	return req
 }
 
-//GetRawCookie gets cookie from raw request
+// GetRawCookie gets cookie from raw request
 func GetRawCookie(cookies []*http.Cookie) string {
 	var rawCookies []string
 	for _, c := range cookies {
@@ -81,9 +84,11 @@ func MakeHeaderQuery(target, hn, hv string, options model.Options) (*http.Reques
 	tempMap["payload"] = hv
 	tempMap["param"] = "thisisheadertesting"
 	req, _ := http.NewRequest("GET", target, nil)
+	req = har.AddMessageIDToRequest(req)
 	if options.Data != "" {
 		d := []byte("")
 		req, _ = http.NewRequest("POST", target, bytes.NewBuffer(d))
+		req = har.AddMessageIDToRequest(req)
 		req.Header.Add("Content-Type", "application/x-www-form-urlencoded")
 	}
 

--- a/pkg/scanning/scan.go
+++ b/pkg/scanning/scan.go
@@ -3,6 +3,7 @@ package scanning
 import (
 	"encoding/json"
 	"fmt"
+	"github.com/hahwul/dalfox/v2/pkg/har"
 	"io/ioutil"
 	"net/http"
 	"net/url"
@@ -694,6 +695,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 									CWE:        "CWE-79",
 									Severity:   "High",
 									PoCType:    options.PoCType,
+									//MessageID:  -1, // we can't do HAR here because it's using chromedp
 								}
 								if showV {
 									if options.Format == "json" {
@@ -777,6 +779,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 															CWE:        "CWE-79",
 															Severity:   "High",
 															PoCType:    options.PoCType,
+															MessageID:  har.MessageIDFromRequest(k),
 														}
 														poc.Data = MakePoC(poc.Data, k, options)
 
@@ -812,6 +815,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 															CWE:        "CWE-79",
 															Severity:   "Medium",
 															PoCType:    options.PoCType,
+															MessageID:  har.MessageIDFromRequest(k),
 														}
 														poc.Data = MakePoC(poc.Data, k, options)
 
@@ -835,6 +839,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 														CWE:        "CWE-79",
 														Severity:   "Medium",
 														PoCType:    options.PoCType,
+														MessageID:  har.MessageIDFromRequest(k),
 													}
 													poc.Data = MakePoC(poc.Data, k, options)
 
@@ -875,6 +880,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 												CWE:        "CWE-83",
 												Severity:   "High",
 												PoCType:    options.PoCType,
+												MessageID:  har.MessageIDFromRequest(k),
 											}
 											poc.Data = MakePoC(poc.Data, k, options)
 
@@ -912,6 +918,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 												CWE:        "CWE-83",
 												Severity:   "Medium",
 												PoCType:    options.PoCType,
+												MessageID:  har.MessageIDFromRequest(k),
 											}
 											poc.Data = MakePoC(poc.Data, k, options)
 
@@ -950,6 +957,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 												CWE:        "CWE-79",
 												Severity:   "High",
 												PoCType:    options.PoCType,
+												MessageID:  har.MessageIDFromRequest(k),
 											}
 											poc.Data = MakePoC(poc.Data, k, options)
 
@@ -987,6 +995,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 												CWE:        "CWE-79",
 												Severity:   "Medium",
 												PoCType:    options.PoCType,
+												MessageID:  har.MessageIDFromRequest(k),
 											}
 											poc.Data = MakePoC(poc.Data, k, options)
 

--- a/pkg/scanning/sendReq.go
+++ b/pkg/scanning/sendReq.go
@@ -4,6 +4,7 @@ import (
 	"compress/gzip"
 	"encoding/json"
 	"errors"
+	"github.com/hahwul/dalfox/v2/pkg/har"
 	"io"
 	"io/ioutil"
 	"net/http"
@@ -54,6 +55,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 					CWE:        "CWE-601",
 					Severity:   "Medium",
 					PoCType:    options.PoCType,
+					MessageID:  har.MessageIDFromRequest(req),
 				}
 				if showG {
 					if options.Format == "json" {
@@ -111,6 +113,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 					CWE:        "CWE-93",
 					Severity:   "Medium",
 					PoCType:    options.PoCType,
+					MessageID:  har.MessageIDFromRequest(req),
 				}
 				poc.Data = MakePoC(poc.Data, req, options)
 
@@ -160,6 +163,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 						CWE:        "CWE-94",
 						Severity:   "High",
 						PoCType:    options.PoCType,
+						MessageID:  har.MessageIDFromRequest(req),
 					}
 					poc.Data = MakePoC(poc.Data, req, options)
 
@@ -202,6 +206,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 					CWE:        "",
 					Severity:   "Low",
 					PoCType:    options.PoCType,
+					MessageID:  har.MessageIDFromRequest(req),
 				}
 				poc.Data = MakePoC(poc.Data, req, options)
 
@@ -253,6 +258,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 					CWE:        "",
 					Severity:   "Low",
 					PoCType:    options.PoCType,
+					MessageID:  har.MessageIDFromRequest(req),
 				}
 				poc.Data = MakePoC(poc.Data, req, options)
 


### PR DESCRIPTION
Hi,

Here is the draft PR that I mentioned in #439. It is **incomplete and only a draft right now**, but I am sharing it early to get your feedback.

## Which HAR package to use?

I looked at https://github.com/vvakame/go-harlog and some other packages (I found other packages by going through the results of [this GitHub search](https://github.com/search?q=startedDateTime+language%3AGo&type=code&l=Go)). There were some issues with the other projects that already existed, so I created my own by forking `github.com/vvakame/go-harlog`. Those issues were:

* Their design required that you use one `http.RoundTripper` per HAR archive. Dalfox creates a `http.RoundTripper` in a few different places and I didn't want to make big changes to Dalfox.
* Their design would store the HAR archive in memory and serialize to JSON at the end. Dalfox can make a *lot* of requests and I didn't want Dalfox to use lots of memory, so I wanted something that would write the file incrementally during the scan.
* Their design would only allow standard HAR files to be written, without modification. I wanted to be able to add a `_messageId` property to the HAR entries to correlate with Dalfox PoCs like ZAP does.

So that's why I created a new HAR package. The package does the same thing Dalfox does in JSON mode: it writes the `[` first, then each JSON object, then commas, then the closing `]`. It also allows multiple `http.RoundTripper` objects (in this case, `*har.RoundTripper`) to write to a single shared `har.Writer`. 

**Question**: should it be a standalone package that Dalfox imports in its `go.mod` or would you prefer it to be contained entirely in Dalfox, e.g. `github.com/hahwul/dalfox/pkg/har`? I think I prefer it to be a Dalfox package, but I don't know how much code you want in the Dalfox repo. Let me know what you prefer.

## Integration into Dalfox

What do you think of the changes to Dalfox so far? Is the design ok? Are there any changes you would like me to make? Right now the code works correctly and generates a HAR archive. I will add another commit that adds a `_messageId` property to the HAR entries and the Dalfox PoC JSON soon. Maybe in a couple of days.