### PR TITLE
Error handled for index out of range

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -32,6 +32,11 @@ var fileCmd = &cobra.Command{
 		printing.Banner(options)
 		tMethod := options.Method
 		options.Method = "FILE Mode"
+		if len(args) == 0 {
+			printing.DalLog("ERROR", "Input file path", options)
+			printing.DalLog("ERROR", "e.g dalfox file ./targets.txt or ./rawdata.raw", options)
+			return
+		}
 		printing.Summary(options, args[0])
 		options.Method = tMethod
 		var targets []string

--- a/cmd/sxss.go
+++ b/cmd/sxss.go
@@ -15,6 +15,11 @@ var sxssCmd = &cobra.Command{
 	Short: "Use Stored XSS mode",
 	Run: func(cmd *cobra.Command, args []string) {
 		printing.Banner(options)
+		if len(args) == 0 {
+			printing.DalLog("ERROR", "Input target url", options)
+			printing.DalLog("ERROR", "e.g dalfox sxss https://google.com/?q=1 --trigger https://target/profile", options)
+			return
+		}
 		printing.Summary(options, args[0])
 		if len(args) >= 1 {
 			options.Trigger = trigger

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -12,6 +12,11 @@ var urlCmd = &cobra.Command{
 	Short: "Use single target mode",
 	Run: func(cmd *cobra.Command, args []string) {
 		printing.Banner(options)
+		if len(args) == 0 {
+			printing.DalLog("ERROR", "Input target url", options)
+			printing.DalLog("ERROR", "e.g dalfox url https://google.com/?q=1", options)
+			return
+		}
 		printing.Summary(options, args[0])
 		if len(args) >= 1 {
 			printing.DalLog("SYSTEM", "Using single target mode", options)


### PR DESCRIPTION
While I was working around dalfox I encountered an issue which is caused a crash due to no Error handling in the args following the reference below.

How the issue I encountered when I ran it returned the following error in the picture, Not only for the **file** command it's the same for **url** and **sxss**, Even though we don't need to run this but incase user forget to provide the argument they might end up getting stack trace.

```bash
dalfox file
```

<img width="950" alt="Screenshot 2023-03-04 at 4 18 48 PM" src="https://user-images.githubusercontent.com/20747656/222894330-3ecab22a-e30a-488f-b54c-8c4b81781490.png">


#### Reference

https://github.com/hahwul/dalfox/blob/efcef0ffbf0fe775d8722940cce02069d7b51fdb/cmd/file.go#L35

https://github.com/hahwul/dalfox/blob/efcef0ffbf0fe775d8722940cce02069d7b51fdb/cmd/url.go#L15

https://github.com/hahwul/dalfox/blob/efcef0ffbf0fe775d8722940cce02069d7b51fdb/cmd/sxss.go#L18

I checked the code coverage using [github action](https://github.com/rudSarkar/dalfox/actions/runs/4329866804), If you think that there will be a better option to handle this error please review the PR and suggest some edits.

Thanks