### PR TITLE
Potential fix for code scanning alert no. 50: Slice memory allocation with excessive size value

### DIFF
--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -259,7 +259,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	}
 
 	var wgg sync.WaitGroup
-	const maxConcurrency = 1000 // Define a reasonable maximum limit
+const maxConcurrency = 1000 // Define a reasonable maximum limit to prevent excessive memory allocation
 	concurrency := options.Concurrence
 	if concurrency > maxConcurrency {
 		concurrency = maxConcurrency

--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -259,7 +259,11 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	}
 
 	var wgg sync.WaitGroup
+	const maxConcurrency = 1000 // Define a reasonable maximum limit
 	concurrency := options.Concurrence
+	if concurrency > maxConcurrency {
+		concurrency = maxConcurrency
+	}
 	paramsQue := make(chan string, concurrency)
 	results := make(chan model.ParamResult, concurrency)
 	miningDictCount := 0


### PR DESCRIPTION
Potential fix for [https://github.com/hahwul/dalfox/security/code-scanning/50](https://github.com/hahwul/dalfox/security/code-scanning/50)

To fix the problem, we need to implement a maximum allowed value for the `concurrency` variable to prevent excessively large allocations. This can be done by adding a check to ensure that the `concurrency` value does not exceed a predefined maximum limit. If the value exceeds the limit, we should set it to the maximum allowed value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
