### PR TITLE
fix: update NewMessageID test to check for positive values

### DIFF
--- a/pkg/har/message_id_test.go
+++ b/pkg/har/message_id_test.go
@@ -8,12 +8,13 @@ func TestNewMessageID(t *testing.T) {
 	}{
 		{
 			name: "Test case 1",
-		}
+		},
 	}
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := NewMessageID(); got != nil {
-				t.Errorf("NewMessageID() = %v, got)
+			if got := NewMessageID(); got <= 0 {
+				t.Errorf("NewMessageID() = %v", got)
 			}
 		})
 	}


### PR DESCRIPTION
The NewMessageID test in message_id_test.go was updated to check for positive values instead of non-nil values. This change ensures that the generated message ID is a valid positive integer.