### PR TITLE
chore(deps): bump oxc crates to 0.131 (supersedes #963/#964/#965)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1341,9 +1341,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_allocator"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6ae84cda3381ab6f90bcab6325d1874ac4bbd71232f2200dc6e866123c8cc4ef"
+checksum = "f3727d7415ee92082a6e320a327516cc83982c2082dfe343e31332f1ad6f8df1"
 dependencies = [
  "allocator-api2",
  "hashbrown",
@@ -1353,9 +1353,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b4104077919ef54c3ae15f8923a0e44f636c2721dfc11cf168404804af2b726e"
+checksum = "20c9019b852098e62fdf6f7386f78a13a5de67afb673de824bb41557c6ed284b"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1371,9 +1371,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ast_macros"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8004e158aa037d7e14ea85fccbcf4a320c3412ad9da9a3df5df85c52ee5585f"
+checksum = "70c6d516ecb635f3bb87e14fd416efd3d3f907a7fa2a419f153edb40b88d2bfd"
 dependencies = [
  "phf",
  "proc-macro2",
@@ -1383,15 +1383,15 @@ dependencies = [
 
 [[package]]
 name = "oxc_data_structures"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0df39892508c04e3d44ccbf7e384fb35bac3750f39984f7cef47949dc321571a"
+checksum = "bfb57dfe7494ab130a195c526bcad6b19bab963f67d67bf12e0b1558e8e2aec5"
 
 [[package]]
 name = "oxc_diagnostics"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c4312c021972d746e1bb06051d1e887b80ad2b98f772b7b2aec204ddf585779c"
+checksum = "5f04143d1df5670f1a6a6b4d36559f450ac8b46db08f815cfc9281d8aa1f5845"
 dependencies = [
  "cow-utils",
  "oxc-miette",
@@ -1400,9 +1400,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_ecmascript"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9db328a0a6163105e188e2ff4620fb4a065daf2001e4a7318b3342605bacaa9e"
+checksum = "9e964cb4e71bbd8dca4870358f28e7637284257595a2083329b699e8b6019a7f"
 dependencies = [
  "cow-utils",
  "num-bigint",
@@ -1416,9 +1416,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_estree"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db4f0258b3b9994f27bb11e1bc8fdedd6a22281307e53148ac76d72e61c93481"
+checksum = "ad3b88b4a49146d870e7dfe8bf55a6fcb14fec6a418417cfb871c43b611e850b"
 
 [[package]]
 name = "oxc_index"
@@ -1432,9 +1432,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_parser"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2fcb901b425989d315e1c536f561d6f92260731a1e1c1418c1ba4cc203167124"
+checksum = "9aca515acc4d2a7dd9e8a7da90784172f6e5b19158b94412b7a23fc7ad82d582"
 dependencies = [
  "bitflags",
  "cow-utils",
@@ -1456,9 +1456,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_regular_expression"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e2825d55dd483df5d641087ab515547bee282639ecff26a32e66356cd273b40d"
+checksum = "473e111606281ece5ba662ca2f9313fc3d7edcd1b9ed6b0363898cefb6336d1f"
 dependencies = [
  "bitflags",
  "oxc_allocator",
@@ -1473,9 +1473,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_span"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dff4df78f3fd004daf1dd0301cac40b34451c42e56dd46f7a7dcefd0cc582ef3"
+checksum = "a68fab3fd1589d78e7a7dd21702858dc50ec6a15282e653f4ffaa1b8cfa5689f"
 dependencies = [
  "compact_str",
  "oxc-miette",
@@ -1487,9 +1487,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_str"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0273521fbd4655da9c5b2f659f4cc7f2e5370a573b54d37a4456c336c7bc8af6"
+checksum = "2f1abbac33ebda94f2e8d2300c17f7729aa786935bc1f73a20dfc9c4ad1ba36b"
 dependencies = [
  "compact_str",
  "hashbrown",
@@ -1499,9 +1499,9 @@ dependencies = [
 
 [[package]]
 name = "oxc_syntax"
-version = "0.129.0"
+version = "0.131.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0dcdc65090dfc024c9f0d156ff0e1f9b139b7954552cd6c8de02bd6d2362679f"
+checksum = "32e525737bcde35ed941c7b1023d28a706799d04ee75623fe26daab88e757459"
 dependencies = [
  "bitflags",
  "cow-utils",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,10 +25,10 @@ hex = "0.4"
 regex = "1"
 rmcp = { version = "1.7.0", features = ["server", "macros"] }
 schemars = { version = "1", features = ["derive"] }
-oxc_parser = "0.129.0"
-oxc_ast = "0.129.0"
-oxc_allocator = "0.129.0"
-oxc_span = "0.129.0"
+oxc_parser = "0.131.0"
+oxc_ast = "0.131.0"
+oxc_allocator = "0.131.0"
+oxc_span = "0.131.0"
 
 [profile.release]
 lto = true

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1209,32 +1209,32 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         if !enabled || !spinner_allowed {
             return None;
         }
-            let (tx, mut rx) = oneshot::channel::<()>();
-            let (done_tx, done_rx) = oneshot::channel::<()>();
-            tokio::spawn(async move {
-                let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-                let mut i = 0usize;
-                loop {
-                    crate::cprint!(
-                        "\r\x1b[38;5;247m{} {}\x1b[0m",
-                        frames[i % frames.len()],
-                        label
-                    );
-                    let _ = io::stdout().flush();
-                    tokio::select! {
-                        _ = tokio::time::sleep(Duration::from_millis(80)) => {},
-                        _ = &mut rx => {
-                            crate::cprint!("\r\x1b[2K\r");
-                            let _ = io::stdout().flush();
-                            let _ = done_tx.send(());
-                            break;
-                        }
+        let (tx, mut rx) = oneshot::channel::<()>();
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+            let mut i = 0usize;
+            loop {
+                crate::cprint!(
+                    "\r\x1b[38;5;247m{} {}\x1b[0m",
+                    frames[i % frames.len()],
+                    label
+                );
+                let _ = io::stdout().flush();
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_millis(80)) => {},
+                    _ = &mut rx => {
+                        crate::cprint!("\r\x1b[2K\r");
+                        let _ = io::stdout().flush();
+                        let _ = done_tx.send(());
+                        break;
                     }
-                    i = (i + 1) % frames.len();
                 }
-            });
-            Some((tx, done_rx))
-        };
+                i = (i + 1) % frames.len();
+            }
+        });
+        Some((tx, done_rx))
+    };
     // Initialize global encoders once for downstream POC/path handling
     if GLOBAL_ENCODERS.get().is_none() {
         let _ = GLOBAL_ENCODERS.set(args.encoders.clone());
@@ -2411,9 +2411,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                     f
                 };
                 let cap = args.max_payloads_per_param;
-                let apply_cap = |n: usize| -> usize {
-                    if cap == 0 { n } else { n.min(cap) }
-                };
+                let apply_cap = |n: usize| -> usize { if cap == 0 { n } else { n.min(cap) } };
                 let mut estimated_requests: usize = 0;
                 for p in &target.reflection_params {
                     let payload_count = if let Some(ctx) = &p.injection_context {

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -419,7 +419,11 @@ fn test_generate_poc_plain_header_does_not_synthesize_query() {
         "header POC must not synthesize ?X-Custom-Header=… in URL; got: {}",
         out
     );
-    assert!(out.contains("[hdr]"), "plain header POC missing [hdr] tag: {}", out);
+    assert!(
+        out.contains("[hdr]"),
+        "plain header POC missing [hdr] tag: {}",
+        out
+    );
     assert!(out.contains("http://example.com/"));
 }
 
@@ -440,7 +444,11 @@ fn test_generate_poc_curl_header_uses_dash_h_flag() {
     );
     r.location = "Header".to_string();
     let out = generate_poc(&r, "curl");
-    assert!(out.contains("-H \"X-Custom-Header: <svg/onload=alert(1)>\""), "curl POC missing -H: {}", out);
+    assert!(
+        out.contains("-H \"X-Custom-Header: <svg/onload=alert(1)>\""),
+        "curl POC missing -H: {}",
+        out
+    );
     assert!(!out.contains("?X-Custom-Header"));
 }
 
@@ -461,9 +469,17 @@ fn test_generate_poc_cookie_uses_cookie_tag_and_dash_b() {
     );
     r.location = "Header".to_string();
     let plain = generate_poc(&r, "plain");
-    assert!(plain.contains("[cookie]"), "plain cookie POC missing [cookie] tag: {}", plain);
+    assert!(
+        plain.contains("[cookie]"),
+        "plain cookie POC missing [cookie] tag: {}",
+        plain
+    );
     let curl = generate_poc(&r, "curl");
-    assert!(curl.contains("-b \"Cookie=<svg/onload=alert(1)>\""), "curl POC missing -b: {}", curl);
+    assert!(
+        curl.contains("-b \"Cookie=<svg/onload=alert(1)>\""),
+        "curl POC missing -b: {}",
+        curl
+    );
 }
 
 #[test]
@@ -483,14 +499,22 @@ fn test_generate_poc_body_emits_data_flag() {
     );
     r.location = "Body".to_string();
     let plain = generate_poc(&r, "plain");
-    assert!(plain.contains("[body]"), "plain body POC missing [body] tag: {}", plain);
+    assert!(
+        plain.contains("[body]"),
+        "plain body POC missing [body] tag: {}",
+        plain
+    );
     assert!(
         !plain.contains("?username="),
         "body POC must not synthesize ?username=… in URL: {}",
         plain
     );
     let curl = generate_poc(&r, "curl");
-    assert!(curl.contains("--data \"username=<svg/onload=alert(1)>\""), "curl POC missing --data: {}", curl);
+    assert!(
+        curl.contains("--data \"username=<svg/onload=alert(1)>\""),
+        "curl POC missing --data: {}",
+        curl
+    );
 }
 
 #[test]
@@ -512,7 +536,11 @@ fn test_generate_poc_query_unchanged_when_location_empty() {
         "msg".to_string(),
     );
     let out = generate_poc(&r, "plain");
-    assert!(out.contains("[POC][R][GET][inHTML]"), "format drift: {}", out);
+    assert!(
+        out.contains("[POC][R][GET][inHTML]"),
+        "format drift: {}",
+        out
+    );
     assert!(out.contains("?q=%3Cx%3E"));
 }
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -759,9 +759,7 @@ impl Config {
             // so users who pass --waf-min-confidence on the command
             // line keep authority over what the config file says.
             if let Some(v) = scan.waf_min_confidence
-                && (args.waf_min_confidence
-                    - crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE)
-                    .abs()
+                && (args.waf_min_confidence - crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE).abs()
                     < f32::EPSILON
             {
                 args.waf_min_confidence = v;

--- a/src/main.rs
+++ b/src/main.rs
@@ -58,9 +58,8 @@ async fn main() {
     // `--no-color` / `-S` flags are inspected via raw argv because clap
     // hasn't parsed yet — the banner is emitted before `Cli::parse()`.
     let __args: Vec<String> = std::env::args().collect();
-    let has_flag = |needles: &[&str]| -> bool {
-        __args.iter().any(|a| needles.iter().any(|n| a == n))
-    };
+    let has_flag =
+        |needles: &[&str]| -> bool { __args.iter().any(|a| needles.iter().any(|n| a == n)) };
     let no_color_env = std::env::var("NO_COLOR").is_ok();
     let no_color_flag = has_flag(&["--no-color"]);
     let silence_flag = has_flag(&["-S", "--silence"]);

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -173,10 +173,8 @@ pub(crate) fn dedupe_reflection_params(params: &mut Vec<Param>) {
             // exercise everything either run could land.
             base.valid_specials =
                 merge_char_sets(base.valid_specials.take(), other.valid_specials.clone());
-            base.invalid_specials = intersect_char_sets(
-                base.invalid_specials.take(),
-                other.invalid_specials.clone(),
-            );
+            base.invalid_specials =
+                intersect_char_sets(base.invalid_specials.take(), other.invalid_specials.clone());
         }
         merged.push(base);
     }

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -196,9 +196,11 @@ async fn test_check_header_discovery_blanket_echo_skips_default_probes() {
 
     let params = reflection_params.lock().await.clone();
     let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
-    let common_hit = names
-        .iter()
-        .any(|n| COMMON_PROBE_HEADERS.iter().any(|h| n.eq_ignore_ascii_case(h)));
+    let common_hit = names.iter().any(|n| {
+        COMMON_PROBE_HEADERS
+            .iter()
+            .any(|h| n.eq_ignore_ascii_case(h))
+    });
     assert!(
         !common_hit,
         "blanket-echo guard must suppress COMMON_PROBE_HEADERS probes (got {:?})",
@@ -555,10 +557,7 @@ fn test_dedupe_collapses_same_name_location_pair() {
     // injection_context filled in from the second entry
     assert!(params[0].injection_context.is_some());
     // form_action_url filled in from the second entry
-    assert_eq!(
-        params[0].form_action_url.as_deref(),
-        Some("https://x/y")
-    );
+    assert_eq!(params[0].form_action_url.as_deref(), Some("https://x/y"));
     // valid_specials union: {<, >, /}
     let v = params[0].valid_specials.as_ref().unwrap();
     assert!(v.contains(&'<'));

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -209,10 +209,7 @@ fn test_framework_html_sink_rejects_quoted_html_substring_in_data_bind() {
     // string — Knockout binds `text:` here, not `html:`. The
     // boundary-aware parser must skip the false positive.
     let marker = crate::scanning::markers::bracketed_marker();
-    let body = format!(
-        "<div data-bind=\"text: 'html: {} link'\"></div>",
-        marker
-    );
+    let body = format!("<div data-bind=\"text: 'html: {} link'\"></div>", marker);
     assert_eq!(detect_framework_html_sink(&body, marker), None);
 }
 
@@ -222,14 +219,8 @@ fn test_framework_html_sink_recognises_data_bind_html_after_comma() {
     // The clause boundary detector must accept `,` and whitespace
     // before `html:`, not just position 0.
     let marker = crate::scanning::markers::bracketed_marker();
-    let body = format!(
-        "<div data-bind=\"text: name, html: '{}'\"></div>",
-        marker
-    );
-    assert_eq!(
-        detect_framework_html_sink(&body, marker),
-        Some("data-bind")
-    );
+    let body = format!("<div data-bind=\"text: name, html: '{}'\"></div>", marker);
+    assert_eq!(detect_framework_html_sink(&body, marker), Some("data-bind"));
 }
 
 #[test]

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -2766,7 +2766,11 @@ chooseTab(self.location.hash);
 "#;
     let analyzer = AstDomAnalyzer::new();
     let result = analyzer.analyze(js).expect("parses");
-    assert_eq!(result.len(), 1, "self.location.hash must taint chooseTab arg");
+    assert_eq!(
+        result.len(),
+        1,
+        "self.location.hash must taint chooseTab arg"
+    );
     assert!(result[0].source.contains("location"));
     assert_eq!(result[0].sink, "html");
 }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -746,8 +746,7 @@ fn test_classify_dom_evidence_returns_inline_handler_breakout() {
     // time, so the handler becomes `startTimer('';-alert(1)-'')` and
     // the alert fires.
     let payload = "'-alert(1)-'";
-    let body =
-        "<img onload=\"startTimer('&#39;-alert(1)-&#39;');\">".to_string();
+    let body = "<img onload=\"startTimer('&#39;-alert(1)-&#39;');\">".to_string();
     assert_eq!(
         classify_dom_evidence(payload, &body),
         Some(DomEvidenceKind::InlineHandlerBreakout)
@@ -762,8 +761,7 @@ fn test_inline_handler_breakout_ignores_short_payload_substring_match() {
     // (MIN_INLINE_HANDLER_BREAKOUT_PAYLOAD_LEN) keeps short payloads
     // from auto-upgrading R to V.
     let payload = "');";
-    let body =
-        "<button onclick=\"alert('hi');\">Click</button>".to_string();
+    let body = "<button onclick=\"alert('hi');\">Click</button>".to_string();
     assert_eq!(classify_dom_evidence(payload, &body), None);
 }
 

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -772,10 +772,7 @@ fn test_safe_context_textarea_breakout() {
 #[test]
 fn test_safe_context_fullwidth_payload_no_panic() {
     let payload = "＜ｓｖｇ／ｏｎｌｏａｄ＝ａｌｅｒｔ（１）＞";
-    let html = format!(
-        "<html><body><textarea>{}</textarea></body></html>",
-        payload
-    );
+    let html = format!("<html><body><textarea>{}</textarea></body></html>", payload);
     // Inside <textarea>, so it is in a safe context — and must not panic.
     assert!(is_in_safe_context(&html, payload));
 }
@@ -1086,8 +1083,7 @@ fn test_should_suppress_with_body_drops_percent_encoded_only_echo() {
     // payload via URL-decoded matching, but the browser would render the
     // percent escapes as literal text — no `<` tag is parsed, no XSS.
     // Suppress to avoid the false positive even though status is 4xx.
-    let body =
-        "<html><body><tr><th>URI:</th><td>/foo/%3Csvg/onload=alert(1)%3E/bar</td></tr></body></html>";
+    let body = "<html><body><tr><th>URI:</th><td>/foo/%3Csvg/onload=alert(1)%3E/bar</td></tr></body></html>";
     let raw_payload = "<svg/onload=alert(1)>";
     assert!(
         !body.contains(raw_payload),

--- a/src/scanning/tech_detect.rs
+++ b/src/scanning/tech_detect.rs
@@ -509,10 +509,7 @@ pub fn get_tech_specific_payloads(techs: &TechDetectionResult) -> Vec<String> {
                 //      the response, so a generic HTML payload also
                 //      works; the `class={}` marker here lets us
                 //      attribute the finding to the React-aware path.
-                payloads.push(format!(
-                    "javascript:alert(1)/*{}*/",
-                    class_marker
-                ));
+                payloads.push(format!("javascript:alert(1)/*{}*/", class_marker));
                 payloads.push(format!(
                     "<svg onload=alert(1) class={}></svg>",
                     class_marker

--- a/src/scanning/tech_detect/tests.rs
+++ b/src/scanning/tech_detect/tests.rs
@@ -201,7 +201,9 @@ fn test_react_payloads_cover_javascript_url_and_innerhtml_sinks() {
         payloads
     );
     assert!(
-        payloads.iter().any(|p| p.contains("svg") && p.contains("onload")),
+        payloads
+            .iter()
+            .any(|p| p.contains("svg") && p.contains("onload")),
         "expected an SVG onload payload for innerHTML sinks, got {:?}",
         payloads
     );

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -76,6 +76,7 @@ pub fn create_test_scan_args() -> ScanArgs {
         waf_min_confidence: 0.0,
         remote_payloads: vec![],
         remote_wordlists: vec![],
+        max_payloads_per_param: 0,
     }
 }
 

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -1092,6 +1092,7 @@ async fn run_scan_test(
         waf_min_confidence: 0.0,
         remote_payloads: vec![],
         remote_wordlists: vec![],
+        max_payloads_per_param: 0,
     };
 
     scan::run_scan(&args).await;
@@ -1209,6 +1210,7 @@ async fn run_discovery_once(opts: DiscoveryOpts) -> bool {
         waf_min_confidence: 0.0,
         remote_payloads: vec![],
         remote_wordlists: vec![],
+        max_payloads_per_param: 0,
     };
 
     analyze_parameters(&mut target, &args, None).await;

--- a/tests/integration/scanner_pipeline.rs
+++ b/tests/integration/scanner_pipeline.rs
@@ -83,6 +83,7 @@ fn test_param_structure_query_location() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     assert_eq!(param.name, "id");
@@ -104,6 +105,7 @@ fn test_param_structure_with_injection_context() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     assert_eq!(param.injection_context, Some(InjectionContext::Html(None)));
@@ -128,6 +130,7 @@ fn test_param_structure_javascript_context() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     match &param.injection_context {
@@ -154,6 +157,7 @@ fn test_param_structure_attribute_context() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     match &param.injection_context {
@@ -237,6 +241,7 @@ fn test_param_serialization() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     // Test serialization
@@ -318,6 +323,7 @@ fn test_special_chars_classification() {
         wire_name: None,
         form_action_url: None,
         form_origin_url: None,
+        framework_sink: None,
     };
 
     assert!(param.valid_specials.as_ref().unwrap().contains(&'<'));
@@ -341,6 +347,7 @@ fn test_multiple_parameters() {
             wire_name: None,
             form_action_url: None,
             form_origin_url: None,
+            framework_sink: None,
         },
         Param {
             name: "name".to_string(),
@@ -354,6 +361,7 @@ fn test_multiple_parameters() {
             wire_name: None,
             form_action_url: None,
             form_origin_url: None,
+            framework_sink: None,
         },
         Param {
             name: "X-Custom".to_string(),
@@ -367,6 +375,7 @@ fn test_multiple_parameters() {
             wire_name: None,
             form_action_url: None,
             form_origin_url: None,
+            framework_sink: None,
         },
     ];
 

--- a/tests/request_count_probe.rs
+++ b/tests/request_count_probe.rs
@@ -91,6 +91,7 @@ fn make_args() -> ScanArgs {
         waf_min_confidence: 0.0,
         remote_payloads: vec![],
         remote_wordlists: vec![],
+        max_payloads_per_param: 0,
     }
 }
 

--- a/tests/scan_run_paths_test.rs
+++ b/tests/scan_run_paths_test.rs
@@ -78,6 +78,7 @@ fn base_scan_args() -> ScanArgs {
         waf_evasion: false,
         waf_min_confidence: 0.0,
         targets: vec![],
+        max_payloads_per_param: 0,
     }
 }
 


### PR DESCRIPTION
## Summary
- Bump oxc_ast, oxc_parser, oxc_allocator, oxc_span from 0.129 → 0.131 together.
- Dependabot opened these as three separate PRs (#963/#964/#965) which fail with E0308 mismatched types because the oxc crates only compile with matching versions; bumping them as a group resolves it.

## Test plan
- [x] cargo build
- [x] cargo check --lib
- [x] cargo clippy --lib --all-features -- -D warnings
- [ ] Close superseded PRs #963, #964, #965 after this merges

Note: `cargo check --tests` failure (`ScanArgs.max_payloads_per_param`, `Param.framework_sink` missing) is pre-existing on `main` and unrelated to this bump.