### PR TITLE
deps: bump oxc_{parser,ast,allocator,span} 0.97.0 -> 0.129.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -184,9 +184,6 @@ name = "bumpalo"
 version = "3.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "46c5e41b57b8bba42a04676d81cb89e9ee8e859a1a66f80a5a72e1cb76b34d43"
-dependencies = [
- "allocator-api2",
-]
 
 [[package]]
 name = "bytes"
@@ -492,9 +489,9 @@ dependencies = [
 
 [[package]]
 name = "dragonbox_ecma"
-version = "0.0.5"
+version = "0.1.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d742b56656e8b14d63e7ea9806597b1849ae25412584c8adf78c0f67bd985e66"
+checksum = "fd8e701084c37e7ef62d3f9e453b618130cbc0ef3573847785952a3ac3f746bf"
 
 [[package]]
 name = "dtoa"
@@ -748,18 +745,12 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.16.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "841d1cc9bed7f9236f321df977030373f4a4163ae1a7dbfe1a51a2c1a51d9100"
-dependencies = [
- "allocator-api2",
-]
-
-[[package]]
-name = "hashbrown"
 version = "0.17.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4f467dd6dccf739c208452f8014c75c18bb8301b050ad1cfb27153803edb0f51"
+dependencies = [
+ "allocator-api2",
+]
 
 [[package]]
 name = "heck"
@@ -1360,22 +1351,21 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9500e5c4bf57e65f931518201a55658fa639a2b923e01a6467c82e18ef9dfdc2"
+checksum = "6ae84cda3381ab6f90bcab6325d1874ac4bbd71232f2200dc6e866123c8cc4ef"
 dependencies = [
  "allocator-api2",
- "bumpalo",
- "hashbrown 0.16.1",
+ "hashbrown 0.17.0",
  "oxc_data_structures",
  "rustc-hash",
 ]
 
 [[package]]
 name = "oxc_ast"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "73849bfea33c22b17c365cc032dc31132d1314a9afd54b9db7285d2660143ea3"
+checksum = "b4104077919ef54c3ae15f8923a0e44f636c2721dfc11cf168404804af2b726e"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
@@ -1385,14 +1375,15 @@ dependencies = [
  "oxc_estree",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bc1b9a1ee12c5369a515460e7e4b2066e4b6249a1469394aa93dd0aa7f940387"
+checksum = "a8004e158aa037d7e14ea85fccbcf4a320c3412ad9da9a3df5df85c52ee5585f"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1402,15 +1393,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f6fb764c02ba8fd4b5a63fe35ec0d96b326a8a5a5ddd4251baea1d2b0c4f777"
+checksum = "0df39892508c04e3d44ccbf7e384fb35bac3750f39984f7cef47949dc321571a"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6fd4d6311ab059f5a70bcb2ec03c156086242f4f5a8ed44fb59c6e4d1c89d98f"
+checksum = "c4312c021972d746e1bb06051d1e887b80ad2b98f772b7b2aec204ddf585779c"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1419,24 +1410,25 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7371190f03d3de13c8c5123cb0aba670690b22fde2e068ee385caacd9e5b1e0f"
+checksum = "9db328a0a6163105e188e2ff4620fb4a065daf2001e4a7318b3342605bacaa9e"
 dependencies = [
  "cow-utils",
  "num-bigint",
  "num-traits",
  "oxc_allocator",
  "oxc_ast",
+ "oxc_regular_expression",
  "oxc_span",
  "oxc_syntax",
 ]
 
 [[package]]
 name = "oxc_estree"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5e9149fe7697266369e9fa081970c13165a78e6c600ff95fb99202dacc518199"
+checksum = "db4f0258b3b9994f27bb11e1bc8fdedd6a22281307e53148ac76d72e61c93481"
 
 [[package]]
 name = "oxc_index"
@@ -1450,9 +1442,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "324174a2bc9857a6ad9bc62f6b99889416c6ff133d65af67d875ba83103013a3"
+checksum = "2fcb901b425989d315e1c536f561d6f92260731a1e1c1418c1ba4cc203167124"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1466,6 +1458,7 @@ dependencies = [
  "oxc_ecmascript",
  "oxc_regular_expression",
  "oxc_span",
+ "oxc_str",
  "oxc_syntax",
  "rustc-hash",
  "seq-macro",
@@ -1473,15 +1466,16 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1896674a4e31a5332c7b57326c6327336a4848c1dc7d274658c3c86ad2be4100"
+checksum = "e2825d55dd483df5d641087ab515547bee282639ecff26a32e66356cd273b40d"
 dependencies = [
  "bitflags 2.11.1",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
+ "oxc_str",
  "phf",
  "rustc-hash",
  "unicode-id-start",
@@ -1489,22 +1483,35 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b01d164645225a9e927de494609b1d981f0a828e4456e0caad097541ff9b81b5"
+checksum = "dff4df78f3fd004daf1dd0301cac40b34451c42e56dd46f7a7dcefd0cc582ef3"
 dependencies = [
  "compact_str",
  "oxc-miette",
  "oxc_allocator",
  "oxc_ast_macros",
  "oxc_estree",
+ "oxc_str",
+]
+
+[[package]]
+name = "oxc_str"
+version = "0.129.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0273521fbd4655da9c5b2f659f4cc7f2e5370a573b54d37a4456c336c7bc8af6"
+dependencies = [
+ "compact_str",
+ "hashbrown 0.17.0",
+ "oxc_allocator",
+ "oxc_estree",
 ]
 
 [[package]]
 name = "oxc_syntax"
-version = "0.97.0"
+version = "0.129.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67543e785d7f4506ac4e95c90d7a6562be5a0c1e37e446a9d6fe6dd94d971f9e"
+checksum = "0dcdc65090dfc024c9f0d156ff0e1f9b139b7954552cd6c8de02bd6d2362679f"
 dependencies = [
  "bitflags 2.11.1",
  "cow-utils",
@@ -1512,10 +1519,10 @@ dependencies = [
  "nonmax",
  "oxc_allocator",
  "oxc_ast_macros",
- "oxc_data_structures",
  "oxc_estree",
  "oxc_index",
  "oxc_span",
+ "oxc_str",
  "phf",
  "unicode-id-start",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ hex = "0.4"
 regex = "1"
 rmcp = { version = "0.8.0", features = ["server", "macros"] }
 schemars = { version = "1", features = ["derive"] }
-oxc_parser = "0.97.0"
-oxc_ast = "0.97.0"
-oxc_allocator = "0.97.0"
-oxc_span = "0.97.0"
+oxc_parser = "0.129.0"
+oxc_ast = "0.129.0"
+oxc_allocator = "0.129.0"
+oxc_span = "0.129.0"
 
 [profile.release]
 lto = true

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -1272,8 +1272,8 @@ impl<'a> DomXssVisitor<'a> {
         params
             .items
             .iter()
-            .filter_map(|param| match &param.pattern.kind {
-                BindingPatternKind::BindingIdentifier(id) => Some(id.name.to_string()),
+            .filter_map(|param| match &param.pattern {
+                BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
                 _ => None,
             })
             .collect::<Vec<_>>()
@@ -1541,7 +1541,7 @@ impl<'a> DomXssVisitor<'a> {
     /// Walk through a variable declarator
     fn walk_variable_declarator(&mut self, decl: &VariableDeclarator<'a>) {
         if let Some(init) = &decl.init {
-            if let BindingPatternKind::BindingIdentifier(id) = &decl.id.kind {
+            if let BindingPattern::BindingIdentifier(id) = &decl.id {
                 let var_name = id.name.as_str();
                 self.clear_url_search_params_field_sources(var_name);
 
@@ -1777,12 +1777,12 @@ impl<'a> DomXssVisitor<'a> {
             }
 
             // Handle object destructuring: const { a, b } = tainted → a, b all tainted
-            if let BindingPatternKind::ObjectPattern(obj_pat) = &decl.id.kind
+            if let BindingPattern::ObjectPattern(obj_pat) = &decl.id
                 && self.is_tainted(init)
             {
                 let source = self.find_source_in_expr(init);
                 for prop in &obj_pat.properties {
-                    if let BindingPatternKind::BindingIdentifier(id) = &prop.value.kind {
+                    if let BindingPattern::BindingIdentifier(id) = &prop.value {
                         let name = id.name.to_string();
                         self.tainted_vars.insert(name.clone());
                         self.global_taints.insert(name.clone());
@@ -1792,7 +1792,7 @@ impl<'a> DomXssVisitor<'a> {
                     }
                 }
                 if let Some(rest) = &obj_pat.rest
-                    && let BindingPatternKind::BindingIdentifier(id) = &rest.argument.kind
+                    && let BindingPattern::BindingIdentifier(id) = &rest.argument
                 {
                     let name = id.name.to_string();
                     self.tainted_vars.insert(name.clone());
@@ -1804,12 +1804,12 @@ impl<'a> DomXssVisitor<'a> {
             }
 
             // Handle array destructuring: const [a, b] = tainted → a, b all tainted
-            if let BindingPatternKind::ArrayPattern(arr_pat) = &decl.id.kind
+            if let BindingPattern::ArrayPattern(arr_pat) = &decl.id
                 && self.is_tainted(init)
             {
                 let source = self.find_source_in_expr(init);
                 for elem in arr_pat.elements.iter().flatten() {
-                    if let BindingPatternKind::BindingIdentifier(id) = &elem.kind {
+                    if let BindingPattern::BindingIdentifier(id) = &elem {
                         let name = id.name.to_string();
                         self.tainted_vars.insert(name.clone());
                         self.global_taints.insert(name.clone());
@@ -2166,7 +2166,7 @@ impl<'a> DomXssVisitor<'a> {
         match right {
             Expression::FunctionExpression(func) => {
                 if let Some(param) = func.params.items.first()
-                    && let BindingPatternKind::BindingIdentifier(id) = &param.pattern.kind
+                    && let BindingPattern::BindingIdentifier(id) = &param.pattern
                     && let Some(body) = &func.body
                 {
                     let event_source = self.message_event_source_for_receiver(receiver);
@@ -2175,7 +2175,7 @@ impl<'a> DomXssVisitor<'a> {
             }
             Expression::ArrowFunctionExpression(arrow) => {
                 if let Some(param) = arrow.params.items.first()
-                    && let BindingPatternKind::BindingIdentifier(id) = &param.pattern.kind
+                    && let BindingPattern::BindingIdentifier(id) = &param.pattern
                 {
                     let event_source = self.message_event_source_for_receiver(receiver);
                     self.walk_event_handler_body(
@@ -2387,7 +2387,7 @@ impl<'a> DomXssVisitor<'a> {
             if let Some(Argument::FunctionExpression(func)) = call.arguments.get(1) {
                 // Mark the first parameter as tainted (it's the event object)
                 if let Some(param) = func.params.items.first()
-                    && let BindingPatternKind::BindingIdentifier(id) = &param.pattern.kind
+                    && let BindingPattern::BindingIdentifier(id) = &param.pattern
                     && let Some(body) = &func.body
                     && let Some(event_source) = event_source.as_deref()
                 {
@@ -2398,7 +2398,7 @@ impl<'a> DomXssVisitor<'a> {
             // Also handle arrow functions
             if let Some(Argument::ArrowFunctionExpression(arrow)) = call.arguments.get(1)
                 && let Some(param) = arrow.params.items.first()
-                && let BindingPatternKind::BindingIdentifier(id) = &param.pattern.kind
+                && let BindingPattern::BindingIdentifier(id) = &param.pattern
                 && let Some(event_source) = event_source.as_deref()
             {
                 self.walk_event_handler_body(


### PR DESCRIPTION
## Summary

Bundles dependabot PRs #933 (oxc_allocator), #934 (oxc_ast), #935 (oxc_span). The four oxc crates share an internal API, so they must move in lock-step; dependabot's three separate PRs would have permanent lockfile conflicts. Also bumps oxc_parser (not flagged by dependabot but on the same release train).

## Migration

oxc 0.129 flattens `BindingPattern`:

```rust
// 0.97
struct BindingPattern<'a> { kind: BindingPatternKind<'a>, ... }
enum BindingPatternKind<'a> { BindingIdentifier(...), ObjectPattern(...), ... }

// 0.129
enum BindingPattern<'a> { BindingIdentifier(...), ObjectPattern(...), ArrayPattern(...), AssignmentPattern(...) }
```

Every `&xxx.kind` field access becomes `&xxx`; every `BindingPatternKind::Variant(...)` pattern becomes `BindingPattern::Variant(...)`. All 19 compile errors in `src/scanning/ast_dom_analysis.rs` were structural rename/flatten only — same variants, same payload types, same matching behaviour.

## Side-effect analysis

- **Taint propagation** (lines 1540–1820): identity-preserving rewrite. The destructuring detection (`const {a, b} = tainted`, `const [a, b] = tainted`) walks the same AST shape; only the pattern syntax changed.
- **Parameter extraction** (line 1271): same — extracts identifier-bound function parameter names.
- **Event-handler walking** (lines 2168–2401): same — first parameter of `addEventListener` callbacks is detected the same way.
- oxc_parser internals between 0.97 and 0.129 may produce slightly different ASTs for new JS syntax (bug fixes, newer ECMAScript features) — these would *expand* what we analyze, not change our analysis logic.

## Test plan

- [x] `cargo build` — clean
- [x] `cargo clippy --all-targets -- -D warnings` — clean
- [x] `cargo test` — 182 passed, 23 ignored (unchanged from pre-bump baseline)
- After merge: close #933, #934, #935 with reference to this PR.