### PR TITLE
Downgrade Go version and update volt dependency

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,13 +1,14 @@
 module github.com/hahwul/dalfox/v2
 
-go 1.24.0
+go 1.23.0
+
 require (
 	github.com/PuerkitoBio/goquery v1.10.2
 	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751
 	github.com/briandowns/spinner v1.23.2
 	github.com/chromedp/cdproto v0.0.0-20250403032234-65de8f5d025b
 	github.com/chromedp/chromedp v0.13.6
-	github.com/hahwul/volt v1.0.6
+	github.com/hahwul/volt v1.0.7
 	github.com/labstack/echo/v4 v4.13.3
 	github.com/logrusorgru/aurora v2.0.3+incompatible
 	github.com/olekukonko/tablewriter v0.0.5

--- a/go.sum
+++ b/go.sum
@@ -48,8 +48,8 @@ github.com/gobwas/pool v0.2.1/go.mod h1:q8bcK0KcYlCgd9e7WYLm9LpyS+YeLd8JVDW6Wezm
 github.com/gobwas/ws v1.4.0 h1:CTaoG1tojrh4ucGPcoJFiAQUAsEWekEWvLy7GsVNqGs=
 github.com/gobwas/ws v1.4.0/go.mod h1:G3gNqMNtPppf5XUz7O4shetPpcZ1VJ7zt18dlUeakrc=
 github.com/google/go-cmp v0.6.0/go.mod h1:17dUlkBOakJ0+DkrSSNjCkIjxS6bF9zb3elmeNGIjoY=
-github.com/hahwul/volt v1.0.6 h1:aagselyxYo7DzEFcjyctof1Mfmh+W1HINyEJw6EUmEw=
-github.com/hahwul/volt v1.0.6/go.mod h1:A8EOQ3G1EKygpWcTqKMqvEue3i+l6a8eAzNOuaIsULY=
+github.com/hahwul/volt v1.0.7 h1:8D3Qbmt82I4r0M/JfLog2VmR5FUIaiboqgx06PWXAbA=
+github.com/hahwul/volt v1.0.7/go.mod h1:Zt5vhIno5O8ZrknLUY5mAssK4N15laDvnaS9NIsrpPA=
 github.com/inconshreveable/mousetrap v1.1.0 h1:wN+x4NVGpMsO7ErUn/mUI3vEoE6Jt13X2s0bqwp9tc8=
 github.com/inconshreveable/mousetrap v1.1.0/go.mod h1:vpF70FUmC8bwa3OWnCshd2FqLfsEA9PFc4w1p2J65bw=
 github.com/josharian/intern v1.0.0 h1:vlS4z54oSdjm0bgjRigI+G1HpF+tI+9rE5LLzOg8HmY=


### PR DESCRIPTION
Downgrade the Go version to 1.23.0 and update the volt dependency to version 1.0.7 to ensure compatibility and stability.