### PR TITLE
Add Snapcraft configuration for Dalfox publishing

### DIFF
--- a/.github/workflows/cd_snapcraft.yml
+++ b/.github/workflows/cd_snapcraft.yml
@@ -1,0 +1,32 @@
+---
+name: Snapcraft tab Publish
+on:
+  push:
+    tags: [v*.*.*]
+  workflow_dispatch:
+jobs:
+  snapcraft-releaser:
+    runs-on: ubuntu-latest
+    name: snapcraft-releaser
+    strategy:
+      fail-fast: false
+      matrix:
+        platform:
+          - amd64
+            #- arm64
+    steps:
+      - name: Check out Git repository
+        uses: actions/checkout@v3
+      - uses: diddlesnaps/snapcraft-multiarch-action@v1
+        with:
+          architecture: ${{ matrix.platform }}
+        id: build
+      - uses: diddlesnaps/snapcraft-review-action@v1
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+      - uses: snapcore/action-publish@master
+        env:
+          SNAPCRAFT_STORE_CREDENTIALS: ${{ secrets.SNAP_STORE_LOGIN }}
+        with:
+          snap: ${{ steps.build.outputs.snap }}
+          release: stable

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,0 +1,25 @@
+name: dalfox
+summary: Powerful open-source XSS scanner and utility focused on automation.
+description: |
+  Dalfox is a powerful open-source tool that focuses on automation, making it ideal for quickly scanning for XSS flaws and analyzing parameters. 
+  Its advanced testing engine and niche features are designed to streamline the process of detecting and verifying vulnerabilities.
+
+adopt-info: ipfs
+base: core18
+grade: stable
+confinement: strict
+
+apps:
+  dalfox:
+    command: dalfox
+    plugs: ["home","network","network-bind"]
+
+parts:
+  dalfox:
+    source: https://github.com/hahwul/dalfox
+    source-tag: main
+    plugin: go
+    go-channel: 1.24/stable
+    go-importpath: github.com/hahwul/dalfox
+    build-packages:
+        - build-essential

--- a/snap/snapcraft.yaml
+++ b/snap/snapcraft.yaml
@@ -1,25 +1,19 @@
+---
 name: dalfox
 summary: Powerful open-source XSS scanner and utility focused on automation.
 description: |
-  Dalfox is a powerful open-source tool that focuses on automation, making it ideal for quickly scanning for XSS flaws and analyzing parameters. 
+  Dalfox is a powerful open-source tool that focuses on automation, making it ideal for quickly scanning for XSS flaws and analyzing parameters.
   Its advanced testing engine and niche features are designed to streamline the process of detecting and verifying vulnerabilities.
-
 adopt-info: ipfs
-base: core18
+base: core24
 grade: stable
 confinement: strict
-
 apps:
   dalfox:
     command: dalfox
-    plugs: ["home","network","network-bind"]
-
+    plugs: [home, network, network-bind]
 parts:
   dalfox:
     source: https://github.com/hahwul/dalfox
-    source-tag: main
     plugin: go
-    go-channel: 1.24/stable
-    go-importpath: github.com/hahwul/dalfox
-    build-packages:
-        - build-essential
+    build-packages: [build-essential]


### PR DESCRIPTION
Introduce a Snapcraft configuration to automate the publishing process for Dalfox, including build and release steps for multiple architectures.