### PR TITLE
fixing issue with logger

### DIFF
--- a/internal/printing/logger.go
+++ b/internal/printing/logger.go
@@ -192,6 +192,7 @@ func DalLog(level, text string, options model.Options) {
 		}
 
 	case "YELLOW":
+		ftext = text
 		if options.AuroraObject != nil {
 			text = options.AuroraObject.BrightYellow(text).String()
 		}


### PR DESCRIPTION
hey this should address https://github.com/hahwul/dalfox/issues/818 - In internal/printing/logger.go:194-198, the "YELLOW" log level case was only setting the display text (text) with color formatting, but not setting ftext (the file text variable).
  I tested the fix with:
```
  ./dalfox payload --make-bulk -o payloads.txt 
  ./dalfox payload --enum-common -o common.txt
```


