### PR TITLE
new: add option to skip discovery

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -55,4 +55,5 @@ type Args struct {
 	ReportBool        bool
 	OutputRequest     bool
 	OutputResponse    bool
+	SkipDiscovery     bool
 }

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -105,6 +105,8 @@ func init() {
 	rootCmd.PersistentFlags().BoolVar(&args.ReportBool, "report", false, "Show detailed report. Example: --report")
 	rootCmd.PersistentFlags().BoolVar(&args.OutputRequest, "output-request", false, "Include raw HTTP requests in the results. Example: --output-request")
 	rootCmd.PersistentFlags().BoolVar(&args.OutputResponse, "output-response", false, "Include raw HTTP responses in the results. Example: --output-response")
+	rootCmd.PersistentFlags().BoolVar(&args.SkipDiscovery, "skip-discovery", false, "Skip the entire discovery phase, proceeding directly to XSS scanning. Requires -p flag to specify parameters. Example: --skip-discovery -p 'username'")
+
 }
 
 // initConfig reads in config file and ENV variables if set.
@@ -165,6 +167,7 @@ func initConfig() {
 		OutputRequest:     args.OutputRequest,
 		OutputResponse:    args.OutputResponse,
 		UseBAV:            args.UseBAV,
+		SkipDiscovery:     args.SkipDiscovery,
 	}
 
 	if args.HarFilePath != "" {

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -84,6 +84,7 @@ type Options struct {
 	OutputResponse    bool `json:"output-response,omitempty"`
 	UseBAV            bool `json:"use-bav,omitempty"`
 	CustomTransport   http.RoundTripper
+	SkipDiscovery     bool `json:"skip-discovery,omitempty"`
 }
 
 // MassJob is list for mass

--- a/pkg/scanning/scan.go
+++ b/pkg/scanning/scan.go
@@ -120,9 +120,9 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 			if paramName != "" {
 				params[paramName] = model.ParamResult{
 					Name:      paramName,
-					Type:      "URL",      // Consider allowing user to specify the type
-					Reflected: true,       // Assume it might be reflected
-					Chars:     []string{}, // Empty slice of special chars
+					Type:      "URL",            // Consider allowing user to specify the type
+					Reflected: true,             // Assume it might be reflected
+					Chars:     GetSpecialChar(), // Assumes all special characters can be reflected
 				}
 			}
 		}

--- a/pkg/scanning/scan.go
+++ b/pkg/scanning/scan.go
@@ -111,7 +111,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 
 		// Check that parameters were provided with -p
 		if len(options.UniqParam) == 0 {
-			printing.DalLog("ERROR", "--skip-discovery requires parameters to be specified with -p flag", options)
+			printing.DalLog("ERROR", "--skip-discovery requires parameters to be specified with -p flag (e.g., -p username)", options)
 			return scanResult, fmt.Errorf("--skip-discovery requires parameters to be specified with -p flag")
 		}
 
@@ -120,7 +120,7 @@ func Scan(target string, options model.Options, sid string) (model.Result, error
 			if paramName != "" {
 				params[paramName] = model.ParamResult{
 					Name:      paramName,
-					Type:      "URL",
+					Type:      "URL",      // Consider allowing user to specify the type
 					Reflected: true,       // Assume it might be reflected
 					Chars:     []string{}, // Empty slice of special chars
 				}


### PR DESCRIPTION
Fixes [Skip discovery/analysis · Issue #643 · hahwul/dalfox](https://github.com/hahwul/dalfox/issues/643).

Successfully tested this change on [Lab: Stored XSS into HTML context with nothing encoded | Web Security Academy](https://portswigger.net/web-security/cross-site-scripting/stored/lab-html-context-nothing-encoded):

```
./dalfox sxss https://<LAB>.web-security-academy.net/post/comment \
    -X POST \
    -H 'Host: <LAB>.web-security-academy.net' \
    -H 'User-Agent: Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/133.0.0.0 Safari/537.36' \
    -H 'Accept: */*' \
    -H 'Content-Type: application/x-www-form-urlencoded' \
    -H 'Cookie: session=<SESSION>' \
    -d 'comment=example_value&csrf=<CSRF>&email=user%40example.com&name=example_value&postId=10&website=https%3A%2F%2Fwww.example.com' \
    --request-method GET \
    --trigger 'https://<LAB>.web-security-academy.net:443/post?postId=10' \
    -p comment \
    --format json \
    --proxy http://127.0.0.1:8081 \
    --skip-discovery \
    --skip-headless

Target                 https://<LAB>.web-security-academy.net/post/comment
Method                 POST
Worker                 100
BAV                    false
Mining                 false (Gf-Patterns)
Mining-DOM             false (mining from DOM)
Timeout                10
FollowRedirect         false
Started at             2025-03-04 10:51:05.202806 -0500 EST m=+0.003689042

 >>>>>>>>>>>>>>>>>>>>>>>>>
[
[*] 🦊 Start scan [SID:Single] / URL: https://<LAB>.web-security-academy.net/post/comment
[I] Discovery phase and content-type checks skipped. Testing with 1 parameters from -p flag
[V] Triggered XSS Payload (found DOM Object): comment="><Svg/onload=alert(1) class=dlafox>
{"type":"V","inject_type":"inHTML","poc_type":"plain","method":"POST","data":"https://<LAB>.web-security-academy.net/post/comment?comment=%2522%253E%253C%2553%2576%2567%252F%256F%256E%256C%256F%2561%2564%253D%2561%256C%2565%2572%2574%2528%2531%2529%2520%2563%256C%2561%2573%2573%253D%2564%256C%2561%2566%256F%2578%253E -d comment=example_value\u0026csrf=<CSRF>\u0026email=user%40example.com\u0026name=example_value\u0026postId=10\u0026website=https%3A%2F%2Fwww.example.com","param":"comment","payload":"\"\u003e\u003cSvg/onload=alert(1) class=dlafox\u003e","evidence":"","cwe":"CWE-79","severity":"High","message_id":288,"message_str":"Triggered XSS Payload (found DOM Object): comment=\"\u003e\u003cSvg/onload=alert(1) class=dlafox\u003e"},
 ⠹  [9/272 Queries][3.31%] Passing "comment" param queries^C
```

@hahwul, a few questions I had while making this change:
- are the results of discovery used anywhere downstream that would break if discovery isn't actually performed?
- should the `-p` option by mandatory if `--skip-discovery` is used (I assume yes)? since we won't have discovered any params
- should we bypass `Content-Type` checks when skipping discovery (I assume yes)?
- do we need to fill out param fields that are normally populated during discovery?
  - param type: e.g., URL, form, path, header, cookie, etc. will dalfox locate the param automatically, or should we specify the type explicitly (perhaps by `-p username:form` or something)?
  - special chars: not sure how this is normally determined
  - reflected: will it cause problems if we initially assume true?