### PR TITLE
feat(scan): stream [POC] lines during scan instead of only at the end

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2376,6 +2376,53 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Semaphore for limiting concurrent targets across all hosts
     let global_semaphore = Arc::new(tokio::sync::Semaphore::new(args.max_concurrent_targets));
 
+    // Streaming finding output: print each [POC] line as soon as it is found
+    // instead of waiting for the end-of-scan flush. Only enabled for the
+    // plain text format — JSON/SARIF/TOML output is built once at the end
+    // and would break if we wrote ad-hoc lines into its stream.
+    let stream_findings_enabled = args.format == "plain";
+    let (finding_tx, finding_printer_handle) = if stream_findings_enabled {
+        let (tx, mut rx) =
+            tokio::sync::mpsc::unbounded_channel::<crate::scanning::result::Result>();
+        let multi_pb_for_printer = multi_pb.clone();
+        let poc_type = args.poc_type.clone();
+        let handle = tokio::spawn(async move {
+            let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+            while let Some(result) = rx.recv().await {
+                // Deduplicate on (type, url, param, payload) so the same
+                // finding emitted along two code paths (e.g. JS-context V
+                // upgrade and DOM verification) only prints once.
+                let key = format!(
+                    "{}|{}|{}|{}",
+                    result.result_type.short(),
+                    result.data,
+                    result.param,
+                    result.payload,
+                );
+                if !seen.insert(key) {
+                    continue;
+                }
+                let poc_line = generate_poc(&result, &poc_type);
+                let trimmed = poc_line.trim_end();
+                let colored = match result.result_type {
+                    FindingType::Verified => format!("\x1b[31m{}\x1b[0m", trimmed),
+                    FindingType::Reflected => format!("\x1b[33m{}\x1b[0m", trimmed),
+                    FindingType::AstDetected => format!("\x1b[35m{}\x1b[0m", trimmed),
+                };
+                // Route through MultiProgress when present so the line is
+                // emitted above the spinner bars without garbling them.
+                if let Some(ref mp) = multi_pb_for_printer {
+                    let _ = mp.println(&colored);
+                } else {
+                    println!("{}", colored);
+                }
+            }
+        });
+        (Some(tx), Some(handle))
+    } else {
+        (None, None)
+    };
+
     let mut group_handles = vec![];
 
     for (host, group) in host_groups {
@@ -2389,6 +2436,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         let args_arc = Arc::new(args.clone());
         let results_clone = results.clone();
         let findings_count_group = findings_count.clone();
+        let finding_tx_group = finding_tx.clone();
 
         let scan_idx = scan_idx.clone();
         let overall_done_clone = overall_done.clone();
@@ -2451,6 +2499,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 let scan_idx_clone = scan_idx.clone();
                 let total_targets_copy = total_targets;
                 let findings_count_target = findings_count_group.clone();
+                let finding_tx_target = finding_tx_group.clone();
 
                 let multi_pb_active = multi_pb_clone_inner.is_some();
                 let target_handle = tokio::spawn(async move {
@@ -2482,6 +2531,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                             overall_pb_clone,
                             findings_count_target,
                             None,
+                            finding_tx_target,
                         )
                         .await;
                         if let Some((tx, done_rx)) = __scan_spinner {
@@ -2517,6 +2567,15 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         {
             break;
         }
+    }
+
+    // Close the streaming channel by dropping the last live sender, then
+    // wait for the printer task to drain any in-flight findings. Without
+    // this, the printer would either leak (if we forgot to drop tx) or
+    // race with end-of-scan output.
+    drop(finding_tx);
+    if let Some(handle) = finding_printer_handle {
+        let _ = handle.await;
     }
 
     if args.format == "plain" && !args.silence && total_targets > 1 {

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2386,6 +2386,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
             tokio::sync::mpsc::unbounded_channel::<crate::scanning::result::Result>();
         let multi_pb_for_printer = multi_pb.clone();
         let poc_type = args.poc_type.clone();
+        let printer_nc = nc;
         let handle = tokio::spawn(async move {
             let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
             while let Some(result) = rx.recv().await {
@@ -2404,17 +2405,21 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 }
                 let poc_line = generate_poc(&result, &poc_type);
                 let trimmed = poc_line.trim_end();
-                let colored = match result.result_type {
-                    FindingType::Verified => format!("\x1b[31m{}\x1b[0m", trimmed),
-                    FindingType::Reflected => format!("\x1b[33m{}\x1b[0m", trimmed),
-                    FindingType::AstDetected => format!("\x1b[35m{}\x1b[0m", trimmed),
+                let line = if printer_nc {
+                    trimmed.to_string()
+                } else {
+                    match result.result_type {
+                        FindingType::Verified => format!("\x1b[31m{}\x1b[0m", trimmed),
+                        FindingType::Reflected => format!("\x1b[33m{}\x1b[0m", trimmed),
+                        FindingType::AstDetected => format!("\x1b[35m{}\x1b[0m", trimmed),
+                    }
                 };
                 // Route through MultiProgress when present so the line is
                 // emitted above the spinner bars without garbling them.
                 if let Some(ref mp) = multi_pb_for_printer {
-                    let _ = mp.println(&colored);
+                    let _ = mp.println(&line);
                 } else {
-                    println!("{}", colored);
+                    println!("{}", line);
                 }
             }
         });

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -599,6 +599,7 @@ async fn run_scan_job(
                         None,
                         param_counter.clone(),
                         Some(cancel_flag.clone()),
+                        None,
                     )
                     .await;
                 })

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -242,6 +242,7 @@ impl DalfoxMcp {
                             None,
                             param_counter.clone(),
                             Some(cancel_flag.clone()),
+                            None,
                         )
                         .await;
                     })

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -423,6 +423,7 @@ pub async fn run_scanning(
     overall_pb: Option<Arc<Mutex<indicatif::ProgressBar>>>,
     findings_count: Arc<AtomicUsize>,
     cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
+    finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
 ) {
     // Short-circuit scanning when skip_xss_scanning is enabled (e.g., in unit tests)
     if args.skip_xss_scanning {
@@ -614,6 +615,7 @@ pub async fn run_scanning(
         let findings_count_clone = findings_count.clone();
         let limit_result_type_clone = limit_result_type.clone();
         let cancel_clone = cancel.clone();
+        let finding_tx_clone = finding_tx.clone();
 
         let handle = tokio::spawn(async move {
             let _permit = semaphore_clone
@@ -622,6 +624,14 @@ pub async fn run_scanning(
                 .expect("semaphore closed unexpectedly");
             // Batch local results to reduce mutex contention
             let mut local_results: Vec<crate::scanning::result::Result> = Vec::new();
+            // Stream every new finding through the channel (if provided) before it's
+            // batched into the shared results — so the CLI can print POC lines while
+            // the scan is still running instead of waiting for the end-of-scan flush.
+            let stream_finding = |r: &crate::scanning::result::Result| {
+                if let Some(tx) = finding_tx_clone.as_ref() {
+                    let _ = tx.send(r.clone());
+                }
+            };
             let mut local_ast_seen: HashSet<String> = HashSet::new();
             let mut ast_analysis_done = false;
             let mut reflection_found_locally = false;
@@ -677,6 +687,9 @@ pub async fn run_scanning(
                     &mut local_ast_seen,
                 )
                 .await;
+                for f in &ast_findings {
+                    stream_finding(f);
+                }
                 local_results.extend(ast_findings);
             }
 
@@ -769,6 +782,9 @@ pub async fn run_scanning(
                         &mut local_ast_seen,
                     )
                     .await;
+                    for f in &ast_findings {
+                        stream_finding(f);
+                    }
                     local_results.extend(ast_findings);
                 }
 
@@ -871,6 +887,7 @@ pub async fn run_scanning(
                         ));
                         result.response = reflection_response_text;
 
+                        stream_finding(&result);
                         // Defer pushing to shared results (batched)
                         local_results.push(result);
                     }
@@ -983,6 +1000,7 @@ pub async fn run_scanning(
                         ));
                         result.response = response_text;
 
+                        stream_finding(&result);
                         // Defer pushing to shared results (batched)
                         local_results.push(result);
                         break;
@@ -1058,6 +1076,7 @@ pub async fn run_scanning(
                                     ),
                                 );
                                 result.response = response_text;
+                                stream_finding(&result);
                                 local_results.push(result);
                                 break 'hpp_outer; // One HPP finding per param is enough
                             }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -415,6 +415,7 @@ fn ast_source_uses_browser_url_surface(source: &str) -> bool {
         || source.contains("event.oldValue")
 }
 
+#[allow(clippy::too_many_arguments)]
 pub async fn run_scanning(
     target: &Target,
     args: Arc<ScanArgs>,

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -627,9 +627,13 @@ pub async fn run_scanning(
             // Stream every new finding through the channel (if provided) before it's
             // batched into the shared results — so the CLI can print POC lines while
             // the scan is still running instead of waiting for the end-of-scan flush.
+            // The printer only needs metadata (type/url/param/payload), so drop the
+            // (potentially large) HTTP response body from the clone we send.
             let stream_finding = |r: &crate::scanning::result::Result| {
                 if let Some(tx) = finding_tx_clone.as_ref() {
-                    let _ = tx.send(r.clone());
+                    let mut light = r.clone();
+                    light.response = None;
+                    let _ = tx.send(light);
                 }
             };
             let mut local_ast_seen: HashSet<String> = HashSet::new();

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -517,6 +517,7 @@ async fn test_xss_scanning_get_query() {
         None,
         Arc::new(AtomicUsize::new(0)),
         None,
+        None,
     )
     .await;
 
@@ -609,6 +610,7 @@ async fn test_xss_scanning_post_body() {
         None,
         None,
         Arc::new(AtomicUsize::new(0)),
+        None,
         None,
     )
     .await;
@@ -716,6 +718,7 @@ async fn test_run_scanning_with_reflection_params() {
         None,
         Arc::new(AtomicUsize::new(0)),
         None,
+        None,
     )
     .await;
 }
@@ -802,6 +805,7 @@ async fn test_run_scanning_empty_params() {
         None,
         None,
         Arc::new(AtomicUsize::new(0)),
+        None,
         None,
     )
     .await;


### PR DESCRIPTION
## Summary
- Findings used to print only after the full scan finished. On moderately complex targets that's several minutes of spinner with no visible output — long enough that users abort before any POC surfaces.
- `run_scanning` now accepts an optional `UnboundedSender<Result>`. Each push into `local_results` (probe-stage AST, reflection-found incl. JS-context V upgrade, DOM-verified, HPP) also sends a clone through the channel before the batched flush to shared state.
- The CLI spawns a printer task that dedupes on `(type, url, param, payload)` and writes through `MultiProgress::println` so streamed lines land cleanly above the progress bars. Gated on `format == "plain"` so JSON/SARIF/TOML still emit a single structured document at the end. The existing end-of-scan report is unchanged.

## Test plan
- [x] `cargo build` clean
- [x] `cargo test --lib` — 883 passed, 0 failed (covers cmd::scan POC formatting + scanning::tests `run_scanning` paths)
- [x] Manual: `./target/debug/dalfox scan --skip-mining --skip-ast-analysis '<reflective target>'` — `[POC][R][GET][inHTML] ...` lines appear while the spinner is still rendering, and the final structured report after `scan completed` is unchanged.