### PR TITLE
feat: add --out-of-scope domain filtering option

### DIFF
--- a/cmd/args.go
+++ b/cmd/args.go
@@ -6,6 +6,7 @@ type Args struct {
 	Header       []string // Custom HTTP headers to add to requests
 	P            []string // Parameters to test for XSS vulnerabilities
 	IgnoreParams []string // Parameters to ignore during scanning
+	OutOfScope   []string // Domains to exclude from scanning
 
 	// String options
 	Config                    string // Path to configuration file
@@ -33,6 +34,7 @@ type Args struct {
 	ReportFormat              string // Report format (plain, json, markdown, md)
 	HarFilePath               string // Path to save HAR files
 	CustomBlindXSSPayloadFile string // Path to custom blind XSS payload file
+	OutOfScopeFile            string // File containing domains to exclude
 
 	// Integer options
 	Timeout     int // Request timeout in seconds

--- a/cmd/pipe.go
+++ b/cmd/pipe.go
@@ -12,6 +12,7 @@ import (
 	"time"
 
 	"github.com/briandowns/spinner"
+	"github.com/hahwul/dalfox/v2/internal/optimization"
 	"github.com/hahwul/dalfox/v2/internal/printing"
 	"github.com/hahwul/dalfox/v2/internal/utils"
 	model "github.com/hahwul/dalfox/v2/pkg/model"
@@ -58,6 +59,9 @@ func runPipeCmd(cmd *cobra.Command, args []string) {
 		targets = append(targets, target)
 	}
 	targets = voltUtils.UniqueStringSlice(targets)
+	if len(options.OutOfScope) > 0 {
+		targets = optimization.FilterOutOfScopeTargets(options, targets)
+	}
 	printing.DalLog("SYSTEM", "Loaded "+strconv.Itoa(len(targets))+" target urls", options)
 
 	multi, _ := cmd.Flags().GetBool("multicast")
@@ -131,6 +135,10 @@ func runRawDataPipeMode(cmd *cobra.Command) {
 		} else {
 			target = "https://" + host + path
 		}
+	}
+	if optimization.IsOutOfScope(options, target) {
+		printing.DalLog("INFO", "Target is out of scope, skipping", options)
+		return
 	}
 	_, _ = scanning.Scan(target, options, "single")
 }

--- a/cmd/sxss.go
+++ b/cmd/sxss.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/hahwul/dalfox/v2/internal/optimization"
 	"github.com/hahwul/dalfox/v2/internal/printing"
 	"github.com/hahwul/dalfox/v2/pkg/scanning"
 	"github.com/spf13/cobra"
@@ -36,6 +37,10 @@ func runSxssCmd(cmd *cobra.Command, args []string) {
 
 	if options.Trigger != "" {
 		printing.DalLog("SYSTEM", "Using Stored XSS mode", options)
+		if optimization.IsOutOfScope(options, args[0]) {
+			printing.DalLog("INFO", "Target is out of scope, skipping", options)
+			return
+		}
 		if options.Format == "json" {
 			printing.DalLog("PRINT", "[", options)
 		}

--- a/cmd/url.go
+++ b/cmd/url.go
@@ -1,6 +1,7 @@
 package cmd
 
 import (
+	"github.com/hahwul/dalfox/v2/internal/optimization"
 	"github.com/hahwul/dalfox/v2/internal/printing"
 	"github.com/hahwul/dalfox/v2/pkg/scanning"
 	"github.com/spf13/cobra"
@@ -23,6 +24,10 @@ func runURLCmd(cmd *cobra.Command, args []string) {
 
 	printing.Summary(options, args[0])
 	printing.DalLog("SYSTEM", "Using single target mode", options)
+	if optimization.IsOutOfScope(options, args[0]) {
+		printing.DalLog("INFO", "Target is out of scope, skipping", options)
+		return
+	}
 	if options.Format == "json" {
 		printing.DalLog("PRINT", "[", options)
 	}

--- a/internal/optimization/inspectionDomain.go
+++ b/internal/optimization/inspectionDomain.go
@@ -1,0 +1,67 @@
+package optimization
+
+import (
+	"net/url"
+	"strings"
+
+	"github.com/hahwul/dalfox/v2/pkg/model"
+)
+
+// IsOutOfScope checks if a URL's host matches any out-of-scope pattern.
+// Supports wildcard matching:
+//   - "stg.example.com" = exact match only
+//   - "*.stg.example.com" = matches subdomains (api.stg.example.com, devapi.stg.example.com)
+func IsOutOfScope(options model.Options, targetURL string) bool {
+	if len(options.OutOfScope) == 0 {
+		return false
+	}
+
+	parsedURL, err := url.Parse(targetURL)
+	if err != nil {
+		// Treat malformed URLs as out-of-scope for safety
+		return true
+	}
+
+	host := strings.ToLower(parsedURL.Hostname())
+	// Handle URLs without scheme - url.Parse puts them in Path with empty Host
+	if host == "" && parsedURL.Path != "" {
+		parsedURL, err = url.Parse("http://" + targetURL)
+		if err != nil {
+			return true
+		}
+		host = strings.ToLower(parsedURL.Hostname())
+	}
+	for _, pattern := range options.OutOfScope {
+		pattern = strings.ToLower(strings.TrimSpace(pattern))
+		if matchDomainPattern(host, pattern) {
+			return true
+		}
+	}
+	return false
+}
+
+// matchDomainPattern checks if host matches the pattern.
+// Pattern "*.example.com" matches "sub.example.com" but not "example.com"
+// Pattern "example.com" matches only "example.com" exactly
+func matchDomainPattern(host, pattern string) bool {
+	if strings.HasPrefix(pattern, "*.") {
+		suffix := pattern[1:] // ".example.com"
+		return strings.HasSuffix(host, suffix)
+	}
+	return host == pattern
+}
+
+// FilterOutOfScopeTargets removes out-of-scope URLs from a target list
+func FilterOutOfScopeTargets(options model.Options, targets []string) []string {
+	if len(options.OutOfScope) == 0 {
+		return targets
+	}
+
+	filtered := make([]string, 0, len(targets))
+	for _, target := range targets {
+		if !IsOutOfScope(options, target) {
+			filtered = append(filtered, target)
+		}
+	}
+	return filtered
+}

--- a/internal/optimization/inspectionDomain_test.go
+++ b/internal/optimization/inspectionDomain_test.go
@@ -1,0 +1,246 @@
+package optimization
+
+import (
+	"testing"
+
+	"github.com/hahwul/dalfox/v2/pkg/model"
+)
+
+func TestIsOutOfScope(t *testing.T) {
+	type args struct {
+		options   model.Options
+		targetURL string
+	}
+	tests := []struct {
+		name string
+		args args
+		want bool
+	}{
+		{
+			name: "exact match - should be out of scope",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com"},
+				},
+				targetURL: "https://stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "exact match - subdomain should NOT match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com"},
+				},
+				targetURL: "https://api.stg.hahwul.com/path",
+			},
+			want: false,
+		},
+		{
+			name: "wildcard match - subdomain should match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"*.stg.hahwul.com"},
+				},
+				targetURL: "https://api.stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "wildcard match - base domain should NOT match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"*.stg.hahwul.com"},
+				},
+				targetURL: "https://stg.hahwul.com/path",
+			},
+			want: false,
+		},
+		{
+			name: "wildcard match - nested subdomain should match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"*.hahwul.com"},
+				},
+				targetURL: "https://api.stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "non-matching domain - should NOT be out of scope",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com"},
+				},
+				targetURL: "https://www.hahwul.com/path",
+			},
+			want: false,
+		},
+		{
+			name: "empty out-of-scope list - should NOT be out of scope",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{},
+				},
+				targetURL: "https://stg.hahwul.com/path",
+			},
+			want: false,
+		},
+		{
+			name: "invalid URL - should be out of scope for safety",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com"},
+				},
+				targetURL: "://invalid-url",
+			},
+			want: true,
+		},
+		{
+			name: "case insensitive - should match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"STG.HAHWUL.COM"},
+				},
+				targetURL: "https://stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "multiple patterns - first matches",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com", "dev.hahwul.com"},
+				},
+				targetURL: "https://stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "multiple patterns - second matches",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com", "dev.hahwul.com"},
+				},
+				targetURL: "https://dev.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "scheme-less URL - should match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"stg.hahwul.com"},
+				},
+				targetURL: "stg.hahwul.com/path",
+			},
+			want: true,
+		},
+		{
+			name: "scheme-less URL with wildcard - should match",
+			args: args{
+				options: model.Options{
+					OutOfScope: []string{"*.hahwul.com"},
+				},
+				targetURL: "stg.hahwul.com/path",
+			},
+			want: true,
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := IsOutOfScope(tt.args.options, tt.args.targetURL); got != tt.want {
+				t.Errorf("IsOutOfScope() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func Test_matchDomainPattern(t *testing.T) {
+	tests := []struct {
+		name    string
+		host    string
+		pattern string
+		want    bool
+	}{
+		{"exact match", "hahwul.com", "hahwul.com", true},
+		{"exact no match", "other.com", "hahwul.com", false},
+		{"wildcard matches subdomain", "api.hahwul.com", "*.hahwul.com", true},
+		{"wildcard matches nested subdomain", "api.stg.hahwul.com", "*.hahwul.com", true},
+		{"wildcard does not match base", "hahwul.com", "*.hahwul.com", false},
+		{"partial match should fail", "nothahwul.com", "hahwul.com", false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := matchDomainPattern(tt.host, tt.pattern); got != tt.want {
+				t.Errorf("matchDomainPattern() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestFilterOutOfScopeTargets(t *testing.T) {
+	tests := []struct {
+		name    string
+		options model.Options
+		targets []string
+		want    []string
+	}{
+		{
+			name: "filter out exact match",
+			options: model.Options{
+				OutOfScope: []string{"stg.hahwul.com"},
+			},
+			targets: []string{
+				"https://www.hahwul.com/path",
+				"https://stg.hahwul.com/path",
+				"https://dev.hahwul.com/path",
+			},
+			want: []string{
+				"https://www.hahwul.com/path",
+				"https://dev.hahwul.com/path",
+			},
+		},
+		{
+			name: "filter out wildcard matches",
+			options: model.Options{
+				OutOfScope: []string{"*.stg.hahwul.com"},
+			},
+			targets: []string{
+				"https://www.hahwul.com/path",
+				"https://api.stg.hahwul.com/path",
+				"https://stg.hahwul.com/path",
+			},
+			want: []string{
+				"https://www.hahwul.com/path",
+				"https://stg.hahwul.com/path",
+			},
+		},
+		{
+			name: "empty out-of-scope returns original",
+			options: model.Options{
+				OutOfScope: []string{},
+			},
+			targets: []string{
+				"https://www.hahwul.com/path",
+			},
+			want: []string{
+				"https://www.hahwul.com/path",
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := FilterOutOfScopeTargets(tt.options, tt.targets)
+			if len(got) != len(tt.want) {
+				t.Errorf("FilterOutOfScopeTargets() returned %d items, want %d", len(got), len(tt.want))
+				return
+			}
+			for i, v := range got {
+				if v != tt.want[i] {
+					t.Errorf("FilterOutOfScopeTargets()[%d] = %v, want %v", i, v, tt.want[i])
+				}
+			}
+		})
+	}
+}

--- a/pkg/model/options.go
+++ b/pkg/model/options.go
@@ -16,6 +16,7 @@ type Options struct {
 	// Target Related
 	UniqParam    []string `json:"param,omitempty"`
 	IgnoreParams []string `json:"ignore-params,omitempty"`
+	OutOfScope   []string `json:"out-of-scope,omitempty"`
 	Method       string   `json:"method,omitempty"`
 	IgnoreReturn string   `json:"ignore-return,omitempty"`
 


### PR DESCRIPTION
  Add --out-of-scope and --out-of-scope-file flags to exclude domains
  from scanning. Supports wildcard patterns (e.g., *.staging.example.com)
  
  Closes #867