### PR TITLE
fix(scanning): cut DOM-verify false positives across redirect, javascript:, entity, and JS-sink paths

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -555,17 +555,25 @@ async fn verify_sxss_dom(
 }
 
 /// Verify DOM evidence from a normal (non-stored) injection response.
+///
+/// Special-case for 3xx responses: browsers do not render the response body
+/// of a redirect — only the `Location:` header drives navigation. So body
+/// content can never become an exploitable DOM in a redirect, and any apparent
+/// "DOM evidence" inside it is structurally a false positive. We still inspect
+/// `Location:` (an executable-URL protocol there is a real sink) but skip
+/// body-based DOM verification entirely.
 async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> (bool, Option<String>) {
     let status = resp.status();
     let headers = resp.headers().clone();
 
-    // Check redirect Location header for executable URL protocols (e.g. javascript:alert(1))
-    if status.is_redirection()
-        && let Some(location) = headers.get(reqwest::header::LOCATION)
-        && let Ok(loc_str) = location.to_str()
-        && let Some(result) = check_redirect_location(loc_str, payload)
-    {
-        return result;
+    if status.is_redirection() {
+        if let Some(location) = headers.get(reqwest::header::LOCATION)
+            && let Ok(loc_str) = location.to_str()
+            && let Some(result) = check_redirect_location(loc_str, payload)
+        {
+            return result;
+        }
+        return (false, None);
     }
 
     // Both HTML and non-HTML (JSONP, JSON with HTML) content types are accepted
@@ -581,6 +589,24 @@ async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> (bool, Opt
 }
 
 /// Check if a redirect Location header contains evidence of payload injection.
+/// Inspect a redirect's `Location:` header for evidence that the payload
+/// itself drives the navigation.
+///
+/// Only one case is treated as DOM-verified: the payload is an executable URL
+/// scheme (`javascript:`, `data:text/html`, `vbscript:`) **and** the response
+/// is redirecting the browser to that exact URL. Browsers honour these schemes
+/// in `Location:` (some still navigate the URL bar to it), so the payload
+/// reaches a real execution sink.
+///
+/// A bare reflection of the payload *inside* a redirect target URL (typically
+/// inside a `?next=…`-style query parameter) is **not** verified evidence —
+/// it merely forwards the attacker-controlled bytes to the next endpoint,
+/// which may or may not turn into a sink there. Surfacing that as a verified
+/// finding is a frequent false positive when one redirect re-encodes the
+/// incoming query into the new URL's query (double-URL-encoded reflections
+/// like `%252527…%252527` end up matching the payload's URL-decoded variant
+/// without ever escaping into HTML). Such reflections are still captured by
+/// the reflection-finding path, which is the appropriate severity tier.
 fn check_redirect_location(loc_str: &str, payload: &str) -> Option<(bool, Option<String>)> {
     let loc_trimmed = loc_str.trim();
     let payload_trimmed = payload.trim();
@@ -591,10 +617,6 @@ fn check_redirect_location(loc_str: &str, payload: &str) -> Option<(bool, Option
             "<html><body><a href=\"{}\">redirect</a></body></html>",
             loc_str
         );
-        return Some((true, Some(synthetic_body)));
-    }
-    if crate::scanning::check_reflection::classify_reflection(loc_str, payload).is_some() {
-        let synthetic_body = format!("<html><body>Redirect to: {}</body></html>", loc_str);
         return Some((true, Some(synthetic_body)));
     }
     None

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -152,10 +152,45 @@ fn payload_is_executable_url_protocol(payload: &str) -> bool {
         || starts_with_ascii_ci(trimmed, "vbscript:")
 }
 
-fn is_dangerous_attr(name: &str) -> bool {
-    ["href", "src", "data", "action", "formaction", "xlink:href"]
-        .iter()
-        .any(|&attr| name.eq_ignore_ascii_case(attr))
+/// Decide whether an `(element, attribute)` pair is a real navigation /
+/// embedding sink for an executable URL scheme (`javascript:`, `data:`,
+/// `vbscript:`).
+///
+/// The previous attribute-only check treated every `src=` / `href=` as
+/// equally dangerous, which over-counts attributes whose URL value the
+/// browser refuses to honour as an executable scheme. The most common
+/// regression is `<img src="javascript:…">`: modern browsers ignore the
+/// scheme on `img@src` (the request is a fetch for an image resource, not
+/// a navigation), so verifying that case produces a High-severity finding
+/// that is structurally not exploitable.
+///
+/// The whitelist below names only attributes a browser will actually
+/// dereference as a top-level navigation, frame load, form submit, or
+/// resource fetch where `javascript:` runs as code:
+///
+/// - `a/@href`, `area/@href`, `base/@href`, `link/@href` — navigation
+/// - `iframe/@src`, `embed/@src`, `frame/@src` — frame load
+/// - `iframe/@srcdoc` — HTML embedded in iframe
+/// - `object/@data` — plugin / embed
+/// - `form/@action`, `input/@formaction`, `button/@formaction` — submit
+/// - `xlink:href` on SVG `<a>` / `<use>` — SVG navigation / external load
+///
+/// Attributes deliberately omitted: `img/@src`, `audio/@src`, `video/@src`,
+/// `source/@src`, `script/@src`, `track/@src` (all of which fetch a
+/// resource rather than execute the URL as code).
+fn is_executable_url_attribute(element_tag: &str, attr_name: &str) -> bool {
+    let attr = attr_name.to_ascii_lowercase();
+    let tag = element_tag.to_ascii_lowercase();
+    match attr.as_str() {
+        "href" => matches!(tag.as_str(), "a" | "area" | "base" | "link"),
+        "src" => matches!(tag.as_str(), "iframe" | "embed" | "frame"),
+        "srcdoc" => tag == "iframe",
+        "data" => tag == "object",
+        "action" => tag == "form",
+        "formaction" => matches!(tag.as_str(), "input" | "button"),
+        "xlink:href" => matches!(tag.as_str(), "a" | "use"),
+        _ => false,
+    }
 }
 
 fn has_executable_url_attribute_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
@@ -167,8 +202,10 @@ fn has_executable_url_attribute_evidence_in_doc(payload: &str, document: &scrape
     let selector = selectors::universal();
 
     document.select(selector).any(|node| {
+        let tag = node.value().name();
         node.value().attrs().any(|(name, value)| {
-            is_dangerous_attr(name) && value.trim().eq_ignore_ascii_case(payload_trimmed)
+            is_executable_url_attribute(tag, name)
+                && value.trim().eq_ignore_ascii_case(payload_trimmed)
         })
     })
 }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -188,9 +188,7 @@ async fn url_attribute_handler(Query(params): Query<HashMap<String, String>>) ->
 /// a `javascript:` URL in `img@src` (it's a resource fetch, not a
 /// navigation), so DOM verification must not promote this to Verified
 /// purely on the basis that the scheme reached the attribute value.
-async fn url_attribute_img_handler(
-    Query(params): Query<HashMap<String, String>>,
-) -> Html<String> {
+async fn url_attribute_img_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
     let q = params.get("q").cloned().unwrap_or_default();
     Html(format!("<img src=\"{}\">", q))
 }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -184,6 +184,17 @@ async fn url_attribute_handler(Query(params): Query<HashMap<String, String>>) ->
     Html(format!("<iframe src=\"{}\"></iframe>", q))
 }
 
+/// Reflects the payload into `<img src=…>`. Modern browsers do not execute
+/// a `javascript:` URL in `img@src` (it's a resource fetch, not a
+/// navigation), so DOM verification must not promote this to Verified
+/// purely on the basis that the scheme reached the attribute value.
+async fn url_attribute_img_handler(
+    Query(params): Query<HashMap<String, String>>,
+) -> Html<String> {
+    let q = params.get("q").cloned().unwrap_or_default();
+    Html(format!("<img src=\"{}\">", q))
+}
+
 /// Returns a 307 whose body echoes the payload verbatim. Browsers never render
 /// the body of a 3xx response, so this is the canonical "DOM evidence inside a
 /// redirect body" false-positive case — verification must not fire here.
@@ -218,6 +229,7 @@ async fn start_mock_server(stored_payload: &str) -> SocketAddr {
         .route("/dom/html", get(html_handler))
         .route("/dom/decoded", get(decoded_payload_handler))
         .route("/dom/url-attribute", get(url_attribute_handler))
+        .route("/dom/url-attribute-img", get(url_attribute_img_handler))
         .route("/dom/redirect-body", get(redirect_body_echo_handler))
         .route("/dom/xhtml", get(xhtml_handler))
         .route("/dom/json", get(json_handler))
@@ -757,6 +769,23 @@ async fn test_check_dom_verification_accepts_decoded_payload_variant_with_marker
     assert!(
         body.unwrap_or_default()
             .contains(crate::scanning::markers::class_marker())
+    );
+}
+
+#[tokio::test]
+async fn test_check_dom_verification_rejects_javascript_url_in_img_src() {
+    // `<img src="javascript:alert(1)">` is structurally not exploitable —
+    // browsers refuse the scheme on img@src. Verification must not fire.
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/dom/url-attribute-img");
+    let param = make_param();
+    let args = default_scan_args();
+
+    let (found, _body) =
+        check_dom_verification(&target, &param, "javascript:alert(1)", &args).await;
+    assert!(
+        !found,
+        "javascript: scheme reflected into img@src must not be a verified finding"
     );
 }
 

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -184,6 +184,23 @@ async fn url_attribute_handler(Query(params): Query<HashMap<String, String>>) ->
     Html(format!("<iframe src=\"{}\"></iframe>", q))
 }
 
+/// Returns a 307 whose body echoes the payload verbatim. Browsers never render
+/// the body of a 3xx response, so this is the canonical "DOM evidence inside a
+/// redirect body" false-positive case — verification must not fire here.
+async fn redirect_body_echo_handler(
+    Query(params): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let q = params.get("q").cloned().unwrap_or_default();
+    (
+        StatusCode::TEMPORARY_REDIRECT,
+        [
+            ("content-type", "text/html"),
+            ("location", "/dom/no-payload"),
+        ],
+        format!("<html><body><div>{}</div></body></html>", q),
+    )
+}
+
 async fn sxss_html_handler(State(state): State<TestState>) -> Html<String> {
     Html(format!("<div>{}</div>", state.stored_payload))
 }
@@ -201,6 +218,7 @@ async fn start_mock_server(stored_payload: &str) -> SocketAddr {
         .route("/dom/html", get(html_handler))
         .route("/dom/decoded", get(decoded_payload_handler))
         .route("/dom/url-attribute", get(url_attribute_handler))
+        .route("/dom/redirect-body", get(redirect_body_echo_handler))
         .route("/dom/xhtml", get(xhtml_handler))
         .route("/dom/json", get(json_handler))
         .route("/dom/no-payload", get(html_without_payload_handler))
@@ -740,4 +758,27 @@ async fn test_check_dom_verification_accepts_decoded_payload_variant_with_marker
         body.unwrap_or_default()
             .contains(crate::scanning::markers::class_marker())
     );
+}
+
+#[tokio::test]
+async fn test_check_dom_verification_skips_body_on_redirect_response() {
+    // A 307 whose body echoes the payload — body has marker, looks like
+    // text/html, would satisfy DOM evidence if naively parsed. Browsers
+    // never render a 3xx body, so verification must short-circuit on the
+    // redirect status without consulting the body.
+    let payload = format!(
+        "<img src=x onerror=alert(1) class={}>",
+        crate::scanning::markers::class_marker()
+    );
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/dom/redirect-body");
+    let param = make_param();
+    let args = default_scan_args();
+
+    let (found, body) = check_dom_verification(&target, &param, &payload, &args).await;
+    assert!(
+        !found,
+        "DOM evidence in a 3xx response body must not be treated as verified"
+    );
+    assert!(body.is_none(), "no body should be returned for redirects");
 }

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -400,8 +400,9 @@ fn html_entity_reflection_in_unsafe_context(html: &str, variants: &[String]) -> 
     static STYLE_RE: OnceLock<Regex> = OnceLock::new();
     static EVENT_HANDLER_RE: OnceLock<Regex> = OnceLock::new();
 
-    let script_re = SCRIPT_RE
-        .get_or_init(|| Regex::new(r"(?is)<script\b[^>]*>(.*?)</script\s*>").expect("script regex"));
+    let script_re = SCRIPT_RE.get_or_init(|| {
+        Regex::new(r"(?is)<script\b[^>]*>(.*?)</script\s*>").expect("script regex")
+    });
     let style_re = STYLE_RE
         .get_or_init(|| Regex::new(r"(?is)<style\b[^>]*>(.*?)</style\s*>").expect("style regex"));
     let event_re = EVENT_HANDLER_RE.get_or_init(|| {

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -389,6 +389,62 @@ fn payload_variants(payload: &str) -> Vec<String> {
     variants
 }
 
+/// Returns true when at least one occurrence of a payload variant (raw or
+/// HTML-entity-decoded form) sits inside a context where HTML entity
+/// escaping is *not* sufficient to neutralize the injection — namely
+/// `<script>` / `<style>` raw-text content or an HTML event-handler
+/// attribute (`on*=…`). When this returns `false`, the entity-escaped
+/// reflection is safe by construction and can be suppressed.
+fn html_entity_reflection_in_unsafe_context(html: &str, variants: &[String]) -> bool {
+    static SCRIPT_RE: OnceLock<Regex> = OnceLock::new();
+    static STYLE_RE: OnceLock<Regex> = OnceLock::new();
+    static EVENT_HANDLER_RE: OnceLock<Regex> = OnceLock::new();
+
+    let script_re = SCRIPT_RE
+        .get_or_init(|| Regex::new(r"(?is)<script\b[^>]*>(.*?)</script\s*>").expect("script regex"));
+    let style_re = STYLE_RE
+        .get_or_init(|| Regex::new(r"(?is)<style\b[^>]*>(.*?)</style\s*>").expect("style regex"));
+    let event_re = EVENT_HANDLER_RE.get_or_init(|| {
+        Regex::new(r#"(?is)\son[a-z]+\s*=\s*("[^"]*"|'[^']*'|[^\s>]+)"#)
+            .expect("event handler regex")
+    });
+
+    let check_body = |body: &str| -> bool {
+        let decoded = decode_html_entities(body);
+        variants
+            .iter()
+            .any(|v| body.contains(v) || decoded.contains(v))
+    };
+
+    for cap in script_re.captures_iter(html) {
+        if let Some(body) = cap.get(1)
+            && check_body(body.as_str())
+        {
+            return true;
+        }
+    }
+    for cap in style_re.captures_iter(html) {
+        if let Some(body) = cap.get(1)
+            && check_body(body.as_str())
+        {
+            return true;
+        }
+    }
+    for cap in event_re.captures_iter(html) {
+        if let Some(val) = cap.get(1) {
+            let raw = val.as_str();
+            let inner = match raw.as_bytes() {
+                [b'"', .., b'"'] | [b'\'', .., b'\''] => &raw[1..raw.len() - 1],
+                _ => raw,
+            };
+            if check_body(inner) {
+                return true;
+            }
+        }
+    }
+    false
+}
+
 /// Determine if payload is reflected in any normalization variant.
 pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<ReflectionKind> {
     // Direct match first (fast path — avoids payload_variants allocation)
@@ -399,12 +455,54 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
     // Only build variant list when the fast path misses
     let payload_variants = payload_variants(payload);
 
-    let html_dec = decode_html_entities(resp_text);
+    // Non-raw payload variant present directly in the raw response — the
+    // server applied URL or HTML-entity decoding before reflecting. Without
+    // this fast path the entity-decoded check below would wrongly classify
+    // a server-side URL-decoded reflection (response holds the raw form)
+    // as `HtmlEntityDecoded` and then suppress it as safe escape, hiding a
+    // genuine reflection. `skip(1)` skips the original payload (already
+    // handled by the raw-match fast path above).
     if payload_variants
         .iter()
-        .any(|candidate| html_dec.contains(candidate))
+        .skip(1)
+        .any(|variant| resp_text.contains(variant))
     {
-        return Some(ReflectionKind::HtmlEntityDecoded);
+        return Some(ReflectionKind::UrlDecoded);
+    }
+
+    let html_dec = decode_html_entities(resp_text);
+    // Only treat as an entity-decoded reflection when the response actually
+    // changed under entity decoding. The previous predicate (variant present
+    // in `html_dec`) is true even when no entities were decoded — in which
+    // case `html_dec == resp_text` and the match is really a raw match.
+    if html_dec != resp_text
+        && payload_variants
+            .iter()
+            .any(|candidate| html_dec.contains(candidate))
+    {
+        // The payload only appears after HTML-entity decoding — the server
+        // applied entity escaping to the reflection. In ordinary HTML body
+        // / attribute-value context, the browser will keep the entities as
+        // literal characters and the payload cannot escape into executable
+        // code. We demote (return `None`) for those reflections so they no
+        // longer surface as R Info findings, mirroring the established rule
+        // that a properly escaped reflection is not a vulnerability.
+        //
+        // We keep the finding when the entity-encoded reflection lands in a
+        // context where escaping is *not* sufficient:
+        // - inside `<script>` / `<style>` raw-text content (JS/CSS parsers
+        //   do not decode HTML entities, but the source still passes
+        //   through the parser and the entities can interact with parsing
+        //   in surprising ways — keep as a signal for manual review),
+        // - inside an HTML event-handler attribute value (`on*=…`) where
+        //   the browser decodes the entities while building the value
+        //   *before* handing it to the JS parser.
+        if html_entity_reflection_in_unsafe_context(resp_text, &payload_variants) {
+            return Some(ReflectionKind::HtmlEntityDecoded);
+        }
+        // Fall through: check URL-decoded variants — an entity-escape on
+        // one occurrence does not rule out a different reflection point
+        // reached via URL decoding alone.
     }
 
     // Check URL decoded version of raw

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -301,8 +301,7 @@ fn test_is_payload_reflected_html_encoded_in_unsafe_context() {
     // decoded by the JS parser but the source still passes through it, so
     // the reflection is kept as an HtmlEntityDecoded finding for review.
     let payload = "<script>alert(1)</script>";
-    let resp =
-        "<script>var x = '&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;';</script>";
+    let resp = "<script>var x = '&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;';</script>";
     assert_eq!(
         classify_reflection(resp, payload),
         Some(ReflectionKind::HtmlEntityDecoded)

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -296,9 +296,50 @@ fn test_classify_reflection_prefers_raw_match() {
 }
 
 #[test]
-fn test_is_payload_reflected_html_encoded() {
+fn test_is_payload_reflected_html_encoded_in_unsafe_context() {
+    // Entity-encoded reflection nested inside <script> — entities are not
+    // decoded by the JS parser but the source still passes through it, so
+    // the reflection is kept as an HtmlEntityDecoded finding for review.
     let payload = "<script>alert(1)</script>";
-    let resp = "prefix &#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e; suffix";
+    let resp =
+        "<script>var x = '&#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e;';</script>";
+    assert_eq!(
+        classify_reflection(resp, payload),
+        Some(ReflectionKind::HtmlEntityDecoded)
+    );
+}
+
+#[test]
+fn test_is_payload_reflected_html_encoded_in_safe_context_demoted() {
+    // Same payload, but reflected into HTML body — the browser keeps the
+    // entities as literal characters, the reflection is not exploitable,
+    // and classification must demote to `None` (no R Info noise).
+    let payload = "<script>alert(1)</script>";
+    let resp = "<div>prefix &#x3c;script&#x3e;alert(1)&#x3c;/script&#x3e; suffix</div>";
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_is_payload_reflected_html_encoded_in_attribute_value_demoted() {
+    // Realistic shape of an Open Graph meta-tag reflecting the query string
+    // back with HTML-entity escaping. Both `&quot;` and `&lt;`/`&gt;` are
+    // present — the attribute value cannot be broken out of, so the
+    // reflection must demote.
+    let payload = "\">'><IMG src=x onerror=alert(1)>\"";
+    let resp = concat!(
+        "<meta property=\"og:url\" ",
+        "content=\"https://example.com/?s=&quot;&gt;&#39;&gt;&lt;IMG src=x onerror=alert(1)&gt;&quot;\">"
+    );
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_is_payload_reflected_html_encoded_in_event_handler_kept() {
+    // The browser decodes entities inside an `on*=…` attribute value before
+    // handing the result to the JS parser, so entity escaping is not
+    // sufficient there — the reflection must remain visible.
+    let payload = "alert(1)";
+    let resp = "<button onclick=\"&#x61;lert&#40;1&#41;\">x</button>";
     assert_eq!(
         classify_reflection(resp, payload),
         Some(ReflectionKind::HtmlEntityDecoded)
@@ -369,8 +410,12 @@ fn test_is_payload_reflected_negative() {
 
 #[test]
 fn test_is_payload_reflected_html_named_uppercase() {
+    // Uppercase named entities must still decode for classification. Placed
+    // inside `<style>` so the unsafe-context gate keeps the reflection
+    // visible — body-context placement would be demoted (covered by the
+    // safe-context test above).
     let payload = "<svg onload=alert(1)>";
-    let resp = "prefix &LT;svg onload=alert(1)&GT; suffix";
+    let resp = "<style>body::before{content:'&LT;svg onload=alert(1)&GT;'}</style>";
     assert_eq!(
         classify_reflection(resp, payload),
         Some(ReflectionKind::HtmlEntityDecoded)
@@ -390,7 +435,11 @@ async fn test_check_reflection_detects_raw_response() {
 }
 
 #[tokio::test]
-async fn test_check_reflection_detects_html_entity_response() {
+async fn test_check_reflection_demotes_html_entity_response_in_safe_context() {
+    // The mock handler entity-encodes the payload and reflects it into a
+    // plain `<div>` — a safe HTML body context. Entity escaping makes the
+    // reflection inert, so classification must demote to `None` and
+    // `check_reflection` must report no reflection found.
     let payload = "<img src=x onerror=alert(1)>";
     let addr = start_mock_server("stored").await;
     let target = make_target(addr, "/reflect/html-entity");
@@ -398,7 +447,10 @@ async fn test_check_reflection_detects_html_entity_response() {
     let args = default_scan_args();
 
     let found = check_reflection(&target, &param, payload, &args).await;
-    assert!(found, "entity-encoded reflection should be detected");
+    assert!(
+        !found,
+        "entity-encoded reflection inside a safe body context should be demoted"
+    );
 }
 
 #[tokio::test]
@@ -466,7 +518,11 @@ async fn test_check_reflection_returns_false_when_not_reflected() {
 }
 
 #[tokio::test]
-async fn test_check_reflection_with_response_reports_kind_and_body() {
+async fn test_check_reflection_with_response_demotes_safe_html_entity_reflection() {
+    // The handler entity-encodes the payload into HTML body — a safe
+    // context. Classification must return `None` while the actual response
+    // body is still returned (callers may need it for AST analysis even
+    // when the reflection itself is not exploitable).
     let payload = "<script>alert(1)</script>";
     let addr = start_mock_server("stored").await;
     let target = make_target(addr, "/reflect/html-entity");
@@ -474,8 +530,14 @@ async fn test_check_reflection_with_response_reports_kind_and_body() {
     let args = default_scan_args();
 
     let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
-    assert_eq!(kind, Some(ReflectionKind::HtmlEntityDecoded));
-    assert!(body.unwrap_or_default().contains("&lt;script&gt;"));
+    assert_eq!(
+        kind, None,
+        "safe-context entity reflection must not produce a reflection kind"
+    );
+    assert!(
+        body.unwrap_or_default().contains("&lt;script&gt;"),
+        "response body should still be propagated to callers"
+    );
 }
 
 #[tokio::test]

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -110,7 +110,7 @@ fn hash_block(script_src: &str) -> u64 {
 /// Parse `script_src` once and collect every sink-call span and every
 /// string-literal span. Returns `None` when the source has parser errors
 /// (treated as inert — injected JS that breaks parsing won't execute).
-fn collect_parsed_spans(script_src: &str) -> Option<(Vec<(u32, u32)>, Vec<(u32, u32)>)> {
+fn collect_parsed_spans(script_src: &str) -> ParsedSpans {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, script_src, SourceType::default()).parse();
     if !ret.errors.is_empty() {

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -89,10 +89,12 @@ fn script_blocks(html: &str) -> impl Iterator<Item = &str> {
 /// hitting many distinct `<script>` blocks.
 const SINK_CACHE_CAPACITY: usize = 1024;
 
-/// Sink-call spans for a parsed `<script>` body, or `None` when the body
-/// failed to parse (and is therefore treated as inert).
-type SinkSpans = Option<Vec<(u32, u32)>>;
-type SinkCache = Mutex<HashMap<u64, SinkSpans>>;
+/// Parsed-spans bundle for a `<script>` body, or `None` when the body
+/// failed to parse (and is therefore treated as inert). The first vector
+/// holds sink-call spans, the second holds string-literal spans (used to
+/// gate sink hits that sit *inside* a string).
+type ParsedSpans = Option<(Vec<(u32, u32)>, Vec<(u32, u32)>)>;
+type SinkCache = Mutex<HashMap<u64, ParsedSpans>>;
 
 fn sink_cache() -> &'static SinkCache {
     static CACHE: OnceLock<SinkCache> = OnceLock::new();
@@ -105,26 +107,28 @@ fn hash_block(script_src: &str) -> u64 {
     h.finish()
 }
 
-/// Parse `script_src` once and collect every sink-call span. Returns `None`
-/// when the source has parser errors (treated as inert — injected JS that
-/// breaks parsing won't execute).
-fn collect_sink_spans(script_src: &str) -> Option<Vec<(u32, u32)>> {
+/// Parse `script_src` once and collect every sink-call span and every
+/// string-literal span. Returns `None` when the source has parser errors
+/// (treated as inert — injected JS that breaks parsing won't execute).
+fn collect_parsed_spans(script_src: &str) -> Option<(Vec<(u32, u32)>, Vec<(u32, u32)>)> {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, script_src, SourceType::default()).parse();
     if !ret.errors.is_empty() {
         return None;
     }
-    let mut spans: Vec<(u32, u32)> = Vec::new();
+    let mut sinks: Vec<(u32, u32)> = Vec::new();
+    let mut strings: Vec<(u32, u32)> = Vec::new();
     for stmt in &ret.program.body {
-        gather_sink_spans_in_statement(stmt, &mut spans);
+        gather_sink_spans_in_statement(stmt, &mut sinks, &mut strings);
     }
-    Some(spans)
+    Some((sinks, strings))
 }
 
-/// Cached `collect_sink_spans`. The same `<script>` body often appears across
-/// many per-payload responses (page boilerplate, inline framework setup); each
-/// distinct block is parsed at most once across the whole process.
-fn cached_sink_spans(script_src: &str) -> Option<Vec<(u32, u32)>> {
+/// Cached `collect_parsed_spans`. The same `<script>` body often appears
+/// across many per-payload responses (page boilerplate, inline framework
+/// setup); each distinct block is parsed at most once across the whole
+/// process.
+fn cached_parsed_spans(script_src: &str) -> ParsedSpans {
     let key = hash_block(script_src);
     {
         let cache = sink_cache().lock().expect("sink cache poisoned");
@@ -132,7 +136,7 @@ fn cached_sink_spans(script_src: &str) -> Option<Vec<(u32, u32)>> {
             return v.clone();
         }
     }
-    let result = collect_sink_spans(script_src);
+    let result = collect_parsed_spans(script_src);
     let mut cache = sink_cache().lock().expect("sink cache poisoned");
     if cache.len() >= SINK_CACHE_CAPACITY {
         let drop_n = cache.len() / 4;
@@ -145,17 +149,38 @@ fn cached_sink_spans(script_src: &str) -> Option<Vec<(u32, u32)>> {
     result
 }
 
-/// Returns true when a cached sink-call span lies fully within the
-/// `[payload_start, payload_end)` byte range inside `script_src`.
+/// Returns true when the payload range introduced a real sink call into
+/// the parsed script. Two guards:
+///
+/// - String-literal containment: if the payload range sits *strictly*
+///   inside any string literal (i.e. the payload did not consume the
+///   opening or closing quote), the reflection never broke out of the
+///   string. Any sink-call token inside is just string content the JS
+///   engine will not evaluate. Without this guard, a reflection like
+///   `decodeURIComponent("…'-alert(1)-'…")` — where the payload is a
+///   literal `'-alert(1)-'` inside a *double-quoted* string — would be
+///   verified, because the payload bytes happen to overlap a sink span
+///   that lives inside the surrounding string literal.
+/// - Sink containment: a sink-call span lies fully within the payload's
+///   byte range, meaning the payload itself produced the call.
 fn script_block_has_sink_call_in_range(
     script_src: &str,
     payload_start: u32,
     payload_end: u32,
 ) -> bool {
-    let Some(spans) = cached_sink_spans(script_src) else {
+    let Some((sinks, strings)) = cached_parsed_spans(script_src) else {
         return false;
     };
-    spans
+    // Strict containment: payload range must sit *between* the quotes,
+    // not touch them — otherwise the payload broke the string and the
+    // surrounding literal is no longer a literal.
+    if strings
+        .iter()
+        .any(|&(s, e)| payload_start > s && payload_end < e)
+    {
+        return false;
+    }
+    sinks
         .iter()
         .any(|&(s, e)| s >= payload_start && e <= payload_end)
 }
@@ -261,29 +286,35 @@ fn callee_identifier_is_sink(callee: &Expression<'_>) -> bool {
 }
 
 /// Walk the AST once and accumulate every sink CallExpression / NewExpression
-/// / TaggedTemplateExpression span. Range filtering happens at lookup time
-/// against the cached span list, so the heavy parse runs at most once per
-/// distinct script body.
-fn gather_sink_spans_in_statement(stmt: &Statement<'_>, out: &mut Vec<(u32, u32)>) {
+/// / TaggedTemplateExpression span and every StringLiteral span. Range filtering
+/// happens at lookup time against the cached span list, so the heavy parse runs
+/// at most once per distinct script body.
+fn gather_sink_spans_in_statement(
+    stmt: &Statement<'_>,
+    out: &mut Vec<(u32, u32)>,
+    strings: &mut Vec<(u32, u32)>,
+) {
     match stmt {
-        Statement::ExpressionStatement(es) => gather_sink_spans_in_expression(&es.expression, out),
+        Statement::ExpressionStatement(es) => {
+            gather_sink_spans_in_expression(&es.expression, out, strings)
+        }
         Statement::VariableDeclaration(decl) => {
             for d in &decl.declarations {
                 if let Some(init) = &d.init {
-                    gather_sink_spans_in_expression(init, out);
+                    gather_sink_spans_in_expression(init, out, strings);
                 }
             }
         }
         Statement::BlockStatement(b) => {
             for s in &b.body {
-                gather_sink_spans_in_statement(s, out);
+                gather_sink_spans_in_statement(s, out, strings);
             }
         }
         Statement::IfStatement(s) => {
-            gather_sink_spans_in_expression(&s.test, out);
-            gather_sink_spans_in_statement(&s.consequent, out);
+            gather_sink_spans_in_expression(&s.test, out, strings);
+            gather_sink_spans_in_statement(&s.consequent, out, strings);
             if let Some(alt) = &s.alternate {
-                gather_sink_spans_in_statement(alt, out);
+                gather_sink_spans_in_statement(alt, out, strings);
             }
         }
         Statement::ForStatement(s) => {
@@ -292,73 +323,73 @@ fn gather_sink_spans_in_statement(stmt: &Statement<'_>, out: &mut Vec<(u32, u32)
                     ForStatementInit::VariableDeclaration(decl) => {
                         for d in &decl.declarations {
                             if let Some(e) = &d.init {
-                                gather_sink_spans_in_expression(e, out);
+                                gather_sink_spans_in_expression(e, out, strings);
                             }
                         }
                     }
                     expr => {
                         if let Some(e) = expr.as_expression() {
-                            gather_sink_spans_in_expression(e, out);
+                            gather_sink_spans_in_expression(e, out, strings);
                         }
                     }
                 }
             }
             if let Some(t) = &s.test {
-                gather_sink_spans_in_expression(t, out);
+                gather_sink_spans_in_expression(t, out, strings);
             }
             if let Some(u) = &s.update {
-                gather_sink_spans_in_expression(u, out);
+                gather_sink_spans_in_expression(u, out, strings);
             }
-            gather_sink_spans_in_statement(&s.body, out);
+            gather_sink_spans_in_statement(&s.body, out, strings);
         }
         Statement::WhileStatement(s) => {
-            gather_sink_spans_in_expression(&s.test, out);
-            gather_sink_spans_in_statement(&s.body, out);
+            gather_sink_spans_in_expression(&s.test, out, strings);
+            gather_sink_spans_in_statement(&s.body, out, strings);
         }
         Statement::DoWhileStatement(s) => {
-            gather_sink_spans_in_statement(&s.body, out);
-            gather_sink_spans_in_expression(&s.test, out);
+            gather_sink_spans_in_statement(&s.body, out, strings);
+            gather_sink_spans_in_expression(&s.test, out, strings);
         }
         Statement::ReturnStatement(s) => {
             if let Some(arg) = &s.argument {
-                gather_sink_spans_in_expression(arg, out);
+                gather_sink_spans_in_expression(arg, out, strings);
             }
         }
         Statement::FunctionDeclaration(f) => {
             if let Some(body) = &f.body {
                 for s in &body.statements {
-                    gather_sink_spans_in_statement(s, out);
+                    gather_sink_spans_in_statement(s, out, strings);
                 }
             }
         }
         Statement::TryStatement(t) => {
             for s in &t.block.body {
-                gather_sink_spans_in_statement(s, out);
+                gather_sink_spans_in_statement(s, out, strings);
             }
             if let Some(handler) = &t.handler {
                 for s in &handler.body.body {
-                    gather_sink_spans_in_statement(s, out);
+                    gather_sink_spans_in_statement(s, out, strings);
                 }
             }
             if let Some(finalizer) = &t.finalizer {
                 for s in &finalizer.body {
-                    gather_sink_spans_in_statement(s, out);
+                    gather_sink_spans_in_statement(s, out, strings);
                 }
             }
         }
         Statement::SwitchStatement(s) => {
-            gather_sink_spans_in_expression(&s.discriminant, out);
+            gather_sink_spans_in_expression(&s.discriminant, out, strings);
             for case in &s.cases {
                 if let Some(t) = &case.test {
-                    gather_sink_spans_in_expression(t, out);
+                    gather_sink_spans_in_expression(t, out, strings);
                 }
                 for s in &case.consequent {
-                    gather_sink_spans_in_statement(s, out);
+                    gather_sink_spans_in_statement(s, out, strings);
                 }
             }
         }
-        Statement::LabeledStatement(s) => gather_sink_spans_in_statement(&s.body, out),
-        Statement::ThrowStatement(s) => gather_sink_spans_in_expression(&s.argument, out),
+        Statement::LabeledStatement(s) => gather_sink_spans_in_statement(&s.body, out, strings),
+        Statement::ThrowStatement(s) => gather_sink_spans_in_expression(&s.argument, out, strings),
         _ => {}
     }
 }
@@ -367,16 +398,28 @@ fn push_span(out: &mut Vec<(u32, u32)>, span: oxc_span::Span) {
     out.push((span.start, span.end));
 }
 
-fn gather_sink_spans_in_expression(expr: &Expression<'_>, out: &mut Vec<(u32, u32)>) {
+fn gather_sink_spans_in_expression(
+    expr: &Expression<'_>,
+    out: &mut Vec<(u32, u32)>,
+    strings: &mut Vec<(u32, u32)>,
+) {
+    // String literals are leaves — record their full source span (quotes
+    // included, as produced by the oxc parser) so the lookup stage can
+    // tell when a payload landed strictly inside a string and never
+    // escaped its delimiters.
+    if let Expression::StringLiteral(lit) = expr {
+        push_span(strings, lit.span);
+        return;
+    }
     match expr {
         Expression::CallExpression(call) => {
             if callee_is_js_sink(call) {
                 push_span(out, call.span());
             }
-            gather_sink_spans_in_expression(&call.callee, out);
+            gather_sink_spans_in_expression(&call.callee, out, strings);
             for arg in &call.arguments {
                 if let Some(e) = arg.as_expression() {
-                    gather_sink_spans_in_expression(e, out);
+                    gather_sink_spans_in_expression(e, out, strings);
                 }
             }
         }
@@ -384,19 +427,19 @@ fn gather_sink_spans_in_expression(expr: &Expression<'_>, out: &mut Vec<(u32, u3
             if callee_identifier_is_sink(&t.tag) {
                 push_span(out, t.span());
             }
-            gather_sink_spans_in_expression(&t.tag, out);
+            gather_sink_spans_in_expression(&t.tag, out, strings);
             for e in &t.quasi.expressions {
-                gather_sink_spans_in_expression(e, out);
+                gather_sink_spans_in_expression(e, out, strings);
             }
         }
         Expression::NewExpression(ne) => {
             if callee_identifier_is_sink(&ne.callee) {
                 push_span(out, ne.span());
             }
-            gather_sink_spans_in_expression(&ne.callee, out);
+            gather_sink_spans_in_expression(&ne.callee, out, strings);
             for arg in &ne.arguments {
                 if let Some(e) = arg.as_expression() {
-                    gather_sink_spans_in_expression(e, out);
+                    gather_sink_spans_in_expression(e, out, strings);
                 }
             }
         }
@@ -404,76 +447,80 @@ fn gather_sink_spans_in_expression(expr: &Expression<'_>, out: &mut Vec<(u32, u3
             if assignment_is_sink(a) {
                 push_span(out, a.span());
             }
-            gather_sink_spans_in_expression(&a.right, out);
+            gather_sink_spans_in_expression(&a.right, out, strings);
         }
         Expression::SequenceExpression(s) => {
             for e in &s.expressions {
-                gather_sink_spans_in_expression(e, out);
+                gather_sink_spans_in_expression(e, out, strings);
             }
         }
         Expression::BinaryExpression(b) => {
-            gather_sink_spans_in_expression(&b.left, out);
-            gather_sink_spans_in_expression(&b.right, out);
+            gather_sink_spans_in_expression(&b.left, out, strings);
+            gather_sink_spans_in_expression(&b.right, out, strings);
         }
         Expression::LogicalExpression(l) => {
-            gather_sink_spans_in_expression(&l.left, out);
-            gather_sink_spans_in_expression(&l.right, out);
+            gather_sink_spans_in_expression(&l.left, out, strings);
+            gather_sink_spans_in_expression(&l.right, out, strings);
         }
         Expression::ConditionalExpression(c) => {
-            gather_sink_spans_in_expression(&c.test, out);
-            gather_sink_spans_in_expression(&c.consequent, out);
-            gather_sink_spans_in_expression(&c.alternate, out);
+            gather_sink_spans_in_expression(&c.test, out, strings);
+            gather_sink_spans_in_expression(&c.consequent, out, strings);
+            gather_sink_spans_in_expression(&c.alternate, out, strings);
         }
-        Expression::UnaryExpression(u) => gather_sink_spans_in_expression(&u.argument, out),
+        Expression::UnaryExpression(u) => {
+            gather_sink_spans_in_expression(&u.argument, out, strings)
+        }
         Expression::UpdateExpression(_) => {}
         Expression::ParenthesizedExpression(p) => {
-            gather_sink_spans_in_expression(&p.expression, out)
+            gather_sink_spans_in_expression(&p.expression, out, strings)
         }
         Expression::ArrayExpression(a) => {
             for el in &a.elements {
                 if let Some(e) = el.as_expression() {
-                    gather_sink_spans_in_expression(e, out);
+                    gather_sink_spans_in_expression(e, out, strings);
                 }
             }
         }
         Expression::ObjectExpression(o) => {
             for prop in &o.properties {
                 if let ObjectPropertyKind::ObjectProperty(p) = prop {
-                    gather_sink_spans_in_expression(&p.value, out);
+                    gather_sink_spans_in_expression(&p.value, out, strings);
                 }
             }
         }
         Expression::TemplateLiteral(t) => {
             for e in &t.expressions {
-                gather_sink_spans_in_expression(e, out);
+                gather_sink_spans_in_expression(e, out, strings);
             }
         }
         Expression::ArrowFunctionExpression(f) => {
             for s in &f.body.statements {
-                gather_sink_spans_in_statement(s, out);
+                gather_sink_spans_in_statement(s, out, strings);
             }
         }
         Expression::FunctionExpression(f) => {
             if let Some(body) = &f.body {
                 for s in &body.statements {
-                    gather_sink_spans_in_statement(s, out);
+                    gather_sink_spans_in_statement(s, out, strings);
                 }
             }
         }
-        Expression::StaticMemberExpression(m) => gather_sink_spans_in_expression(&m.object, out),
+        Expression::StaticMemberExpression(m) => {
+            gather_sink_spans_in_expression(&m.object, out, strings)
+        }
         Expression::ComputedMemberExpression(m) => {
-            gather_sink_spans_in_expression(&m.object, out);
-            gather_sink_spans_in_expression(&m.expression, out);
+            gather_sink_spans_in_expression(&m.object, out, strings);
+            gather_sink_spans_in_expression(&m.expression, out, strings);
         }
         Expression::ChainExpression(c) => {
             if let ChainElement::CallExpression(call) = &c.expression {
                 if callee_is_js_sink(call) {
                     push_span(out, call.span());
                 }
-                gather_sink_spans_in_expression(&call.callee, out);
+                gather_sink_spans_in_expression(&call.callee, out, strings);
                 for arg in &call.arguments {
                     if let Some(e) = arg.as_expression() {
-                        gather_sink_spans_in_expression(e, out);
+                        gather_sink_spans_in_expression(e, out, strings);
                     }
                 }
             }

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -125,10 +125,7 @@ fn cached_parsed_spans_returns_same_result_for_identical_blocks() {
     let first = cached_parsed_spans(block).expect("parses cleanly");
     let second = cached_parsed_spans(block).expect("parses cleanly (cache hit)");
     assert_eq!(first, second);
-    assert!(
-        !first.0.is_empty(),
-        "should record at least one sink span"
-    );
+    assert!(!first.0.is_empty(), "should record at least one sink span");
 }
 
 #[test]

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -55,6 +55,39 @@ fn rejects_when_payload_breaks_syntax() {
 }
 
 #[test]
+fn rejects_payload_kept_inside_outer_string_literal() {
+    // The payload string `'-alert(1)-'` lands intact inside a double-quoted
+    // string literal — single quotes do not close a double-quoted string,
+    // so `alert(1)` parses as content of the outer string, not as a call.
+    // Without the string-literal containment guard the sink-span check
+    // would still fire (the AST sink span happens to overlap the payload
+    // range only because the source bytes line up), even though the
+    // surrounding string keeps it inert.
+    let payload = "'-alert(1)-'";
+    let html = format!(
+        "<script>var x = decodeURIComponent(\"prefix {} suffix\");</script>",
+        payload
+    );
+    assert!(
+        !has_js_context_evidence(payload, &html),
+        "payload kept entirely inside a string literal must not be verified"
+    );
+}
+
+#[test]
+fn detects_payload_that_breaks_out_of_outer_string_literal() {
+    // Reflection into the middle of a single-argument string slot. The
+    // payload's outer quotes merge with the surrounding quotes to form
+    // two empty strings on either side of `-alert(1)-`, producing a real
+    // `alert(1)` CallExpression *outside* any string literal. Without the
+    // payload, the slot would just be `foo("")` — a harmless empty call.
+    // The containment guard must allow this case through.
+    let payload = "\"-alert(1)-\"";
+    let html = format!("<script>foo(\"{}\");</script>", payload);
+    assert!(has_js_context_evidence(payload, &html));
+}
+
+#[test]
 fn ignores_pre_existing_alert_outside_payload_range() {
     let payload = "\"-foo-\"";
     let html = format!("<script>alert(1); var x = \"{}\";</script>", payload);
@@ -85,14 +118,17 @@ fn payload_quick_filter_rejects_non_sink_payload() {
 }
 
 #[test]
-fn cached_sink_spans_returns_same_result_for_identical_blocks() {
+fn cached_parsed_spans_returns_same_result_for_identical_blocks() {
     // Two distinct calls on the same script source must yield the same
     // span set; the second call should hit the cache rather than re-parse.
     let block = "var c2 = \"\"-alert(1)-\"\"; var x = 5; window.foo = 1;";
-    let first = cached_sink_spans(block).expect("parses cleanly");
-    let second = cached_sink_spans(block).expect("parses cleanly (cache hit)");
+    let first = cached_parsed_spans(block).expect("parses cleanly");
+    let second = cached_parsed_spans(block).expect("parses cleanly (cache hit)");
     assert_eq!(first, second);
-    assert!(!first.is_empty(), "should record at least one sink span");
+    assert!(
+        !first.0.is_empty(),
+        "should record at least one sink span"
+    );
 }
 
 #[test]
@@ -233,10 +269,10 @@ fn does_not_flag_assignment_to_innocuous_property() {
 }
 
 #[test]
-fn cached_sink_spans_distinct_for_different_blocks() {
+fn cached_parsed_spans_distinct_for_different_blocks() {
     let a = "var c1 = ''-alert(1)-'';";
     let b = "var c2 = \"-prompt(1)-\";";
-    let sa = cached_sink_spans(a).expect("a parses");
-    let sb = cached_sink_spans(b).expect("b parses");
+    let sa = cached_parsed_spans(a).expect("a parses");
+    let sb = cached_parsed_spans(b).expect("b parses");
     assert_ne!(sa, sb);
 }

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -141,7 +141,11 @@ pub async fn verify_dom_xss_light_with_client(
         // header inspection is handled by `check_dom_verification`'s
         // `check_redirect_location` and does not belong here.
         if resp.status().is_redirection() {
-            return (false, None, Some("3xx response — DOM verify skipped".to_string()));
+            return (
+                false,
+                None,
+                Some("3xx response — DOM verify skipped".to_string()),
+            );
         }
         // Extract needed header values without cloning the entire HeaderMap
         let ct = resp

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -135,6 +135,14 @@ pub async fn verify_dom_xss_light_with_client(
 
     let mut note: Option<String> = None;
     if let Ok(resp) = request.send().await {
+        // Browsers do not render the body of a 3xx response, so any apparent
+        // reflection/marker evidence inside that body cannot be exploited.
+        // Skip body-based verification entirely on redirects — `Location`
+        // header inspection is handled by `check_dom_verification`'s
+        // `check_redirect_location` and does not belong here.
+        if resp.status().is_redirection() {
+            return (false, None, Some("3xx response — DOM verify skipped".to_string()));
+        }
         // Extract needed header values without cloning the entire HeaderMap
         let ct = resp
             .headers()


### PR DESCRIPTION
## Summary

A handful of structural false positives in the verified-XSS pipeline came up in recent scans. Each was the same shape — verification ran without checking a condition that makes the underlying mechanism impossible — and each fix is small and isolated. Four commits, no behavioural changes for true positives.

- **3xx redirect bodies stop counting as DOM evidence.** `verify_normal_dom`, `light_verify`, and `check_redirect_location` were treating the body of a 307/302 response as if a browser would render it. Body content of a redirect is never rendered, so a marker or sink inside it is not exploitable. Only `Location:` with an executable URL scheme (`javascript:` / `data:text/html` / `vbscript:`) is now treated as a verified sink in a redirect; bare reflections of the payload into the redirect target URL (the typical `?next=…` re-encoding case) drop to the reflection-finding path.
- **`javascript:` verification is now element-aware.** Previously, *any* `href`/`src`/`data`/`action`/`formaction`/`xlink:href` attribute carrying a `javascript:` payload produced a Verified High finding — including `<img src=\"javascript:…\">`, where browsers do not execute the scheme. Replaced the attribute-only check with an `(element, attribute)` whitelist limited to pairs the browser actually dereferences as code (`a@href`, `iframe@src`, `form@action`, `xlink:href` on `<a>`/`<use>`, etc.). Resource-fetch attributes (`img@src`, `audio@src`, `video@src`, `source@src`, `script@src`, `track@src`) are explicitly excluded.
- **HTML-entity-only reflections in safe contexts no longer fire R Info.** `classify_reflection` flagged a reflection as `HtmlEntityDecoded` whenever any decoded variant appeared in the response, even when the response had no entities at all (the no-entity case is really a server-side URL-decoded reflection — added a direct fast path for that). Then layered a context check on top: an entity-encoded reflection that lands in HTML body / plain attribute-value context is now suppressed (the browser keeps the entities as literal characters and the reflection is not exploitable), while reflections inside `<script>` / `<style>` raw-text content or event-handler attributes (`on*=…`) are still kept — those contexts either don't decode entities at all or decode them straight into JS.
- **JS-context sink verification gates on string-literal containment.** `has_js_context_evidence` would report a verified sink even when the payload's byte range sat entirely inside an outer string literal — the JS parser keeps the contents inert in that case. Threaded string-literal spans alongside the existing sink spans through the single AST walk, and short-circuit verification when the payload range is strictly contained in any string literal. The breakout shape (`foo(\"<payload>\")` where the payload's own quotes merge with the surrounding quotes to produce two empty strings around a real `CallExpression`) is preserved as a true positive.

## Test plan

- [x] `cargo test --lib` — 883 passing locally
- [x] Per-fix regression tests added next to each commit:
  - 3xx redirect: 307 mock whose body echoes a marker-bearing payload — verification must not fire.
  - `javascript:` whitelist: `javascript:alert(1)` reflected into `img@src` — must not be verified.
  - Entity demotion: payload entity-encoded into HTML body / OG-style attribute value — must demote to `None`; in `<script>` / `<style>` / `on*=` — must remain `HtmlEntityDecoded`.
  - String-literal containment: payload kept inside a wrapping string literal — must not verify; quote-breakout shape — must still verify.
- [x] No behavioural regression for real sink-call reflections: the brutelogic c2-style `var x = \"\"<payload>\"\";` shape still triggers `JS-context AST` verification through the same code path.