### PR TITLE
fix(mcp): validate workers range in scan_with_dalfox

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -41,8 +41,8 @@ use rmcp::{
 use crate::{
     cmd::JobStatus,
     cmd::job::{
-        JOB_RETENTION_SECS, Job, MAX_DELAY_MS, MAX_TIMEOUT_SECS, now_ms, parse_job_status,
-        purge_expired_jobs as purge_jobs_map, send_reachability_probe,
+        JOB_RETENTION_SECS, Job, MAX_DELAY_MS, MAX_TIMEOUT_SECS, MAX_WORKERS, now_ms,
+        parse_job_status, purge_expired_jobs as purge_jobs_map, send_reachability_probe,
     },
     cmd::scan::ScanArgs,
     parameter_analysis::analyze_parameters,
@@ -658,6 +658,21 @@ Final results (via get_results_dalfox) include finding type \
                 format!(
                     "delay must be between 0 and {} ms (got {})",
                     MAX_DELAY_MS, delay
+                ),
+                None,
+            ));
+        }
+        if workers == 0 {
+            return Err(ErrorData::invalid_params(
+                "workers must be at least 1",
+                None,
+            ));
+        }
+        if workers > MAX_WORKERS {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "workers must be at most {} (got {})",
+                    MAX_WORKERS, workers
                 ),
                 None,
             ));

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -662,16 +662,10 @@ Final results (via get_results_dalfox) include finding type \
                 None,
             ));
         }
-        if workers == 0 {
-            return Err(ErrorData::invalid_params(
-                "workers must be at least 1",
-                None,
-            ));
-        }
-        if workers > MAX_WORKERS {
+        if workers == 0 || workers > MAX_WORKERS {
             return Err(ErrorData::invalid_params(
                 format!(
-                    "workers must be at most {} (got {})",
+                    "workers must be between 1 and {} (got {})",
                     MAX_WORKERS, workers
                 ),
                 None,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -837,6 +837,48 @@ async fn test_tick_waf_block_is_scoped_per_job() {
 }
 
 #[tokio::test]
+async fn test_scan_with_dalfox_rejects_zero_workers() {
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        workers: 0,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    let err = mcp
+        .scan_with_dalfox(Parameters(params))
+        .await
+        .expect_err("zero workers must be rejected");
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("workers must be at least 1"));
+}
+
+#[tokio::test]
+async fn test_scan_with_dalfox_rejects_workers_over_max() {
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        workers: MAX_WORKERS + 1,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    let err = mcp
+        .scan_with_dalfox(Parameters(params))
+        .await
+        .expect_err("workers over MAX_WORKERS must be rejected");
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("workers must be at most"));
+}
+
+#[tokio::test]
+async fn test_scan_with_dalfox_accepts_workers_at_max() {
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        workers: MAX_WORKERS,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    mcp.scan_with_dalfox(Parameters(params))
+        .await
+        .expect("workers == MAX_WORKERS must be accepted");
+}
+
+#[tokio::test]
 async fn test_purge_expired_jobs_removes_old_terminal_jobs() {
     let mcp = DalfoxMcp::new();
     {

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -848,7 +848,7 @@ async fn test_scan_with_dalfox_rejects_zero_workers() {
         .await
         .expect_err("zero workers must be rejected");
     assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
-    assert!(err.message.contains("workers must be at least 1"));
+    assert!(err.message.contains("workers must be between"));
 }
 
 #[tokio::test]
@@ -863,7 +863,7 @@ async fn test_scan_with_dalfox_rejects_workers_over_max() {
         .await
         .expect_err("workers over MAX_WORKERS must be rejected");
     assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
-    assert!(err.message.contains("workers must be at most"));
+    assert!(err.message.contains("workers must be between"));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- The MCP `scan_with_dalfox` tool validated `timeout` and `delay` but accepted any `workers` value.
- `workers = 0` would have flowed into `target.workers` and stalled scanning semaphores; values above `MAX_WORKERS` (500) bypassed the cap the CLI enforces via `validate_numeric_args` (src/cmd/scan.rs:1082).
- Added the same range check (1..=MAX_WORKERS) to the MCP path, reusing the existing `MAX_WORKERS` constant from `cmd/job.rs`.

## Test plan
- [x] \`cargo test --lib mcp::tests\` — 39 tests pass (3 new: \`rejects_zero_workers\`, \`rejects_workers_over_max\`, \`accepts_workers_at_max\`).
- [x] \`cargo clippy --lib --tests -- -D warnings\` clean.