### PR TITLE
perf(discovery): cut path-segment scan request count ~17x on noisy 404s

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2619,19 +2619,16 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 let mut total_overall_tasks = 0u64;
                 for target in &group {
                     for param in &target.reflection_params {
-                        let reflection_payloads =
-                            if let Some(context) = &param.injection_context {
-                                crate::scanning::xss_common::get_dynamic_payloads(
-                                    context, &args_arc,
-                                )
+                        let reflection_payloads = if let Some(context) = &param.injection_context {
+                            crate::scanning::xss_common::get_dynamic_payloads(context, &args_arc)
                                 .unwrap_or_else(|_| vec![])
-                            } else {
-                                crate::scanning::xss_common::get_dynamic_payloads(
-                                    &crate::parameter_analysis::InjectionContext::Html(None),
-                                    &args_arc,
-                                )
-                                .unwrap_or_else(|_| vec![])
-                            };
+                        } else {
+                            crate::scanning::xss_common::get_dynamic_payloads(
+                                &crate::parameter_analysis::InjectionContext::Html(None),
+                                &args_arc,
+                            )
+                            .unwrap_or_else(|_| vec![])
+                        };
                         let dom_payloads = crate::scanning::get_dom_payloads(param, &args_arc)
                             .unwrap_or_else(|_| vec![]);
                         total_overall_tasks +=

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2605,33 +2605,39 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         let scan_idx = scan_idx.clone();
         let overall_done_clone = overall_done.clone();
         let group_handle = tokio::spawn(async move {
-            // Calculate total overall tasks for this group. Must mirror what
-            // run_scanning actually increments — one tick per reflection
-            // payload, one per DOM payload — otherwise the overall bar rolls
-            // past 100% (the previous reflection-only count was the cause).
-            let mut total_overall_tasks = 0u64;
-            for target in &group {
-                for param in &target.reflection_params {
-                    let reflection_payloads = if let Some(context) = &param.injection_context {
-                        crate::scanning::xss_common::get_dynamic_payloads(context, &args_arc)
-                            .unwrap_or_else(|_| vec![])
-                    } else {
-                        crate::scanning::xss_common::get_dynamic_payloads(
-                            &crate::parameter_analysis::InjectionContext::Html(None),
-                            &args_arc,
-                        )
-                        .unwrap_or_else(|_| vec![])
-                    };
-                    let dom_payloads = crate::scanning::get_dom_payloads(param, &args_arc)
-                        .unwrap_or_else(|_| vec![]);
-                    total_overall_tasks +=
-                        reflection_payloads.len() as u64 + dom_payloads.len() as u64;
-                }
-            }
-
-            let overall_pb: Option<Arc<Mutex<indicatif::ProgressBar>>> = if let Some(ref mp) =
+            // Skip the (expensive) payload-counting loop entirely when no
+            // overall progress bar will be drawn — generating ~10k payloads
+            // per param twice (here and again inside run_scanning) added a
+            // measurable CPU tax for every --silence / non-TTY scan.
+            let overall_pb: Option<Arc<indicatif::ProgressBar>> = if let Some(ref mp) =
                 multi_pb_clone
             {
+                // Calculate total overall tasks for this group. Must mirror what
+                // run_scanning actually increments — one tick per reflection
+                // payload, one per DOM payload — otherwise the overall bar rolls
+                // past 100% (the previous reflection-only count was the cause).
+                let mut total_overall_tasks = 0u64;
+                for target in &group {
+                    for param in &target.reflection_params {
+                        let reflection_payloads =
+                            if let Some(context) = &param.injection_context {
+                                crate::scanning::xss_common::get_dynamic_payloads(
+                                    context, &args_arc,
+                                )
+                                .unwrap_or_else(|_| vec![])
+                            } else {
+                                crate::scanning::xss_common::get_dynamic_payloads(
+                                    &crate::parameter_analysis::InjectionContext::Html(None),
+                                    &args_arc,
+                                )
+                                .unwrap_or_else(|_| vec![])
+                            };
+                        let dom_payloads = crate::scanning::get_dom_payloads(param, &args_arc)
+                            .unwrap_or_else(|_| vec![]);
+                        total_overall_tasks +=
+                            reflection_payloads.len() as u64 + dom_payloads.len() as u64;
+                    }
+                }
                 let pb = mp.add(indicatif::ProgressBar::new(total_overall_tasks));
                 // See `crate::scanning::req_per_sec_tracker` for why we
                 // replace `{per_sec}` (pb-position rate, inflated by
@@ -2649,7 +2655,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                         .progress_chars("#>-"),
                 );
                 pb.enable_steady_tick(Duration::from_millis(120));
-                Some(Arc::new(Mutex::new(pb)))
+                Some(Arc::new(pb))
             } else {
                 None
             };
@@ -2725,9 +2731,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
             }
 
             if let Some(pb) = overall_pb {
-                pb.lock()
-                    .await
-                    .finish_with_message(format!("All scanning completed for {}", host));
+                pb.finish_with_message(format!("All scanning completed for {}", host));
             }
         });
         group_handles.push(group_handle);

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -925,11 +925,8 @@ pub async fn check_path_discovery(
                     // URL paths, so the trade-off is acceptable; if it surfaces
                     // in benchmarks, swap to the `ascii_ci_contains` helper used
                     // by `check_reflection::marker_case_fold_reflected`.
-                    let bracket_survives = if exploitable_context
-                        && !(200..300).contains(&status)
-                    {
-                        let needle =
-                            format!("<{}>", crate::scanning::markers::bracketed_marker());
+                    let bracket_survives = if exploitable_context && !(200..300).contains(&status) {
+                        let needle = format!("<{}>", crate::scanning::markers::bracketed_marker());
                         let probe = crate::utils::build_request(
                             &client_clone,
                             &target_clone,

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -916,6 +916,15 @@ pub async fn check_path_discovery(
                     // entity-escapes either bracket, no HTML-tag payload
                     // will ever reflect — keeping the segment would burn
                     // thousands of requests on guaranteed-negative payloads.
+                    //
+                    // Known limitation: `t.contains(&needle)` is case-sensitive,
+                    // so a server that ASCII-uppercases / -lowercases reflected
+                    // path bytes (e.g. xssmaze's `obfuscation/level2` shape, but
+                    // applied to a 4xx path-echo) would slip past this gate and
+                    // get treated as inert. Real-world servers rarely case-fold
+                    // URL paths, so the trade-off is acceptable; if it surfaces
+                    // in benchmarks, swap to the `ascii_ci_contains` helper used
+                    // by `check_reflection::marker_case_fold_reflected`.
                     let bracket_survives = if exploitable_context
                         && !(200..300).contains(&status)
                     {

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -832,6 +832,20 @@ pub async fn check_path_discovery(
         let mut new_url = target.url.clone();
         new_url.set_path(&new_path);
 
+        // For non-2xx responses, the URL-attr-only filter above keeps any path
+        // reflection that lands in text content — including 404 templates like
+        // `<span class='path'>/{uri}/</span>` where the server HTML-escapes
+        // every `<` and `>` before echoing. Treating those as scannable made
+        // path-segment params dominate the wall time on real benchmarks (xssmaze:
+        // ~99% of requests with zero true positives). The bracket-wrapped
+        // probe below is sent only when the first probe says non-2xx +
+        // exploitable_context, and we keep the path-segment registration only
+        // if the response contains the literal `<MARKER>` substring — i.e. `<`
+        // and `>` both survived reflection without entity-escaping.
+        let bracket_path = new_path.replace(test_value, &format!("%3C{}%3E", test_value));
+        let mut bracket_url = target.url.clone();
+        bracket_url.set_path(&bracket_path);
+
         let client_clone = client.clone();
         let data = target.data.clone();
         let parsed_method = target.parse_method();
@@ -859,8 +873,13 @@ pub async fn check_path_discovery(
                 .await
                 .expect("acquire semaphore permit");
             let m = parsed_method;
-            let request =
-                crate::utils::build_request(&client_clone, &target_clone, m, new_url, data.clone());
+            let request = crate::utils::build_request(
+                &client_clone,
+                &target_clone,
+                m.clone(),
+                new_url,
+                data.clone(),
+            );
 
             crate::tick_request_count();
             let mut discovered: Option<Param> = None;
@@ -890,7 +909,37 @@ pub async fn check_path_discovery(
                             &text,
                             crate::scanning::markers::bracketed_marker(),
                         );
-                    if exploitable_context {
+                    // For 4xx/5xx error pages whose templates echo the URL
+                    // path into text content, require the second probe
+                    // (`<MARKER>`) to come back with raw `<` and `>` before
+                    // declaring the segment scannable. If the server
+                    // entity-escapes either bracket, no HTML-tag payload
+                    // will ever reflect — keeping the segment would burn
+                    // thousands of requests on guaranteed-negative payloads.
+                    let bracket_survives = if exploitable_context
+                        && !(200..300).contains(&status)
+                    {
+                        let needle =
+                            format!("<{}>", crate::scanning::markers::bracketed_marker());
+                        let probe = crate::utils::build_request(
+                            &client_clone,
+                            &target_clone,
+                            m.clone(),
+                            bracket_url,
+                            data.clone(),
+                        );
+                        crate::tick_request_count();
+                        match probe.send().await {
+                            Ok(r) => match r.text().await {
+                                Ok(t) => t.contains(&needle),
+                                Err(_) => false,
+                            },
+                            Err(_) => false,
+                        }
+                    } else {
+                        true
+                    };
+                    if exploitable_context && bracket_survives {
                         let (valid, invalid) = classify_special_chars(&text);
                         discovered = Some(Param {
                             name: param_name,

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -348,11 +348,18 @@ async fn test_check_discovery_skip_discovery_true_keeps_empty() {
 /// echoed in an HTML `<td>...</td>` — exploitable text-content context.
 async fn start_404_td_echo_mock_server() -> SocketAddr {
     async fn echo_404(uri: Uri) -> (axum::http::StatusCode, String) {
+        // Mirror a real "exploitable" 404 template: server decodes the
+        // URL path (`%3C` → `<`) before emitting it into the response.
+        // Without that decode, the bracket-survival probe used by
+        // `check_path_discovery` correctly skips the endpoint as
+        // structurally inert, which would defeat this test's intent.
+        let decoded =
+            urlencoding::decode(uri.path()).map(|c| c.into_owned()).unwrap_or_else(|_| uri.path().to_string());
         (
             axum::http::StatusCode::NOT_FOUND,
             format!(
                 "<html><body><tr><th>URI:</th><td>{}</td></tr></body></html>",
-                uri.path()
+                decoded
             ),
         )
     }

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -380,6 +380,48 @@ async fn start_404_td_echo_mock_server() -> SocketAddr {
     addr
 }
 
+/// Mock that mimics the xssmaze 404 template: path echoed inside a
+/// `<span>` text-content element with `<` / `>` HTML-entity-escaped.
+/// The URL-attr-only filter keeps this candidate (text content, not a
+/// URL attribute), so it's the bracket-survival probe that has to
+/// reject it — without that gate, every 4xx error page like this
+/// would burn the full payload set on guaranteed-negative requests.
+async fn start_404_escaped_text_echo_mock_server() -> SocketAddr {
+    async fn echo_404(uri: Uri) -> (axum::http::StatusCode, String) {
+        // Decode the percent-encoded path first (mirrors a real
+        // template's URL parsing) and then HTML-entity-escape the
+        // brackets the way `html_escape`-style helpers do. The result:
+        // the marker survives but `<MARKER>` shows up as `&lt;MARKER&gt;`,
+        // so the structural probe should treat the segment as inert.
+        let decoded = urlencoding::decode(uri.path())
+            .map(|c| c.into_owned())
+            .unwrap_or_else(|_| uri.path().to_string());
+        let escaped = decoded.replace('<', "&lt;").replace('>', "&gt;");
+        (
+            axum::http::StatusCode::NOT_FOUND,
+            format!(
+                "<html><body><span class='path'>{}</span></body></html>",
+                escaped
+            ),
+        )
+    }
+    async fn ok_root() -> &'static str {
+        "ok"
+    }
+    let app = Router::new()
+        .route("/", any(ok_root))
+        .fallback(any(echo_404));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
 /// Mock that mimics a generic 404 page echoing the path only inside an
 /// `<a href>` breadcrumb — URL-attribute echo with no script-execution
 /// surface, the noise pattern that should still be suppressed.
@@ -432,6 +474,30 @@ async fn test_check_path_discovery_keeps_exploitable_404_td_echo() {
         names.contains(&"path_segment_0"),
         "exploitable 404 td-echo path discovery must surface path_segment_0 (got {:?})",
         names
+    );
+}
+
+#[tokio::test]
+async fn test_check_path_discovery_drops_escaped_text_echo_404() {
+    // xssmaze-style 404 page: server decodes `%3C` but then HTML-entity-
+    // escapes the brackets before emitting them into text content. The
+    // URL-attr-only filter keeps the candidate (it's not a URL attribute),
+    // so this case is the bracket-survival probe's contract: `<MARKER>`
+    // never appears literally in the response, so no tag-shaped payload
+    // can ever land — discovery must skip the segment.
+    let addr = start_404_escaped_text_echo_mock_server().await;
+    let mut target = parse_target(&format!("http://{}/no/such/route", addr)).unwrap();
+    target.delay = 1;
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(Semaphore::new(1));
+    check_path_discovery(&target, reflection_params.clone(), semaphore).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params.is_empty(),
+        "bracket-escaped 404 echo must NOT surface path segments (got {:?})",
+        params.iter().map(|p| &p.name).collect::<Vec<_>>()
     );
 }
 

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -353,8 +353,9 @@ async fn start_404_td_echo_mock_server() -> SocketAddr {
         // Without that decode, the bracket-survival probe used by
         // `check_path_discovery` correctly skips the endpoint as
         // structurally inert, which would defeat this test's intent.
-        let decoded =
-            urlencoding::decode(uri.path()).map(|c| c.into_owned()).unwrap_or_else(|_| uri.path().to_string());
+        let decoded = urlencoding::decode(uri.path())
+            .map(|c| c.into_owned())
+            .unwrap_or_else(|_| uri.path().to_string());
         (
             axum::http::StatusCode::NOT_FOUND,
             format!(

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -518,7 +518,7 @@ pub async fn run_scanning(
     args: Arc<ScanArgs>,
     results: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
     multi_pb: Option<Arc<MultiProgress>>,
-    overall_pb: Option<Arc<Mutex<indicatif::ProgressBar>>>,
+    overall_pb: Option<Arc<indicatif::ProgressBar>>,
     findings_count: Arc<AtomicUsize>,
     cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
     finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
@@ -913,7 +913,7 @@ pub async fn run_scanning(
                     pb.inc(1);
                 }
                 if let Some(ref opb) = overall_pb_clone {
-                    opb.lock().await.inc(1);
+                    opb.inc(1);
                 }
                 if let Some(kind) = reflected_kind {
                     let should_add = if args_clone.deep_scan {
@@ -1074,7 +1074,7 @@ pub async fn run_scanning(
                         pb.inc(1);
                     }
                     if let Some(ref opb) = overall_pb_clone {
-                        opb.lock().await.inc(1);
+                        opb.inc(1);
                     }
                     continue;
                 }
@@ -1162,7 +1162,7 @@ pub async fn run_scanning(
                     pb.inc(1);
                 }
                 if let Some(ref opb) = overall_pb_clone {
-                    opb.lock().await.inc(1);
+                    opb.inc(1);
                 }
             }
             // HPP (HTTP Parameter Pollution) phase: test duplicate-param URLs


### PR DESCRIPTION
## Summary

- Generic 4xx/5xx templates that echo the URL path into text content (e.g. `<span class='path'>/{uri}/</span>`) were registering every path segment as a reflection_param. Servers that HTML-escape `<`/`>` make any tag-shaped payload structurally unreachable, but the scanner still sent the full payload set against each segment — dominating wall time and request count on any target with a verbose 404 template.
- `check_path_discovery` now sends one structural probe with `%3CMARKER%3E` after the existing URL-attr-only filter passes. The segment is kept only when the response contains literal `<MARKER>` — i.e. `<` and `>` both survived the round trip without entity-escaping or stayed-percent-encoded round-tripping.
- Cleanup: drop the dead `Arc<Mutex<ProgressBar>>` wrap (indicatif is internally synchronized) and skip the group's `total_overall_tasks` payload-counting loop when no overall bar will be drawn (`--silence` / non-TTY).

## Measurement (xssmaze, `--workers 1 --max-concurrent-targets 1`)

895 endpoints:

|        | before    | after   | delta |
|--------|-----------|---------|-------|
| wall   | 857s      | 65.8s   | 13× faster |
| reqs   | 9,695,435 | 571,379 | 17× fewer |
| finds  | 937       | 936     | −1 (non-exploitable R; see below) |

50 endpoints, three runs:
- workers=1: 47s → 0.83–0.95s (~50×)
- workers=10, conc=5: 19s → 0.29–0.53s (~50×)

## Detection impact

One R finding is dropped: `javascript:alert(1)/*MARKER*/` reflected inside `<span class='path'>` text content on a 404 page. The server escapes `<`/`>`, so the scheme is just text — there is no DOM sink. All V findings and 936/937 R findings are preserved.

The discovery test mock for the exploitable-404-`<td>`-echo case now URL-decodes the path before echoing — real exploitable templates decode `%3C` → `<` before reflecting, and without that decode the new probe would correctly classify the old mock as inert.

## Test plan

- [x] `cargo test --release --lib` — 998 passing
- [x] Diff full xssmaze (895 endpoints) finding sets before/after, normalized by per-run marker
- [x] Variance check on 50-URL subset across sequential and parallel worker configs