### PR TITLE
fix(reflection): suppress [R] for entity-encoded payloads reflected verbatim

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -609,10 +609,42 @@ fn html_entity_reflection_in_unsafe_context(html: &str, variants: &[String]) -> 
     false
 }
 
+/// True when every HTML-significant character (`<`, `>`, `"`, `'`) in the
+/// payload is already represented as an HTML entity reference. Such payloads
+/// reflected verbatim are inert in HTML body / regular-attribute contexts —
+/// the browser decodes the entities into text characters rather than
+/// re-parsing them as markup, so no element or attribute boundary is
+/// crossed. Returns `false` when the payload carries any raw structural
+/// character (which would be exploitable on reflection).
+fn payload_is_fully_entity_encoded(payload: &str) -> bool {
+    if payload.contains(['<', '>', '"', '\'']) {
+        return false;
+    }
+    let decoded = decode_html_entities(payload);
+    decoded != payload && decoded.contains(['<', '>', '"', '\''])
+}
+
 /// Determine if payload is reflected in any normalization variant.
 pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<ReflectionKind> {
     // Direct match first (fast path — avoids payload_variants allocation)
     if resp_text.contains(payload) {
+        // False-positive guard: when the payload is itself HTML-entity
+        // encoded (e.g. `&#x003c;br&#x003e;`, `&lt;script&gt;alert(1)&lt;/script&gt;`)
+        // and the response reflects that exact encoded form, the reflection
+        // is functionally equivalent to the server having entity-escaped its
+        // output — both render as literal text in HTML body / non-event
+        // attribute context rather than as executable markup. Reuse the same
+        // safe-context heuristic the entity-decoded path below applies so
+        // these reflections do not surface as [R] noise. Keep the finding
+        // when the reflection lands in a context where entity escaping is
+        // not sufficient (event-handler attributes, `<script>` / `<style>`
+        // raw-text bodies).
+        if payload_is_fully_entity_encoded(payload) {
+            let variants = [payload.to_string()];
+            if !html_entity_reflection_in_unsafe_context(resp_text, &variants) {
+                return None;
+            }
+        }
         return Some(ReflectionKind::Raw);
     }
 

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -335,6 +335,70 @@ fn test_is_payload_reflected_html_encoded_in_attribute_value_demoted() {
 }
 
 #[test]
+fn test_classify_reflection_demotes_entity_encoded_payload_in_html_body() {
+    // The payload itself is HTML-entity encoded (e.g. encoder produced
+    // `&#x003c;br&#x003e;`). The server reflects it verbatim into HTML body
+    // context. Browsers decode the entities into literal text characters
+    // and do NOT re-parse them as markup, so no `<br>` element is created.
+    // Classification must demote — surfacing this as [R] is the false
+    // positive we are trying to eliminate.
+    let payload = "&#x003c;br&#x003e;";
+    let resp = "<div>Hello &#x003c;br&#x003e; world</div>";
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_entity_encoded_named_payload_in_html_body() {
+    // Same idea using named entities. `&lt;img src=x onerror=alert(1)&gt;`
+    // reflected verbatim into body context renders as visible text, not as
+    // an `<img>` element.
+    let payload = "&lt;img src=x onerror=alert(1)&gt;";
+    let resp = format!("<p>echo: {} done</p>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_keeps_entity_encoded_payload_in_event_handler() {
+    // Inside an `on*=` attribute the browser decodes HTML entities before
+    // handing the value to the JS parser, so an entity-encoded payload
+    // landing there IS exploitable. The reflection must survive.
+    let payload = "&#x27;-alert(1)-&#x27;";
+    let resp = "<button onclick=\"x=&#x27;-alert(1)-&#x27;\">x</button>";
+    assert_eq!(
+        classify_reflection(resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_classify_reflection_keeps_mixed_payload_with_raw_specials() {
+    // The payload mixes entity-encoded fragments with raw `<` / `>`, so the
+    // raw portion creates real markup when reflected. The full-entity guard
+    // must NOT demote here.
+    let payload = "&#x003c;br&#x003e;<script>alert(1)</script>";
+    let resp = format!("<div>{}</div>", payload);
+    assert_eq!(
+        classify_reflection(&resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_payload_is_fully_entity_encoded_detection() {
+    assert!(payload_is_fully_entity_encoded("&#x003c;br&#x003e;"));
+    assert!(payload_is_fully_entity_encoded(
+        "&lt;script&gt;alert(1)&lt;/script&gt;"
+    ));
+    // Has raw `<` — not fully encoded
+    assert!(!payload_is_fully_entity_encoded("<br>"));
+    // Has no entities at all
+    assert!(!payload_is_fully_entity_encoded("plain text"));
+    // Entity decodes to something with no HTML-significant chars — not the
+    // shape this guard cares about (won't change reflection semantics).
+    assert!(!payload_is_fully_entity_encoded("&#x41;"));
+}
+
+#[test]
 fn test_is_payload_reflected_html_encoded_in_event_handler_kept() {
     // The browser decodes entities inside an `on*=…` attribute value before
     // handing the result to the JS parser, so entity escaping is not


### PR DESCRIPTION
## Summary
- `classify_reflection`'s fast path was returning `Raw` whenever the response contained the payload byte-for-byte. For payloads whose HTML-significant chars (`<>\"'`) are already entity-encoded (e.g. `&#x003c;br&#x003e;`, `&lt;script&gt;alert(1)&lt;/script&gt;`), a verbatim reflection in HTML body / regular-attribute context is inert — the browser decodes entities into text characters but does not re-parse them as markup. The previous behaviour surfaced these as `[R]` Info noise.
- Add `payload_is_fully_entity_encoded()` and reuse the existing `html_entity_reflection_in_unsafe_context()` heuristic on the fast path: demote when reflection lands only in safe contexts, keep the finding when it lands inside `on*=` attributes / `<script>` / `<style>`. This mirrors the rule already applied to server-side entity-escaped reflections (`test_is_payload_reflected_html_encoded_in_safe_context_demoted`).

## Test plan
- [x] `cargo test --lib scanning::check_reflection` — 78 passed
- [x] `cargo test --lib` — 1021 passed (no regressions)
- [x] New unit tests cover: numeric entity payload in body (demote), named entity payload in body (demote), entity payload in `onclick` (keep), mixed raw+entity payload (keep), `payload_is_fully_entity_encoded` detection helper