### PR TITLE
fix(reflection): extend entity regex to 8 hex digits for htmlpad payloads

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -457,9 +457,12 @@ pub enum ReflectionKind {
 ///   "&#60;alert(1)&#62;"  -> "<alert(1)>"
 fn decode_html_entities(input: &str) -> String {
     // Match patterns like &#xHH; or &#xHHHH; or &#DDDD; (hex 'x' is case-insensitive)
-    // We purposely limit to reasonable length to avoid catastrophic replacements.
+    // Upper bound is 8 hex / 8 decimal digits — covers zero-padded WAF-bypass
+    // payloads emitted by `html_entity_zero_padded_encode` (`&#x0000003c;`,
+    // 7 hex digits) while still capping the regex so a pathological response
+    // can't fan out into catastrophic replacements.
     let re = ENTITY_REGEX.get_or_init(|| {
-        Regex::new(r"&#([xX][0-9a-fA-F]{2,6}|[0-9]{2,6});")
+        Regex::new(r"&#([xX][0-9a-fA-F]{2,8}|[0-9]{2,8});")
             .expect("entity regex pattern must be valid")
     });
     let mut out = String::with_capacity(input.len());

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -288,6 +288,25 @@ fn test_decode_html_entities_ignores_invalid_numeric_sequences() {
 }
 
 #[test]
+fn test_decode_html_entities_zero_padded_hex() {
+    // Output shape of `html_entity_zero_padded_encode` — 7 hex digits per char.
+    // The regex must accept this length so the resulting payload classifies
+    // as entity-encoded by the same safe-context guard the 4-digit form uses.
+    let s = "&#x0000003c;script&#x0000003e;alert(1)&#x0000003c;/script&#x0000003e;";
+    let d = decode_html_entities(s);
+    assert_eq!(d, "<script>alert(1)</script>");
+}
+
+#[test]
+fn test_decode_html_entities_eight_digit_hex_boundary() {
+    // 8 hex digits is the new upper bound. Verify it still decodes and that
+    // 9-digit sequences fall through as literal text (regex must not match).
+    assert_eq!(decode_html_entities("&#x0000003e;"), ">");
+    let nine = "&#x000000003e;";
+    assert_eq!(decode_html_entities(nine), nine);
+}
+
+#[test]
 fn test_classify_reflection_prefers_raw_match() {
     let payload = "<script>alert(1)</script>";
     let resp = format!("raw:{} encoded:{}", payload, urlencoding::encode(payload));
@@ -379,6 +398,30 @@ fn test_classify_reflection_keeps_mixed_payload_with_raw_specials() {
     let resp = format!("<div>{}</div>", payload);
     assert_eq!(
         classify_reflection(&resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_classify_reflection_demotes_zero_padded_entity_payload_in_html_body() {
+    // `html_entity_zero_padded_encode` is a common WAF-bypass encoder. With
+    // the entity regex bumped to {2,8}, these payloads decode the same way
+    // 4-digit hex entities do, so the entity-encoded safe-context guard
+    // automatically demotes verbatim reflections in HTML body context.
+    let payload = "&#x0000003c;br&#x0000003e;";
+    let resp = "<div>echo &#x0000003c;br&#x0000003e; done</div>";
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_keeps_zero_padded_entity_payload_in_event_handler() {
+    // Same context rule as the 4-digit case: zero-padded entities decoded
+    // inside an `on*=` attribute can still produce JS-significant chars,
+    // so the reflection must survive.
+    let payload = "&#x00000027;-alert(1)-&#x00000027;";
+    let resp = "<button onclick=\"x=&#x00000027;-alert(1)-&#x00000027;\">x</button>";
+    assert_eq!(
+        classify_reflection(resp, payload),
         Some(ReflectionKind::Raw)
     );
 }


### PR DESCRIPTION
## Summary
- Follow-up to #981. `html_entity_zero_padded_encode` (the `htmlpad` adaptive encoder) emits `&#x0000003c;`-style WAF-bypass payloads with 7 hex digits, but the reflection-classifier's entity decoder regex was capped at `{2,6}` hex digits. Those payloads never decoded, so the entity-encoded safe-context guard introduced in #981 never matched, and a verbatim reflection in HTML body context still surfaced as `[R]` Info noise.
- Bump the bound to `{2,8}` (covers 7- and 8-digit padded forms) while keeping the cap to avoid catastrophic regex behavior on pathological responses. No other change needed — the existing `payload_is_fully_entity_encoded` / `html_entity_reflection_in_unsafe_context` flow auto-covers the htmlpad case once decoding works.

## Test plan
- [x] `cargo test --lib scanning::check_reflection` — 82 passed
- [x] `cargo test --lib` — 1025 passed (no regressions)
- [x] New unit tests cover: 7-digit hex decode, 8-digit upper boundary + 9-digit rejection, htmlpad reflection demoted in HTML body, htmlpad reflection kept in `onclick`