### PR TITLE
Add result limit option to file and pipe commands

### DIFF
--- a/cmd/file.go
+++ b/cmd/file.go
@@ -166,10 +166,11 @@ func runFileMode(filePath string, cmd *cobra.Command, sf bool) {
 	printing.DalLog("SYSTEM", "Loaded "+strconv.Itoa(len(targets))+" target urls", options)
 	multi, _ := cmd.Flags().GetBool("multicast")
 	mass, _ := cmd.Flags().GetBool("mass")
+	limit, _ := cmd.Flags().GetInt("limit")
 	if multi || mass {
-		runMulticastMode(targets, cmd, sf)
+		runMulticastMode(targets, cmd, sf, limit)
 	} else {
-		runSingleMode(targets, sf)
+		runSingleMode(targets, sf, limit)
 	}
 }
 
@@ -197,4 +198,5 @@ func init() {
 	fileCmd.Flags().Bool("mass", false, "Enable parallel scanning in N*Host mode (only shows PoC code). Example: --mass")
 	fileCmd.Flags().Bool("silence-force", false, "Only print PoC code, suppress progress output. Example: --silence-force")
 	fileCmd.Flags().Int("mass-worker", 10, "Set the number of parallel workers for --mass and --multicast options. Example: --mass-worker 10")
+	fileCmd.Flags().Int("limit", 0, "Limit the number of results to display. Example: --limit 10")
 }

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -94,10 +94,6 @@ func runMulticastMode(targets []string, cmd *cobra.Command, sf bool, limit int) 
 		go func() {
 			defer wg.Done()
 			for kv := range tasks {
-				//if shouldStop {
-				//	continue // Skip processing if we reached the limit
-				//}
-
 				v := kv.URLs
 				for i := range v {
 					if shouldStop {
@@ -154,6 +150,7 @@ func runMulticastMode(targets []string, cmd *cobra.Command, sf bool, limit int) 
 
 func runSingleMode(targets []string, sf bool, limit int) {
 	options.AllURLS = len(targets)
+
 	if (!options.NoSpinner || !options.Silence) && !sf {
 		options.SpinnerObject.Prefix = " "
 		options.SpinnerObject.Suffix = "  [" + strconv.Itoa(options.NowURL) + "/" + strconv.Itoa(options.AllURLS) + " Tasks][0%] Multiple scanning from pipe"

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -51,14 +51,15 @@ func runPipeCmd(cmd *cobra.Command, args []string) {
 
 	multi, _ := cmd.Flags().GetBool("multicast")
 	mass, _ := cmd.Flags().GetBool("mass")
+	limit, _ := cmd.Flags().GetInt("limit")
 	if multi || mass {
-		runMulticastMode(targets, cmd, sf)
+		runMulticastMode(targets, cmd, sf, limit)
 	} else {
-		runSingleMode(targets, sf)
+		runSingleMode(targets, sf, limit)
 	}
 }
 
-func runMulticastMode(targets []string, cmd *cobra.Command, sf bool) {
+func runMulticastMode(targets []string, cmd *cobra.Command, sf bool, limit int) {
 	printing.DalLog("SYSTEM", "Using multicasting mode", options)
 	options.Silence = true
 	options.MulticastMode = true
@@ -84,14 +85,39 @@ func runMulticastMode(targets []string, cmd *cobra.Command, sf bool) {
 			printing.DalLog("SYSTEM-M", "Parallel testing to '"+k+"' => "+strconv.Itoa(len(v))+" urls", options)
 		}
 	}
+	var totalResults int
+	var resultsMutex sync.Mutex
+	var shouldStop bool
+
 	for task := 0; task < concurrency; task++ {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
 			for kv := range tasks {
+				if shouldStop {
+					continue // Skip processing if we reached the limit
+				}
+
 				v := kv.URLs
 				for i := range v {
-					_, _ = scanning.Scan(v[i], options, strconv.Itoa(len(v)))
+					if shouldStop {
+						break // Skip processing if we reached the limit
+					}
+
+					result, _ := scanning.Scan(v[i], options, strconv.Itoa(len(v)))
+
+					if limit > 0 {
+						resultsMutex.Lock()
+						totalResults += len(result.PoCs)
+						if totalResults >= limit {
+							if !options.Silence || !sf {
+								printing.DalLog("SYSTEM-M", "Result limit reached ("+strconv.Itoa(limit)+"). Stopping scan.", options)
+							}
+							shouldStop = true
+						}
+						resultsMutex.Unlock()
+					}
+
 					if (!options.NoSpinner || !options.Silence) && !sf {
 						options.Mutex.Lock()
 						options.NowURL++
@@ -126,7 +152,7 @@ func runMulticastMode(targets []string, cmd *cobra.Command, sf bool) {
 	}
 }
 
-func runSingleMode(targets []string, sf bool) {
+func runSingleMode(targets []string, sf bool, limit int) {
 	options.AllURLS = len(targets)
 	if (!options.NoSpinner || !options.Silence) && !sf {
 		options.SpinnerObject.Prefix = " "
@@ -136,12 +162,32 @@ func runSingleMode(targets []string, sf bool) {
 		}
 		options.SpinnerObject.Start()
 	}
+	var totalResults int
+	var allResults []model.Result
+
 	if options.Format == "json" {
 		printing.DalLog("PRINT", "[", options)
 	}
 	for i := range targets {
 		options.NowURL = i + 1
-		_, _ = scanning.Scan(targets[i], options, strconv.Itoa(i))
+		result, _ := scanning.Scan(targets[i], options, strconv.Itoa(i))
+
+		// Add the current result to our collection
+		allResults = append(allResults, result)
+
+		// Count total PoCs across all results
+		totalResults = 0
+		for _, res := range allResults {
+			totalResults += len(res.PoCs)
+		}
+
+		if limit > 0 && totalResults >= limit {
+			if !options.Silence || !sf {
+				printing.DalLog("SYSTEM", "Result limit reached ("+strconv.Itoa(limit)+"). Stopping scan.", options)
+			}
+			break
+		}
+
 		if (!options.NoSpinner || !options.Silence) && !sf {
 			options.Mutex.Lock()
 			options.NowURL++
@@ -164,4 +210,5 @@ func init() {
 	pipeCmd.Flags().Bool("mass", false, "Enable parallel scanning in N*Host mode (only shows PoC code). Example: --mass")
 	pipeCmd.Flags().Bool("silence-force", false, "Only print PoC code, suppress progress output. Example: --silence-force")
 	pipeCmd.Flags().Int("mass-worker", 10, "Set the number of parallel workers for --mass and --multicast options. Example: --mass-worker 10")
+	pipeCmd.Flags().Int("limit", 0, "Limit the number of results to display. Example: --limit 10")
 }

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -94,9 +94,9 @@ func runMulticastMode(targets []string, cmd *cobra.Command, sf bool, limit int) 
 		go func() {
 			defer wg.Done()
 			for kv := range tasks {
-				if shouldStop {
-					continue // Skip processing if we reached the limit
-				}
+				//if shouldStop {
+				//	continue // Skip processing if we reached the limit
+				//}
 
 				v := kv.URLs
 				for i := range v {

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -85,6 +85,7 @@ type Options struct {
 	UseBAV            bool `json:"use-bav,omitempty"`
 	CustomTransport   http.RoundTripper
 	SkipDiscovery     bool `json:"skip-discovery,omitempty"`
+	LimitResult       int  `json:"limit-result,omitempty"`
 }
 
 // MassJob is list for mass


### PR DESCRIPTION
Introduce a limit option for the file and pipe commands to control the number of results displayed. This enhancement allows users to specify a maximum number of results, improving usability and performance.