### PR TITLE
Change 'BAV' behavior to be disabled by default; add 'use-bav' option to enable it

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -25,7 +25,7 @@ var ignoreReturn, miningWord, method, customAlertValue, customAlertType, remoteP
 var timeout, concurrence, delay int
 var onlyDiscovery, silence, followRedirect, mining, findingDOM, noColor, noSpinner, onlyCustomPayload, debug, useDeepDXSS, outputAll bool
 var options model.Options
-var skipMiningDom, skipMiningDict, skipMiningAll, skipXSSScan, skipBAV, skipGrep, skipHeadless, wafEvasion, reportBool, outputRequest, outputResponse bool
+var skipMiningDom, skipMiningDict, skipMiningAll, skipXSSScan, skipBAV, skipGrep, skipHeadless, wafEvasion, reportBool, outputRequest, outputResponse, useBAV bool
 var onlyPoC, foundActionShell, pocType, reportFormat string
 
 var rootCmd = &cobra.Command{
@@ -96,6 +96,7 @@ func init() {
 	rootCmd.PersistentFlags().BoolVarP(&followRedirect, "follow-redirects", "F", false, "Following redirection")
 	rootCmd.PersistentFlags().BoolVar(&noColor, "no-color", false, "Not use colorize")
 	rootCmd.PersistentFlags().BoolVar(&noSpinner, "no-spinner", false, "Not use spinner")
+	rootCmd.PersistentFlags().BoolVar(&useBAV, "use-bav", false, "Use BAV(Basic Another Vulnerability) analysis")
 	rootCmd.PersistentFlags().BoolVar(&skipBAV, "skip-bav", false, "Skipping BAV(Basic Another Vulnerability) analysis")
 	rootCmd.PersistentFlags().BoolVar(&skipMiningDom, "skip-mining-dom", false, "Skipping DOM base parameter mining")
 	rootCmd.PersistentFlags().BoolVar(&skipMiningDict, "skip-mining-dict", false, "Skipping Dict base parameter mining")
@@ -169,6 +170,7 @@ func initConfig() {
 		ReportFormat:      reportFormat,
 		OutputRequest:     outputRequest,
 		OutputResponse:    outputResponse,
+		UseBAV:            useBAV,
 	}
 	// var skipMiningDom, skipMiningDict, skipMiningAll, skipXSSScan, skipBAV bool
 

--- a/lib/func.go
+++ b/lib/func.go
@@ -65,6 +65,7 @@ func Initialize(target Target, options Options) model.Options {
 		WAFEvasion:        false,
 		OutputRequest:     false,
 		OutputResponse:    false,
+		UseBAV:            false,
 	}
 	if len(options.UniqParam) > 0 {
 		newOptions.UniqParam = append(newOptions.UniqParam, options.UniqParam...)
@@ -176,6 +177,9 @@ func Initialize(target Target, options Options) model.Options {
 	}
 	if options.Sequence != -1 {
 		newOptions.Sequence = options.Sequence
+	}
+	if options.UseBAV == true {
+		newOptions.UseBAV = true
 	}
 
 	return newOptions

--- a/lib/func_test.go
+++ b/lib/func_test.go
@@ -34,6 +34,7 @@ func TestInitialize(t *testing.T) {
 		RemotePayloads:   "portswigger",
 		RemoteWordlists:  "burp",
 		PoCType:          "curl",
+		UseBAV:           false,
 	}
 	target := dalfox.Target{
 		URL:     "https://www.hahwul.com",

--- a/lib/interface.go
+++ b/lib/interface.go
@@ -47,6 +47,7 @@ type Options struct {
 	HarWriter         *har.Writer `json:"har-file-path"`
 	OutputRequest     bool        `json:"output-request,omitempty"`
 	OutputResponse    bool        `json:"output-response,omitempty"`
+	UseBAV            bool        `json:"use-bav,omitempty"`
 }
 
 // Target is target object

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -79,6 +79,7 @@ type Options struct {
 	ReportBool        bool
 	OutputRequest     bool `json:"output-request,omitempty"`
 	OutputResponse    bool `json:"output-response,omitempty"`
+	UseBAV            bool `json:"use-bav,omitempty"`
 }
 
 // MassJob is list for mass

--- a/pkg/printing/logger.go
+++ b/pkg/printing/logger.go
@@ -21,6 +21,11 @@ func boolToColorStr(b bool, options model.Options) string {
 
 // Summary is printing options
 func Summary(options model.Options, target string) {
+	bavState := false
+	if options.UseBAV {
+		bavState = true
+	}
+
 	if !options.Silence {
 		miningWord := "Gf-Patterns"
 		if options.MiningWordlist != "" {
@@ -32,7 +37,7 @@ func Summary(options model.Options, target string) {
 		}
 		fmt.Fprintf(os.Stderr, " 🏁  Method                 %s\n", options.AuroraObject.BrightBlue(options.Method).String())
 		fmt.Fprintf(os.Stderr, " 🖥   Worker                 %d\n", options.Concurrence)
-		fmt.Fprintf(os.Stderr, " 🔦  BAV                    %s\n", boolToColorStr(!options.NoBAV, options))
+		fmt.Fprintf(os.Stderr, " 🔦  BAV                    %s\n", boolToColorStr(bavState, options))
 		fmt.Fprintf(os.Stderr, " ⛏   Mining                 %s (%s)\n", boolToColorStr(options.Mining, options), miningWord)
 		fmt.Fprintf(os.Stderr, " 🔬  Mining-DOM             %s (mining from DOM)\n", boolToColorStr(options.FindingDOM, options))
 		if options.BlindURL != "" {

--- a/pkg/scanning/scan.go
+++ b/pkg/scanning/scan.go
@@ -136,7 +136,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 	sa := "SA: ✓ "
 	pa := "PA: ✓ "
 	bav := "BAV: ✓ "
-	if options.NoBAV {
+	if !options.UseBAV {
 		task = 2
 		bav = ""
 	}
@@ -155,7 +155,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 		pa = options.AuroraObject.Green(pa).String()
 		printing.DalLog("SYSTEM", "["+sa+pa+bav+"] Waiting for analysis 🔍", options)
 	}()
-	if !options.NoBAV {
+	if options.UseBAV {
 		go func() {
 			defer wait.Done()
 			var bavWaitGroup sync.WaitGroup

--- a/pkg/scanning/sendReq.go
+++ b/pkg/scanning/sendReq.go
@@ -42,7 +42,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 	}
 
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
-		if (!options.NoBAV) && (payload == "toOpenRedirecting") && !(strings.Contains(oReq.Host, ".google.com")) {
+		if (options.UseBAV) && (payload == "toOpenRedirecting") && !(strings.Contains(oReq.Host, ".google.com")) {
 			if strings.Contains(req.URL.Host, "google.com") {
 				printing.DalLog("GREP", "Found Open Redirect. Payload: "+via[0].URL.String(), options)
 				poc := model.PoC{
@@ -110,7 +110,7 @@ func SendReq(req *http.Request, payload string, options model.Options) (string, 
 		ssti := getSSTIPayload()
 
 		grepResult := make(map[string][]string)
-		if !options.NoBAV {
+		if options.UseBAV {
 			if len(resp.Header["Dalfoxcrlf"]) != 0 {
 				poc := model.PoC{
 					Type:       "G",


### PR DESCRIPTION
- Updated BAV to be disabled by default for improved flexibility.
- Introduced the 'use-bav' option to explicitly enable BAV functionality.

Closed #595

Signed-off-by: HAHWUL <hahwul@gmail.com>