### PR TITLE
fix: resolve data race and nil pointer panic in processParams (parameterAnalysis.go)

### DIFF
--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -147,7 +147,7 @@ func processParams(target string, paramsQue chan string, results chan model.Para
 			var code string
 			rl.Block(tempURL.Host)
 			resbody, resp, _, vrs, err := SendReq(tempURL, "Dalfox", options)
-			if err == nil {
+			if err == nil && resp != nil {
 				wafCheck, wafN := checkWAF(resp.Header, resbody)
 				if wafCheck {
 					options.WAF = true
@@ -184,6 +184,7 @@ func processParams(target string, paramsQue chan string, results chan model.Para
 					ReflectedCode:  code,
 				}
 				var wg sync.WaitGroup
+				var charsMu sync.Mutex
 				chars := payload.GetSpecialChar()
 				for _, c := range chars {
 					wg.Add(1)
@@ -201,7 +202,9 @@ func processParams(target string, paramsQue chan string, results chan model.Para
 							rl.Block(tempURL.Host)
 							_, _, _, vrs, _ := SendReq(turl, "dalfox"+char, options)
 							if vrs {
+								charsMu.Lock()
 								paramResult.Chars = append(paramResult.Chars, char)
+								charsMu.Unlock()
 							}
 						}
 					}()


### PR DESCRIPTION
## Summary

Fixes a panic reported in the wild when scanning large sites with many parameters and DOM mining enabled:

```
panic: runtime error: invalid memory address or nil pointer dereference
pkg/scanning/parameterAnalysis.go:210
github.com/hahwul/dalfox/v2/pkg/scanning.ParameterAnalysis.func2()
    parameterAnalysis.go:322 +0x68
created by ...ParameterAnalysis in goroutine 21361
    parameterAnalysis.go:321 +0x848
```

### Root cause 1 — data race on `paramResult.Chars` (the actual crash)

In `processParams`, a goroutine is spawned per special character to probe each encoder variant. All goroutines write to the **same** `paramResult.Chars` slice concurrently:

```go
// BEFORE — no synchronization:
go func() {
    if vrs {
        paramResult.Chars = append(paramResult.Chars, char) // ← data race
    }
}()
```

`append` is not atomic. Concurrent goroutines reading the same slice header both write to `slice[len]`, corrupting the backing array. When `UniqueStringSlice` dereferences the corrupted slice at the `wg.Wait()` boundary, it panics with a nil pointer.

**Fix:** protect the append with a `sync.Mutex`.

```go
// AFTER:
var charsMu sync.Mutex
go func() {
    if vrs {
        charsMu.Lock()
        paramResult.Chars = append(paramResult.Chars, char)
        charsMu.Unlock()
    }
}()
```

### Root cause 2 — nil `resp` dereference

`SendReq` can return `err == nil` with a nil `*http.Response` in certain network edge cases (context cancellation, transport-level errors that don't surface as errors). The existing guard only checked `err == nil`, so `resp.Header` could panic:

```go
// BEFORE:
if err == nil {
    wafCheck, wafN := checkWAF(resp.Header, resbody) // resp may be nil
```

**Fix:** add `&& resp != nil`.

## Test plan

- [x] `go build ./...` — compiles clean
- [x] `go test ./pkg/scanning/...` — all tests pass
- [x] `go fmt ./pkg/scanning/parameterAnalysis.go` — formatted

🤖 Generated with [Claude Code](https://claude.com/claude-code)