### PR TITLE
fix(server): harden REST/MCP scan options and second-stage param channel

### DIFF
--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -441,10 +441,12 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	// `results` channel above — that channel is already closed, so any send
 	// from processParams would panic and crash the whole process (in server
 	// mode this is a remote DoS — see GHSA-2g4x-fq3j-cgq4). Allocate a fresh
-	// channel and consumer for this stage.
+	// channel and consumer for this stage, and wait for the consumer to drain
+	// before returning so callers see a fully-populated `params` map.
 	var wggg sync.WaitGroup
 	paramsDataQue := make(chan string, concurrency)
 	resultsData := make(chan model.ParamResult, concurrency)
+	resultsDataDone := make(chan struct{})
 
 	go func() {
 		for result := range resultsData {
@@ -452,6 +454,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 			params[result.Name] = result
 			mutex.Unlock()
 		}
+		close(resultsDataDone)
 	}()
 
 	for j := 0; j < concurrency; j++ {
@@ -477,6 +480,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	close(paramsDataQue)
 	wggg.Wait()
 	close(resultsData)
+	<-resultsDataDone
 	if miningDictCount != 0 {
 		printing.DalLog("INFO", "Found "+strconv.Itoa(miningDictCount)+" testing points in dictionary-based parameter mining", options)
 	}

--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -437,12 +437,27 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	wgg.Wait()
 	close(results)
 
+	// Second stage processes POST-body parameters. It must NOT reuse the
+	// `results` channel above — that channel is already closed, so any send
+	// from processParams would panic and crash the whole process (in server
+	// mode this is a remote DoS — see GHSA-2g4x-fq3j-cgq4). Allocate a fresh
+	// channel and consumer for this stage.
 	var wggg sync.WaitGroup
 	paramsDataQue := make(chan string, concurrency)
+	resultsData := make(chan model.ParamResult, concurrency)
+
+	go func() {
+		for result := range resultsData {
+			mutex.Lock()
+			params[result.Name] = result
+			mutex.Unlock()
+		}
+	}()
+
 	for j := 0; j < concurrency; j++ {
 		wggg.Add(1)
 		go func() {
-			processParams(target, paramsDataQue, results, options, rl, miningCheckerLine, pLog)
+			processParams(target, paramsDataQue, resultsData, options, rl, miningCheckerLine, pLog)
 			wggg.Done()
 		}()
 	}
@@ -461,6 +476,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 
 	close(paramsDataQue)
 	wggg.Wait()
+	close(resultsData)
 	if miningDictCount != 0 {
 		printing.DalLog("INFO", "Found "+strconv.Itoa(miningDictCount)+" testing points in dictionary-based parameter mining", options)
 	}

--- a/pkg/scanning/parameterAnalysis.go
+++ b/pkg/scanning/parameterAnalysis.go
@@ -396,6 +396,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	}
 	paramsQue := make(chan string, concurrency)
 	results := make(chan model.ParamResult, concurrency)
+	resultsDone := make(chan struct{})
 	miningDictCount := 0
 	mutex := &sync.Mutex{}
 
@@ -405,6 +406,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 			params[result.Name] = result
 			mutex.Unlock()
 		}
+		close(resultsDone)
 	}()
 
 	for i := 0; i < concurrency; i++ {
@@ -436,6 +438,7 @@ func ParameterAnalysis(target string, options model.Options, rl *rateLimiter) ma
 	close(paramsQue)
 	wgg.Wait()
 	close(results)
+	<-resultsDone
 
 	// Second stage processes POST-body parameters. It must NOT reuse the
 	// `results` channel above — that channel is already closed, so any send

--- a/pkg/scanning/parameterAnalysis_test.go
+++ b/pkg/scanning/parameterAnalysis_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"os"
 	"reflect"
 	"testing"
 	"time"
@@ -315,4 +316,52 @@ func TestParameterAnalysis(t *testing.T) {
 	if param, exists := results["test"]; !exists || !param.Reflected {
 		t.Errorf("ParameterAnalysis() failed to identify reflected parameter")
 	}
+}
+
+// Regression for GHSA-2g4x-fq3j-cgq4: the second worker stage (POST-body
+// parameters, populated when options.Data != "") used to write to a `results`
+// channel that the first stage had already closed. As soon as a POST-body
+// parameter was reflected, processParams would `results <- ...` on the closed
+// channel, panic, and crash the dalfox process — remotely triggerable in
+// server mode. The fix gives the second stage its own results channel; this
+// test exercises that path and asserts it returns without panic.
+func TestParameterAnalysis_PostBodyParamsDoNotPanic(t *testing.T) {
+	// Reflection detection in processParams probes with the literal
+	// "Dalfox"; the server must echo that string for any submitted param so
+	// the second stage's vrs check succeeds and processParams attempts the
+	// channel write that used to panic.
+	ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		w.Write([]byte("<html><body>Reflected: Dalfox</body></html>"))
+	}))
+	defer ts.Close()
+
+	origDalLog := dalLogFunc
+	dalLogFunc = mockDalLog
+	defer func() { dalLogFunc = origDalLog }()
+
+	// Tiny custom wordlist keeps the second stage to a single iteration; the
+	// channel-write panic is order-of-operations, not iteration-count
+	// dependent, so one entry is enough to trigger it.
+	wl := t.TempDir() + "/wl.txt"
+	if err := os.WriteFile(wl, []byte("q\n"), 0600); err != nil {
+		t.Fatalf("write wordlist: %v", err)
+	}
+	options := model.Options{
+		Timeout:        10,
+		Concurrence:    2,
+		Mining:         true,    // mining populates dp via setP when Data != ""
+		Data:           "q=aaa", // any non-empty Data routes wordlist entries into dp
+		MiningWordlist: wl,
+		UniqParam:      []string{"q"}, // restrict both stages to a single param
+	}
+	rl := newRateLimiter(time.Duration(0))
+
+	defer func() {
+		if r := recover(); r != nil {
+			t.Fatalf("ParameterAnalysis panicked with POST-body params: %v", r)
+		}
+	}()
+
+	_ = ParameterAnalysis(ts.URL+"?q=aaa", options, rl)
 }

--- a/pkg/server/mcp.go
+++ b/pkg/server/mcp.go
@@ -184,6 +184,12 @@ func RunMCPServer(options model.Options) {
 			rqOptions.FindingDOM = false
 		}
 
+		// Defence-in-depth: even though the MCP handler only fills a fixed
+		// allowlist of fields, run the same scrub the REST handler uses so
+		// any future field additions don't silently re-expose host-side
+		// filesystem or shell execution to API callers.
+		sanitizeAPIScanOptions(&rqOptions)
+
 		// Create a goroutine to run the scan
 		go func() {
 			// Set up the target

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -184,6 +184,10 @@ func sanitizeAPIScanOptions(o *model.Options) {
 	o.CustomPayloadFile = ""
 	o.CustomBlindXSSPayloadFile = ""
 	o.HarFilePath = ""
+	// MiningWordlist (mining-dict-word) is also a server-side file path read
+	// by voltFile.ReadLinesOrLiteral; lines become probed parameter names and
+	// are exfiltrated through scan traffic — same class as CustomPayloadFile.
+	o.MiningWordlist = ""
 }
 
 func postScanHandler(c echo.Context, scans *[]string, options *model.Options) error {

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -170,6 +170,22 @@ func scanHandler(c echo.Context, scans *[]string, options *model.Options) error 
 	return respondJSONorJSONP(c, status, res, options)
 }
 
+// sanitizeAPIScanOptions strips fields that would let an API caller drive
+// host-side filesystem or shell execution. These options are only safe for
+// local CLI users; in REST/MCP mode the caller is the request body, so we
+// refuse to honor them regardless of authentication state.
+//
+// See GHSA-v25v-m36w-jp4h, GHSA-8hf9-3q64-q2qf, GHSA-35wr-x7v6-9fv2.
+func sanitizeAPIScanOptions(o *model.Options) {
+	o.FoundAction = ""
+	o.FoundActionShell = ""
+	o.OutputFile = ""
+	o.OutputAll = false
+	o.CustomPayloadFile = ""
+	o.CustomBlindXSSPayloadFile = ""
+	o.HarFilePath = ""
+}
+
 func postScanHandler(c echo.Context, scans *[]string, options *model.Options) error {
 	rq := new(Req)
 	if err := c.Bind(rq); err != nil {
@@ -179,6 +195,7 @@ func postScanHandler(c echo.Context, scans *[]string, options *model.Options) er
 		}
 		return respondJSONorJSONP(c, http.StatusInternalServerError, res, options)
 	}
+	sanitizeAPIScanOptions(&rq.Options)
 	sid := utils.GenerateRandomToken(rq.URL)
 	res := &Res{
 		Code: http.StatusOK,

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -141,6 +141,70 @@ func Test_healthHandler(t *testing.T) {
 	}
 }
 
+// Regression for GHSA-v25v-m36w-jp4h, GHSA-8hf9-3q64-q2qf, GHSA-35wr-x7v6-9fv2:
+// API-supplied options must not be able to drive host-side filesystem or shell
+// execution. sanitizeAPIScanOptions is the chokepoint that strips them before
+// they reach ScanFromAPI / Initialize.
+func Test_sanitizeAPIScanOptions(t *testing.T) {
+	o := model.Options{
+		FoundAction:               "echo owned > /tmp/x",
+		FoundActionShell:          "bash",
+		OutputFile:                "/tmp/dalfox.log",
+		OutputAll:                 true,
+		CustomPayloadFile:         "/etc/hostname",
+		CustomBlindXSSPayloadFile: "/etc/passwd",
+		HarFilePath:               "/tmp/dalfox.har",
+		// Fields that should be preserved.
+		Method: "POST",
+		Data:   "q=1",
+		Debug:  true,
+	}
+
+	sanitizeAPIScanOptions(&o)
+
+	assert.Empty(t, o.FoundAction, "FoundAction must be stripped")
+	assert.Empty(t, o.FoundActionShell, "FoundActionShell must be stripped")
+	assert.Empty(t, o.OutputFile, "OutputFile must be stripped")
+	assert.False(t, o.OutputAll, "OutputAll must be cleared")
+	assert.Empty(t, o.CustomPayloadFile, "CustomPayloadFile must be stripped")
+	assert.Empty(t, o.CustomBlindXSSPayloadFile, "CustomBlindXSSPayloadFile must be stripped")
+	assert.Empty(t, o.HarFilePath, "HarFilePath must be stripped")
+	// Non-dangerous fields untouched.
+	assert.Equal(t, "POST", o.Method)
+	assert.Equal(t, "q=1", o.Data)
+	assert.True(t, o.Debug)
+}
+
+func Test_postScanHandler_stripsDangerousOptions(t *testing.T) {
+	e := echo.New()
+	rq := Req{
+		URL: "http://127.0.0.1:1", // unreachable; goroutine scan will fail fast
+		Options: model.Options{
+			FoundAction:       "echo owned",
+			FoundActionShell:  "bash",
+			OutputFile:        "/tmp/should_not_be_written",
+			CustomPayloadFile: "/etc/hostname",
+			HarFilePath:       "/tmp/should_not_exist.har",
+		},
+	}
+	body, _ := json.Marshal(rq)
+	req := httptest.NewRequest(http.MethodPost, "/scan", bytes.NewReader(body))
+	req.Header.Set(echo.HeaderContentType, echo.MIMEApplicationJSON)
+	rec := httptest.NewRecorder()
+	c := e.NewContext(req, rec)
+
+	scans := []string{}
+	options := model.Options{Scan: map[string]model.Scan{}}
+
+	if assert.NoError(t, postScanHandler(c, &scans, &options)) {
+		assert.Equal(t, http.StatusOK, rec.Code)
+	}
+	// rq is bound and copied inside the handler, so we can't observe the
+	// stripped struct directly here. The unit test above pins the helper;
+	// this test pins that the handler accepts and returns 200 even when the
+	// caller submits all-dangerous options, i.e. no path validation regresses.
+}
+
 func Test_postScanHandler(t *testing.T) {
 	e := echo.New()
 	rq := Req{

--- a/pkg/server/server_test.go
+++ b/pkg/server/server_test.go
@@ -154,6 +154,7 @@ func Test_sanitizeAPIScanOptions(t *testing.T) {
 		CustomPayloadFile:         "/etc/hostname",
 		CustomBlindXSSPayloadFile: "/etc/passwd",
 		HarFilePath:               "/tmp/dalfox.har",
+		MiningWordlist:            "/etc/passwd",
 		// Fields that should be preserved.
 		Method: "POST",
 		Data:   "q=1",
@@ -169,6 +170,7 @@ func Test_sanitizeAPIScanOptions(t *testing.T) {
 	assert.Empty(t, o.CustomPayloadFile, "CustomPayloadFile must be stripped")
 	assert.Empty(t, o.CustomBlindXSSPayloadFile, "CustomBlindXSSPayloadFile must be stripped")
 	assert.Empty(t, o.HarFilePath, "HarFilePath must be stripped")
+	assert.Empty(t, o.MiningWordlist, "MiningWordlist must be stripped")
 	// Non-dangerous fields untouched.
 	assert.Equal(t, "POST", o.Method)
 	assert.Equal(t, "q=1", o.Data)


### PR DESCRIPTION
## Summary

Closes the four open security advisories on `dalfox server` mode by stripping host-side filesystem/shell options at the API boundary and giving the POST-body parameter stage its own channel.

| Advisory | Severity | Fix |
|---|---|---|
| **GHSA-v25v-m36w-jp4h** | critical | Strip `found-action` / `found-action-shell` from API-sourced options |
| **GHSA-8hf9-3q64-q2qf** | high | Strip `output` / `output-all` |
| **GHSA-35wr-x7v6-9fv2** | high | Strip `custom-payload-file` / `custom-blind-xss-payload-file`, also `har-file-path` |
| **GHSA-2g4x-fq3j-cgq4** | high | Give second-stage `processParams` its own `results` channel + consumer (was reusing the channel that the first stage already closed) |

### Why strip at the API boundary

These fields are CLI-only by design — they let the local operator drive log-file paths, payload files, and post-find shell hooks. In REST/MCP mode the "operator" is whoever sent the JSON body, so the same fields turn into RCE / file write / file read primitives. Refusing them at the API boundary works regardless of `--api-key` state and doesn't break any documented REST/MCP usage (MCP only fills a fixed allowlist of safe fields anyway; the strip there is defence-in-depth for future field additions).

The same fix is applied in **both** REST and MCP handlers via a shared `sanitizeAPIScanOptions` helper.

### Why a fresh channel for stage 2

`ParameterAnalysis` ran two sequential worker stages but reused the same `results` channel. Stage 1 closed it, then stage 2 sent on it — `panic: send on closed channel` whenever a POST-body parameter was reflected. Remotely triggerable in server mode. Stage 2 now owns `resultsData` (allocated and closed inside the stage).

## Test plan

- [x] `go test ./...` — all suites pass
- [x] New unit test `Test_sanitizeAPIScanOptions` pins the strip helper
- [x] New handler test `Test_postScanHandler_stripsDangerousOptions` exercises the REST path with all-dangerous options
- [x] New regression `TestParameterAnalysis_PostBodyParamsDoNotPanic` reproduces the panic on the pre-fix code (verified by reverting only the channel fix → test fails with `panic: send on closed channel` at `parameterAnalysis.go:299`) and passes with the fix
- [x] `go vet ./...` clean