### PR TITLE
fix(reflection): suppress [R] for fullwidth-unicode payloads reflected verbatim

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -628,6 +628,22 @@ fn payload_is_fully_entity_encoded(payload: &str) -> bool {
 }
 
 /// True when the payload carries no raw structural HTML characters
+/// (`<`, `>`, `"`, `'`) but does contain at least one ASCII-fullwidth
+/// codepoint (U+FF01-U+FF5E). Output of the `unicode` adaptive encoder.
+/// Reflected verbatim such payloads are inert in every browser context:
+/// fullwidth codepoints are distinct Unicode characters, never normalized
+/// to ASCII by the HTML, JS, CSS, or URL parsers, so they cannot start a
+/// tag, break an attribute, or form an executable URL scheme.
+fn payload_is_fully_fullwidth_encoded(payload: &str) -> bool {
+    if payload.contains(['<', '>', '"', '\'']) {
+        return false;
+    }
+    payload
+        .chars()
+        .any(|c| (0xFF01..=0xFF5E).contains(&(c as u32)))
+}
+
+/// True when the payload carries no raw structural HTML characters
 /// (`<`, `>`, `"`, `'`) and URL-decoding actually transforms it. Such
 /// payloads reflected verbatim are inert in HTML body, non-URL attribute,
 /// `<script>`, `<style>`, and event-handler contexts — none of those
@@ -704,6 +720,15 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
         if payload_is_fully_url_encoded(payload)
             && !url_encoded_payload_reflects_in_unsafe_url_context(resp_text, payload)
         {
+            return None;
+        }
+        // Fullwidth-unicode payloads (`unicode` adaptive encoder, e.g.
+        // `＜br＞` made of U+FF1C/U+FF1E) reflected verbatim are inert in
+        // every browser context: those codepoints are never normalized to
+        // ASCII `<>` by any parser, so they can't start a tag or escape
+        // an attribute. Demote unconditionally — there is no analogue to
+        // the URL-scheme exception here.
+        if payload_is_fully_fullwidth_encoded(payload) {
             return None;
         }
         return Some(ReflectionKind::Raw);

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -475,6 +475,74 @@ fn test_classify_reflection_demotes_url_encoded_javascript_scheme_in_non_url_att
 }
 
 #[test]
+fn test_classify_reflection_demotes_fullwidth_payload_in_html_body() {
+    // `unicode` adaptive encoder maps ASCII to fullwidth (U+FF01-U+FF5E).
+    // `<br>` becomes `＜br＞`. Browsers never normalize fullwidth to ASCII,
+    // so the reflection cannot start a tag — must demote.
+    let payload = "\u{ff1c}br\u{ff1e}";
+    let resp = format!("<div>echo {} done</div>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_fullwidth_payload_in_event_handler() {
+    // Fullwidth bytes are inert in every parser, including the JS parser
+    // reached via event-handler entity decoding.
+    let payload = "\u{ff1c}script\u{ff1e}alert(1)\u{ff1c}/script\u{ff1e}";
+    let resp = format!("<button onclick=\"x='{}'\">x</button>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_fullwidth_payload_in_script_block() {
+    let payload = "\u{ff1c}svg onload=alert(1)\u{ff1e}";
+    let resp = format!("<script>var x = '{}';</script>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_demotes_fullwidth_payload_in_href() {
+    // Even URL-valued attributes are safe — fullwidth `:` (U+FF1A) isn't
+    // recognized as a scheme delimiter by URL parsers.
+    let payload = "javascript\u{ff1a}alert(1)";
+    let resp = format!("<a href=\"{}\">x</a>", payload);
+    assert_eq!(classify_reflection(&resp, payload), None);
+}
+
+#[test]
+fn test_classify_reflection_keeps_mixed_fullwidth_and_raw_specials() {
+    // A payload mixing fullwidth and raw `<` still has the raw structural
+    // char, so reflection IS exploitable. Guard must not demote.
+    let payload = "\u{ff1c}br\u{ff1e}<script>alert(1)</script>";
+    let resp = format!("<div>{}</div>", payload);
+    assert_eq!(
+        classify_reflection(&resp, payload),
+        Some(ReflectionKind::Raw)
+    );
+}
+
+#[test]
+fn test_payload_is_fully_fullwidth_encoded_detection() {
+    assert!(payload_is_fully_fullwidth_encoded("\u{ff1c}br\u{ff1e}"));
+    assert!(payload_is_fully_fullwidth_encoded(
+        "\u{ff1c}script\u{ff1e}alert(1)\u{ff1c}/script\u{ff1e}"
+    ));
+    // Fullwidth `:` enough to gate — covers fullwidth `javascript:` URLs
+    // which the URL parser also refuses to recognize as a scheme.
+    assert!(payload_is_fully_fullwidth_encoded(
+        "javascript\u{ff1a}alert(1)"
+    ));
+    // Raw `<` present — not fully encoded
+    assert!(!payload_is_fully_fullwidth_encoded("<br>"));
+    // No fullwidth chars at all
+    assert!(!payload_is_fully_fullwidth_encoded("plain text"));
+    // A non-fullwidth non-ASCII char (CJK) by itself doesn't qualify —
+    // the guard is specifically for the U+FF01-U+FF5E ASCII-fullwidth
+    // block produced by `unicode_fullwidth_encode`.
+    assert!(!payload_is_fully_fullwidth_encoded("\u{4e2d}"));
+}
+
+#[test]
 fn test_payload_is_fully_url_encoded_detection() {
     assert!(payload_is_fully_url_encoded("%3Cscript%3E"));
     // `javascript:`-scheme payload: decoded form differs even though it


### PR DESCRIPTION
## Summary
Final follow-up to #981 / #982 / #983, closing the adaptive-encoder false-positive audit. The `unicode` encoder maps ASCII `0x21-0x7E` to their U+FF01-U+FF5E fullwidth counterparts (`<` → `＜`, `>` → `＞`, `:` → `：`, etc.). Reflected verbatim, these codepoints are inert in every browser context — HTML, JS, CSS, and URL parsers never normalize fullwidth back to ASCII, so the payload cannot start a tag, break an attribute, or form an executable URL scheme. Demote unconditionally when the gate matches; no URL-scheme exception is needed because fullwidth `：` (U+FF1A) isn't a recognized scheme delimiter.

## Design
- `payload_is_fully_fullwidth_encoded(payload)` — payload has no raw `<>\"'` and contains at least one codepoint in U+FF01-U+FF5E. Threaded into `classify_reflection`'s fast path immediately after the URL-encoded guard from #983.

## Test plan
- [x] `cargo fmt --check` — clean
- [x] `cargo clippy --lib --all-targets -- -D warnings` — clean
- [x] `cargo test --lib scanning::check_reflection` — 97 passed
- [x] `cargo test --lib` — 1040 passed (no regressions)
- [x] New unit tests cover: fullwidth payload in HTML body, in `onclick`, in `<script>`, in `<a href>` (still safe because fullwidth `:` isn't a scheme delimiter), mixed fullwidth + raw `<` (keep finding), `payload_is_fully_fullwidth_encoded` detection