### PR TITLE
fix(server): isolate scan-task panics and fire webhook on pre-start cancel

### DIFF
--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -570,8 +570,29 @@ async fn run_scan_job(
                 "JOB",
                 &format!("cancelled-pre-start id={} url={}", job_id, url),
             );
-            send_terminal_webhook(&state, callback_url, &job_id, &url, "cancelled", &[], None)
-                .await;
+            // Honor opts.proxy / follow_redirects / TLS settings on this
+            // path the same way the mid-flight cancel path does — otherwise
+            // a webhook behind a corporate proxy would silently fail only
+            // for "cancel-before-start" scans. Fall back to the default
+            // client when parse_target can't make sense of the URL (the
+            // user-submitted url may be invalid; we still want the
+            // webhook to fire so subscribers see the terminal callback).
+            let timeout_secs = opts
+                .timeout
+                .unwrap_or(crate::cmd::scan::DEFAULT_TIMEOUT_SECS);
+            let cb_client = hydrate_preflight_target(&url, &opts, timeout_secs)
+                .ok()
+                .map(|t| t.build_client_or_default());
+            send_terminal_webhook(
+                &state,
+                callback_url,
+                &job_id,
+                &url,
+                "cancelled",
+                &[],
+                cb_client,
+            )
+            .await;
             return;
         }
         StartDecision::Missing => return,

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -399,6 +399,129 @@ fn log(state: &AppState, level: &str, message: &str) {
     }
 }
 
+/// Spawn `run_scan_job` on the blocking pool with full panic / runtime-build
+/// isolation. Without this wrapper, a panic inside the spawned task — or a
+/// failure to build the inner current-thread runtime — silently drops the
+/// `JoinHandle` and leaves the job pinned in `Queued`/`Running` forever.
+/// `purge_expired_jobs` only collects terminal jobs, so the orphan also
+/// leaks the job slot indefinitely.
+fn spawn_scan_task(
+    state: AppState,
+    job_id: String,
+    url: String,
+    opts: ScanOptions,
+    include_request: bool,
+    include_response: bool,
+) {
+    tokio::task::spawn_blocking(move || {
+        let rt = match tokio::runtime::Builder::new_current_thread()
+            .enable_all()
+            .build()
+        {
+            Ok(r) => r,
+            Err(e) => {
+                let msg = format!("scan runtime build failed: {}", e);
+                eprintln!("[server] {} for job {}", msg, job_id);
+                fail_job_via_fresh_runtime(&state, &job_id, msg);
+                return;
+            }
+        };
+
+        let state_for_recovery = state.clone();
+        let job_id_for_recovery = job_id.clone();
+
+        let rt_ref = &rt;
+        let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(move || {
+            rt_ref.block_on(run_scan_job(
+                state,
+                job_id,
+                url,
+                opts,
+                include_request,
+                include_response,
+            ));
+        }));
+
+        if let Err(panic) = result {
+            let payload = if let Some(s) = panic.downcast_ref::<String>() {
+                s.clone()
+            } else if let Some(s) = panic.downcast_ref::<&str>() {
+                (*s).to_string()
+            } else {
+                "unknown panic payload".to_string()
+            };
+            let msg = format!("scan task panicked: {}", payload);
+            eprintln!(
+                "[server] {} (job_id={})",
+                msg, job_id_for_recovery
+            );
+            // The scan runtime itself is still valid after a panic inside the
+            // future, so reuse it for the recovery write rather than spinning
+            // up a second runtime just to update one map entry.
+            rt.block_on(async {
+                mark_job_error(&state_for_recovery, &job_id_for_recovery, msg).await;
+            });
+        }
+    });
+}
+
+/// Best-effort recovery path used when the scan runtime could not be built at
+/// all. Builds a tiny one-shot runtime just to update the job map; if even
+/// that fails, the job is unrecoverable from this thread.
+fn fail_job_via_fresh_runtime(state: &AppState, job_id: &str, msg: String) {
+    let Ok(rt) = tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    else {
+        eprintln!(
+            "[server] could not build recovery runtime to fail job {}",
+            job_id
+        );
+        return;
+    };
+    let state = state.clone();
+    let job_id = job_id.to_string();
+    rt.block_on(async move {
+        mark_job_error(&state, &job_id, msg).await;
+    });
+}
+
+/// Transition a non-terminal job into `Error` with the supplied message. Safe
+/// to call even after the job has reached a terminal state (the update is
+/// gated on `!is_terminal()`) so panic / cancel races don't clobber a real
+/// outcome.
+async fn mark_job_error(state: &AppState, job_id: &str, msg: String) {
+    let mut jobs = state.jobs.lock().await;
+    if let Some(job) = jobs.get_mut(job_id)
+        && !job.is_terminal()
+    {
+        job.status = JobStatus::Error;
+        job.error_message = Some(msg);
+        if job.finished_at_ms.is_none() {
+            job.finished_at_ms = Some(now_ms());
+        }
+    }
+}
+
+/// Decision made by the run_scan_job preamble after looking up the job.
+/// Capturing it in a value type lets us release the jobs lock before any
+/// awaits — important because the pre-cancelled path needs to fire a
+/// webhook and we don't want to hold the lock across that network call.
+enum StartDecision {
+    Run {
+        progress: JobProgress,
+        cancel_flag: Arc<std::sync::atomic::AtomicBool>,
+    },
+    /// Job was cancelled (or its cancel flag set) before the scan task got
+    /// a chance to start. Caller must still fire the webhook so subscribers
+    /// see a terminal callback for this scan_id.
+    PreCancelled {
+        callback_url: Option<String>,
+    },
+    /// Job was deleted from the map between submission and dispatch.
+    Missing,
+}
+
 async fn run_scan_job(
     state: AppState,
     job_id: String,
@@ -408,20 +531,50 @@ async fn run_scan_job(
     include_response: bool,
 ) {
     // Grab progress counters and cancellation flag
-    let (progress, cancel_flag) = {
+    let decision = {
         let mut jobs = state.jobs.lock().await;
-        if let Some(job) = jobs.get_mut(&job_id) {
-            if job.status == JobStatus::Cancelled
-                || job.cancelled.load(std::sync::atomic::Ordering::Relaxed)
-            {
-                return;
+        match jobs.get_mut(&job_id) {
+            Some(job) => {
+                if job.status == JobStatus::Cancelled
+                    || job.cancelled.load(std::sync::atomic::Ordering::Relaxed)
+                {
+                    StartDecision::PreCancelled {
+                        callback_url: job.callback_url.clone(),
+                    }
+                } else {
+                    job.status = JobStatus::Running;
+                    job.started_at_ms = Some(now_ms());
+                    StartDecision::Run {
+                        progress: job.progress.clone(),
+                        cancel_flag: job.cancelled.clone(),
+                    }
+                }
             }
-            job.status = JobStatus::Running;
-            job.started_at_ms = Some(now_ms());
-            (job.progress.clone(), job.cancelled.clone())
-        } else {
+            None => StartDecision::Missing,
+        }
+    };
+
+    let (progress, cancel_flag) = match decision {
+        StartDecision::Run {
+            progress,
+            cancel_flag,
+        } => (progress, cancel_flag),
+        StartDecision::PreCancelled { callback_url } => {
+            // Previously this branch returned silently, so any subscriber
+            // wired to the webhook never received a terminal callback for
+            // scans that were cancelled before the task got a chance to
+            // run. Mirror the mid-flight cancellation contract here so the
+            // webhook fires for every terminal state, not just some.
+            log(
+                &state,
+                "JOB",
+                &format!("cancelled-pre-start id={} url={}", job_id, url),
+            );
+            send_terminal_webhook(&state, callback_url, &job_id, &url, "cancelled", &[], None)
+                .await;
             return;
         }
+        StartDecision::Missing => return,
     };
 
     let args = ScanArgs {
@@ -700,44 +853,67 @@ async fn run_scan_job(
         &format!("{} id={} url={}", status_label, job_id, url),
     );
 
-    // Fire webhook callback if configured (only http/https to mitigate SSRF)
-    if let Some(cb_url) = callback_url
-        && (cb_url.starts_with("http://") || cb_url.starts_with("https://"))
-    {
-        // Report the actual terminal status so downstream consumers can tell
-        // a fully-completed scan from one that was cancelled mid-flight.
-        let payload = serde_json::json!({
-            "scan_id": job_id,
-            "status": if was_cancelled { "cancelled" } else { "done" },
-            "url": url,
-            "results": &*final_results_arc
-        });
-        // Reuse the target's HTTP configuration (proxy, TLS relaxation, redirect
-        // policy) so webhook delivery respects the same network boundary as the
-        // scan itself.
-        let cb_client = target.build_client_or_default();
-        let cb_result: Result<reqwest::Response, reqwest::Error> = cb_client
-            .post(&cb_url)
-            .json(&payload)
-            .timeout(std::time::Duration::from_secs(10))
-            .send()
-            .await;
-        match cb_result {
-            Ok(resp) => {
-                log(
-                    &state,
-                    "CALLBACK",
-                    &format!("POST {} -> {}", cb_url, resp.status()),
-                );
-            }
-            Err(e) => {
-                log(
-                    &state,
-                    "CALLBACK",
-                    &format!("POST {} failed: {}", cb_url, e),
-                );
-            }
-        }
+    // Reuse the target's HTTP configuration (proxy, TLS relaxation, redirect
+    // policy) so webhook delivery respects the same network boundary as the
+    // scan itself.
+    let cb_client = target.build_client_or_default();
+    send_terminal_webhook(
+        &state,
+        callback_url,
+        &job_id,
+        &url,
+        status_label,
+        &final_results_arc,
+        Some(cb_client),
+    )
+    .await;
+}
+
+/// POST the scan-completion payload to the configured webhook, if any.
+/// Only `http`/`https` URLs are dialed (mitigates SSRF via odd schemes such
+/// as `file://`). The status string is the same one we put in the response
+/// payload (`"done"` or `"cancelled"`) so downstream consumers can branch
+/// on it without re-deriving terminal state.
+async fn send_terminal_webhook(
+    state: &AppState,
+    callback_url: Option<String>,
+    job_id: &str,
+    url: &str,
+    status_label: &str,
+    results: &[SanitizedResult],
+    client: Option<reqwest::Client>,
+) {
+    let Some(cb_url) = callback_url else { return };
+    if !(cb_url.starts_with("http://") || cb_url.starts_with("https://")) {
+        return;
+    }
+    let payload = serde_json::json!({
+        "scan_id": job_id,
+        "status": status_label,
+        "url": url,
+        "results": results,
+    });
+    // When the caller has no parsed target (e.g. pre-start cancellation),
+    // fall back to a default client. Webhook delivery should not silently
+    // drop just because the scan never got far enough to build a target.
+    let client = client.unwrap_or_default();
+    let result = client
+        .post(&cb_url)
+        .json(&payload)
+        .timeout(std::time::Duration::from_secs(10))
+        .send()
+        .await;
+    match result {
+        Ok(resp) => log(
+            state,
+            "CALLBACK",
+            &format!("POST {} -> {}", cb_url, resp.status()),
+        ),
+        Err(e) => log(
+            state,
+            "CALLBACK",
+            &format!("POST {} failed: {}", cb_url, e),
+        ),
     }
 }
 
@@ -802,24 +978,14 @@ async fn start_scan_handler(
     }
     log(&state, "JOB", &format!("queued id={} url={}", id, req.url));
 
-    // Spawn the scanning task (run !Send future inside blocking thread with local runtime)
-    let state_clone = state.clone();
-    let url = req.url.clone();
-    let job_id = id.clone();
-    tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build current-thread runtime");
-        rt.block_on(run_scan_job(
-            state_clone,
-            job_id,
-            url,
-            opts.clone(),
-            include_request,
-            include_response,
-        ));
-    });
+    spawn_scan_task(
+        state.clone(),
+        id.clone(),
+        req.url.clone(),
+        opts,
+        include_request,
+        include_response,
+    );
 
     let resp = ApiResponse::<serde_json::Value> {
         code: 200,
@@ -1110,22 +1276,14 @@ async fn get_scan_handler(
     log(&state, "JOB", &format!("queued id={} url={}", id, url));
 
     let id_for_resp = id.clone();
-    let state_clone = state.clone();
-    let url_clone = url.clone();
-    tokio::task::spawn_blocking(move || {
-        let rt = tokio::runtime::Builder::new_current_thread()
-            .enable_all()
-            .build()
-            .expect("failed to build current-thread runtime");
-        rt.block_on(run_scan_job(
-            state_clone,
-            id,
-            url_clone,
-            opts,
-            include_request,
-            include_response,
-        ));
-    });
+    spawn_scan_task(
+        state.clone(),
+        id,
+        url.clone(),
+        opts,
+        include_request,
+        include_response,
+    );
 
     let resp = ApiResponse::<serde_json::Value> {
         code: 200,

--- a/src/cmd/server/tests.rs
+++ b/src/cmd/server/tests.rs
@@ -1666,6 +1666,162 @@ async fn test_list_scans_handler_zero_limit_returns_all() {
 }
 
 #[tokio::test]
+async fn test_run_scan_job_webhook_fires_on_pre_start_cancellation() {
+    // Regression: previously run_scan_job returned silently when it
+    // observed the job was already cancelled / cancel_flag set before
+    // entering the Running state, so subscribers wired to the webhook
+    // never got a terminal callback for "cancel immediately after submit"
+    // scans. The mid-flight cancel path already fired the webhook with
+    // status=cancelled — this asserts the pre-start path matches that
+    // contract.
+    let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+    let captured_clone = captured.clone();
+    let webhook_app = Router::new().route(
+        "/hook",
+        any(move |body: axum::body::Bytes| {
+            let captured = captured_clone.clone();
+            async move {
+                let parsed: serde_json::Value =
+                    serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+                *captured.lock().await = Some(parsed);
+                StatusCode::OK
+            }
+        }),
+    );
+    let webhook_listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind webhook listener");
+    let webhook_addr = webhook_listener.local_addr().expect("webhook local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(webhook_listener, webhook_app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let state = make_state(None, None, false, false, "callback");
+    let id = "pre-cancel-webhook".to_string();
+    let target_url = "http://example.com/will-not-be-scanned";
+    let mut job = test_job(JobStatus::Queued, None, target_url);
+    job.callback_url = Some(format!("http://{}/hook", webhook_addr));
+    // Trip the cancel flag *before* run_scan_job starts. The new code
+    // path must observe this, fire the webhook, and return — without
+    // ever issuing a request to the target.
+    job.cancelled
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), job);
+    }
+
+    let opts = ScanOptions {
+        callback_url: Some(format!("http://{}/hook", webhook_addr)),
+        ..ScanOptions::default()
+    };
+
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        run_scan_job(
+            state.clone(),
+            id.clone(),
+            target_url.to_string(),
+            opts,
+            false,
+            false,
+        ),
+    )
+    .await;
+    assert!(run.is_ok(), "pre-cancelled run_scan_job should return fast");
+
+    // The webhook is awaited in run_scan_job, so by the time it returns
+    // the body should already be captured.
+    let payload = captured
+        .lock()
+        .await
+        .clone()
+        .expect("webhook must fire for pre-start cancellation");
+    assert_eq!(payload["status"], "cancelled");
+    assert_eq!(payload["scan_id"], serde_json::Value::String(id));
+    assert_eq!(payload["url"], target_url);
+    // No scan ran, so results must be an empty array (not missing).
+    assert!(
+        payload["results"].is_array() && payload["results"].as_array().unwrap().is_empty(),
+        "results should be [] for pre-start cancellation, got {:?}",
+        payload["results"]
+    );
+}
+
+#[tokio::test]
+async fn test_send_terminal_webhook_skips_non_http_url() {
+    // The webhook helper must refuse non-http(s) URLs (file:// etc.) so
+    // a malicious callback_url can't trick the server into touching odd
+    // schemes. Verified by passing a `file://` URL and confirming the
+    // helper returns without panicking (and we have no other side effect
+    // we can observe — the contract is "silently drop").
+    let state = make_state(None, None, false, false, "cb");
+    // Should be a no-op; main assertion is that this returns at all.
+    send_terminal_webhook(
+        &state,
+        Some("file:///etc/passwd".to_string()),
+        "id",
+        "http://example.com",
+        "cancelled",
+        &[],
+        None,
+    )
+    .await;
+    send_terminal_webhook(&state, None, "id", "http://example.com", "done", &[], None).await;
+}
+
+#[tokio::test]
+async fn test_mark_job_error_transitions_non_terminal() {
+    // Recovery primitive used by spawn_scan_task when the inner scan
+    // panics or the scan runtime fails to build. Verify the basic
+    // contract: a non-terminal job is moved to Error with the message
+    // and a finished_at_ms timestamp.
+    let state = make_state(None, None, false, false, "cb");
+    let id = "panic-recover".to_string();
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), test_job(JobStatus::Running, None, "http://x"));
+    }
+
+    mark_job_error(&state, &id, "synthetic panic".to_string()).await;
+
+    let jobs = state.jobs.lock().await;
+    let job = jobs.get(&id).expect("job present");
+    assert_eq!(job.status, JobStatus::Error);
+    assert_eq!(job.error_message.as_deref(), Some("synthetic panic"));
+    assert!(job.finished_at_ms.is_some());
+}
+
+#[tokio::test]
+async fn test_mark_job_error_does_not_clobber_terminal_state() {
+    // If the scan task panics *after* it has already written a terminal
+    // outcome (e.g. cancelled mid-flight, then the cleanup path panics),
+    // the recovery must not rewrite Done/Cancelled/Error to Error. The
+    // gate is `!is_terminal()`; assert it holds for each terminal state.
+    let state = make_state(None, None, false, false, "cb");
+
+    for (id, status) in [
+        ("done-stays-done", JobStatus::Done),
+        ("cancelled-stays-cancelled", JobStatus::Cancelled),
+        ("error-stays-error", JobStatus::Error),
+    ] {
+        {
+            let mut jobs = state.jobs.lock().await;
+            jobs.insert(id.to_string(), test_job(status.clone(), None, "http://x"));
+        }
+        mark_job_error(&state, id, "should-not-overwrite".to_string()).await;
+        let jobs = state.jobs.lock().await;
+        let job = jobs.get(id).expect("job present");
+        assert_eq!(
+            job.status, status,
+            "terminal status must not be rewritten by recovery"
+        );
+        assert!(job.error_message.is_none());
+    }
+}
+
+#[tokio::test]
 async fn test_cancel_scan_handler_purge_deletes_terminal_job() {
     let state = make_state(None, None, false, false, "cb");
     {

--- a/src/cmd/server/tests.rs
+++ b/src/cmd/server/tests.rs
@@ -1750,25 +1750,120 @@ async fn test_run_scan_job_webhook_fires_on_pre_start_cancellation() {
 }
 
 #[tokio::test]
-async fn test_send_terminal_webhook_skips_non_http_url() {
-    // The webhook helper must refuse non-http(s) URLs (file:// etc.) so
-    // a malicious callback_url can't trick the server into touching odd
-    // schemes. Verified by passing a `file://` URL and confirming the
-    // helper returns without panicking (and we have no other side effect
-    // we can observe — the contract is "silently drop").
-    let state = make_state(None, None, false, false, "cb");
-    // Should be a no-op; main assertion is that this returns at all.
-    send_terminal_webhook(
-        &state,
-        Some("file:///etc/passwd".to_string()),
-        "id",
-        "http://example.com",
-        "cancelled",
-        &[],
-        None,
+async fn test_run_scan_job_pre_cancel_webhook_falls_back_when_url_unparseable() {
+    // Companion to the pre-start cancellation webhook test: even when the
+    // submitted URL is garbage (so `parse_target` would fail when we try to
+    // honor opts.proxy/TLS), the webhook must still fire with status=
+    // cancelled. The pre-cancel path falls back to a default reqwest
+    // client in that case rather than dropping the callback.
+    let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+    let captured_clone = captured.clone();
+    let webhook_app = Router::new().route(
+        "/hook",
+        any(move |body: axum::body::Bytes| {
+            let captured = captured_clone.clone();
+            async move {
+                let parsed: serde_json::Value =
+                    serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+                *captured.lock().await = Some(parsed);
+                StatusCode::OK
+            }
+        }),
+    );
+    let webhook_listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind webhook listener");
+    let webhook_addr = webhook_listener.local_addr().expect("webhook local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(webhook_listener, webhook_app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let state = make_state(None, None, false, false, "callback");
+    let id = "pre-cancel-bad-url".to_string();
+    let target_url = "definitely-not-a-valid-url";
+    let mut job = test_job(JobStatus::Queued, None, target_url);
+    job.callback_url = Some(format!("http://{}/hook", webhook_addr));
+    job.cancelled
+        .store(true, std::sync::atomic::Ordering::Relaxed);
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), job);
+    }
+
+    let opts = ScanOptions {
+        callback_url: Some(format!("http://{}/hook", webhook_addr)),
+        ..ScanOptions::default()
+    };
+
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(5),
+        run_scan_job(
+            state.clone(),
+            id.clone(),
+            target_url.to_string(),
+            opts,
+            false,
+            false,
+        ),
     )
     .await;
+    assert!(run.is_ok(), "pre-cancelled run_scan_job should return fast");
+
+    let payload = captured
+        .lock()
+        .await
+        .clone()
+        .expect("webhook must fire even when target url is unparseable");
+    assert_eq!(payload["status"], "cancelled");
+    assert_eq!(payload["scan_id"], serde_json::Value::String(id));
+}
+
+#[tokio::test]
+async fn test_send_terminal_webhook_skips_non_http_url() {
+    // The webhook helper must refuse non-http(s) URLs so a malicious
+    // callback_url can't trick the server into dialing odd schemes
+    // (file://, ftp://, javascript://, etc.). The contract is "silently
+    // drop"; verify two observable things:
+    //
+    //   1. Each scheme returns under a tight deadline — proves we never
+    //      reached reqwest's transport layer, which for unsupported
+    //      schemes would emit a callback-failed log line. The default
+    //      reqwest request timeout for these helpers is 10s, so a sub-
+    //      second deadline reliably catches a regression that lets a
+    //      non-http URL through to the client.
+    //   2. The `None` callback_url path is also a no-op (no scheme to
+    //      check at all).
+    let state = make_state(None, None, false, false, "cb");
+    for url in [
+        "file:///etc/passwd",
+        "ftp://example.com/payload",
+        "javascript:alert(1)",
+        "ws://example.com/hook",
+    ] {
+        let started = std::time::Instant::now();
+        send_terminal_webhook(
+            &state,
+            Some(url.to_string()),
+            "id",
+            "http://example.com",
+            "cancelled",
+            &[],
+            None,
+        )
+        .await;
+        assert!(
+            started.elapsed() < std::time::Duration::from_millis(500),
+            "send_terminal_webhook took too long for {} ({:?}) — scheme filter may have leaked",
+            url,
+            started.elapsed()
+        );
+    }
+
+    // None-callback path: should be a fast no-op as well.
+    let started = std::time::Instant::now();
     send_terminal_webhook(&state, None, "id", "http://example.com", "done", &[], None).await;
+    assert!(started.elapsed() < std::time::Duration::from_millis(500));
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary
- Wrap the `spawn_blocking(run_scan_job)` dispatch with `catch_unwind` plus a recovery primitive — a panicking scan or failed runtime build now marks the job `Error` instead of pinning it in `Queued`/`Running` forever (which also leaked the slot past `purge_expired_jobs`, since that only collects terminal jobs).
- Extract webhook delivery into `send_terminal_webhook` and call it from the pre-start cancellation path. Previously a scan cancelled before the task started returned silently, so webhook subscribers never got a terminal callback for those — out of step with the mid-flight cancel path which did fire `status=cancelled`.
- Tests cover the recovery primitive (transition + terminal-state guard), the pre-start webhook contract, and the non-http(s) callback URL filter.

## Test plan
- [x] `cargo test --lib cmd::server::tests` — 55 pass, 0 fail
- [x] `cargo test --lib` — 1071 pass, 0 fail
- [x] `cargo build` — clean