### PR TITLE
perf(scan): hoist marker-carrying autotriggers, prune dead-angle payloads

### DIFF
--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -216,9 +216,7 @@ fn prune_blocked_raw_angles(payloads: Vec<String>, invalid_specials: &[char]) ->
     }
     payloads
         .into_iter()
-        .filter(|p| {
-            !((block_lt && p.contains('<')) || (block_gt && p.contains('>')))
-        })
+        .filter(|p| !((block_lt && p.contains('<')) || (block_gt && p.contains('>'))))
         .collect()
 }
 
@@ -274,10 +272,7 @@ fn payload_is_angle_free(p: &str) -> bool {
 /// request usually comes from an angle-free payload, the loop short-
 /// circuits, and the budget for the param collapses from thousands of
 /// requests to dozens.
-fn hoist_angle_free_payloads(
-    payloads: Vec<String>,
-    invalid_specials: &[char],
-) -> Vec<String> {
+fn hoist_angle_free_payloads(payloads: Vec<String>, invalid_specials: &[char]) -> Vec<String> {
     let block_lt = invalid_specials.contains(&'<');
     let block_gt = invalid_specials.contains(&'>');
     if !block_lt && !block_gt {
@@ -783,8 +778,7 @@ pub async fn run_scanning(
             reflection_payloads = hoist_angle_free_payloads(reflection_payloads, invalid);
             dom_payloads = hoist_angle_free_payloads(dom_payloads, invalid);
             if crate::DEBUG.load(Ordering::Relaxed)
-                && (refl_before != reflection_payloads.len()
-                    || dom_before != dom_payloads.len())
+                && (refl_before != reflection_payloads.len() || dom_before != dom_payloads.len())
             {
                 eprintln!(
                     "[DBG] adaptive prune (param={}): reflection {}→{}, dom {}→{} (invalid_specials={:?})",

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -193,6 +193,109 @@ fn reflection_kind_note(kind: crate::scanning::check_reflection::ReflectionKind)
     }
 }
 
+/// Drop payloads whose raw bytes carry an HTML-structural character the
+/// server has been observed to filter (recorded in
+/// `Param.invalid_specials` by Stage 3 active probing). Raw `<`/`>` cannot
+/// pass through a server-side blocklist that strips those bytes after
+/// decoding, so the corresponding payload has no chance to reflect — every
+/// HTTP request spent on it is wasted. The encoded variants of the same
+/// payload (`%3Csvg%3E`, `&lt;svg&gt;`, multi-URL-encoded forms) carry no
+/// raw `<`/`>` themselves and survive this pass, preserving the bypass
+/// surface for naive filters that decode only once.
+///
+/// Conservative on quotes: attribute-breakout payloads intentionally lead
+/// with the same delimiter character the surrounding HTML attribute uses,
+/// and that delimiter must already be a "valid" special (the server
+/// emitted it), so pruning on `"`/`'` would mistakenly drop the very
+/// payloads that exploit attribute injection.
+fn prune_blocked_raw_angles(payloads: Vec<String>, invalid_specials: &[char]) -> Vec<String> {
+    let block_lt = invalid_specials.contains(&'<');
+    let block_gt = invalid_specials.contains(&'>');
+    if !block_lt && !block_gt {
+        return payloads;
+    }
+    payloads
+        .into_iter()
+        .filter(|p| {
+            !((block_lt && p.contains('<')) || (block_gt && p.contains('>')))
+        })
+        .collect()
+}
+
+/// Common encoded forms of `<` / `>` we look for when deciding whether a
+/// payload depends on angle brackets. A payload that carries any of these
+/// forms is hoping the server single-pass-decodes the input — when the
+/// server filters `<` after decode (the common case), the bypass fails.
+/// Hoisting payloads that carry no angle bracket in any form (event-
+/// handler quote-breakouts, protocol-URI payloads) ahead of these
+/// angle-dependent variants lets the scanner hit a working payload first
+/// and short-circuit the rest of the loop via `reflection_found_locally`.
+const ANGLE_ENCODED_NEEDLES_LT: &[&str] = &[
+    "%3C", "%3c", "%253C", "%253c", "&lt;", "&LT;", "&#60;", "&#x3c;", "&#x3C;", "&#x003c;",
+    "&#x003C;",
+];
+const ANGLE_ENCODED_NEEDLES_GT: &[&str] = &[
+    "%3E", "%3e", "%253E", "%253e", "&gt;", "&GT;", "&#62;", "&#x3e;", "&#x3E;", "&#x003e;",
+    "&#x003E;",
+];
+
+/// True when the payload carries no `<` or `>` in any of: raw bytes,
+/// percent-encoded form (single or double), or HTML entity (named,
+/// decimal, hex). Used to hoist angle-free payloads to the front of the
+/// payload list when `Param.invalid_specials` flags angle brackets — those
+/// payloads (event-handler quote-breakouts, `javascript:` protocol URIs)
+/// are the ones that actually reflect through an angle-stripping filter,
+/// and the loop's `reflection_found_locally` short-circuit means the
+/// first hit zeros out the rest of the budget.
+fn payload_is_angle_free(p: &str) -> bool {
+    if p.contains('<') || p.contains('>') {
+        return false;
+    }
+    for n in ANGLE_ENCODED_NEEDLES_LT {
+        if p.contains(n) {
+            return false;
+        }
+    }
+    for n in ANGLE_ENCODED_NEEDLES_GT {
+        if p.contains(n) {
+            return false;
+        }
+    }
+    true
+}
+
+/// Stable-partition the payload list so payloads that don't depend on
+/// `<`/`>` (in any encoded form) come first when active probing has
+/// flagged angles as invalid. Pairs with [`prune_blocked_raw_angles`]:
+/// pruning kills raw-angle payloads outright, hoisting reorders the
+/// remaining list so the angle-free survivors get tested before the
+/// encoded-angle variants whose only hope is a naive single-pass-decode
+/// filter (rare in practice). Net effect: the first reflection-finding
+/// request usually comes from an angle-free payload, the loop short-
+/// circuits, and the budget for the param collapses from thousands of
+/// requests to dozens.
+fn hoist_angle_free_payloads(
+    payloads: Vec<String>,
+    invalid_specials: &[char],
+) -> Vec<String> {
+    let block_lt = invalid_specials.contains(&'<');
+    let block_gt = invalid_specials.contains(&'>');
+    if !block_lt && !block_gt {
+        return payloads;
+    }
+    let mut clean: Vec<String> = Vec::with_capacity(payloads.len());
+    let mut rest: Vec<String> = Vec::with_capacity(payloads.len());
+    for p in payloads {
+        if payload_is_angle_free(&p) {
+            clean.push(p);
+        } else {
+            rest.push(p);
+        }
+    }
+    clean.extend(rest);
+    clean
+}
+
 fn get_fallback_reflection_payloads(
     args: &ScanArgs,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -655,6 +758,42 @@ pub async fn run_scanning(
                 dom_payloads = crate::encoding::apply_encoders_to_payloads(
                     &dom_payloads,
                     &strategy.extra_encoders,
+                );
+            }
+        }
+
+        // Adaptive prune + reorder: when active probing recorded that the
+        // server strips `<` / `>`, (a) drop reflection/DOM payloads whose
+        // raw bytes carry those characters (guaranteed misses), and
+        // (b) hoist payloads that carry no `<`/`>` in any encoded form to
+        // the front of the list. The reorder is the bigger lever: the
+        // loop's `reflection_found_locally` short-circuit means the first
+        // reflecting payload zeros out the rest of the budget, so putting
+        // angle-free payloads (event-handler / quote-breakout shapes that
+        // actually work against an angle-stripping filter) before the
+        // angle-encoded variants collapses the per-param request count
+        // from thousands to dozens on attribute-context params.
+        if let Some(invalid) = param.invalid_specials.as_deref()
+            && !invalid.is_empty()
+        {
+            let refl_before = reflection_payloads.len();
+            let dom_before = dom_payloads.len();
+            reflection_payloads = prune_blocked_raw_angles(reflection_payloads, invalid);
+            dom_payloads = prune_blocked_raw_angles(dom_payloads, invalid);
+            reflection_payloads = hoist_angle_free_payloads(reflection_payloads, invalid);
+            dom_payloads = hoist_angle_free_payloads(dom_payloads, invalid);
+            if crate::DEBUG.load(Ordering::Relaxed)
+                && (refl_before != reflection_payloads.len()
+                    || dom_before != dom_payloads.len())
+            {
+                eprintln!(
+                    "[DBG] adaptive prune (param={}): reflection {}→{}, dom {}→{} (invalid_specials={:?})",
+                    param.name,
+                    refl_before,
+                    reflection_payloads.len(),
+                    dom_before,
+                    dom_payloads.len(),
+                    invalid,
                 );
             }
         }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -613,11 +613,7 @@ fn test_prune_blocked_raw_angles_partial_block_keeps_other_angle() {
     // Only `>` is blocked: payloads carrying `>` get dropped, but a raw `<`
     // alone is still allowed through. Captures servers that strip one angle
     // but not the other (uncommon, but the helper should respect that).
-    let payloads = vec![
-        "<a>".to_string(),
-        "<a".to_string(),
-        "a>".to_string(),
-    ];
+    let payloads = vec!["<a>".to_string(), "<a".to_string(), "a>".to_string()];
     let pruned = prune_blocked_raw_angles(payloads, &['>']);
     assert_eq!(pruned, vec!["<a".to_string()]);
 }
@@ -639,9 +635,9 @@ fn test_payload_is_angle_free_detects_encoded_forms() {
 fn test_hoist_angle_free_payloads_orders_clean_first() {
     let payloads = vec![
         "%3Csvg%20onload%3Dalert(1)%3E".to_string(), // encoded angles
-        "\" onfocus=alert(1) \"".to_string(),         // angle-free
-        "&lt;img&gt;".to_string(),                    // encoded angles
-        "javascript:alert(1)".to_string(),            // angle-free
+        "\" onfocus=alert(1) \"".to_string(),        // angle-free
+        "&lt;img&gt;".to_string(),                   // encoded angles
+        "javascript:alert(1)".to_string(),           // angle-free
     ];
     let hoisted = hoist_angle_free_payloads(payloads, &['<']);
     assert_eq!(hoisted[0], "\" onfocus=alert(1) \"");
@@ -653,10 +649,7 @@ fn test_hoist_angle_free_payloads_orders_clean_first() {
 
 #[test]
 fn test_hoist_angle_free_payloads_no_op_without_block() {
-    let payloads = vec![
-        "<svg>".to_string(),
-        "\" onfocus=alert(1) \"".to_string(),
-    ];
+    let payloads = vec!["<svg>".to_string(), "\" onfocus=alert(1) \"".to_string()];
     let original = payloads.clone();
     let hoisted = hoist_angle_free_payloads(payloads, &['"']);
     assert_eq!(hoisted, original, "non-angle invalids must not reorder");

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -583,6 +583,86 @@ fn test_format_req_per_sec_zero_delta_is_zero_rate() {
 }
 
 #[test]
+fn test_prune_blocked_raw_angles_drops_lt_and_gt_when_blocked() {
+    let payloads = vec![
+        "<svg onload=alert(1)>".to_string(),
+        "\" onfocus=alert(1) \"".to_string(),
+        "%3Csvg%20onload%3Dalert(1)%3E".to_string(),
+        "&lt;svg&gt;".to_string(),
+        "\"><img src=x onerror=alert(1)>".to_string(),
+    ];
+    let pruned = prune_blocked_raw_angles(payloads, &['<', '>']);
+    assert_eq!(pruned.len(), 3, "raw < / > payloads must be dropped");
+    assert!(pruned.iter().all(|p| !p.contains('<') && !p.contains('>')));
+}
+
+#[test]
+fn test_prune_blocked_raw_angles_no_op_without_block() {
+    let payloads = vec![
+        "<svg onload=alert(1)>".to_string(),
+        "\" onfocus=alert(1) \"".to_string(),
+    ];
+    let original = payloads.clone();
+    // Empty invalid set — must be a pass-through.
+    let pruned = prune_blocked_raw_angles(payloads, &[]);
+    assert_eq!(pruned, original);
+}
+
+#[test]
+fn test_prune_blocked_raw_angles_partial_block_keeps_other_angle() {
+    // Only `>` is blocked: payloads carrying `>` get dropped, but a raw `<`
+    // alone is still allowed through. Captures servers that strip one angle
+    // but not the other (uncommon, but the helper should respect that).
+    let payloads = vec![
+        "<a>".to_string(),
+        "<a".to_string(),
+        "a>".to_string(),
+    ];
+    let pruned = prune_blocked_raw_angles(payloads, &['>']);
+    assert_eq!(pruned, vec!["<a".to_string()]);
+}
+
+#[test]
+fn test_payload_is_angle_free_detects_encoded_forms() {
+    assert!(payload_is_angle_free("\" onfocus=alert(1) \""));
+    assert!(payload_is_angle_free("javascript:alert(1)"));
+    assert!(!payload_is_angle_free("<svg>"));
+    assert!(!payload_is_angle_free("%3Csvg%3E"));
+    assert!(!payload_is_angle_free("%3csvg%3e"));
+    assert!(!payload_is_angle_free("&lt;svg&gt;"));
+    assert!(!payload_is_angle_free("&#60;svg&#62;"));
+    assert!(!payload_is_angle_free("&#x3c;svg&#x3e;"));
+    assert!(!payload_is_angle_free("%253Csvg%253E"));
+}
+
+#[test]
+fn test_hoist_angle_free_payloads_orders_clean_first() {
+    let payloads = vec![
+        "%3Csvg%20onload%3Dalert(1)%3E".to_string(), // encoded angles
+        "\" onfocus=alert(1) \"".to_string(),         // angle-free
+        "&lt;img&gt;".to_string(),                    // encoded angles
+        "javascript:alert(1)".to_string(),            // angle-free
+    ];
+    let hoisted = hoist_angle_free_payloads(payloads, &['<']);
+    assert_eq!(hoisted[0], "\" onfocus=alert(1) \"");
+    assert_eq!(hoisted[1], "javascript:alert(1)");
+    // The encoded-angle ones come after, in original relative order.
+    assert!(hoisted[2].contains("%3C"));
+    assert!(hoisted[3].contains("&lt;"));
+}
+
+#[test]
+fn test_hoist_angle_free_payloads_no_op_without_block() {
+    let payloads = vec![
+        "<svg>".to_string(),
+        "\" onfocus=alert(1) \"".to_string(),
+    ];
+    let original = payloads.clone();
+    let hoisted = hoist_angle_free_payloads(payloads, &['"']);
+    assert_eq!(hoisted, original, "non-angle invalids must not reorder");
+}
+
+#[test]
 fn test_get_fallback_reflection_payloads_none_encoder_keeps_raw_only() {
     let mut args = default_scan_args();
     args.encoders = vec!["none".to_string()];

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -27,10 +27,16 @@ pub fn generate_dynamic_payloads(context: &InjectionContext) -> Vec<String> {
                     for payload in html_payloads.iter() {
                         payloads.push(format!("'>{}'", payload));
                     }
-                    for payload in attr_payloads.iter() {
-                        payloads.push(format!("' {} a='", payload));
-                    }
-                    // Self-triggering event handler payloads (work even when < > are filtered)
+                    // Self-triggering event handler payloads (work even when < > are filtered).
+                    // Carry the scan's id marker so a reflection in attribute context
+                    // promotes straight to V via marker-based DOM evidence — the first
+                    // hit collapses both the reflection and DOM verification loops
+                    // together. Ordered BEFORE `attr_payloads` (marker-less event
+                    // handlers) so the first angle-free payload sent is marker-
+                    // carrying — critical on servers that strip `<` / `>`, where
+                    // every prior payload that lacks a marker only yields [R] and
+                    // drains the DOM verification budget.
+                    let id_marker = crate::scanning::markers::id_marker();
                     let autotrigger_events = [
                         "onfocus=alert(1) autofocus",
                         "onmouseover=alert(1)",
@@ -42,9 +48,12 @@ pub fn generate_dynamic_payloads(context: &InjectionContext) -> Vec<String> {
                         "onslotchange=alert(1)",
                     ];
                     for ev in &autotrigger_events {
-                        payloads.push(format!("' {} '", ev));
+                        payloads.push(format!("' {} id={} '", ev, id_marker));
                         // Tab separator variant (bypasses space filtering)
-                        payloads.push(format!("'\t{}\t'", ev));
+                        payloads.push(format!("'\t{}\tid={}\t'", ev, id_marker));
+                    }
+                    for payload in attr_payloads.iter() {
+                        payloads.push(format!("' {} a='", payload));
                     }
                     if !url_like {
                         // Protocol payloads for src/href attributes (e.g. iframe src='VALUE')
@@ -61,10 +70,12 @@ pub fn generate_dynamic_payloads(context: &InjectionContext) -> Vec<String> {
                     for payload in html_payloads.iter() {
                         payloads.push(format!("\">{}\"", payload));
                     }
-                    for payload in attr_payloads.iter() {
-                        payloads.push(format!("\" {} \"", payload));
-                    }
-                    // Self-triggering event handler payloads (work even when < > are filtered)
+                    // Self-triggering event handler payloads (work even when < > are filtered).
+                    // Marker-carrying so the first reflecting payload also DOM-verifies
+                    // and the scanner short-circuits both loops in a single round-trip.
+                    // Ordered BEFORE `attr_payloads` so the first angle-free payload
+                    // sent is marker-carrying — see SingleQuote branch for full rationale.
+                    let id_marker = crate::scanning::markers::id_marker();
                     let autotrigger_events = [
                         "onfocus=alert(1) autofocus",
                         "onmouseover=alert(1)",
@@ -76,9 +87,12 @@ pub fn generate_dynamic_payloads(context: &InjectionContext) -> Vec<String> {
                         "onslotchange=alert(1)",
                     ];
                     for ev in &autotrigger_events {
-                        payloads.push(format!("\" {} \"", ev));
+                        payloads.push(format!("\" {} id={} \"", ev, id_marker));
                         // Tab separator variant (bypasses space filtering)
-                        payloads.push(format!("\"\t{}\t\"", ev));
+                        payloads.push(format!("\"\t{}\tid={}\t\"", ev, id_marker));
+                    }
+                    for payload in attr_payloads.iter() {
+                        payloads.push(format!("\" {} \"", payload));
                     }
                     if !url_like {
                         // Protocol payloads for src/href attributes (e.g. iframe src="VALUE")

--- a/tests/request_count_probe.rs
+++ b/tests/request_count_probe.rs
@@ -161,13 +161,29 @@ async fn handler_echo_all(Query(p): Query<HashMap<String, String>>) -> impl Into
     Html(body)
 }
 
+/// Reflects `q` inside an attribute value while stripping every `<` / `>`
+/// byte from the input. The attribute context exposes autotrigger event
+/// handler / quote-break payloads (no angle brackets needed), so a finding
+/// is still reachable — but every raw `<svg…>` style payload becomes a
+/// guaranteed miss. Used to measure the request savings from the
+/// adaptive-prune step in `scanning/mod.rs::run_scanning` that drops raw
+/// `<`/`>` payloads when `Param.invalid_specials` flags them.
+async fn handler_filter_angles(Query(p): Query<HashMap<String, String>>) -> impl IntoResponse {
+    let q = p.get("q").cloned().unwrap_or_default();
+    let stripped: String = q.chars().filter(|c| *c != '<' && *c != '>').collect();
+    Html(format!(
+        "<!DOCTYPE html><html><body><input value=\"{stripped}\"></body></html>"
+    ))
+}
+
 async fn start_server() -> SocketAddr {
     let app = Router::new()
         .route("/plain", get(handler_plain))
         .route("/b64", get(handler_b64_json))
         .route("/jwt", get(handler_jwt))
         .route("/urljson", get(handler_url_json))
-        .route("/echo_all", get(handler_echo_all));
+        .route("/echo_all", get(handler_echo_all))
+        .route("/filter_angles", get(handler_filter_angles));
     let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
         .await
         .expect("bind");
@@ -232,6 +248,17 @@ async fn measure_request_counts() {
     measure(
         "non_reflected",
         format!("http://{addr}/plain?other=ignored"),
+    )
+    .await;
+
+    // Angle-filtering server: `<` / `>` get stripped, so any raw-angle
+    // reflection payload is doomed. Stage 3 marks both chars as invalid
+    // and the scanning hot path prunes them out, so the request budget
+    // should be visibly smaller than `plain_query` even though both
+    // produce one finding.
+    measure(
+        "angle_filtered",
+        format!("http://{addr}/filter_angles?q=hello"),
     )
     .await;
 


### PR DESCRIPTION
## Summary
- Reorder `generate_dynamic_payloads` in attribute contexts so marker-carrying autotrigger event-handler payloads (`" onfocus=alert(1) autofocus id={id_marker} "`) sit **before** marker-less `attr_payloads`. This lets the first reflecting payload also trip `dom_found_locally` via `classify_dom_evidence → Marker`, collapsing the reflection + DOM-verification loops in one round-trip instead of draining DOM-payload requests with [R]-only hits.
- Add adaptive helpers `prune_blocked_raw_angles` / `hoist_angle_free_payloads` in `run_scanning`: when `Param.invalid_specials` (from Stage 3 active probing) flags `<` / `>`, drop raw-angle payloads (guaranteed misses) and stable-partition angle-free survivors to the front of both reflection and DOM payload lists.
- Add `request_count_probe`'s `/filter_angles` handler so regressions in this lever get caught — server strips `<` / `>` but still reflects into `<input value=…>`.

## Impact

| Probe shape       | before  | after | change |
| ----------------- | ------- | ----- | ------ |
| `angle_filtered`  | 15,814  | **31** | **−510×** |
| `plain_query`     | 29      | 29    | — |
| `b64_json`        | 36      | 36    | — |
| `jwt`             | 36      | 36    | — |
| `url_json`        | 35      | 35    | — |
| `non_reflected`   | 10      | 10    | — |
| `echo_all` (all)  | 33/53/32 | 33/53/32 | — |

One finding preserved on the new `angle_filtered` case.

## Test plan
- [x] `cargo test --release --lib` (1067 passed, +6 new unit tests for prune/hoist helpers)
- [x] `cargo test --release` (1067 lib + 186 integration, no regressions)
- [x] `cargo test --release --test request_count_probe -- --nocapture --include-ignored` (baseline targets unchanged, `angle_filtered` collapses)
- [x] `cargo test --release --test unit_tests functional::dom_xss_tests::` (DOM XSS functional tests pass)

The pre-existing `functional::xss_mock_server::*` panics (axum 0.8 router `:` path segments) reproduce on `main` unchanged — not a regression from this PR.