### PR TITLE
scanning: improve --sxss accuracy (retrieval, inline sinks, tagging)

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -870,10 +870,21 @@ async fn fetch_injection_response_with_client(
         sleep(Duration::from_millis(target.delay)).await;
     }
 
-    // For Stored XSS, check reflection on auto-resolved URLs with retry logic
+    // For Stored XSS, check reflection on auto-resolved URLs with retry logic.
+    //
+    // We MUST verify the payload actually reflects in each candidate body
+    // before returning it — otherwise the first non-empty page (a login
+    // form, an empty list, a session-expired page) short-circuits the loop
+    // and the real retrieval URL is never tried, producing a false negative.
+    //
+    // Fallback: if no candidate URL contains the payload but at least one
+    // returned a non-empty body, return that body. Callers downstream will
+    // run classify_reflection again and conclude "no reflection" — same
+    // outcome as before, but only after every URL had a fair chance.
     if args.sxss {
         let check_urls = resolve_sxss_check_urls(target, param, args);
         let retries = args.sxss_retries.max(1) as u64;
+        let mut fallback_body: Option<String> = None;
         for sxss_url in &check_urls {
             // Retry with delay to handle session / content propagation
             for attempt in 0u64..retries {
@@ -889,11 +900,16 @@ async fn fetch_injection_response_with_client(
                     && let Ok(text) = resp.text().await
                     && !text.is_empty()
                 {
-                    return Some(text);
+                    if classify_reflection(&text, payload).is_some() {
+                        return Some(text);
+                    }
+                    if fallback_body.is_none() {
+                        fallback_body = Some(text);
+                    }
                 }
             }
         }
-        None
+        fallback_body
     } else {
         // Normal reflection check
         if let Ok(resp) = inject_resp {

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -881,7 +881,22 @@ async fn fetch_injection_response_with_client(
     // returned a non-empty body, return that body. Callers downstream will
     // run classify_reflection again and conclude "no reflection" — same
     // outcome as before, but only after every URL had a fair chance.
+    //
+    // Inline-stored sinks: many stored sinks (comment boxes, profile
+    // updaters, message composers) render the payload directly into the
+    // write-response body — i.e. the same response we already have in hand
+    // from the injection request. If retrieval URLs don't surface the
+    // payload, classify the inject body before giving up.
     if args.sxss {
+        // Eagerly consume the injection response body so we can use it as
+        // an inline-rendered fallback. We drop status/headers because the
+        // retrieval-URL path doesn't gate on them either, and we want
+        // consistent SXSS evidence semantics.
+        let inject_body: Option<String> = match inject_resp {
+            Ok(resp) => resp.text().await.ok().filter(|t| !t.is_empty()),
+            Err(_) => None,
+        };
+
         let check_urls = resolve_sxss_check_urls(target, param, args);
         let retries = args.sxss_retries.max(1) as u64;
         let mut fallback_body: Option<String> = None;
@@ -909,7 +924,16 @@ async fn fetch_injection_response_with_client(
                 }
             }
         }
-        fallback_body
+        // Inline-stored sink fallback: the inject response body itself often
+        // renders the stored value (e.g. POST /comments returns the rendered
+        // /comments page). Without this check we'd miss the entire class
+        // of sinks where the write-response is the rendered view.
+        if let Some(body) = inject_body.as_ref()
+            && classify_reflection(body, payload).is_some()
+        {
+            return inject_body;
+        }
+        fallback_body.or(inject_body)
     } else {
         // Normal reflection check
         if let Ok(resp) = inject_resp {

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -600,11 +600,44 @@ async fn test_check_reflection_sxss_skips_junk_url_and_finds_later_candidate() {
     );
 }
 
+/// Inline-stored sink: the write-response body itself renders the stored
+/// value (think POST /comments returning the rendered /comments page).
+/// None of the retrieval URLs surface the payload, but the inject response
+/// does — the SXSS path must catch this via the inject-body fallback.
+#[tokio::test]
+async fn test_check_reflection_sxss_falls_back_to_inject_response_body() {
+    let payload = "STORED_XSS_PAYLOAD";
+    let addr = start_mock_server("ignored").await;
+    // target.url is /reflect/raw, which echoes the q param back in its
+    // body. The inject GET to /reflect/raw?q=PAYLOAD therefore returns a
+    // body containing the payload. The SXSS retrieval candidates all fail
+    // to surface it (the original target.url uses q=seed, form_origin_url
+    // points at /reflect/none).
+    let target = make_target(addr, "/reflect/raw");
+    let mut param = make_param();
+    param.form_origin_url = Some(format!("http://{}:{}/reflect/none", addr.ip(), addr.port()));
+    let mut args = default_scan_args();
+    args.sxss = true;
+    args.sxss_url = None;
+    args.sxss_retries = 1;
+
+    let found = check_reflection(&target, &param, payload, &args).await;
+    assert!(
+        found,
+        "sxss must fall back to the inject-response body when retrieval URLs miss the payload"
+    );
+}
+
 #[tokio::test]
 async fn test_check_reflection_sxss_without_url_returns_false() {
     let payload = "STORED_XSS_PAYLOAD";
     let addr = start_mock_server(payload).await;
-    let target = make_target(addr, "/reflect/raw");
+    // Point target at a handler that does NOT echo the query param, so
+    // neither the retrieval fallback (GET target.url) nor the inject-body
+    // fallback surface the payload. This isolates the "no SXSS signal
+    // anywhere" case — distinct from the inline-stored-sink fallback test
+    // above, which deliberately uses /reflect/raw to exercise the fallback.
+    let target = make_target(addr, "/reflect/none");
     let param = make_param();
     let mut args = default_scan_args();
     args.sxss = true;

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -569,6 +569,37 @@ async fn test_check_reflection_sxss_uses_secondary_url() {
     assert!(found, "sxss mode should verify reflection via sxss_url");
 }
 
+/// Regression: in SXSS mode the retrieval loop used to return the first
+/// non-empty body without verifying the payload was in it. When the highest-
+/// priority candidate (form_origin_url) returns an unrelated page (login
+/// redirect, empty list, etc.) the loop exited before trying form_action_url
+/// or target.url — even when those URLs contained the stored payload. Each
+/// candidate body must now be classified before we give up.
+#[tokio::test]
+async fn test_check_reflection_sxss_skips_junk_url_and_finds_later_candidate() {
+    let payload = "STORED_XSS_PAYLOAD";
+    let addr = start_mock_server(payload).await;
+    // Injection target points at /reflect/none, but the stored payload only
+    // surfaces at /sxss/stored. form_origin_url points at a junk URL
+    // (/reflect/none returns "<div>not reflected</div>") and form_action_url
+    // is the real retrieval URL. The fix must continue past the junk URL.
+    let target = make_target(addr, "/reflect/none");
+    let mut param = make_param();
+    param.form_origin_url = Some(format!("http://{}:{}/reflect/none", addr.ip(), addr.port()));
+    param.form_action_url = Some(format!("http://{}:{}/sxss/stored", addr.ip(), addr.port()));
+    let mut args = default_scan_args();
+    args.sxss = true;
+    args.sxss_url = None;
+    // Single retry per candidate keeps the test fast.
+    args.sxss_retries = 1;
+
+    let found = check_reflection(&target, &param, payload, &args).await;
+    assert!(
+        found,
+        "sxss retrieval must continue past a candidate URL whose body lacks the payload"
+    );
+}
+
 #[tokio::test]
 async fn test_check_reflection_sxss_without_url_returns_false() {
     let payload = "STORED_XSS_PAYLOAD";

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -68,6 +68,14 @@ struct FoundParams {
     dom: HashSet<String>,
 }
 
+/// Label written to `Result.inject_type` for findings produced by the scan
+/// loop. Findings under `--sxss` are prefixed so JSON / markdown / plain
+/// reports distinguish stored from reflected results — downstream tooling
+/// parses this field, so the contract is pinned by `tests::test_inject_type_label_for_sxss`.
+fn inject_type_label_for(sxss: bool) -> &'static str {
+    if sxss { "sxss-inHTML" } else { "inHTML" }
+}
+
 fn reflection_kind_note(kind: crate::scanning::check_reflection::ReflectionKind) -> &'static str {
     match kind {
         crate::scanning::check_reflection::ReflectionKind::Raw => "reflected",
@@ -874,14 +882,9 @@ pub async fn run_scanning(
                         // Record reflected/verified XSS finding (fallback path).
                         // In SXSS mode, prefix inject_type so downstream output
                         // (JSON, markdown, plain) makes the stored route visible.
-                        let inject_type_label = if args_clone.sxss {
-                            "sxss-inHTML".to_string()
-                        } else {
-                            "inHTML".to_string()
-                        };
                         let mut result = crate::scanning::result::Result::new(
                             finding_type,
-                            inject_type_label,
+                            inject_type_label_for(args_clone.sxss).to_string(),
                             target_clone.method.clone(),
                             result_url,
                             param_clone.name.clone(),
@@ -986,14 +989,9 @@ pub async fn run_scanning(
                             .map(|k| k.label())
                             .unwrap_or("DOM evidence");
 
-                        let dom_inject_type_label = if args_clone.sxss {
-                            "sxss-inHTML".to_string()
-                        } else {
-                            "inHTML".to_string()
-                        };
                         let mut result = crate::scanning::result::Result::new(
                             FindingType::Verified, // DOM-verified => Vulnerability
-                            dom_inject_type_label,
+                            inject_type_label_for(args_clone.sxss).to_string(),
                             target_clone.method.clone(),
                             result_url,
                             param_clone.name.clone(),

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -871,10 +871,17 @@ pub async fn run_scanning(
                             )
                         };
 
-                        // Record reflected/verified XSS finding (fallback path)
+                        // Record reflected/verified XSS finding (fallback path).
+                        // In SXSS mode, prefix inject_type so downstream output
+                        // (JSON, markdown, plain) makes the stored route visible.
+                        let inject_type_label = if args_clone.sxss {
+                            "sxss-inHTML".to_string()
+                        } else {
+                            "inHTML".to_string()
+                        };
                         let mut result = crate::scanning::result::Result::new(
                             finding_type,
-                            "inHTML".to_string(),
+                            inject_type_label,
                             target_clone.method.clone(),
                             result_url,
                             param_clone.name.clone(),
@@ -979,9 +986,14 @@ pub async fn run_scanning(
                             .map(|k| k.label())
                             .unwrap_or("DOM evidence");
 
+                        let dom_inject_type_label = if args_clone.sxss {
+                            "sxss-inHTML".to_string()
+                        } else {
+                            "inHTML".to_string()
+                        };
                         let mut result = crate::scanning::result::Result::new(
                             FindingType::Verified, // DOM-verified => Vulnerability
-                            "inHTML".to_string(),
+                            dom_inject_type_label,
                             target_clone.method.clone(),
                             result_url,
                             param_clone.name.clone(),

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -19,6 +19,15 @@ fn make_result(ft: FindingType) -> crate::scanning::result::Result {
 }
 
 #[test]
+fn test_inject_type_label_for_sxss() {
+    // Pins the public JSON contract — downstream tooling parses
+    // `inject_type` to distinguish stored from reflected findings.
+    // Changes to these strings break consumers; bump intentionally.
+    assert_eq!(super::inject_type_label_for(false), "inHTML");
+    assert_eq!(super::inject_type_label_for(true), "sxss-inHTML");
+}
+
+#[test]
 fn test_count_matching_results_all() {
     let results = vec![
         make_result(FindingType::Verified),


### PR DESCRIPTION
## Summary

Three improvements that make Dalfox more reliable as a Stored XSS tool. All three live in the same `--sxss` code path.

### 1. Fix SXSS retrieval false negatives

When `--sxss` is set, `fetch_injection_response_with_client` resolves a priority-ordered list of candidate retrieval URLs (`--sxss-url` → `form_origin_url` → `form_action_url` → `target.url`) and tries each. The previous loop returned the **first non-empty body** without verifying the payload was actually in it. So if the highest-priority candidate returned an unrelated page (login redirect, empty list, session-expired view), the loop exited before trying the later candidates that actually contained the stored payload — silently producing a false negative.

The fix classifies each candidate response and only short-circuits on a real reflection. The first non-empty body is preserved as a fallback so downstream behavior is unchanged when no candidate contains the payload.

### 2. Catch inline-stored sinks via inject-response fallback

Many stored sinks render the payload directly in the write-response body — POST `/comments` returns the rendered comments page, profile updates re-render the profile on save, etc. The previous implementation discarded the injection response entirely in SXSS mode and only checked retrieval URLs, missing this whole class.

The inject body is now saved once at the top of the SXSS branch. If no retrieval URL surfaces the payload, the inject body is classified before giving up. Retrieval URLs still win when both have evidence — the user pointed at them explicitly, so they're the trusted source.

### 3. Tag stored-XSS findings distinctly

Reflected and stored findings used the same `inject_type = "inHTML"` label, so users triaging JSON / markdown / plain reports couldn't tell which findings came from the `--sxss` path. Findings produced under `--sxss` now record `inject_type = "sxss-inHTML"`. The existing `(param, inject_type)`-keyed R→V collapse still works within a single scan because every finding in that scan shares the same prefix.

## Tests

- `test_check_reflection_sxss_skips_junk_url_and_finds_later_candidate` — exercises (1): `form_origin_url` returns no payload, `form_action_url` does; SXSS must continue past the junk URL.
- `test_check_reflection_sxss_falls_back_to_inject_response_body` — exercises (2): retrieval URLs miss, inject response echoes the payload; SXSS must fall back.
- `test_check_reflection_sxss_without_url_returns_false` updated: pointed at `/reflect/none` so it isolates the no-signal case (its prior target unintentionally exercised the new fallback).

## Test plan

- [x] `cargo test --lib` — 901 / 901 pass
- [x] All four SXSS tests in `scanning::check_reflection::tests::test_check_reflection_sxss_*` pass
- [x] DOM-verification SXSS tests still pass (`scanning::check_dom_verification::tests::test_check_dom_verification_sxss_*`)
- [x] R→V collapse logic unaffected (`scanning::tests::test_collapse_*` pass)