### PR TITLE
scanning: broaden static V upgrade beyond JS-context to all DOM evidence

### DIFF
--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -744,6 +744,47 @@ fn test_classify_dom_evidence_returns_executable_url() {
 }
 
 #[test]
+fn test_classify_dom_evidence_realworld_marker_in_comment_and_body() {
+    // xssmaze /realworld/level1 reflects the query twice: once with angles
+    // stripped inside an HTML comment, and once raw inside `<h2>`. With
+    // the standard marker-bearing payload, the marker should be found in
+    // the parsed DOM. Pinning this regression: dalfox previously reported
+    // only R against this shape (3045 R-only on deep-scan).
+    let class_marker = crate::scanning::markers::class_marker();
+    let payload = format!("<svg/onload=alert(1) class={}>", class_marker);
+    let body = format!(
+        "<!-- search: svg/onload=alert(1) class={} --><h2>Results for: {}</h2>",
+        class_marker, payload
+    );
+    assert!(
+        has_dom_evidence(&payload, &body),
+        "marker carried on a <svg> inside <h2> must be detected as DOM evidence; \
+         current behavior on /realworld/level1 was 'R only'"
+    );
+}
+
+#[test]
+fn test_classify_dom_evidence_comment_breakout() {
+    // xssmaze /realworld/level1 shape: payload reflects raw inside a
+    // following <h2>, and via a comment-breakout sequence
+    // (--><payload><!--) the comment is closed mid-page. After parsing,
+    // the introduced <svg onload=…> element should fire structural
+    // evidence. Pinning this here flagged the gap where dalfox surfaced
+    // only R despite the payload trivially producing a sink element.
+    let payload = "--><svg/onload=alert(1)><!--";
+    let body = format!(
+        "<!-- search: {} --><h2>Results for: {}</h2>",
+        payload, payload
+    );
+    assert_eq!(
+        classify_dom_evidence(payload, &body),
+        Some(DomEvidenceKind::HtmlStructural),
+        "comment-breakout payload that introduces <svg onload=alert(1)> \
+         must classify as structural HTML evidence"
+    );
+}
+
+#[test]
 fn test_classify_dom_evidence_returns_none_for_inert() {
     let payload = "harmless";
     let body = "<html><body>harmless</body></html>";
@@ -842,4 +883,61 @@ async fn test_check_dom_verification_skips_body_on_redirect_response() {
         "DOM evidence in a 3xx response body must not be treated as verified"
     );
     assert!(body.is_none(), "no body should be returned for redirects");
+}
+
+#[test]
+fn test_is_executable_url_attribute_pin_whitelist() {
+    // Pin the (element, attribute) pairs that browsers actually dereference
+    // as code. xssmaze /mediacontext exercises src reflections on every media
+    // element; verification must NOT promote those to V, while the genuine
+    // navigation/frame-load/submit pairs must keep doing so. Any change to
+    // the whitelist surfaces here instead of silently flipping behavior.
+
+    // Should be exec URL contexts (V allowed):
+    for (tag, attr) in [
+        ("a", "href"),
+        ("area", "href"),
+        ("base", "href"),
+        ("link", "href"),
+        ("iframe", "src"),
+        ("embed", "src"),
+        ("frame", "src"),
+        ("iframe", "srcdoc"),
+        ("object", "data"),
+        ("form", "action"),
+        ("input", "formaction"),
+        ("button", "formaction"),
+        ("a", "xlink:href"),
+        ("use", "xlink:href"),
+        // Case insensitivity guarantee
+        ("A", "HREF"),
+        ("IFRAME", "Src"),
+    ] {
+        assert!(
+            is_executable_url_attribute(tag, attr),
+            "{tag}@{attr} must be a verified-V exec URL context"
+        );
+    }
+
+    // Resource-fetch / inert pairs (V forbidden — only R should fire):
+    for (tag, attr) in [
+        ("img", "src"),
+        ("audio", "src"),
+        ("video", "src"),
+        ("source", "src"),
+        ("script", "src"),
+        ("track", "src"),
+        // Other innocuous combinations
+        ("img", "alt"),
+        ("a", "target"),
+        ("div", "data-href"),
+        ("link", "rel"),
+        ("meta", "content"),
+        ("iframe", "name"),
+    ] {
+        assert!(
+            !is_executable_url_attribute(tag, attr),
+            "{tag}@{attr} must NOT be treated as exec URL context"
+        );
+    }
 }

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -273,3 +273,18 @@ fn cached_parsed_spans_distinct_for_different_blocks() {
     let sb = cached_parsed_spans(b).expect("b parses");
     assert_ne!(sa, sb);
 }
+
+#[test]
+fn redirect_location_wrapper_does_not_trigger_js_context() {
+    // Regression for xssmaze /redirect/level1: when a 3xx Location header
+    // is wrapped as `<html><body>javascript:alert(1)</body></html>` so it
+    // reaches the reflection path, the JS-context AST verifier must NOT
+    // upgrade to V. Browsers never execute the Location's URL scheme on
+    // a 3xx redirect, so any V upgrade here is a false positive.
+    let payload = "javascript:alert(1)";
+    let body = format!("<html><body>{}</body></html>", payload);
+    assert!(
+        !has_js_context_evidence(payload, &body),
+        "wrapped Location body must not produce JS-context evidence"
+    );
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -831,37 +831,55 @@ pub async fn run_scanning(
 
                         let reflection_note = reflection_kind_note(kind);
 
-                        // JS-context static V upgrade: if the payload introduced
-                        // an executable sink call inside a <script> block, treat
-                        // the finding as DOM-verified. Saves one HTTP request
-                        // since we re-use the reflection response body.
-                        let js_verified = reflection_response_text
+                        // Static V upgrade: re-use the reflection response body
+                        // to look for browser-executable DOM evidence. Saves one
+                        // HTTP request relative to running a separate
+                        // `check_dom_verification` request. The four evidence
+                        // kinds (marker, executable URL in dangerous attribute,
+                        // HTML element with sink handler, JS-context sink call)
+                        // are the same set DOM verification ultimately uses, so
+                        // the static path is consistent with the dedicated path.
+                        //
+                        // Without this broader check, multi-site reflections where
+                        // the reflection-phase payload already contains the
+                        // structurally exploitable bytes (e.g. xssmaze
+                        // /realworld/level1 reflecting `<svg onload=alert(1)>`
+                        // raw into <h2>, and xssmaze /hpp/level1 where the
+                        // first-value reflection renders the unfiltered payload)
+                        // surfaced as R-only despite being trivially V — the
+                        // adaptive DOM payload generator drops HTML-tag payloads
+                        // when angles are reported "invalid" at one of the
+                        // reflection sites, and the prior `has_js_context_evidence`
+                        // check only covered the `<script>`-block case.
+                        let dom_evidence_kind = reflection_response_text
                             .as_deref()
-                            .map(|body| {
-                                crate::scanning::js_context_verify::has_js_context_evidence(
+                            .and_then(|body| {
+                                crate::scanning::check_dom_verification::classify_dom_evidence(
                                     &reflection_payload,
                                     body,
                                 )
-                            })
-                            .unwrap_or(false);
+                            });
 
-                        let (finding_type, severity, summary, poc_msg) = if js_verified {
+                        let (finding_type, severity, summary, poc_msg) = if let Some(kind) =
+                            dom_evidence_kind
+                        {
                             // Mark dom_found so we skip redundant DOM verification
                             {
                                 let mut found = found_params_clone.write().await;
                                 found.dom.insert(param_clone.name.clone());
                             }
                             dom_found_locally = true;
+                            let evidence_label = kind.label();
                             (
                                 FindingType::Verified,
                                 "High".to_string(),
                                 format!(
-                                    "DOM verification successful for param {} (JS-context AST)",
-                                    param_clone.name
+                                    "DOM verification successful for param {} ({})",
+                                    param_clone.name, evidence_label
                                 ),
                                 format!(
-                                    "Triggered XSS Payload (JS-context sink call): {}={}",
-                                    param_clone.name, reflection_payload
+                                    "Triggered XSS Payload ({}): {}={}",
+                                    evidence_label, param_clone.name, reflection_payload
                                 ),
                             )
                         } else {

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -851,51 +851,49 @@ pub async fn run_scanning(
                         // when angles are reported "invalid" at one of the
                         // reflection sites, and the prior `has_js_context_evidence`
                         // check only covered the `<script>`-block case.
-                        let dom_evidence_kind = reflection_response_text
-                            .as_deref()
-                            .and_then(|body| {
+                        let dom_evidence_kind =
+                            reflection_response_text.as_deref().and_then(|body| {
                                 crate::scanning::check_dom_verification::classify_dom_evidence(
                                     &reflection_payload,
                                     body,
                                 )
                             });
 
-                        let (finding_type, severity, summary, poc_msg) = if let Some(kind) =
-                            dom_evidence_kind
-                        {
-                            // Mark dom_found so we skip redundant DOM verification
-                            {
-                                let mut found = found_params_clone.write().await;
-                                found.dom.insert(param_clone.name.clone());
-                            }
-                            dom_found_locally = true;
-                            let evidence_label = kind.label();
-                            (
-                                FindingType::Verified,
-                                "High".to_string(),
-                                format!(
-                                    "DOM verification successful for param {} ({})",
-                                    param_clone.name, evidence_label
-                                ),
-                                format!(
-                                    "Triggered XSS Payload ({}): {}={}",
-                                    evidence_label, param_clone.name, reflection_payload
-                                ),
-                            )
-                        } else {
-                            (
-                                FindingType::Reflected,
-                                "Info".to_string(),
-                                format!(
-                                    "Reflected XSS detected for param {} ({})",
-                                    param_clone.name, reflection_note
-                                ),
-                                format!(
-                                    "[R] Triggered XSS Payload ({}): {}={}",
-                                    reflection_note, param_clone.name, reflection_payload
-                                ),
-                            )
-                        };
+                        let (finding_type, severity, summary, poc_msg) =
+                            if let Some(kind) = dom_evidence_kind {
+                                // Mark dom_found so we skip redundant DOM verification
+                                {
+                                    let mut found = found_params_clone.write().await;
+                                    found.dom.insert(param_clone.name.clone());
+                                }
+                                dom_found_locally = true;
+                                let evidence_label = kind.label();
+                                (
+                                    FindingType::Verified,
+                                    "High".to_string(),
+                                    format!(
+                                        "DOM verification successful for param {} ({})",
+                                        param_clone.name, evidence_label
+                                    ),
+                                    format!(
+                                        "Triggered XSS Payload ({}): {}={}",
+                                        evidence_label, param_clone.name, reflection_payload
+                                    ),
+                                )
+                            } else {
+                                (
+                                    FindingType::Reflected,
+                                    "Info".to_string(),
+                                    format!(
+                                        "Reflected XSS detected for param {} ({})",
+                                        param_clone.name, reflection_note
+                                    ),
+                                    format!(
+                                        "[R] Triggered XSS Payload ({}): {}={}",
+                                        reflection_note, param_clone.name, reflection_payload
+                                    ),
+                                )
+                            };
 
                         // Record reflected/verified XSS finding (fallback path).
                         // In SXSS mode, prefix inject_type so downstream output

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -887,7 +887,10 @@ async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
         "the realworld/level1 shape must produce at least one Verified finding on `query`; \
          got {} total results: {:?}",
         guard.len(),
-        guard.iter().map(|r| (&r.result_type, &r.param)).collect::<Vec<_>>()
+        guard
+            .iter()
+            .map(|r| (&r.result_type, &r.param))
+            .collect::<Vec<_>>()
     );
     // The evidence label should reflect the actual DOM evidence kind that
     // fired, not the hard-coded "JS-context AST" string the prior code

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2,6 +2,81 @@ use super::*;
 use crate::parameter_analysis::{InjectionContext, Location, Param};
 use crate::target_parser::parse_target;
 
+/// ScanArgs preset for run_scanning integration tests below. Keeps
+/// `skip_xss_scanning` toggleable per-test so the empty/short-circuit
+/// tests can still opt out of real HTTP traffic while the
+/// `realworld_level1_shape_v_upgrade` test exercises the full pipeline.
+fn integration_scan_args(skip_xss: bool) -> crate::cmd::scan::ScanArgs {
+    crate::cmd::scan::ScanArgs {
+        input_type: "auto".to_string(),
+        format: "json".to_string(),
+        targets: vec![],
+        param: vec![],
+        data: None,
+        headers: vec![],
+        cookies: vec![],
+        method: "GET".to_string(),
+        user_agent: None,
+        cookie_from_raw: None,
+        include_url: vec![],
+        exclude_url: vec![],
+        ignore_param: vec![],
+        out_of_scope: vec![],
+        out_of_scope_file: None,
+        mining_dict_word: None,
+        skip_mining: true,
+        skip_mining_dict: true,
+        skip_mining_dom: true,
+        only_discovery: false,
+        skip_discovery: true,
+        skip_reflection_header: true,
+        skip_reflection_cookie: true,
+        skip_reflection_path: true,
+        timeout: 5,
+        delay: 0,
+        proxy: None,
+        follow_redirects: false,
+        ignore_return: vec![],
+        output: None,
+        include_request: false,
+        include_response: false,
+        include_all: false,
+        no_color: true,
+        silence: true,
+        dry_run: false,
+        poc_type: "plain".to_string(),
+        limit: None,
+        limit_result_type: "all".to_string(),
+        only_poc: vec![],
+        workers: 4,
+        max_concurrent_targets: 4,
+        max_targets_per_host: 8,
+        encoders: vec!["url".to_string()],
+        custom_blind_xss_payload: None,
+        blind_callback_url: None,
+        custom_payload: None,
+        only_custom_payload: false,
+        inject_marker: None,
+        custom_alert_value: "1".to_string(),
+        custom_alert_type: "none".to_string(),
+        skip_xss_scanning: skip_xss,
+        deep_scan: false,
+        sxss: false,
+        sxss_url: None,
+        sxss_method: "GET".to_string(),
+        sxss_retries: 1,
+        skip_ast_analysis: true,
+        hpp: false,
+        waf_bypass: "off".to_string(),
+        skip_waf_probe: true,
+        force_waf: None,
+        waf_evasion: false,
+        waf_min_confidence: 0.0,
+        remote_payloads: vec![],
+        remote_wordlists: vec![],
+    }
+}
+
 fn make_result(ft: FindingType) -> crate::scanning::result::Result {
     crate::scanning::result::Result::new(
         ft,
@@ -730,6 +805,104 @@ async fn test_run_scanning_with_reflection_params() {
         None,
     )
     .await;
+}
+
+/// End-to-end test for the static V upgrade broadened in #960. Runs
+/// `run_scanning` against a mock that mimics the xssmaze `/realworld/level1`
+/// shape — reflects the query twice, once with angles stripped inside an
+/// HTML comment, once raw inside `<h2>`. Before the fix the static V
+/// upgrade only checked `has_js_context_evidence`, so this shape produced
+/// R findings only (3045 R-only on deep-scan). After the fix the
+/// reflection-phase response itself carries `<svg/onload=alert(1)>` and
+/// `classify_dom_evidence` returns `HtmlStructural`, so a Verified
+/// finding must appear.
+#[tokio::test]
+async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
+    use axum::{Router, extract::Query, response::Html, routing::get};
+    use std::collections::HashMap;
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::time::{Duration, sleep};
+
+    async fn realworld_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
+        // Mirror xssmaze /realworld/level1: strip < and > inside the comment,
+        // reflect raw inside <h2>. Filters::strip_angles equivalent.
+        let q = params.get("query").cloned().unwrap_or_default();
+        let safe: String = q.chars().filter(|c| *c != '<' && *c != '>').collect();
+        Html(format!(
+            "<!-- search: {} --><h2>Results for: {}</h2>",
+            safe, q
+        ))
+    }
+
+    let app = Router::new().route("/", get(realworld_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let url = format!("http://{}/?query=a", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    // Skip discovery entirely (it would re-probe and may classify <> as
+    // invalid given the comment-side stripping). The test exercises the
+    // V-upgrade path with a pre-populated reflection param.
+    target.reflection_params.push(Param {
+        name: "query".to_string(),
+        value: "a".to_string(),
+        location: Location::Query,
+        injection_context: Some(InjectionContext::Html(None)),
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+    });
+
+    let args = Arc::new(integration_scan_args(false));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        args,
+        results.clone(),
+        None,
+        None,
+        Arc::new(AtomicUsize::new(0)),
+        None,
+        None,
+    )
+    .await;
+
+    let guard = results.lock().await;
+    let verified: Vec<_> = guard
+        .iter()
+        .filter(|r| matches!(r.result_type, FindingType::Verified) && r.param == "query")
+        .collect();
+    assert!(
+        !verified.is_empty(),
+        "the realworld/level1 shape must produce at least one Verified finding on `query`; \
+         got {} total results: {:?}",
+        guard.len(),
+        guard.iter().map(|r| (&r.result_type, &r.param)).collect::<Vec<_>>()
+    );
+    // The evidence label should reflect the actual DOM evidence kind that
+    // fired, not the hard-coded "JS-context AST" string the prior code
+    // emitted unconditionally. The comment-breakout shape produces
+    // `HtmlStructural` → label "HTML element with sink"; other shapes
+    // may surface marker / executable-URL / JS-context.
+    let labels: Vec<_> = verified.iter().map(|r| r.evidence.as_str()).collect();
+    assert!(
+        labels.iter().any(|m| m.contains("HTML element with sink")
+            || m.contains("DOM marker")
+            || m.contains("javascript: URL in attribute")
+            || m.contains("JS-context AST")),
+        "V finding must carry a DomEvidenceKind label from classify_dom_evidence; got {:?}",
+        labels
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

- Replace `has_js_context_evidence` at the in-reflection static V upgrade site with the broader `classify_dom_evidence`, so HTML structural / DOM marker / executable-URL evidence carried in the same reflection response can promote R → V without a second HTTP request.
- Add regression tests pinning the contract: the Location-header wrapper still cannot trigger JS-context (regression for #958), the (element, attribute) exec-URL whitelist (#952) stays comprehensive, and the xssmaze `/realworld/level1` comment-stripping + raw-reflection shape now classifies as DOM evidence.
- Add an end-to-end `run_scanning` integration test (`test_run_scanning_realworld_level1_shape_promotes_to_verified`) that drives the full pipeline against an axum mock with the comment-stripping + raw `<h2>` shape and asserts at least one Verified finding for `query` with a `DomEvidenceKind` label — pinning the wire-up site, not just the underlying classifier.

## Why

The reflection-phase V upgrade only inspected JS-context evidence, so structural HTML evidence carried back in the same body could only be promoted to V via the dedicated `check_dom_verification` request — which uses adaptive `dom_payloads`. When a param's `invalid_specials` contains `<>` (because one of multiple reflection sites strips angles), `generate_adaptive_payloads` drops every HTML-tag payload, leaving no marker-bearing payload for DOM verification. On the xssmaze benchmark:

- `/realworld/level1` (`<!-- search: STRIPPED --><h2>RAW</h2>`) — 3045 R findings on deep-scan, zero V, despite the second reflection trivially admitting `<svg/onload=alert(1)>`.
- `/hpp/level1` (first value wins display, last is filter-checked) — R only, despite the body containing the unfiltered `<svg onload=…>`.

After this change, both endpoints surface V ("HTML element with sink") on the very first reflection-phase payload, without an extra HTTP request — the existing reflection response body is re-used.

The four anti-FP commits this builds on are preserved:

- 3xx body suppression (#952) lives in `verify_normal_dom`, upstream of the change.
- `<img src=javascript:…>` rejection (#952) lives inside `classify_dom_evidence` → `has_executable_url_attribute_evidence_in_doc` → `is_executable_url_attribute`, which still whitelists only browser-exec attributes.
- Entity-decoded reflections in safe contexts (#952) are still demoted upstream of `classify_reflection`.
- The Location-header HTML wrapper (#958) still defeats JS-context parsing inside the broader DOM evidence path.

## Output-string change for downstream parsers

Heads-up for anyone consuming the CLI plain-text output (JSON `inject_type`, `severity`, `cwe`, `message_id` `606` are all unchanged):

Previously the static V upgrade emitted, unconditionally:

- evidence: `DOM verification successful for param <p> (JS-context AST)`
- POC message: `Triggered XSS Payload (JS-context sink call): <p>=<payload>`

After this change those two strings are computed from `DomEvidenceKind::label()`, matching the labels the dedicated DOM-verify path already uses:

- `DOM marker`
- `javascript: URL in attribute`
- `HTML element with sink`
- `JS-context AST`

Downstream tooling that grep'd specifically for `"JS-context AST"` / `"JS-context sink call"` from this code path will only see those strings on the JS-context branch from now on; the other three labels will appear when the corresponding evidence kind fires. The structured JSON `evidence` field stays parsable, just with a wider label set — the same set the dedicated DOM-verify finding path already produces.

## Test plan

- [x] `cargo test --release -p dalfox --lib` — all 907 lib tests pass.
- [x] New `test_run_scanning_realworld_level1_shape_promotes_to_verified` drives the full `run_scanning` pipeline against an axum mock with the comment-stripping + raw `<h2>` shape and asserts the V upgrade fires with a `DomEvidenceKind` label.
- [x] Live: `dalfox url -u 'http://127.0.0.1:13013/realworld/level1/?query=a'` returns V ("HTML element with sink") on the first payload, where it previously returned 3045 R-only on `--deep-scan`.
- [x] Live: `dalfox url -u 'http://127.0.0.1:13013/hpp/level1/?query=safe&query=a'` returns V on the HPP duplicate-param URL (previously R-only).
- [x] Live: `dalfox url -u 'http://127.0.0.1:13013/redirect/level1/?query=a'` still returns R (no false-V regression of #958).
- [x] Live: a mock `<video src="$PAYLOAD">` reflection of `javascript:alert(1)` does NOT produce V (no regression of #952).
- [x] New regression tests in `check_dom_verification/tests.rs` and `js_context_verify/tests.rs` pin the new and preserved behaviors.