### PR TITLE
fix(dom-xss): gate native append/prepend/after/before behind jQuery receiver

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -845,6 +845,43 @@ impl<'a> DomXssVisitor<'a> {
         }
     }
 
+    /// Walk the object chain of a member-expression callee and return true
+    /// when the chain terminates in a `$(...)` or `jQuery(...)` call.
+    ///
+    /// Used to gate native-vs-jQuery DOM insertion methods (`append`,
+    /// `prepend`, `after`, `before`). On a native `Element` these methods
+    /// insert string arguments as text nodes — no HTML parsing, no script
+    /// execution — so they are NOT XSS sinks. They only behave as sinks
+    /// when called on a jQuery selector chain, where `.append(html)`
+    /// invokes `innerHTML` semantics under the hood.
+    ///
+    /// Handles chains like `$('#x').append(...)` and
+    /// `$('#x').find('.y').append(...)` by following the `object` link of
+    /// each intermediate `StaticMemberExpression` / `CallExpression`.
+    fn callee_receiver_is_jquery_chain(callee: &Expression<'a>) -> bool {
+        let mut current: &Expression<'a> = match callee {
+            Expression::StaticMemberExpression(m) => &m.object,
+            Expression::ComputedMemberExpression(m) => &m.object,
+            _ => return false,
+        };
+        loop {
+            match current {
+                Expression::CallExpression(call) => match &call.callee {
+                    Expression::Identifier(id) => {
+                        return id.name == "$" || id.name == "jQuery";
+                    }
+                    Expression::StaticMemberExpression(m) => current = &m.object,
+                    Expression::ComputedMemberExpression(m) => current = &m.object,
+                    _ => return false,
+                },
+                Expression::StaticMemberExpression(m) => current = &m.object,
+                Expression::ComputedMemberExpression(m) => current = &m.object,
+                Expression::ParenthesizedExpression(p) => current = &p.expression,
+                _ => return false,
+            }
+        }
+    }
+
     fn build_bound_alias_from_bind_call(
         &self,
         bind_call: &CallExpression<'a>,
@@ -3224,6 +3261,20 @@ impl<'a> DomXssVisitor<'a> {
                         return;
                     }
                 }
+            } else if matches!(
+                method_name.as_str(),
+                "append" | "prepend" | "after" | "before"
+            ) && !Self::callee_receiver_is_jquery_chain(&call.callee)
+            {
+                // FP suppression: native `Element.append / .prepend / .after
+                // / .before` insert string arguments as text nodes — they do
+                // NOT parse HTML and cannot trigger script execution. Only
+                // jQuery's same-named methods are real HTML sinks (they call
+                // `innerHTML` internally). Without a `$(...)` / `jQuery(...)`
+                // receiver chain, treat these method calls as inert.
+                //
+                // Falls through to walk the callee so taint tracking through
+                // arguments and sub-expressions still proceeds.
             } else {
                 // Generic method sink: if any argument is tainted
                 let mut tainted_source: Option<String> = None;

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3180,3 +3180,73 @@ document.addEventListener('paste', function(e) {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn native_element_append_is_not_a_sink() {
+    // `Element.prototype.append(string)` inserts the string as a Text node
+    // — no HTML parsing — so a tainted argument is not exploitable. The
+    // analyzer must not flag this shape.
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.getElementById('out').append(q);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "native el.append(tainted) is not an XSS sink; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn native_element_prepend_after_before_are_not_sinks() {
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+document.getElementById('a').prepend(q);
+document.getElementById('b').after(q);
+document.getElementById('c').before(q);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "native el.prepend/.after/.before(tainted) are not XSS sinks; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_append_remains_a_sink() {
+    // jQuery's `.append(html)` invokes innerHTML semantics — a tainted
+    // string argument is exploitable, so the analyzer must still flag it.
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+$('#out').append(q);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "append"),
+        "jQuery $(...).append(tainted) must surface; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_chained_append_remains_a_sink() {
+    // `$('#x').find('.y').append(tainted)` — the chain must still be
+    // recognised as a jQuery receiver even through an intermediate
+    // method call.
+    let js = r#"
+const q = new URLSearchParams(location.search).get('q');
+$('#root').find('.target').append(q);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let r = analyzer.analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "append"),
+        "jQuery chained .find().append(tainted) must surface; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary
- AST analyzer's method-name sink path matched `append`/`prepend`/`after`/`before` on **any** receiver. Native `Element.prototype.{append,prepend,after,before}` insert string arguments as **text nodes** — no HTML parsing, no script execution — so `parent.append(textValue)` on a tainted source was producing AstDetected Medium false positives on every modern DOM app.
- Add `callee_receiver_is_jquery_chain` and gate the four insertion methods to fire only when the receiver chain terminates in `$(...)` or `jQuery(...)`. jQuery's same-named methods stay flagged because they invoke `innerHTML` under the hood.
- Direct-sink path (`append(userInput)` top-level identifier) and every other method sink (`insertAdjacentHTML`, `setAttribute`, `execCommand`, `write`, `html`, …) unchanged.

## Test plan
- [x] `cargo test --lib` — 1061 pass (+4 new), 0 fail
- [x] `cargo test --test unit_tests` — 186 pass, 0 regression
- [x] `cargo clippy --lib --all-targets -- -D warnings` — clean
- [x] `cargo fmt --check` — clean
- [x] New regression tests cover both directions:
  - `native_element_append_is_not_a_sink` — `el.append(tainted)` suppressed
  - `native_element_prepend_after_before_are_not_sinks` — same for the other three
  - `jquery_append_remains_a_sink` — `$('#x').append(tainted)` still flagged
  - `jquery_chained_append_remains_a_sink` — `$('#x').find('.y').append(tainted)` still flagged
- [x] xssmaze unaffected by inspection: csti-level5 (the only jQuery case) uses `.html()`, not the gated four methods

## Known follow-ups (not in this PR)
- `$('.x')[0].append(q)` — wrapper `[0]` extracts native node; current chain walk still treats it as jQuery. Missed FP cut, not a TP regression. Worth chasing only with a concrete real-world example.
- Other FP-suspect surfaces (`html` method-sink, broad sources like `event.target.value` / `Response.text`, unverified `AstDetected` Medium findings) intentionally left for separate, targeted PRs.