### PR TITLE
fix: cleanup found action to prevent zombie processes

### DIFF
--- a/pkg/scanning/foundaction.go
+++ b/pkg/scanning/foundaction.go
@@ -19,4 +19,5 @@ func foundAction(options model.Options, target, query, ptype string) {
 	if err != nil {
 		printing.DalLog("ERROR", "execution error from found-action", options)
 	}
+	defer cmd.Process.Release()
 }


### PR DESCRIPTION
I'm encountering a lot of `<defunct>` curl processes when running Dalfox with `--found-action`. The eventual cause my system to crash as they are not cleaned up. This fix cleans up the process resource