### PR TITLE
test(integration): serialize scan_verification to fix #939 flakes

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1598,9 +1598,8 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // scanning loop and read at target_summary build time. The Arc is
     // shared with `target.mutation_stats`; both increment the same
     // counters via the MutationStats methods.
-    let target_mutation_stats: Arc<
-        Mutex<HashMap<String, Arc<crate::waf::bypass::MutationStats>>>,
-    > = Arc::new(Mutex::new(HashMap::new()));
+    let target_mutation_stats: Arc<Mutex<HashMap<String, Arc<crate::waf::bypass::MutationStats>>>> =
+        Arc::new(Mutex::new(HashMap::new()));
 
     let multi_pb: Option<Arc<MultiProgress>> = None;
 

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -139,7 +139,8 @@ fn test_collapse_does_not_drop_r_from_other_targets() {
     assert!(
         after
             .iter()
-            .any(|r| r.data.starts_with("http://b.example") && r.result_type == FindingType::Reflected)
+            .any(|r| r.data.starts_with("http://b.example")
+                && r.result_type == FindingType::Reflected)
     );
 }
 

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -81,10 +81,7 @@ fn finding_belongs_header_inject_no_query_exact_match() {
 fn finding_belongs_path_injection_rejects_sibling_path() {
     let target = "http://h/path/level1/a";
     // Different parent path — must not match.
-    assert!(!finding_belongs_to_target(
-        target,
-        "http://h/path/level2/a"
-    ));
+    assert!(!finding_belongs_to_target(target, "http://h/path/level2/a"));
     assert!(!finding_belongs_to_target(target, "http://h/other/x"));
 }
 
@@ -95,7 +92,6 @@ fn finding_belongs_query_target_does_not_borrow_path_parent_fallback() {
     let target = "http://h/a/b?q=x";
     assert!(!finding_belongs_to_target(target, "http://h/a/c?q=x"));
 }
-
 
 #[tokio::test]
 async fn test_init_remote_resources_noop_when_no_providers() {

--- a/src/waf/bypass.rs
+++ b/src/waf/bypass.rs
@@ -368,7 +368,7 @@ pub fn merge_strategies(waf_types: &[&WafType]) -> BypassStrategy {
         // Merge mutations (deduplicate via HashSet)
         for mutation in strategy.mutations {
             if !seen_mutations.contains(&mutation) {
-                seen_mutations.insert(mutation.clone());
+                seen_mutations.insert(mutation);
                 combined.mutations.push(mutation);
             }
         }

--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -53,10 +53,7 @@ fn test_html_comment_split_covers_new_tags() {
 
 #[test]
 fn test_slash_separator_covers_new_tags() {
-    assert_eq!(
-        slash_separator("<form action=x>"),
-        "<form/action=x>"
-    );
+    assert_eq!(slash_separator("<form action=x>"), "<form/action=x>");
 }
 
 #[test]
@@ -211,8 +208,7 @@ fn test_merge_strategies_three_wafs_accumulates_unique_mutations() {
 
 #[test]
 fn test_merge_strategies_unknown_waf_with_known_dedups() {
-    let merged =
-        merge_strategies(&[&WafType::Unknown("hint".to_string()), &WafType::Cloudflare]);
+    let merged = merge_strategies(&[&WafType::Unknown("hint".to_string()), &WafType::Cloudflare]);
     let mut seen = std::collections::HashSet::new();
     assert!(merged.mutations.iter().all(|m| seen.insert(m)));
     let mut seen_e = std::collections::HashSet::new();
@@ -311,10 +307,7 @@ fn apply_mutations_tagged_marks_origin() {
     // The base payload has no origin; each derived variant carries
     // its mutation type so callers can attribute outcomes.
     let payloads = vec!["<svg onload=alert(1)>".to_string()];
-    let mutations = vec![
-        MutationType::HtmlCommentSplit,
-        MutationType::SlashSeparator,
-    ];
+    let mutations = vec![MutationType::HtmlCommentSplit, MutationType::SlashSeparator];
     let tagged = apply_mutations_tagged(&payloads, &mutations, 5);
     let bases = tagged.iter().filter(|(_, o)| o.is_none()).count();
     assert!(bases >= 1, "original payload must be tagged with None");

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -272,10 +272,7 @@ pub async fn fingerprint_with_probe(
         Ok(r) => r,
         Err(e) => {
             if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!(
-                    "[DBG] waf probe network error for {}: {}",
-                    target.url, e
-                );
+                eprintln!("[DBG] waf probe network error for {}: {}", target.url, e);
             }
             return WafDetectionResult::default();
         }

--- a/src/waf/tests.rs
+++ b/src/waf/tests.rs
@@ -66,8 +66,7 @@ async fn probe_post_handler(
     (StatusCode::OK, "ok")
 }
 
-async fn spawn_probe_recorder()
--> (String, StdArc<ProbeRecorder>, tokio::task::JoinHandle<()>) {
+async fn spawn_probe_recorder() -> (String, StdArc<ProbeRecorder>, tokio::task::JoinHandle<()>) {
     let state = StdArc::new(ProbeRecorder::default());
     let app = Router::new()
         .route("/r", get(probe_get_handler).post(probe_post_handler))

--- a/tests/integration/scan_verification.rs
+++ b/tests/integration/scan_verification.rs
@@ -31,6 +31,14 @@ use crate::common::create_test_scan_args;
 /// Monotonic counter for unique temp file names across parallel tests.
 static TEST_COUNTER: AtomicU64 = AtomicU64::new(0);
 
+/// Serializes every call to `scan::run_scan` in this binary. `run_scan`
+/// resets the process-wide `REQUEST_COUNT` atomic at startup
+/// (`src/cmd/scan.rs`), so any two overlapping scans race on that reset
+/// — a `run_scan_and_count` assertion would observe `count = 0` if a
+/// neighbouring `run_scan_and_collect` re-entered `run_scan` between
+/// its store/load. See issue #939 (reproduced on Ubuntu CI).
+static SCAN_LOCK: tokio::sync::Mutex<()> = tokio::sync::Mutex::const_new(());
+
 // ===========================================================================
 // Vulnerable endpoint handlers
 // ===========================================================================
@@ -558,6 +566,7 @@ async fn run_scan_and_collect(mut args: ScanArgs) -> Vec<serde_json::Value> {
     let out_path = std::env::temp_dir().join(format!("dalfox_scan_verify_{id}.json"));
     args.output = Some(out_path.to_string_lossy().to_string());
 
+    let _guard = SCAN_LOCK.lock().await;
     scan::run_scan(&args).await;
 
     let content = match std::fs::read_to_string(&out_path) {
@@ -584,6 +593,7 @@ async fn run_scan_and_count(mut args: ScanArgs) -> (Vec<serde_json::Value>, u64)
     let out_path = std::env::temp_dir().join(format!("dalfox_scan_count_{id}.json"));
     args.output = Some(out_path.to_string_lossy().to_string());
 
+    let _guard = SCAN_LOCK.lock().await;
     dalfox::REQUEST_COUNT.store(0, AtomicOrdering::Relaxed);
     scan::run_scan(&args).await;
     let count = dalfox::REQUEST_COUNT.load(AtomicOrdering::Relaxed);
@@ -1125,7 +1135,6 @@ const PARTIAL_REFLECTION_BASELINE_REQUESTS: u64 = 20;
 /// and the `text.contains(open_marker())` check would miss reflection.
 /// The bracketed sandwich probe survives as `inner+close` (SuffixOnly),
 /// so discovery still records the param and the scan proceeds.
-#[ignore = "flaky on Ubuntu CI; see issue #939"]
 #[tokio::test]
 async fn test_partial_reflection_prefix_strip() {
     let addr = start_test_server().await;
@@ -1143,7 +1152,6 @@ async fn test_partial_reflection_prefix_strip() {
 
 /// Mirror of the above: trailing 4 chars stripped. The bracketed probe
 /// survives as `open+inner` (PrefixOnly).
-#[ignore = "flaky on Ubuntu CI; see issue #939"]
 #[tokio::test]
 async fn test_partial_reflection_suffix_strip() {
     let addr = start_test_server().await;
@@ -1163,7 +1171,6 @@ async fn test_partial_reflection_suffix_strip() {
 /// random hex segments survive concatenated. `inner_marker()` is
 /// `dlxmid<8hex>`, whose 8-hex tail survives as a contiguous run and
 /// is detected by `classify_probe_reflection`'s InnerOnly branch.
-#[ignore = "flaky on Ubuntu CI; see issue #939"]
 #[tokio::test]
 async fn test_partial_reflection_hex_extract() {
     let addr = start_test_server().await;


### PR DESCRIPTION
Closes #939.

## Root cause

The hypotheses in the issue body (task-local scope, test-server bind, early short-circuit) all turned out to be wrong. The actual race:

1. `run_scan_and_count` reads/writes the **process-wide** static `dalfox::REQUEST_COUNT` (scan_verification.rs:587-589) — not a task-local.
2. `scan::run_scan` itself does `REQUEST_COUNT.store(0)` at startup (src/cmd/scan.rs:1041).
3. So when a neighbouring `run_scan_and_collect` test runs in parallel, its `run_scan` call resets the counter mid-flight on a `run_scan_and_count` test, which then loads `0` and panics.
4. macOS happened to interleave less aggressively than ubuntu-latest runners, hiding the bug locally.

## Fix

Serialize every call to `scan::run_scan` in the `unit_tests` binary with a single `tokio::Mutex`. Both helpers (`run_scan_and_collect`, `run_scan_and_count`) now hold the lock around the scan invocation. The three previously-`#[ignore]`-d `test_partial_reflection_*` tests are re-enabled.

## Test plan

- [x] `cargo test --test unit_tests integration::scan_verification` — 37 passed (was 34 + 3 ignored)
- [x] `cargo test --test unit_tests test_partial_reflection` — 3 passed
- [ ] CI on ubuntu-latest passes the three formerly-flaky tests

Test wall time goes from ~2.3s to ~4.4s due to serialization — acceptable.