### PR TITLE
fix(reflection): suppress [R] for URL-encoded payloads reflected verbatim

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -627,6 +627,54 @@ fn payload_is_fully_entity_encoded(payload: &str) -> bool {
     decoded != payload && decoded.contains(['<', '>', '"', '\''])
 }
 
+/// True when the payload carries no raw structural HTML characters
+/// (`<`, `>`, `"`, `'`) and URL-decoding actually transforms it. Such
+/// payloads reflected verbatim are inert in HTML body, non-URL attribute,
+/// `<script>`, `<style>`, and event-handler contexts — none of those
+/// parsers percent-decode their content. The one remaining execution path
+/// (URL-valued attributes navigating to an executable scheme) is handled
+/// separately by [`url_encoded_payload_reflects_in_unsafe_url_context`].
+fn payload_is_fully_url_encoded(payload: &str) -> bool {
+    if payload.contains(['<', '>', '"', '\'']) {
+        return false;
+    }
+    let Ok(decoded) = urlencoding::decode(payload) else {
+        return false;
+    };
+    decoded.as_ref() != payload
+}
+
+/// True when a percent-encoded payload that decodes to a JS-executable URL
+/// scheme (`javascript:`, `data:text/html`, `data:image/svg`, `vbscript:`)
+/// is reflected inside at least one URL-valued attribute. URL attributes
+/// are the one context where browsers percent-decode the value (when
+/// parsing the URL), so a dangerous decoded scheme there is exploitable
+/// on navigation. Other contexts (body, non-URL attr, script, style,
+/// event-handler) never decode percent encoding, so they remain safe.
+fn url_encoded_payload_reflects_in_unsafe_url_context(html: &str, payload: &str) -> bool {
+    let Ok(decoded) = urlencoding::decode(payload) else {
+        return false;
+    };
+    let lower = decoded.trim_start().to_ascii_lowercase();
+    let dangerous_scheme = lower.starts_with("javascript:")
+        || lower.starts_with("data:text/html")
+        || lower.starts_with("data:image/svg")
+        || lower.starts_with("vbscript:");
+    if !dangerous_scheme {
+        return false;
+    }
+    let bytes = html.as_bytes();
+    let mut search_start = 0;
+    while let Some(pos) = html[search_start..].find(payload) {
+        let abs = search_start + pos;
+        if occurrence_is_in_url_attr(bytes, abs) {
+            return true;
+        }
+        search_start = next_char_boundary(html, abs + 1);
+    }
+    false
+}
+
 /// Determine if payload is reflected in any normalization variant.
 pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<ReflectionKind> {
     // Direct match first (fast path — avoids payload_variants allocation)
@@ -647,6 +695,16 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
             if !html_entity_reflection_in_unsafe_context(resp_text, &variants) {
                 return None;
             }
+        }
+        // Same FP guard for percent-encoded payloads: `%3C` etc. survive
+        // HTML/JS/CSS parsing as literal text — no parser decodes percent
+        // encoding inside its tokens. The only execution path is when the
+        // payload lands inside a URL-valued attribute and decodes to an
+        // executable URL scheme (`javascript:`, `data:text/html`, etc.).
+        if payload_is_fully_url_encoded(payload)
+            && !url_encoded_payload_reflects_in_unsafe_url_context(resp_text, payload)
+        {
+            return None;
         }
         return Some(ReflectionKind::Raw);
     }

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -390,6 +390,106 @@ fn test_classify_reflection_keeps_entity_encoded_payload_in_event_handler() {
 }
 
 #[test]
+fn test_classify_reflection_demotes_url_encoded_payload_in_html_body() {
+    // The `url` adaptive encoder produces `%3Cbr%3E`. Reflected verbatim
+    // in HTML body context, no HTML / JS / CSS parser decodes percent
+    // sequences, so the reflection is inert. Without this guard the fast
+    // path returned `Raw` and surfaced as [R] Info noise.
+    let payload = "%3Cscript%3Ealert(1)%3C%2Fscript%3E";
+    let resp = format!("<div>echo {} done</div>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_double_url_encoded_payload_in_html_body() {
+    // `2url` encoder doubles the percent layer (`%253C…`). Iterative URL
+    // decode via `payload_variants` collapses both layers and ultimately
+    // produces `<>` — the guard must demote.
+    let payload = "%253Cscript%253Ealert(1)%253C%252Fscript%253E";
+    let resp = format!("<p>{}</p>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_url_encoded_payload_in_event_handler() {
+    // `%XX` is NOT decoded by the HTML parser inside attribute values, so
+    // it is also inert in event-handler contexts. Unlike entity-encoded
+    // payloads, URL-encoded payloads can be safely demoted here too.
+    let payload = "%3Cscript%3E";
+    let resp = "<button onclick=\"x='%3Cscript%3E'\">x</button>";
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_url_encoded_payload_in_script_block() {
+    // Inside `<script>` the JS parser sees `%XX` as literal characters
+    // (likely a syntax error), never as `<` or `>`. Safe.
+    let payload = "%3Cscript%3E";
+    let resp = "<script>var x = '%3Cscript%3E';</script>";
+    assert_eq!(classify_reflection(resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_keeps_url_encoded_javascript_scheme_in_href() {
+    // URL-valued attributes are the one context where the browser DOES
+    // percent-decode the value (when parsing the URL on navigation). A
+    // payload decoding to `javascript:alert(1)` reflected in `href` IS
+    // exploitable — the finding must survive.
+    let payload = "javascript%3Aalert%281%29";
+    let resp = format!("<a href=\"{}\">click</a>", payload);
+    assert_eq!(
+        classify_reflection(&resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_classify_reflection_keeps_url_encoded_data_html_in_href() {
+    // `data:text/html` URLs execute inline content on navigation.
+    let payload = "data%3Atext%2Fhtml%2C%3Cscript%3Ealert(1)%3C%2Fscript%3E";
+    let resp = format!("<iframe src=\"{}\"></iframe>", payload);
+    assert_eq!(
+        classify_reflection(&resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_classify_reflection_demotes_url_encoded_javascript_scheme_outside_url_attr() {
+    // Same `javascript:`-scheme payload but reflected only in body text.
+    // Without a URL attribute boundary the browser never navigates to
+    // it — pure text rendering, safe.
+    let payload = "javascript%3Aalert%281%29";
+    let resp = format!("<div>visit {} please</div>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_url_encoded_javascript_scheme_in_non_url_attr() {
+    // `title` is not a URL-valued attribute, so the browser never
+    // percent-decodes its content for URL parsing. URL-encoded
+    // `javascript:` here just renders as a tooltip string — safe.
+    let payload = "javascript%3Aalert%281%29";
+    let resp = format!("<span title=\"{}\">x</span>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_payload_is_fully_url_encoded_detection() {
+    assert!(payload_is_fully_url_encoded("%3Cscript%3E"));
+    // `javascript:`-scheme payload: decoded form differs even though it
+    // contains no raw `<>"'`. The URL-attr-scheme check downstream is
+    // responsible for keeping these when reflected in href/src/etc.
+    assert!(payload_is_fully_url_encoded("javascript%3Aalert%281%29"));
+    // Double-URL form decodes to another encoded layer — still differs.
+    assert!(payload_is_fully_url_encoded("%253Cscript%253E"));
+    // Raw `<` present — not fully encoded
+    assert!(!payload_is_fully_url_encoded("<script>%3C"));
+    // No percent encoding — URL decode is a no-op.
+    assert!(!payload_is_fully_url_encoded("plain text"));
+}
+
+#[test]
 fn test_classify_reflection_keeps_mixed_payload_with_raw_specials() {
     // The payload mixes entity-encoded fragments with raw `<` / `>`, so the
     // raw portion creates real markup when reflected. The full-entity guard


### PR DESCRIPTION
## Summary
- Follow-up to #981 / #982 for the `url` / `2url` / `3url` / `4url` adaptive encoders. Percent-encoded payloads (`%3Cscript%3E…`) reflected verbatim are inert in every HTML/JS/CSS context: HTML, `<script>`, `<style>`, and event-handler parsers never percent-decode their content.
- The only execution path left is a URL-valued attribute whose decoded value names an executable URL scheme — `javascript:`, `data:text/html`, `data:image/svg`, `vbscript:`. We keep `Raw` in that narrow case and demote everywhere else.

## Design
Add two helpers next to the entity-encoded guard introduced in #981:
- `payload_is_fully_url_encoded(payload)` — payload has no raw `<>\"'` and `urlencoding::decode` changes the bytes.
- `url_encoded_payload_reflects_in_unsafe_url_context(html, payload)` — true iff at least one occurrence sits inside a URL-valued attribute (`occurrence_is_in_url_attr` walk) **and** the decoded form (lowercased, leading-whitespace-trimmed) starts with one of the executable schemes.

Threaded into the `classify_reflection` fast path right after the existing entity-encoded check.

## Test plan
- [x] `cargo test --lib scanning::check_reflection` — 91 passed
- [x] `cargo test --lib` — 1030 passed (no regressions)
- [x] New unit tests cover: percent-encoded payload in body, double-URL form in body, `<script>` body, `onclick` event handler, `<span title=…>` non-URL attribute, plus the keep-finding cases for `javascript:`-scheme in `<a href>` and `data:text/html` in `<iframe src>`, and a `payload_is_fully_url_encoded` detection unit test.