### PR TITLE
feat(dom-xss): broaden AST source/sink coverage and verify exec-URL with surrounding bytes

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -156,11 +156,11 @@ const DOM_SOURCES: &[&str] = &[
     "XMLHttpRequest.responseText",
     "XMLHttpRequest.response",
     // Clipboard reads on `paste` events expose attacker-controlled bytes from
-    // the OS clipboard. The `getData(...)` call is the canonical reach.
+    // the OS clipboard. The `getData(...)` call is the canonical reach; the
+    // bare `clipboardData` object holds metadata (`.types`, `.files`, …) that
+    // isn't user-controlled string content, so we don't mark it as a source.
     "event.clipboardData.getData",
     "e.clipboardData.getData",
-    "event.clipboardData",
-    "e.clipboardData",
     "navigator.clipboard.readText",
     // Keyboard / composition events – `key` / `code` carry user input
     // verbatim and are the natural source on autocompletion-style handlers.
@@ -2368,7 +2368,13 @@ impl<'a> DomXssVisitor<'a> {
                         right_source.clone(),
                     );
                 }
-                let is_sink = self.is_assignment_sink_property(prop_name);
+                // Suppress the generic assignment-sink path when the more
+                // specific script-element sink already fired — otherwise
+                // `s.innerHTML = tainted` (where `s` is a script element)
+                // would surface twice, once as `script.innerHTML` and once
+                // as the generic `innerHTML`. The script-element form is
+                // the correct one for PoC payload selection.
+                let is_sink = !script_text_sink && self.is_assignment_sink_property(prop_name);
 
                 // Also check if the full member path is a sink (e.g., location.href)
                 let full_path_is_sink = if let Some(full_path) = self.get_member_string(member) {

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -88,6 +88,12 @@ struct DomXssVisitor<'a> {
     url_search_params_objects: HashSet<String>,
     /// Track `paramsVar.key -> upstream source` for URLSearchParams set/get reparses.
     url_search_params_field_sources: HashMap<String, String>,
+    /// Variables that hold a `<script>` element created via
+    /// `document.createElement('script')`. Assigning a tainted value to
+    /// `.text` / `.textContent` / `.innerText` / `.innerHTML` on these
+    /// variables runs the value as JS once the element is appended, which
+    /// is otherwise indistinguishable from a harmless text assignment.
+    script_element_vars: HashSet<String>,
 }
 
 // Module-level DOM source/sink/sanitizer constants
@@ -149,6 +155,28 @@ const DOM_SOURCES: &[&str] = &[
     "Response.json",
     "XMLHttpRequest.responseText",
     "XMLHttpRequest.response",
+    // Clipboard reads on `paste` events expose attacker-controlled bytes from
+    // the OS clipboard. The `getData(...)` call is the canonical reach.
+    "event.clipboardData.getData",
+    "e.clipboardData.getData",
+    "event.clipboardData",
+    "e.clipboardData",
+    "navigator.clipboard.readText",
+    // Keyboard / composition events – `key` / `code` carry user input
+    // verbatim and are the natural source on autocompletion-style handlers.
+    "event.key",
+    "e.key",
+    "event.code",
+    "e.code",
+    // `event.target.innerText` / `textContent` / `innerHTML` is the common
+    // contenteditable / paste-into-div shape: the user typed it, so the
+    // value is tainted at read time.
+    "event.target.innerText",
+    "e.target.innerText",
+    "event.target.textContent",
+    "e.target.textContent",
+    "event.target.innerHTML",
+    "e.target.innerHTML",
 ];
 
 const DOM_SINKS: &[&str] = &[
@@ -177,6 +205,12 @@ const DOM_SINKS: &[&str] = &[
     "after",
     "before",
     "execCommand",
+    // Modern Sanitizer-API methods. `setHTML` accepts a Sanitizer config and
+    // strips known XSS vectors, so on its own it is not an exploitable sink —
+    // we leave it out. `setHTMLUnsafe` is explicitly the opt-out path that
+    // parses the argument as HTML with no sanitization, which is exactly the
+    // shape of an exploitable injection.
+    "setHTMLUnsafe",
 ];
 
 const DOM_SANITIZERS: &[&str] = &[
@@ -449,7 +483,51 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_sources: HashMap::new(),
             url_search_params_objects: HashSet::new(),
             url_search_params_field_sources: HashMap::new(),
+            script_element_vars: HashSet::new(),
         }
+    }
+
+    /// Recognise `document.createElement('script')` (and the spelling variants
+    /// the AST gives us) so the caller can remember which JS variables hold a
+    /// script element. We accept the call with a case-insensitive `script`
+    /// argument because HTML element tag names are case-insensitive.
+    fn expr_creates_script_element(&self, expr: &Expression<'a>) -> bool {
+        let Expression::CallExpression(call) = expr else {
+            return false;
+        };
+        let callee = match &call.callee {
+            Expression::StaticMemberExpression(m) => self.get_member_string(m),
+            _ => None,
+        };
+        if callee.as_deref() != Some("document.createElement") {
+            return false;
+        }
+        let Some(arg) = call.arguments.first() else {
+            return false;
+        };
+        let tag = match arg.as_expression() {
+            Some(Expression::StringLiteral(s)) => Some(s.value.as_str()),
+            Some(Expression::TemplateLiteral(t))
+                if t.expressions.is_empty() && t.quasis.len() == 1 =>
+            {
+                t.quasis
+                    .first()
+                    .and_then(|q| q.value.cooked.as_ref())
+                    .map(|c| c.as_str())
+            }
+            _ => None,
+        };
+        matches!(tag.map(|s| s.eq_ignore_ascii_case("script")), Some(true))
+    }
+
+    /// Property names that, when assigned on a `<script>` element variable,
+    /// turn the assigned value into executable JavaScript once the element
+    /// is inserted into the document. `text` / `textContent` / `innerText`
+    /// all set the script body; `innerHTML` does the same and additionally
+    /// re-parses tag soup inside. We do *not* include `src` here because
+    /// `src` is already covered by the generic URL-attribute sink path.
+    fn is_script_element_text_sink_prop(prop: &str) -> bool {
+        matches!(prop, "text" | "textContent" | "innerText" | "innerHTML")
     }
 
     /// Get a string representation of an expression if it's an identifier or member expression
@@ -1630,6 +1708,16 @@ impl<'a> DomXssVisitor<'a> {
                     self.url_object_sources.remove(var_name);
                 }
 
+                // `let s = document.createElement('script')` — remember the
+                // variable so a later `s.text = tainted` is recognised as a
+                // sink even though `text` is a benign property on every
+                // other element kind.
+                if self.expr_creates_script_element(init) {
+                    self.script_element_vars.insert(var_name.to_string());
+                } else {
+                    self.script_element_vars.remove(var_name);
+                }
+
                 let mut assigned_url_search_params_source = false;
                 if let Expression::StaticMemberExpression(member) = init
                     && let Some(source) = self.url_search_params_source_for_member(member)
@@ -2263,6 +2351,23 @@ impl<'a> DomXssVisitor<'a> {
                     prop_name,
                     &assign.right,
                 );
+                // Script-element body assignments (e.g. `s.text = tainted`
+                // where `s` came from `document.createElement('script')`).
+                // The browser parses the value as JS source once the
+                // element is inserted, so this is a real eval-equivalent
+                // sink that the generic `is_assignment_sink_property`
+                // check below would miss.
+                let script_text_sink = right_tainted
+                    && Self::is_script_element_text_sink_prop(prop_name)
+                    && matches!(&member.object, Expression::Identifier(id) if self.script_element_vars.contains(id.name.as_str()));
+                if script_text_sink {
+                    self.report_vulnerability_with_source(
+                        assign.span(),
+                        &format!("script.{prop_name}"),
+                        "Assignment to script-element body executes as JS",
+                        right_source.clone(),
+                    );
+                }
                 let is_sink = self.is_assignment_sink_property(prop_name);
 
                 // Also check if the full member path is a sink (e.g., location.href)

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -2927,3 +2927,93 @@ document.body.innerHTML = cfg.title;
         "JSON.parse(tainted) → property access → innerHTML must surface"
     );
 }
+
+#[test]
+fn detects_set_html_unsafe_method_call() {
+    let js = r#"
+const el = document.getElementById('out');
+el.setHTMLUnsafe(location.hash.slice(1));
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.source.contains("location.hash") && v.sink == "setHTMLUnsafe"),
+        "setHTMLUnsafe is an explicit-unsafe HTML parsing sink: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_script_text_assignment_from_hash() {
+    let js = r#"
+const s = document.createElement('script');
+s.text = location.hash.slice(1);
+document.body.appendChild(s);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.source.contains("location.hash") && v.sink == "script.text"),
+        "script.text assignment runs the value as JS once appended: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_script_text_content_assignment_from_search() {
+    let js = r#"
+const s = document.createElement('script');
+const q = new URLSearchParams(location.search).get('q');
+s.textContent = q;
+document.body.appendChild(s);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "script.textContent"),
+        "script.textContent assignment from URLSearchParams.get must surface: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn script_text_sink_does_not_fire_on_div_element() {
+    let js = r#"
+const d = document.createElement('div');
+d.text = location.hash.slice(1);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        !r.iter().any(|v| v.sink.starts_with("script.")),
+        ".text on a non-script element is not a sink; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clipboard_get_data_is_recognised_as_source() {
+    let js = r#"
+document.addEventListener('paste', function(e) {
+    document.body.innerHTML = e.clipboardData.getData('text');
+});
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("clipboardData")),
+        "paste-event clipboardData.getData → innerHTML must surface; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -2985,6 +2985,34 @@ document.body.appendChild(s);
 }
 
 #[test]
+fn detects_script_inner_html_assignment_without_duplicate_finding() {
+    // `s.innerHTML = tainted` where `s` is a script element must be
+    // reported as `script.innerHTML` (the form the PoC generator emits
+    // raw JS for). The generic `innerHTML` sink path must NOT fire in
+    // addition — otherwise the same line surfaces twice.
+    let js = r#"
+const s = document.createElement('script');
+s.innerHTML = location.hash.slice(1);
+document.body.appendChild(s);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    let script_findings: Vec<_> = r.iter().filter(|v| v.sink == "script.innerHTML").collect();
+    let generic_findings: Vec<_> = r.iter().filter(|v| v.sink == "innerHTML").collect();
+    assert_eq!(
+        script_findings.len(),
+        1,
+        "expected exactly one script.innerHTML finding; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+    assert!(
+        generic_findings.is_empty(),
+        "script-element sink must suppress the generic innerHTML report; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn script_text_sink_does_not_fire_on_div_element() {
     let js = r#"
 const d = document.createElement('div');

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -114,9 +114,23 @@ pub fn generate_dom_xss_poc(source: &str, sink: &str) -> (String, String) {
         sink,
         "src" | "href" | "xlink:href" | "action" | "formaction" | "poster" | "background"
     );
+    // Sinks whose value is fed directly to a JS evaluator. `script.text` /
+    // `script.textContent` / `script.innerText` are listed alongside the
+    // classic eval family because once the created script element is
+    // appended to the DOM the browser parses the assigned value as JS
+    // source verbatim — same effective shape as `eval(payload)`.
     let is_js_eval_sink = matches!(
         sink,
-        "eval" | "Function" | "setTimeout" | "setInterval" | "execScript" | "execCommand"
+        "eval"
+            | "Function"
+            | "setTimeout"
+            | "setInterval"
+            | "execScript"
+            | "execCommand"
+            | "script.text"
+            | "script.textContent"
+            | "script.innerText"
+            | "script.innerHTML"
     );
     let attr_url_payload = format!("data:text/javascript,alert(1)/*{}*/", marker);
     let js_eval_payload = format!("alert(1)/*{}*/", marker);

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -242,6 +242,31 @@ fn is_executable_url_attribute(element_tag: &str, attr_name: &str) -> bool {
     }
 }
 
+/// Decide whether a reflected attribute value should count as an executable
+/// URL hit for `payload_trimmed`. The previous check required strict equality,
+/// which over-rejected real exploits like `<a href="javascript:alert(1)//xyz">`
+/// where the server appends or prepends bytes around our reflected scheme.
+///
+/// Browsers parse the *whole* attribute value as a single URL, so the
+/// observable rule is: the trimmed value must start with one of the
+/// executable URL schemes (case-insensitive), and the bytes of `payload_trimmed`
+/// must appear verbatim somewhere in the value so we know the payload
+/// genuinely drives the execution rather than merely sharing a scheme with an
+/// unrelated server-emitted `javascript:` URL.
+fn attribute_value_executes_payload(value: &str, payload_trimmed: &str) -> bool {
+    let trimmed = value.trim();
+    if trimmed.eq_ignore_ascii_case(payload_trimmed) {
+        return true;
+    }
+    let starts_executable = starts_with_ascii_ci(trimmed, "javascript:")
+        || starts_with_ascii_ci(trimmed, "data:text/html")
+        || starts_with_ascii_ci(trimmed, "vbscript:");
+    if !starts_executable {
+        return false;
+    }
+    trimmed.contains(payload_trimmed)
+}
+
 fn has_executable_url_attribute_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
     if !payload_is_executable_url_protocol(payload) {
         return false;
@@ -254,7 +279,7 @@ fn has_executable_url_attribute_evidence_in_doc(payload: &str, document: &scrape
         let tag = node.value().name();
         node.value().attrs().any(|(name, value)| {
             is_executable_url_attribute(tag, name)
-                && value.trim().eq_ignore_ascii_case(payload_trimmed)
+                && attribute_value_executes_payload(value, payload_trimmed)
         })
     })
 }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -610,6 +610,34 @@ fn test_has_executable_url_attribute_evidence_detects_iframe_src_protocol() {
     assert!(has_dom_evidence(payload, body));
 }
 
+/// The server-side template often appends bytes around the reflected
+/// payload (a trailing comment, a serialized `&next=…`, an HTML entity).
+/// Browsers parse the entire attribute value as one URL, so when the value
+/// still *starts* with an executable scheme and the payload bytes appear
+/// verbatim inside it, the navigation still fires. The previous strict
+/// equality check rejected these, costing real findings.
+#[test]
+fn test_has_executable_url_attribute_evidence_with_trailing_bytes() {
+    let payload = "javascript:alert(1)";
+    let body = "<html><body><a href=\"javascript:alert(1)//&next=/home\">go</a></body></html>";
+    assert!(
+        has_dom_evidence(payload, body),
+        "trailing bytes after the reflected javascript: URL must still verify"
+    );
+}
+
+#[test]
+fn test_has_executable_url_attribute_evidence_not_a_substring_match() {
+    // Page already had its own javascript: URL; our payload appears nowhere
+    // inside the attribute value. Must NOT count as evidence.
+    let payload = "javascript:alert(1)";
+    let body = "<html><body><a href=\"javascript:console.log('hi')\">x</a></body></html>";
+    assert!(
+        !has_dom_evidence(payload, body),
+        "an unrelated javascript: URL must not verify our payload"
+    );
+}
+
 #[test]
 fn test_has_dom_evidence_skips_parse_for_irrelevant_payload() {
     // Payload has neither Dalfox markers nor an executable URL protocol,

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -38,6 +38,10 @@ const JS_SINK_NAMES: &[&str] = &[
     "write",
     "writeln",
     "insertAdjacentHTML",
+    // Modern Sanitizer-API opt-out: explicitly parses its argument as
+    // HTML with no sanitization, so a payload that names it is almost
+    // certainly attempting code execution through that path.
+    "setHTMLUnsafe",
 ];
 
 /// Properties whose assignment from injected content is itself an XSS sink


### PR DESCRIPTION
## Summary
- **AST sinks**: add `setHTMLUnsafe` (modern Sanitizer-API opt-out path); listed in both `DOM_SINKS` and the `payload_carries_js_sink` pre-filter.
- **AST sources**: add `clipboardData.getData` (paste events), `navigator.clipboard.readText`, `event.key` / `event.code`, and `event.target.innerText` / `textContent` / `innerHTML` (covers `e.*` aliases too).
- **Script-element tracking**: remember variables assigned from `document.createElement('script')` so that `s.text = tainted`, `s.textContent = tainted`, `s.innerText = tainted`, and `s.innerHTML = tainted` are recognised as JS-eval sinks. Falls back cleanly for non-script elements (no FP on `div.text = …`).
- **PoC generator**: emit a raw-JS payload (`alert(1)/*marker*/`) for the new `script.text` / `textContent` / `innerText` / `innerHTML` sinks.
- **Runtime verification**: accept executable-URL evidence when the reflected attribute value still starts with `javascript:` / `data:text/html` / `vbscript:` and contains the payload bytes verbatim — previously a trailing `//&next=…` or similar template glue rejected the verification. Substring-only matches without the executable prefix are still rejected to keep FP risk low.

## Test plan
- [x] `cargo test --lib` — 1047 passing (8 new, 0 failures)
- [x] `cargo clippy --lib` clean
- [x] `cargo fmt --check` clean
- [x] New regression tests cover: `setHTMLUnsafe` detection, script-element `.text` / `.textContent` assignment, `.text` on a div does *not* fire, `clipboardData.getData` → `innerHTML` flow, executable-URL evidence with trailing bytes, executable-URL evidence rejects unrelated `javascript:` URLs.