### PR TITLE
scanning: cut Location-header javascript: FPs + recover case-folded reflections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ docs/public
 .direnv/
 /result
 /result-*
+xssmaze/

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -625,37 +625,24 @@ async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> (bool, Opt
     (false, None)
 }
 
-/// Check if a redirect Location header contains evidence of payload injection.
 /// Inspect a redirect's `Location:` header for evidence that the payload
 /// itself drives the navigation.
 ///
-/// Only one case is treated as DOM-verified: the payload is an executable URL
-/// scheme (`javascript:`, `data:text/html`, `vbscript:`) **and** the response
-/// is redirecting the browser to that exact URL. Browsers honour these schemes
-/// in `Location:` (some still navigate the URL bar to it), so the payload
-/// reaches a real execution sink.
+/// Returns `None` in every case today: modern browsers (Chrome, Firefox,
+/// Safari, all Chromium derivatives) refuse to navigate to `javascript:`,
+/// `data:text/html`, and `vbscript:` URLs supplied via a 3xx `Location:`
+/// header — the redirect is silently dropped without executing the URL.
+/// Treating such a redirect as DOM-verified produced High-severity findings
+/// that no real browser actually fires (observed on xssmaze
+/// `/redirect/level{1..4}`), so the V upgrade is removed.
 ///
 /// A bare reflection of the payload *inside* a redirect target URL (typically
-/// inside a `?next=…`-style query parameter) is **not** verified evidence —
+/// inside a `?next=…`-style query parameter) is also not verified evidence:
 /// it merely forwards the attacker-controlled bytes to the next endpoint,
-/// which may or may not turn into a sink there. Surfacing that as a verified
-/// finding is a frequent false positive when one redirect re-encodes the
-/// incoming query into the new URL's query (double-URL-encoded reflections
-/// like `%252527…%252527` end up matching the payload's URL-decoded variant
-/// without ever escaping into HTML). Such reflections are still captured by
-/// the reflection-finding path, which is the appropriate severity tier.
-fn check_redirect_location(loc_str: &str, payload: &str) -> Option<(bool, Option<String>)> {
-    let loc_trimmed = loc_str.trim();
-    let payload_trimmed = payload.trim();
-    if payload_is_executable_url_protocol(payload)
-        && starts_with_ascii_ci(loc_trimmed, payload_trimmed)
-    {
-        let synthetic_body = format!(
-            "<html><body><a href=\"{}\">redirect</a></body></html>",
-            loc_str
-        );
-        return Some((true, Some(synthetic_body)));
-    }
+/// which may or may not turn into a sink there. The reflection-finding path
+/// still surfaces these as R when the body contains the payload, which is
+/// the appropriate severity tier.
+fn check_redirect_location(_loc_str: &str, _payload: &str) -> Option<(bool, Option<String>)> {
     None
 }
 

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -76,6 +76,38 @@ fn payload_has_any_marker(payload: &str) -> bool {
         || payload_uses_legacy_id_marker(payload)
 }
 
+/// Returns `true` when at least one element's whitespace-separated class
+/// list contains `marker` under ASCII case-fold comparison. The standard
+/// CSS class selector path used elsewhere is case-sensitive (HTML5 class
+/// attributes are case-sensitive when matched as CSS selectors), so this
+/// scan is the only way to surface marker evidence on servers that
+/// case-fold the entire reflected input.
+fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
+    let selector = super::selectors::universal();
+    document.select(selector).any(|node| {
+        node.value()
+            .attr("class")
+            .map(|cls| {
+                cls.split_ascii_whitespace()
+                    .any(|c| c.eq_ignore_ascii_case(marker))
+            })
+            .unwrap_or(false)
+    })
+}
+
+/// Like `any_element_has_class_ascii_ci`, but compares the element's `id`
+/// attribute as a whole token. HTML id values are not whitespace-separated
+/// lists, so the comparison is over the trimmed attribute value.
+fn any_element_has_id_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
+    let selector = super::selectors::universal();
+    document.select(selector).any(|node| {
+        node.value()
+            .attr("id")
+            .map(|id| id.trim().eq_ignore_ascii_case(marker))
+            .unwrap_or(false)
+    })
+}
+
 fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
     let class_marker = crate::scanning::markers::class_marker();
     let id_marker = crate::scanning::markers::id_marker();
@@ -96,12 +128,23 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
                 .select(cached_class_marker_selector())
                 .next()
                 .is_some();
+            if !found {
+                // Case-folded fallback for servers that uppercase/lowercase
+                // reflected input. Markers are 11-char `dlx<hex>` strings
+                // with no realistic ASCII case-fold collisions, so a
+                // case-insensitive class-list match is still a unique
+                // "came from our payload" signal.
+                found = any_element_has_class_ascii_ci(document, class_marker);
+            }
         }
         if !found && has_legacy_class {
             found = document
                 .select(cached_legacy_class_selector())
                 .next()
                 .is_some();
+            if !found {
+                found = any_element_has_class_ascii_ci(document, "dalfox");
+            }
         }
         found
     } else {
@@ -115,12 +158,18 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
                 .select(cached_id_marker_selector())
                 .next()
                 .is_some();
+            if !found {
+                found = any_element_has_id_ascii_ci(document, id_marker);
+            }
         }
         if !found && has_legacy_id {
             found = document
                 .select(cached_legacy_id_selector())
                 .next()
                 .is_some();
+            if !found {
+                found = any_element_has_id_ascii_ci(document, "dalfox");
+            }
         }
         found
     } else {

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -115,6 +115,11 @@ async fn html_handler(Query(params): Query<HashMap<String, String>>) -> Html<Str
     Html(format!("<div>{}</div>", q))
 }
 
+async fn html_uppercase_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
+    let q = params.get("q").cloned().unwrap_or_default();
+    Html(format!("<div>{}</div>", q.to_uppercase()))
+}
+
 async fn xhtml_handler(Query(params): Query<HashMap<String, String>>) -> impl IntoResponse {
     let q = params.get("q").cloned().unwrap_or_default();
     (
@@ -225,6 +230,7 @@ async fn sxss_json_handler(State(state): State<TestState>) -> impl IntoResponse 
 async fn start_mock_server(stored_payload: &str) -> SocketAddr {
     let app = Router::new()
         .route("/dom/html", get(html_handler))
+        .route("/dom/html-upper", get(html_uppercase_handler))
         .route("/dom/decoded", get(decoded_payload_handler))
         .route("/dom/url-attribute", get(url_attribute_handler))
         .route("/dom/url-attribute-img", get(url_attribute_img_handler))
@@ -280,6 +286,34 @@ async fn test_check_dom_verification_detects_html_reflection() {
     let (found, body) = check_dom_verification(&target, &param, &payload, &args).await;
     assert!(found, "text/html responses with payload should be detected");
     assert!(body.unwrap_or_default().contains(&payload));
+}
+
+// Server uppercases every reflected byte; the marker survives as a
+// case-folded class value. The standard CSS class selector is case-
+// sensitive so it misses the match, but the case-insensitive
+// attribute walk added to `has_marker_evidence_in_doc` recovers V.
+#[tokio::test]
+async fn test_check_dom_verification_marker_survives_case_fold() {
+    let payload = format!(
+        "<img src=x onerror=alert(1) class={}>",
+        crate::scanning::markers::class_marker()
+    );
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/dom/html-upper");
+    let param = make_param();
+    let args = default_scan_args();
+
+    let (found, body) = check_dom_verification(&target, &param, &payload, &args).await;
+    assert!(
+        found,
+        "uppercased marker class should still satisfy DOM evidence via case-insensitive scan"
+    );
+    let body = body.unwrap_or_default();
+    let marker = crate::scanning::markers::class_marker();
+    assert!(
+        body.to_ascii_lowercase().contains(marker),
+        "marker should appear in the body under ASCII case fold"
+    );
 }
 
 #[tokio::test]

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -577,26 +577,69 @@ fn marker_case_fold_reflected(resp_text: &str, payload: &str) -> bool {
     let id_marker = crate::scanning::markers::id_marker();
     let candidates: [&str; 3] = [class_marker, id_marker, "dalfox"];
 
-    let mut payload_carries_any = false;
+    // Cheap reject — fast-fail before touching response bytes when the
+    // payload carries no marker at all. classify_reflection runs once
+    // per payload variant per response, so the hot-path cost of this
+    // fallback must stay near a few substring scans on payload itself.
+    let mut carried: [&str; 3] = [""; 3];
+    let mut carried_len = 0usize;
     for marker in &candidates {
         if payload.contains(*marker) {
-            payload_carries_any = true;
-            // Same-case marker already in response — let the standard
-            // reflection / marker-evidence paths handle it and avoid
-            // re-classifying as case-folded.
-            if resp_text.contains(*marker) {
-                return false;
-            }
+            carried[carried_len] = *marker;
+            carried_len += 1;
         }
     }
-    if !payload_carries_any {
+    if carried_len == 0 {
         return false;
     }
 
-    let lower_resp = resp_text.to_ascii_lowercase();
-    candidates
+    // Same-case marker already in response — let the standard
+    // reflection / marker-evidence paths handle it and avoid
+    // re-classifying as case-folded.
+    for marker in carried[..carried_len].iter() {
+        if resp_text.contains(*marker) {
+            return false;
+        }
+    }
+
+    // Case-insensitive substring search over response bytes without
+    // allocating a lowercased copy. Markers are short (~11 bytes), so
+    // O(n*m) is fine here while avoiding the per-call String alloc
+    // that the naive `to_ascii_lowercase().contains(...)` shape costs
+    // on every redundant fallback invocation.
+    carried[..carried_len]
         .iter()
-        .any(|m| payload.contains(*m) && lower_resp.contains(*m))
+        .any(|m| ascii_ci_contains(resp_text, m))
+}
+
+/// True iff `needle` appears in `haystack` under ASCII case-fold,
+/// without allocating a lowercased copy of either string.
+fn ascii_ci_contains(haystack: &str, needle: &str) -> bool {
+    let h = haystack.as_bytes();
+    let n = needle.as_bytes();
+    if n.is_empty() {
+        return true;
+    }
+    if n.len() > h.len() {
+        return false;
+    }
+    let first = n[0].to_ascii_lowercase();
+    let end = h.len() - n.len();
+    let mut i = 0;
+    'outer: while i <= end {
+        if h[i].to_ascii_lowercase() != first {
+            i += 1;
+            continue;
+        }
+        for j in 1..n.len() {
+            if !h[i + j].eq_ignore_ascii_case(&n[j]) {
+                i += 1;
+                continue 'outer;
+            }
+        }
+        return true;
+    }
+    false
 }
 
 /// Resolve SXSS check URLs with priority:

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -542,7 +542,61 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
         return Some(ReflectionKind::HtmlThenUrlDecoded);
     }
 
+    // Case-folded marker fallback: when none of the byte-exact variants
+    // match, but the payload carries a Dalfox marker that survived the
+    // round-trip under ASCII case-folding (e.g. a server that uppercases
+    // everything before reflecting), treat the response as a reflection.
+    //
+    // The dynamic markers are `dlx` + 8 random hex digits — case-folded
+    // they remain unique to this scan, so finding the marker in the
+    // lowercased response is a strong "this came from our payload" signal.
+    // Without this fallback, endpoints like xssmaze `obfuscation/level2`
+    // (`query.upcase`) and `casemanip/level3` (alpha case swap) escape
+    // every reflection check above and produce zero findings.
+    if marker_case_fold_reflected(resp_text, payload) {
+        return Some(ReflectionKind::Raw);
+    }
+
     None
+}
+
+/// True when the payload embeds a Dalfox marker (class/id, dynamic or
+/// legacy) and that marker appears in `resp_text` only after ASCII
+/// case-folding. Used as a last-chance reflection signal for servers
+/// that uppercase / lowercase every reflected byte (xssmaze
+/// `obfuscation/level2`, `casemanip/level3`) where every other variant
+/// check still produces a byte-exact mismatch.
+///
+/// The fallback intentionally returns `false` whenever any carried
+/// marker is already present in `resp_text` under exact case: the
+/// standard reflection-variant paths above will have already fired (or
+/// can be reached by callers via `has_marker_evidence`) and we should
+/// not double-classify the same response as a case-folded reflection.
+fn marker_case_fold_reflected(resp_text: &str, payload: &str) -> bool {
+    let class_marker = crate::scanning::markers::class_marker();
+    let id_marker = crate::scanning::markers::id_marker();
+    let candidates: [&str; 3] = [class_marker, id_marker, "dalfox"];
+
+    let mut payload_carries_any = false;
+    for marker in &candidates {
+        if payload.contains(*marker) {
+            payload_carries_any = true;
+            // Same-case marker already in response — let the standard
+            // reflection / marker-evidence paths handle it and avoid
+            // re-classifying as case-folded.
+            if resp_text.contains(*marker) {
+                return false;
+            }
+        }
+    }
+    if !payload_carries_any {
+        return false;
+    }
+
+    let lower_resp = resp_text.to_ascii_lowercase();
+    candidates
+        .iter()
+        .any(|m| payload.contains(*m) && lower_resp.contains(*m))
 }
 
 /// Resolve SXSS check URLs with priority:

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -876,9 +876,19 @@ async fn fetch_injection_response_with_client(
                 && let Some(location) = resp.headers().get("location").and_then(|v| v.to_str().ok())
                 && (location.contains(&*encoded_payload) || location.contains(payload))
             {
-                // Synthesize a response text that includes the Location value
-                // so reflection detection can find it
-                return Some(location.to_string());
+                // Wrap the Location value in a minimal HTML container so the
+                // downstream reflection check still finds the payload via
+                // substring match, but the JS-context AST verifier cannot
+                // parse the synthesized text as JavaScript and wrongly
+                // upgrade the finding to V. Without the wrapper, a literal
+                // `Location: javascript:alert(1)` becomes a freestanding
+                // expression statement that the oxc parser accepts, which
+                // triggered V on redirects that no browser ever follows
+                // (browsers refuse `javascript:` / `data:` schemes in 3xx
+                // `Location:` headers). The wrapper starts with `<html>`,
+                // which fails JS parsing cleanly, so reflection-finding
+                // R is preserved while the false V upgrade is blocked.
+                return Some(format!("<html><body>{}</body></html>", location));
             }
             match resp.text().await {
                 Ok(body) => Some(body),


### PR DESCRIPTION
## Summary

Three independent improvements to the scanning pipeline, driven by a baseline run against the full xssmaze benchmark (895 endpoints) and a 30-sample V-finding audit.

- **FP↓ (5 removed)** — Drop V upgrades for `Location: javascript:` / `data:text/html` / `vbscript:` in 3xx redirects. Modern browsers (Chrome, Firefox, Safari and derivatives) refuse to navigate to such URLs in `Location:` headers, so these findings cannot actually fire. Two cooperating paths produced the FPs (`check_redirect_location` synthetic body, `check_reflection.rs` raw Location synthesis that the JSONP-fallback JS parser then accepted); both are fixed.
- **Detection↑ (+2 endpoints)** — Recover reflection signal on servers that case-fold reflected input (`obfuscation/level2`, `casemanip/level3` in xssmaze, common in real apps with `.upcase`/`.downcase` filters). Adds a marker-substring case-fold fallback in `classify_reflection` and a case-insensitive class/id attribute walk in `has_marker_evidence_in_doc`. The Dalfox marker is `dlx{8 random hex}`, so case-folding has no realistic collision risk.
- **Perf neutral** — `ascii_ci_contains` does the case-insensitive match without allocating a lowercased copy of the response; classify_reflection sits in the hot path so the per-call allocation a naive `to_ascii_lowercase().contains()` would cost is avoided.

## xssmaze benchmark (895 endpoints)

| | baseline | after | Δ |
|---|---|---|---|
| Endpoints with findings | 880 (98.3%) | 889 (99.3%) | +9 |
| Missed | 8 | 6 | -2 |
| V (Verified) | 806 | 801 | -5 (all FPs) |
| R (Reflected) | 60 | 67 | +7 (4 FP→R + 2 new + 1 incidental) |
| A (AST) | 56 | 56 | 0 |
| Total findings | 922 | 924 | +2 |
| Total requests | 639,380 | 660,131 | +3% |
| Wall time | 188.78s | 184.19s | within noise |

V diff is exactly the 5 expected FP removals: `/redirect/level{1,2,3,4}/` and `/realworld-input/level4/`. All five servers return `302` with an executable-URL scheme in `Location:`.

## Audit limitation

V findings were sampled at n=30 with a GET-based auto-verifier. 29 confirmed verbatim payload reflection; 1 (`/postmethod/level1/`) is a real POST endpoint where the auditor's GET landed on the form HTML, not the reflected response — not a FP, just an audit-script gap. Cross-method V findings were not exhaustively re-checked.

## Out of scope

- Promoting `obfuscation/level2` / `casemanip/level3` from R to V needs `parameter_analysis` to detect reflection under case-folding so HTML-element payloads (with `<img …>`) get queued. Separate concern with its own FP surface — left for a follow-up.
- `dom/level9` (sets `innerText` on an existing `<script>` element) stays missed because the HTML5 spec doesn't execute it; chasing it would mean a synthetic detection that wouldn't fire in any browser.

## Test plan

- [x] `cargo test --release` — 899 lib + 186 functional + 10 integration tests pass (0 fail, 18 ignored as before)
- [x] New unit test `test_check_dom_verification_marker_survives_case_fold` covers the case-fold marker evidence path end-to-end via an axum mock that uppercases every reflected byte
- [x] xssmaze benchmark re-run after each commit; numbers above
- [x] Manual spot-check of each demoted V (5 redirects) and each new R (2 case-fold endpoints)