### PR TITLE
feat(scan): show request count, rate, and ETA during scanning

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1601,7 +1601,18 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     let target_mutation_stats: Arc<Mutex<HashMap<String, Arc<crate::waf::bypass::MutationStats>>>> =
         Arc::new(Mutex::new(HashMap::new()));
 
-    let multi_pb: Option<Arc<MultiProgress>> = None;
+    // Enable the indicatif progress UI (per-target bar + per-host overall bar)
+    // when running interactive plain output. Indicatif writes to stderr, so
+    // JSON/JSONL stdout stays clean; gating on stderr-tty avoids dumping
+    // control codes into pipes/logfiles.
+    let multi_pb: Option<Arc<MultiProgress>> = if args.format == "plain"
+        && !args.silence
+        && std::io::IsTerminal::is_terminal(&std::io::stderr())
+    {
+        Some(Arc::new(MultiProgress::new()))
+    } else {
+        None
+    };
 
     // Group targets by host
     let mut host_groups: std::collections::HashMap<String, Vec<Target>> =
@@ -1920,9 +1931,11 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                     }
                 }
 
-                // Silence parameter analysis logs and progress; show spinner for single-target runs
+                // Silence parameter analysis logs and progress; show spinner for single-target runs.
+                // When multi_pb_clone is active, analyze_parameters renders its own indicatif
+                // spinner via that MultiProgress — skip the stdout spinner so we don't double up.
                 let current = analyze_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
-                let __analyze_spinner = if total_targets_copy == 1 {
+                let __analyze_spinner = if total_targets_copy == 1 && multi_pb_clone.is_none() {
                     start_spinner(
                         !args_clone.silence,
                         if total_targets_copy > 1 {
@@ -2380,11 +2393,14 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         let scan_idx = scan_idx.clone();
         let overall_done_clone = overall_done.clone();
         let group_handle = tokio::spawn(async move {
-            // Calculate total overall tasks for this group
+            // Calculate total overall tasks for this group. Must mirror what
+            // run_scanning actually increments — one tick per reflection
+            // payload, one per DOM payload — otherwise the overall bar rolls
+            // past 100% (the previous reflection-only count was the cause).
             let mut total_overall_tasks = 0u64;
             for target in &group {
                 for param in &target.reflection_params {
-                    let payloads = if let Some(context) = &param.injection_context {
+                    let reflection_payloads = if let Some(context) = &param.injection_context {
                         crate::scanning::xss_common::get_dynamic_payloads(context, &args_arc)
                             .unwrap_or_else(|_| vec![])
                     } else {
@@ -2394,7 +2410,10 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                         )
                         .unwrap_or_else(|_| vec![])
                     };
-                    total_overall_tasks += payloads.len() as u64;
+                    let dom_payloads = crate::scanning::get_dom_payloads(param, &args_arc)
+                        .unwrap_or_else(|_| vec![]);
+                    total_overall_tasks +=
+                        reflection_payloads.len() as u64 + dom_payloads.len() as u64;
                 }
             }
 
@@ -2404,10 +2423,11 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 let pb = mp.add(indicatif::ProgressBar::new(total_overall_tasks));
                 pb.set_style(
                     indicatif::ProgressStyle::default_bar()
-                        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} Overall scanning")
+                        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({per_sec}, ETA {eta}) Overall scanning")
                         .expect("valid progress bar template")
                         .progress_chars("#>-"),
                 );
+                pb.enable_steady_tick(Duration::from_millis(120));
                 Some(Arc::new(Mutex::new(pb)))
             } else {
                 None
@@ -2432,10 +2452,15 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 let total_targets_copy = total_targets;
                 let findings_count_target = findings_count_group.clone();
 
+                let multi_pb_active = multi_pb_clone_inner.is_some();
                 let target_handle = tokio::spawn(async move {
                     if !args_clone.skip_xss_scanning && !args_clone.only_discovery {
                         let __scan_spinner = {
-                            let enabled = !args_clone.silence && total_targets_copy == 1;
+                            // When the indicatif bar is active, run_scanning renders a
+                            // per-target progress bar with rate/ETA — suppress the stdout
+                            // spinner so we don't show two competing scan indicators.
+                            let enabled =
+                                !args_clone.silence && total_targets_copy == 1 && !multi_pb_active;
                             let current = scan_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
                             start_spinner(
                                 enabled,

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -734,7 +734,8 @@ pub async fn analyze_parameters(
     }
     target.reflection_params = probed;
 
-    // Logging parameter analysis (stderr)
+    // Logging parameter analysis (stderr). When an indicatif spinner is active,
+    // route through `pb.println` so the redraw doesn't shred each log line.
     if !args.silence {
         for p in &target.reflection_params {
             let valid = p
@@ -747,10 +748,15 @@ pub async fn analyze_parameters(
                 .as_ref()
                 .map(|v| v.iter().collect::<String>())
                 .unwrap_or_else(|| "-".to_string());
-            eprintln!(
+            let line = format!(
                 "[param-analysis] name={} type={:?} reflected=true context={:?} valid_specials=\"{}\" invalid_specials=\"{}\"",
                 p.name, p.location, p.injection_context, valid, invalid
             );
+            if let Some(ref pb) = pb {
+                pb.println(line);
+            } else {
+                eprintln!("{}", line);
+            }
         }
     }
 

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -39,6 +39,7 @@ use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::collections::HashSet;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicUsize, Ordering};
+use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, Semaphore};
 
 /// Maximum number of WAF mutation variants generated per base payload.
@@ -136,7 +137,7 @@ fn get_js_breakout_payloads() -> Vec<String> {
     payloads
 }
 
-fn get_dom_payloads(
+pub(crate) fn get_dom_payloads(
     param: &Param,
     args: &ScanArgs,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -541,7 +542,11 @@ pub async fn run_scanning(
             }
         }
 
-        total_tasks += reflection_payloads.len() as u64 * (1 + dom_payloads.len() as u64);
+        // One pb.inc(1) per reflection payload (line ~770) plus one per DOM
+        // payload (lines ~904 / ~988). The previous `len * (1 + len)` formula
+        // overcounted by orders of magnitude, which made `{eta}` meaningless
+        // (it would project hours for a sub-minute scan).
+        total_tasks += reflection_payloads.len() as u64 + dom_payloads.len() as u64;
         param_jobs.push((param.clone(), reflection_payloads, dom_payloads));
     }
 
@@ -550,11 +555,12 @@ pub async fn run_scanning(
         pb.set_style(
             ProgressStyle::default_bar()
                 .template(
-                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} {msg}",
+                    "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({per_sec}, ETA {eta}) {msg}",
                 )
                 .expect("valid progress bar template")
                 .progress_chars("#>-"),
         );
+        pb.enable_steady_tick(Duration::from_millis(120));
         pb.set_message(format!("Scanning {}", target.url));
         Some(pb)
     } else {


### PR DESCRIPTION
## Summary
- Activate the previously-inert `MultiProgress` plumbing so scanning renders a per-target and per-host indicatif bar with payload count, rate (req/s), and ETA — replacing the bare `Scanning...` spinner described in #951.
- Gate the new UI on `format == "plain" && !silence && stderr is a TTY` so JSON/JSONL stdout and piped runs stay clean (progress writes to stderr).
- Fix two pre-existing total-count bugs that would have made the new ETA meaningless: the per-target formula counted `len * (1 + len)` but actually increments `len + len`, and the overall total ignored DOM payloads (bar rolled past 100%).
- Suppress the redundant single-target stdout spinners (analyze/scan) when the indicatif bar is active, and route the parameter-analysis stderr log through `pb.println` so it doesn't tear the redraw.

Closes #951.

## Test plan
- [x] `cargo test --quiet` — 883 lib tests pass
- [x] `cargo clippy --all-targets -- -D warnings` clean
- [x] `cargo fmt --check` clean
- [x] Manual: local Python XSS server (`/?name=<reflected>`) — bar reaches 768/768, rate ~51K req/s, ETA 0s, 1 reflected XSS detected, total elapsed 0.24s
- [x] Manual: piped output (no TTY) — indicatif bar suppressed; existing log lines preserved
- [x] Manual: `--format json` — bar disabled; JSON output unaffected by new code path

## Before / After
Before: `Scanning...` (no progress information)

After:
```
⠒ [00:00:06] [########################>---------------]   36634/60900   (10,201.95/s, ETA 2s) Scanning http://...
⠉ [00:00:06] [########################>---------------]   36634/60900   (8,085.27/s, ETA 3s) Overall scanning
```