### PR TITLE
test: cover banner, scanning selectors, and cmd job status

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -53,3 +53,75 @@ impl fmt::Display for JobStatus {
         }
     }
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn job_status_display_matches_lowercase_variant_name() {
+        assert_eq!(JobStatus::Queued.to_string(), "queued");
+        assert_eq!(JobStatus::Running.to_string(), "running");
+        assert_eq!(JobStatus::Done.to_string(), "done");
+        assert_eq!(JobStatus::Error.to_string(), "error");
+        assert_eq!(JobStatus::Cancelled.to_string(), "cancelled");
+    }
+
+    /// The Display impl and the `#[serde(rename_all = "lowercase")]`
+    /// representation must agree — REST and MCP clients parse the JSON
+    /// form, and CLI logs print the Display form. Drift between them
+    /// would silently break consumers that compare the two strings.
+    #[test]
+    fn job_status_serde_matches_display() {
+        let variants = [
+            JobStatus::Queued,
+            JobStatus::Running,
+            JobStatus::Done,
+            JobStatus::Error,
+            JobStatus::Cancelled,
+        ];
+        for v in variants {
+            let json = serde_json::to_string(&v).unwrap();
+            // serde_json wraps the variant name in quotes.
+            assert_eq!(json, format!("\"{}\"", v));
+            let round: JobStatus = serde_json::from_str(&json).unwrap();
+            assert_eq!(round, v);
+        }
+    }
+
+    #[test]
+    fn job_status_deserializes_from_lowercase_string() {
+        let s: JobStatus = serde_json::from_str("\"queued\"").unwrap();
+        assert_eq!(s, JobStatus::Queued);
+        let s: JobStatus = serde_json::from_str("\"cancelled\"").unwrap();
+        assert_eq!(s, JobStatus::Cancelled);
+    }
+
+    #[test]
+    fn job_status_rejects_unknown_variant() {
+        assert!(serde_json::from_str::<JobStatus>("\"finished\"").is_err());
+    }
+
+    /// Error code string values are part of the wire contract (JSON
+    /// output reaches CLI scripts, REST clients, and MCP). Lock the
+    /// exact strings so an accidental rename causes a test failure
+    /// rather than a silent break.
+    #[test]
+    fn error_code_constants_have_stable_string_values() {
+        assert_eq!(error_codes::NO_TARGETS, "NO_TARGETS");
+        assert_eq!(error_codes::NO_FILE, "NO_FILE");
+        assert_eq!(error_codes::INVALID_INPUT_TYPE, "INVALID_INPUT_TYPE");
+        assert_eq!(error_codes::PARSE_ERROR, "PARSE_ERROR");
+        assert_eq!(error_codes::FILE_READ_ERROR, "FILE_READ_ERROR");
+        assert_eq!(error_codes::STDIN_ERROR, "STDIN_ERROR");
+        assert_eq!(error_codes::CONNECTION_FAILED, "CONNECTION_FAILED");
+        assert_eq!(
+            error_codes::CONTENT_TYPE_MISMATCH,
+            "CONTENT_TYPE_MISMATCH"
+        );
+        assert_eq!(
+            error_codes::TRUNCATED_PER_HOST_CAP,
+            "TRUNCATED_PER_HOST_CAP"
+        );
+    }
+}

--- a/src/scanning/selectors.rs
+++ b/src/scanning/selectors.rs
@@ -45,3 +45,67 @@ pub fn meta_csp() -> &'static Selector {
         Selector::parse("meta[http-equiv][content]").expect("valid CSS meta CSP selector")
     })
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use scraper::Html;
+
+    /// Each call to a selector accessor must return the SAME static
+    /// reference — that's the contract the OnceLock cache provides and
+    /// what makes the rest of the scanner cheap to call in hot loops.
+    #[test]
+    fn selectors_are_cached_across_calls() {
+        let a = universal() as *const Selector;
+        let b = universal() as *const Selector;
+        assert_eq!(a, b);
+
+        let a = script() as *const Selector;
+        let b = script() as *const Selector;
+        assert_eq!(a, b);
+    }
+
+    #[test]
+    fn universal_matches_any_element() {
+        let doc = Html::parse_fragment("<div><span>x</span></div>");
+        let count = doc.select(universal()).count();
+        assert!(count >= 2, "universal selector must match all elements");
+    }
+
+    #[test]
+    fn script_and_style_match_their_tags() {
+        let doc = Html::parse_document(
+            "<html><head><style>a{}</style></head><body><script>1</script></body></html>",
+        );
+        assert_eq!(doc.select(script()).count(), 1);
+        assert_eq!(doc.select(style()).count(), 1);
+    }
+
+    #[test]
+    fn input_with_id_or_name_matches_either_attribute() {
+        let doc = Html::parse_fragment(
+            "<input id=\"a\"><input name=\"b\"><input><input id=\"c\" name=\"d\">",
+        );
+        // 3 inputs have id or name; the bare <input> does not.
+        assert_eq!(doc.select(input_with_id_or_name()).count(), 3);
+    }
+
+    #[test]
+    fn input_textarea_select_matches_all_three_form_controls() {
+        let doc =
+            Html::parse_fragment("<form><input><textarea></textarea><select></select></form>");
+        assert_eq!(doc.select(input_textarea_select()).count(), 3);
+        assert_eq!(doc.select(form()).count(), 1);
+    }
+
+    #[test]
+    fn meta_csp_requires_both_http_equiv_and_content() {
+        let doc = Html::parse_fragment(
+            r#"<meta http-equiv="Content-Security-Policy" content="default-src 'self'">
+               <meta http-equiv="X-UA-Compatible">
+               <meta name="viewport" content="width=device-width">"#,
+        );
+        // Only the first meta has both http-equiv and content.
+        assert_eq!(doc.select(meta_csp()).count(), 1);
+    }
+}

--- a/src/utils/banner.rs
+++ b/src/utils/banner.rs
@@ -75,3 +75,43 @@ pub fn print_banner_once(version: &str, color: bool) {
         print_banner(version, color);
     });
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn render_banner_contains_version_and_tagline() {
+        let s = render_banner("9.9.9", false);
+        assert!(s.contains("Dalfox v9.9.9"));
+        assert!(s.contains("Powerful open-source XSS scanner"));
+        assert!(s.contains("and utility focused on automation."));
+    }
+
+    #[test]
+    fn render_banner_without_color_has_no_ansi_escapes() {
+        let s = render_banner(env!("CARGO_PKG_VERSION"), false);
+        assert!(
+            !s.contains('\x1b'),
+            "color=false must not emit ANSI escape codes"
+        );
+    }
+
+    #[test]
+    fn render_banner_with_color_emits_ansi_escapes() {
+        let s = render_banner("1.2.3", true);
+        // cyan around the version and dim around the tagline lines
+        assert!(s.contains("\x1b[36m"), "expected cyan ANSI sequence");
+        assert!(s.contains("\x1b[90m"), "expected dim ANSI sequence");
+        assert!(s.contains("\x1b[0m"), "expected reset ANSI sequence");
+    }
+
+    #[test]
+    fn render_banner_starts_and_ends_with_blank_lines() {
+        // Banner brackets itself with whitespace so it doesn't collide with
+        // surrounding CLI output.
+        let s = render_banner("0.0.0", false);
+        assert!(s.starts_with('\n'));
+        assert!(s.ends_with("\n\n"));
+    }
+}


### PR DESCRIPTION
## Summary
- Added unit tests for three modules that previously had none: `src/utils/banner.rs`, `src/scanning/selectors.rs`, `src/cmd/mod.rs`
- `JobStatus` test asserts Display output and `serde(rename_all = "lowercase")` JSON form stay in sync, so REST/MCP clients and CLI logs can't drift
- `error_codes` constants are pinned to their exact string values since they're part of the JSON wire contract

## Test plan
- [x] `cargo test` — 898 unit tests pass (+15)
- [x] `cargo clippy --tests` — no warnings