### PR TITLE
Update Scan tests and mock server usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,6 +5,7 @@
 <p align="center">
   <a href="https://github.com/hahwul/dalfox/releases/latest"><img src="https://img.shields.io/github/v/release/hahwul/dalfox?style=for-the-badge&logoColor=%2330365e&label=dalfox&labelColor=%2330365e&color=%2330365e"></a>
   <a href="https://dalfox.hahwul.com/page/overview/"><img src="https://img.shields.io/badge/documents---.svg?style=for-the-badge&labelColor=%2330365e&color=%2330365e"></a>
+  <a href="https://app.codecov.io/gh/hahwul/dalfox"><img src="https://img.shields.io/codecov/c/gh/hahwul/dalfox?style=for-the-badge&labelColor=%2330365e&color=%2330365e"></a>
   <a href="https://x.com/intent/follow?screen_name=hahwul"><img src="https://img.shields.io/twitter/follow/hahwul?style=for-the-badge&logo=x&labelColor=%2330365e&color=%2330365e"></a>
   <a href="https://github.com/hahwul/dalfox/blob/main/CONTRIBUTING.md"><img src="https://img.shields.io/badge/contributions-welcome-brightgreen.svg?style=for-the-badge&labelColor=%2330365e&color=%2330365e"></a>
 </p>

--- a/pkg/scanning/scan_test.go
+++ b/pkg/scanning/scan_test.go
@@ -255,7 +255,7 @@ func Test_updateSpinner(t *testing.T) {
 
 func Test_Scan(t *testing.T) {
 	// Create a mock server
-	server := mockServer()
+	server := mockServerForScanTest()
 	defer server.Close()
 
 	type args struct {
@@ -286,14 +286,14 @@ func Test_Scan(t *testing.T) {
 		{
 			name: "Basic scan with skip discovery",
 			args: args{
-				target: server.URL + "/?param=test",
+				target: server.URL + "/?query=test",
 				options: model.Options{
 					Concurrence:   1,
 					Format:        "plain",
 					Silence:       true,
 					NoSpinner:     true,
 					SkipDiscovery: true,
-					UniqParam:     []string{"param"},
+					UniqParam:     []string{"query"},
 					OnlyDiscovery: true, // To make test faster
 				},
 				sid: "1",
@@ -303,14 +303,14 @@ func Test_Scan(t *testing.T) {
 		{
 			name: "Basic scan with remote payloads",
 			args: args{
-				target: server.URL + "/?param=test",
+				target: server.URL + "/?query=test",
 				options: model.Options{
 					Concurrence:    1,
 					Format:         "plain",
 					Silence:        true,
 					NoSpinner:      true,
 					SkipDiscovery:  true,
-					UniqParam:      []string{"param"},
+					UniqParam:      []string{"query"},
 					RemotePayloads: "portswigger,payloadbox",
 				},
 				sid: "1",
@@ -320,15 +320,16 @@ func Test_Scan(t *testing.T) {
 		{
 			name: "Basic scan with blind xss",
 			args: args{
-				target: server.URL + "/?param=test",
+				target: server.URL + "/?query=test",
 				options: model.Options{
 					Concurrence:   1,
 					Format:        "plain",
 					Silence:       true,
 					NoSpinner:     true,
 					SkipDiscovery: true,
-					UniqParam:     []string{"param"},
+					UniqParam:     []string{"query"},
 					BlindURL:      "https://dalfox.hahwul.com",
+					Data:          "query=1234",
 				},
 				sid: "1",
 			},
@@ -337,15 +338,16 @@ func Test_Scan(t *testing.T) {
 		{
 			name: "Basic scan with headless",
 			args: args{
-				target: server.URL + "/?param=test",
+				target: server.URL + "/?query=test",
 				options: model.Options{
 					Concurrence:   1,
 					Format:        "plain",
 					Silence:       true,
 					NoSpinner:     true,
 					SkipDiscovery: true,
-					UniqParam:     []string{"param"},
+					UniqParam:     []string{"query"},
 					UseHeadless:   true,
+					IgnoreReturn:  "404",
 				},
 				sid: "1",
 			},

--- a/pkg/scanning/scan_test.go
+++ b/pkg/scanning/scan_test.go
@@ -140,8 +140,53 @@ func Test_generatePayloads(t *testing.T) {
 			pathReflection: map[int]string{
 				0: "Injected:/inHTML",
 			},
-			params:         make(map[string]model.ParamResult),
+			params: map[string]model.ParamResult{
+				"param": {
+					Name:           "param",
+					Type:           "URL",
+					Reflected:      true,
+					ReflectedPoint: "Injected:inJS-single",
+					Chars:          []string{},
+				},
+			},
 			wantQueryCount: 1, // At least one query should be generated
+			wantDurlsCount: 0,
+		},
+		{
+			name:   "Path reflection payload (body)",
+			target: server.URL + "/path",
+			options: model.Options{
+				Concurrence:     1,
+				Format:          "plain",
+				Silence:         true,
+				NoSpinner:       true,
+				CustomAlertType: "none",
+				Data:            "param=test",
+			},
+			policy: map[string]string{"Content-Type": "text/html"},
+			pathReflection: map[int]string{
+				0: "Injected:/inHTML",
+			},
+			params: map[string]model.ParamResult{
+				"param": {
+					Name:           "param",
+					Type:           "URL",
+					Reflected:      true,
+					ReflectedPoint: "Injected:inJS-single",
+					Chars:          []string{},
+				},
+			},
+			wantQueryCount: 1, // At least one query should be generated
+			wantDurlsCount: 0,
+		},
+		{
+			name:           "Reflected, but not chars",
+			target:         server.URL,
+			options:        options,
+			policy:         map[string]string{"Content-Type": "text/html"},
+			pathReflection: make(map[int]string),
+			params:         make(map[string]model.ParamResult),
+			wantQueryCount: 0,
 			wantDurlsCount: 0,
 		},
 		{

--- a/pkg/scanning/scan_test.go
+++ b/pkg/scanning/scan_test.go
@@ -144,6 +144,49 @@ func Test_generatePayloads(t *testing.T) {
 			wantQueryCount: 1, // At least one query should be generated
 			wantDurlsCount: 0,
 		},
+		{
+			name:           "inJS reflected parameter",
+			target:         server.URL + "/path/?param=test",
+			options:        options,
+			policy:         map[string]string{"Content-Type": "text/html"},
+			pathReflection: make(map[int]string),
+			params: map[string]model.ParamResult{
+				"param": {
+					Name:           "param",
+					Type:           "URL",
+					Reflected:      true,
+					ReflectedPoint: "Injected:inJS-single",
+					Chars:          []string{"'", "\"", "<", ">", "(", ")", "{", "}", "[", "]", " ", "\t", "\n", "\r", "\f", "\v", "\\", "/", "?", "#", "&", "=", "%", ":", ";", ",", "@", "$", "*", "+", "-", "_", ".", "!", "~", "`", "|", "^"},
+				},
+			},
+			wantQueryCount: 1,
+			wantDurlsCount: 0,
+		},
+		{
+			name:   "inJS reflected parameter",
+			target: server.URL + "/path/",
+			options: model.Options{
+				Concurrence:     1,
+				Format:          "plain",
+				Silence:         true,
+				NoSpinner:       true,
+				CustomAlertType: "none",
+				Data:            "param=test",
+			},
+			policy:         map[string]string{"Content-Type": "text/html"},
+			pathReflection: make(map[int]string),
+			params: map[string]model.ParamResult{
+				"param": {
+					Name:           "param",
+					Type:           "URL",
+					Reflected:      true,
+					ReflectedPoint: "Injected:inATTR-none",
+					Chars:          []string{"'", "\"", "<", ">", "(", ")", "{", "}", "[", "]", " ", "\t", "\n", "\r", "\f", "\v", "\\", "/", "?", "#", "&", "=", "%", ":", ";", ",", "@", "$", "*", "+", "-", "_", ".", "!", "~", "`", "|", "^"},
+				},
+			},
+			wantQueryCount: 1,
+			wantDurlsCount: 0,
+		},
 	}
 
 	for _, tt := range tests {
@@ -338,7 +381,7 @@ func Test_Scan(t *testing.T) {
 		{
 			name: "Basic scan with headless",
 			args: args{
-				target: server.URL + "/?query=test",
+				target: server.URL + "/abcd/?query=test",
 				options: model.Options{
 					Concurrence:   1,
 					Format:        "plain",
@@ -361,6 +404,38 @@ func Test_Scan(t *testing.T) {
 			if (err != nil) != tt.wantErr {
 				t.Errorf("Scan() error = %v, wantErr %v", err, tt.wantErr)
 			}
+		})
+	}
+}
+
+func Test_initializeSpinner(t *testing.T) {
+	type args struct {
+		options model.Options
+	}
+	tests := []struct {
+		name string
+		args args
+	}{
+		{
+			name: "No spinner",
+			args: args{
+				options: model.Options{
+					NoSpinner: true,
+				},
+			},
+		},
+		{
+			name: "Spinner",
+			args: args{
+				options: model.Options{
+					NoSpinner: false,
+				},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			initializeSpinner(tt.args.options)
 		})
 	}
 }

--- a/pkg/scanning/scan_test.go
+++ b/pkg/scanning/scan_test.go
@@ -105,9 +105,17 @@ func Test_generatePayloads(t *testing.T) {
 		wantDurlsCount int
 	}{
 		{
-			name:           "Basic payload generation",
-			target:         server.URL + "/?param=test",
-			options:        options,
+			name:   "Basic payload generation",
+			target: server.URL + "/?param=test",
+			options: model.Options{
+				Concurrence:     1,
+				Format:          "plain",
+				Silence:         true,
+				NoSpinner:       true,
+				CustomAlertType: "none",
+				IgnoreParams:    []string{"param2"},
+				UseHeadless:     true,
+			},
 			policy:         map[string]string{"Content-Type": "text/html"},
 			pathReflection: make(map[int]string),
 			params: map[string]model.ParamResult{
@@ -117,6 +125,13 @@ func Test_generatePayloads(t *testing.T) {
 					Reflected:      true,
 					ReflectedPoint: "Injected:inHTML",
 					Chars:          []string{"'", "\"", "<", ">", "(", ")", "{", "}", "[", "]", " ", "\t", "\n", "\r", "\f", "\v", "\\", "/", "?", "#", "&", "=", "%", ":", ";", ",", "@", "$", "*", "+", "-", "_", ".", "!", "~", "`", "|", "^"},
+				},
+				"param2": {
+					Name:           "param2",
+					Type:           "URL",
+					Reflected:      true,
+					ReflectedPoint: "",
+					Chars:          []string{},
 				},
 			},
 			wantQueryCount: 1, // At least one query should be generated

--- a/pkg/scanning/transport_example_test.go
+++ b/pkg/scanning/transport_example_test.go
@@ -391,3 +391,33 @@ func TestCreateTransportChainWithExamples(t *testing.T) {
 		t.Errorf("Expected response to be '%s', got '%s'", expected, body)
 	}
 }
+
+func TestExampleCustomTransportWithTLS(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "ExampleCustomTransportWithTLS",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ExampleCustomTransportWithTLS()
+		})
+	}
+}
+
+func TestExampleTransportChain(t *testing.T) {
+	tests := []struct {
+		name string
+	}{
+		{
+			name: "ExampleTransportChain",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			ExampleTransportChain()
+		})
+	}
+}


### PR DESCRIPTION
Revise the usage of the mock server in Scan tests and enhance test coverage by adding cases for reflected parameters and the `initializeSpinner` function.