### PR TITLE
feat(dom-xss): resolve inline script-element sinks via HTML context

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -2218,10 +2218,12 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                     && let Some(response_text) = preflight_response_body {
                         let mut ast_batch: Vec<crate::scanning::result::Result> = Vec::new();
                         let js_blocks = crate::scanning::ast_integration::extract_javascript_from_html(&response_text);
+                        let script_element_ids = crate::scanning::ast_integration::extract_script_element_ids(&response_text);
                         for js_code in js_blocks {
-                            let findings = crate::scanning::ast_integration::analyze_javascript_for_dom_xss(
+                            let findings = crate::scanning::ast_integration::analyze_javascript_for_dom_xss_with_html_context(
                                 &js_code,
                                 target.url.as_str(),
+                                &script_element_ids,
                             );
                             for (vuln, payload, description) in findings {
                                 let self_bootstrap_verified =

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -553,6 +553,7 @@ impl<'a> DomXssVisitor<'a> {
     ///     when the selector statically picks a script element;
     ///   * `document.getElementsByTagName('script')[N]` /
     ///     `document.scripts[N]`.
+    ///
     /// The selector parsing is intentionally conservative — only fully
     /// static literal arguments resolve, so a dynamic selector never
     /// false-positives on a non-script element.
@@ -608,10 +609,10 @@ impl<'a> DomXssVisitor<'a> {
             // `<script>` elements, so any numeric / string-numeric index
             // returns a script element.
             Expression::StaticMemberExpression(inner) => {
-                if let Some(path) = self.get_member_string(inner) {
-                    if path == "document.scripts" {
-                        return true;
-                    }
+                if let Some(path) = self.get_member_string(inner)
+                    && path == "document.scripts"
+                {
+                    return true;
                 }
                 false
             }
@@ -658,14 +659,12 @@ impl<'a> DomXssVisitor<'a> {
         // we'd need real CSS parsing to handle these reliably.
         if trimmed
             .chars()
-            .any(|c| c == ',' || c == ' ' || c == '>' || c == '+' || c == '~')
+            .any(|c| [',', ' ', '>', '+', '~'].contains(&c))
         {
             return false;
         }
         // The tag portion is everything up to the first `.`, `#`, `[`, or `:`.
-        let tag_end = trimmed
-            .find(|c: char| c == '.' || c == '#' || c == '[' || c == ':')
-            .unwrap_or(trimmed.len());
+        let tag_end = trimmed.find(['.', '#', '[', ':']).unwrap_or(trimmed.len());
         let tag = &trimmed[..tag_end];
         tag.eq_ignore_ascii_case("script")
     }

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -94,6 +94,13 @@ struct DomXssVisitor<'a> {
     /// variables runs the value as JS once the element is appended, which
     /// is otherwise indistinguishable from a harmless text assignment.
     script_element_vars: HashSet<String>,
+    /// IDs of `<script>` elements observed in the surrounding HTML.
+    /// When `document.getElementById('id')` resolves to one of these,
+    /// the returned element is a real `<script>` and text-property
+    /// assignments execute as JS, even though the call is inline and
+    /// never bound to a variable. Populated by the HTML pre-scan in
+    /// `ast_integration::extract_script_element_ids`.
+    script_element_ids: HashSet<String>,
 }
 
 // Module-level DOM source/sink/sanitizer constants
@@ -484,7 +491,13 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_objects: HashSet::new(),
             url_search_params_field_sources: HashMap::new(),
             script_element_vars: HashSet::new(),
+            script_element_ids: HashSet::new(),
         }
+    }
+
+    fn with_script_element_ids(mut self, ids: HashSet<String>) -> Self {
+        self.script_element_ids = ids;
+        self
     }
 
     /// Recognise `document.createElement('script')` (and the spelling variants
@@ -528,6 +541,133 @@ impl<'a> DomXssVisitor<'a> {
     /// `src` is already covered by the generic URL-attribute sink path.
     fn is_script_element_text_sink_prop(prop: &str) -> bool {
         matches!(prop, "text" | "textContent" | "innerText" | "innerHTML")
+    }
+
+    /// Decide whether an expression resolves to a `<script>` DOM element.
+    /// Covers:
+    ///   * identifiers previously assigned a script element
+    ///     (`document.createElement('script')` or a script lookup);
+    ///   * inline `document.getElementById('id')` when `id` matches a
+    ///     `<script id="...">` observed in the surrounding HTML;
+    ///   * inline `document.querySelector(...)` / `querySelectorAll(...)[N]`
+    ///     when the selector statically picks a script element;
+    ///   * `document.getElementsByTagName('script')[N]` /
+    ///     `document.scripts[N]`.
+    /// The selector parsing is intentionally conservative — only fully
+    /// static literal arguments resolve, so a dynamic selector never
+    /// false-positives on a non-script element.
+    fn expr_resolves_to_script_element(&self, expr: &Expression<'a>) -> bool {
+        match expr {
+            Expression::Identifier(id) => self.script_element_vars.contains(id.name.as_str()),
+            Expression::ParenthesizedExpression(p) => {
+                self.expr_resolves_to_script_element(&p.expression)
+            }
+            Expression::CallExpression(call) => self.call_resolves_to_script_element(call),
+            Expression::ComputedMemberExpression(member) => {
+                self.computed_member_resolves_to_script_element(member)
+            }
+            Expression::StaticMemberExpression(member) => {
+                // `document.scripts` as a *value* is a collection, not an
+                // element. Only `document.scripts[N]` resolves, and that
+                // shape is handled in `computed_member_resolves_to_script_element`.
+                let _ = member;
+                false
+            }
+            _ => false,
+        }
+    }
+
+    fn call_resolves_to_script_element(&self, call: &CallExpression<'a>) -> bool {
+        let Some(method) = self.get_callee_property_name(&call.callee) else {
+            return false;
+        };
+        match method.as_str() {
+            "getElementById" => {
+                let Some(id) = Self::extract_static_string_argument(call, 0) else {
+                    return false;
+                };
+                self.script_element_ids.contains(&id)
+            }
+            "querySelector" => {
+                let Some(sel) = Self::extract_static_string_argument(call, 0) else {
+                    return false;
+                };
+                Self::selector_targets_script(&sel)
+            }
+            _ => false,
+        }
+    }
+
+    fn computed_member_resolves_to_script_element(
+        &self,
+        member: &ComputedMemberExpression<'a>,
+    ) -> bool {
+        // Look at the object being indexed.
+        match &member.object {
+            // `document.scripts[N]` — `scripts` is an HTMLCollection of all
+            // `<script>` elements, so any numeric / string-numeric index
+            // returns a script element.
+            Expression::StaticMemberExpression(inner) => {
+                if let Some(path) = self.get_member_string(inner) {
+                    if path == "document.scripts" {
+                        return true;
+                    }
+                }
+                false
+            }
+            // `document.getElementsByTagName('script')[N]` and
+            // `document.querySelectorAll('script')[N]`.
+            Expression::CallExpression(call) => {
+                let Some(method) = self.get_callee_property_name(&call.callee) else {
+                    return false;
+                };
+                match method.as_str() {
+                    "getElementsByTagName" => Self::call_first_arg_eq_ignore_case(call, "script"),
+                    "querySelectorAll" => {
+                        let Some(sel) = Self::extract_static_string_argument(call, 0) else {
+                            return false;
+                        };
+                        Self::selector_targets_script(&sel)
+                    }
+                    _ => false,
+                }
+            }
+            _ => false,
+        }
+    }
+
+    fn call_first_arg_eq_ignore_case(call: &CallExpression<'a>, expected: &str) -> bool {
+        Self::extract_static_string_argument(call, 0)
+            .map(|s| s.eq_ignore_ascii_case(expected))
+            .unwrap_or(false)
+    }
+
+    /// Static-selector matcher for "this picks a `<script>`."
+    /// Accepts the conservative shapes that appear in real bundles —
+    /// `script`, `script#id`, `script[id="x"]`, `script.cls`, `script[*]`.
+    /// Combinators (`,`, ` `, `>`, `+`, `~`) are rejected so we never
+    /// claim a selector resolves to script when the rightmost element
+    /// could be anything.
+    fn selector_targets_script(selector: &str) -> bool {
+        let trimmed = selector.trim();
+        if trimmed.is_empty() {
+            return false;
+        }
+        // A descendant / sibling / list combinator means the matched
+        // element is the *last* compound selector. Be safe and reject —
+        // we'd need real CSS parsing to handle these reliably.
+        if trimmed
+            .chars()
+            .any(|c| c == ',' || c == ' ' || c == '>' || c == '+' || c == '~')
+        {
+            return false;
+        }
+        // The tag portion is everything up to the first `.`, `#`, `[`, or `:`.
+        let tag_end = trimmed
+            .find(|c: char| c == '.' || c == '#' || c == '[' || c == ':')
+            .unwrap_or(trimmed.len());
+        let tag = &trimmed[..tag_end];
+        tag.eq_ignore_ascii_case("script")
     }
 
     /// Get a string representation of an expression if it's an identifier or member expression
@@ -1711,8 +1851,13 @@ impl<'a> DomXssVisitor<'a> {
                 // `let s = document.createElement('script')` — remember the
                 // variable so a later `s.text = tainted` is recognised as a
                 // sink even though `text` is a benign property on every
-                // other element kind.
-                if self.expr_creates_script_element(init) {
+                // other element kind. Also covers element lookups that
+                // statically resolve to a `<script>` element
+                // (`getElementById('script-id')`, `querySelector('script')`,
+                // `document.scripts[N]`, …).
+                if self.expr_creates_script_element(init)
+                    || self.expr_resolves_to_script_element(init)
+                {
                     self.script_element_vars.insert(var_name.to_string());
                 } else {
                     self.script_element_vars.remove(var_name);
@@ -2359,7 +2504,7 @@ impl<'a> DomXssVisitor<'a> {
                 // check below would miss.
                 let script_text_sink = right_tainted
                     && Self::is_script_element_text_sink_prop(prop_name)
-                    && matches!(&member.object, Expression::Identifier(id) if self.script_element_vars.contains(id.name.as_str()));
+                    && self.expr_resolves_to_script_element(&member.object);
                 if script_text_sink {
                     self.report_vulnerability_with_source(
                         assign.span(),
@@ -3116,12 +3261,26 @@ impl<'a> DomXssVisitor<'a> {
 }
 
 /// AST-based DOM XSS analyzer
-pub struct AstDomAnalyzer;
+#[derive(Default)]
+pub struct AstDomAnalyzer {
+    /// IDs of `<script>` elements gathered from the surrounding HTML
+    /// (see `ast_integration::extract_script_element_ids`). Empty when
+    /// the caller has no HTML context.
+    script_element_ids: HashSet<String>,
+}
 
 impl AstDomAnalyzer {
     /// Create a new AST DOM analyzer
     pub fn new() -> Self {
-        Self
+        Self::default()
+    }
+
+    /// Attach the set of `<script>` element IDs from the surrounding HTML
+    /// so `document.getElementById('id').innerText = tainted` can be
+    /// recognised as a JS-eval sink even when the lookup is inline.
+    pub fn with_script_element_ids(mut self, ids: HashSet<String>) -> Self {
+        self.script_element_ids = ids;
+        self
     }
 
     /// Analyze JavaScript source code for DOM XSS vulnerabilities
@@ -3136,16 +3295,11 @@ impl AstDomAnalyzer {
             return Err(format!("Parse errors: {}", error_messages.join(", ")));
         }
 
-        let mut visitor = DomXssVisitor::new(source_code);
+        let mut visitor = DomXssVisitor::new(source_code)
+            .with_script_element_ids(self.script_element_ids.clone());
         visitor.walk_statements(&ret.program.body);
 
         Ok(visitor.vulnerabilities)
-    }
-}
-
-impl Default for AstDomAnalyzer {
-    fn default() -> Self {
-        Self::new()
     }
 }
 

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3039,9 +3039,8 @@ const urlParams = new URL(location.href).searchParams;
 const query = urlParams.get('query');
 document.getElementById('scriptTag').innerText = query;
 "#;
-    let analyzer = AstDomAnalyzer::new().with_script_element_ids(
-        std::iter::once("scriptTag".to_string()).collect(),
-    );
+    let analyzer = AstDomAnalyzer::new()
+        .with_script_element_ids(std::iter::once("scriptTag".to_string()).collect());
     let r = analyzer.analyze(js).expect("parses");
     assert!(
         r.iter().any(|v| v.sink == "script.innerText"),
@@ -3081,9 +3080,8 @@ const urlParams = new URL(location.href).searchParams;
 const query = urlParams.get('query');
 document.getElementById('output').innerText = query;
 "#;
-    let analyzer = AstDomAnalyzer::new().with_script_element_ids(
-        std::iter::once("scriptTag".to_string()).collect(),
-    );
+    let analyzer = AstDomAnalyzer::new()
+        .with_script_element_ids(std::iter::once("scriptTag".to_string()).collect());
     let r = analyzer.analyze(js).expect("parses");
     assert!(
         !r.iter().any(|v| v.sink.starts_with("script.")),

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3028,6 +3028,143 @@ d.text = location.hash.slice(1);
 }
 
 #[test]
+fn detects_get_element_by_id_script_element_inline_inner_text() {
+    // Matches xssmaze dom-level9: an empty <script id="scriptTag"></script>
+    // placeholder, then an inline `getElementById('scriptTag').innerText = tainted`
+    // populates it. The HTML pre-scan tells the analyzer that `scriptTag`
+    // is a script-element id, so the inline call resolves to a script
+    // element and the assignment must be reported as a JS-eval sink.
+    let js = r#"
+const urlParams = new URL(location.href).searchParams;
+const query = urlParams.get('query');
+document.getElementById('scriptTag').innerText = query;
+"#;
+    let analyzer = AstDomAnalyzer::new().with_script_element_ids(
+        std::iter::once("scriptTag".to_string()).collect(),
+    );
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "script.innerText"),
+        "inline getElementById('script-id').innerText must be a JS-eval sink; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn get_element_by_id_script_sink_requires_html_context() {
+    // Without an HTML pre-scan, `getElementById('whatever')` could be any
+    // element — we must not surface `.innerText` assignments as a JS-eval
+    // sink in that case.
+    let js = r#"
+const urlParams = new URL(location.href).searchParams;
+const query = urlParams.get('query');
+document.getElementById('whatever').innerText = query;
+"#;
+    let analyzer = AstDomAnalyzer::new(); // no script_element_ids supplied
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        !r.iter().any(|v| v.sink.starts_with("script.")),
+        "getElementById without HTML context must not be claimed as script element; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn get_element_by_id_non_script_id_is_not_script_element() {
+    // The HTML pre-scan only seeds ids whose tag is `<script>`. A page
+    // with `<div id="output">` and `<script id="scriptTag">` must yield
+    // only `scriptTag` — assignments on `output.innerText` stay benign.
+    let js = r#"
+const urlParams = new URL(location.href).searchParams;
+const query = urlParams.get('query');
+document.getElementById('output').innerText = query;
+"#;
+    let analyzer = AstDomAnalyzer::new().with_script_element_ids(
+        std::iter::once("scriptTag".to_string()).collect(),
+    );
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        !r.iter().any(|v| v.sink.starts_with("script.")),
+        ".innerText on a non-script element id must not surface; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_query_selector_script_inner_text_pure_ast() {
+    // `document.querySelector('script')` returns the first script element
+    // without needing HTML context — the selector itself declares the tag.
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.querySelector('script').textContent = q;
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "script.textContent"),
+        "querySelector('script') resolves to a script element; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_document_scripts_index_inner_text_pure_ast() {
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.scripts[0].innerText = q;
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "script.innerText"),
+        "document.scripts[N] is a script element; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_get_elements_by_tag_name_script_index_text() {
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.getElementsByTagName('script')[0].text = q;
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "script.text"),
+        "getElementsByTagName('script')[N] is a script element; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn query_selector_combinator_selector_does_not_resolve_to_script() {
+    // `'div script'` ends in `script` but is a descendant combinator —
+    // play it safe and don't claim resolution without real CSS parsing.
+    // What we actually want to assert is the *negative* direction: the
+    // text-property assignment must not be reported as a script.* sink.
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.querySelector('div script').textContent = q;
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        !r.iter().any(|v| v.sink.starts_with("script.")),
+        "descendant combinator must not resolve statically; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn clipboard_get_data_is_recognised_as_source() {
     let js = r#"
 document.addEventListener('paste', function(e) {

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -1,6 +1,29 @@
 use scraper::Html;
+use std::collections::HashSet;
 
 use super::selectors;
+
+/// Collect the `id` attribute of every `<script>` element in `html`.
+///
+/// Used to teach the AST DOM analyzer that an inline call like
+/// `document.getElementById('scriptTag').innerText = tainted` is writing
+/// into a `<script>` body — i.e. an eval-equivalent sink — even when the
+/// JS file has no `document.createElement('script')` of its own. The
+/// caller threads the returned set into `AstDomAnalyzer::with_script_element_ids`.
+pub fn extract_script_element_ids(html: &str) -> HashSet<String> {
+    let mut ids = HashSet::new();
+    let document = Html::parse_document(html);
+    let selector = selectors::script();
+    for element in document.select(selector) {
+        if let Some(id) = element.value().attr("id") {
+            let trimmed = id.trim();
+            if !trimmed.is_empty() {
+                ids.insert(trimmed.to_string());
+            }
+        }
+    }
+    ids
+}
 
 /// Extract JavaScript code from HTML response
 /// Looks for <script> tags and inline event handlers
@@ -620,7 +643,24 @@ pub fn analyze_javascript_for_dom_xss(
     String,
     String,
 )> {
-    let analyzer = crate::scanning::ast_dom_analysis::AstDomAnalyzer::new();
+    analyze_javascript_for_dom_xss_with_html_context(js_code, _url, &HashSet::new())
+}
+
+/// Same as `analyze_javascript_for_dom_xss`, but supplies the AST analyzer
+/// with the set of `<script>` element IDs observed in the surrounding HTML
+/// so inline `getElementById('id').innerText = tainted` shapes resolve to
+/// a JS-eval sink. Use `extract_script_element_ids(html)` to build the set.
+pub fn analyze_javascript_for_dom_xss_with_html_context(
+    js_code: &str,
+    _url: &str,
+    script_element_ids: &HashSet<String>,
+) -> Vec<(
+    crate::scanning::ast_dom_analysis::DomXssVulnerability,
+    String,
+    String,
+)> {
+    let analyzer = crate::scanning::ast_dom_analysis::AstDomAnalyzer::new()
+        .with_script_element_ids(script_element_ids.clone());
 
     match analyzer.analyze(js_code) {
         Ok(vulnerabilities) => {

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -666,3 +666,33 @@ fn test_has_self_bootstrap_verification_ignores_manual_only_sources() {
 
     assert!(!has_self_bootstrap_verification(js, "document.referrer"));
 }
+
+#[test]
+fn test_extract_script_element_ids_collects_only_script_ids() {
+    let html = r#"
+<html>
+<body>
+<div id='output'></div>
+<script id='scriptTag'></script>
+<script id='another'></script>
+<script>
+  document.getElementById('scriptTag').innerText = location.hash.slice(1);
+</script>
+</body>
+</html>
+"#;
+    let ids = extract_script_element_ids(html);
+    assert!(ids.contains("scriptTag"));
+    assert!(ids.contains("another"));
+    // The <div id='output'> id must NOT be in the set — only script tags.
+    assert!(!ids.contains("output"));
+}
+
+#[test]
+fn test_extract_script_element_ids_ignores_blank_ids() {
+    let html = r#"<script id='   '></script><script></script><script id='ok'></script>"#;
+    let ids = extract_script_element_ids(html);
+    assert_eq!(ids.len(), 1);
+    assert!(ids.contains("ok"));
+}
+

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -695,4 +695,3 @@ fn test_extract_script_element_ids_ignores_blank_ids() {
     assert_eq!(ids.len(), 1);
     assert!(ids.contains("ok"));
 }
-

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -328,11 +328,15 @@ async fn run_ast_dom_analysis(
 ) -> Vec<crate::scanning::result::Result> {
     let mut results = Vec::new();
     let js_blocks = crate::scanning::ast_integration::extract_javascript_from_html(response_text);
+    let script_element_ids =
+        crate::scanning::ast_integration::extract_script_element_ids(response_text);
     for js_code in js_blocks {
-        let findings = crate::scanning::ast_integration::analyze_javascript_for_dom_xss(
-            &js_code,
-            target.url.as_str(),
-        );
+        let findings =
+            crate::scanning::ast_integration::analyze_javascript_for_dom_xss_with_html_context(
+                &js_code,
+                target.url.as_str(),
+                &script_element_ids,
+            );
         for (vuln, payload, description) in findings {
             let self_bootstrap_verified =
                 crate::scanning::ast_integration::has_self_bootstrap_verification(


### PR DESCRIPTION
## Summary

- AST DOM analyzer can now report `getElementById('X').innerText = tainted` when `<script id="X">` exists in the response HTML — the only remaining xssmaze `/dom/*` gap (`dom-level9`).
- Adds an HTML pre-scan (`extract_script_element_ids`) that threads `<script id="...">` IDs into the analyzer via `AstDomAnalyzer::with_script_element_ids`.
- New `expr_resolves_to_script_element` covers identifier aliases, inline `getElementById(known-script-id)`, and pure-AST shapes that need no HTML context: `querySelector('script…')`, `getElementsByTagName('script')[N]`, `querySelectorAll('script')[N]`, `document.scripts[N]`. Selector parser conservatively rejects combinators (`,`, ` `, `>`, `+`, `~`) to keep false positives off.
- Assignment-sink check switched from an identifier-only `matches!` to the resolver, so the inline call form fires (not just `let s = …; s.innerText = …`).

## Benchmark

xssmaze `/dom/*`: **40/41 → 41/41**, no regressions on the 40 previously-passing cases. `dom-level9` now surfaces as `URLSearchParams.get(query) → script.innerText` with the correct `alert(1)/*marker*/` JS-eval payload shape.

## Test plan

- [x] `cargo test --release --lib` — 1057 pass, 0 fail
- [x] 7 new unit tests in `ast_dom_analysis/tests.rs` covering: HTML-context resolution, missing-context negative, non-script-id negative, `querySelector('script')`, `document.scripts[N]`, `getElementsByTagName('script')[N]`, combinator-selector negative
- [x] 2 new unit tests in `ast_integration/tests.rs` covering `extract_script_element_ids` collects only `<script>` ids and ignores blank ids
- [x] xssmaze `/dom/*` end-to-end scan: 41/41 detections