### PR TITLE
fix(scan): probe form-discovered query params at the action URL

### DIFF
--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -451,10 +451,7 @@ fn spawn_scan_task(
                 "unknown panic payload".to_string()
             };
             let msg = format!("scan task panicked: {}", payload);
-            eprintln!(
-                "[server] {} (job_id={})",
-                msg, job_id_for_recovery
-            );
+            eprintln!("[server] {} (job_id={})", msg, job_id_for_recovery);
             // The scan runtime itself is still valid after a panic inside the
             // future, so reuse it for the recovery write rather than spinning
             // up a second runtime just to update one map entry.
@@ -515,9 +512,7 @@ enum StartDecision {
     /// Job was cancelled (or its cancel flag set) before the scan task got
     /// a chance to start. Caller must still fire the webhook so subscribers
     /// see a terminal callback for this scan_id.
-    PreCancelled {
-        callback_url: Option<String>,
-    },
+    PreCancelled { callback_url: Option<String> },
     /// Job was deleted from the map between submission and dispatch.
     Missing,
 }
@@ -930,11 +925,7 @@ async fn send_terminal_webhook(
             "CALLBACK",
             &format!("POST {} -> {}", cb_url, resp.status()),
         ),
-        Err(e) => log(
-            state,
-            "CALLBACK",
-            &format!("POST {} failed: {}", cb_url, e),
-        ),
+        Err(e) => log(state, "CALLBACK", &format!("POST {} failed: {}", cb_url, e)),
     }
 }
 

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -256,18 +256,27 @@ pub async fn active_probe_param(
                 }
                 _ => parsed_method,
             };
+            // Resolve the probe destination: when this param came from form
+            // discovery (issue #424), `form_action_url` points at the form's
+            // action endpoint, which may differ from the page URL where the
+            // form was found. Body/JsonBody/Multipart all probe at the action;
+            // Query must do the same, otherwise we test the form-host page
+            // instead of the sink and produce a false negative.
             let body_url = form_action_url
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| url_original.clone());
-            let mut url = url_original.clone();
+            let mut url = match location {
+                Location::Query => body_url.clone(),
+                _ => url_original.clone(),
+            };
             let mut request_builder;
 
             match location {
                 Location::Query => {
                     let mut new_pairs: Vec<(String, String)> = Vec::new();
                     let mut replaced = false;
-                    for (k, v) in url_original.query_pairs() {
+                    for (k, v) in url.query_pairs() {
                         if k == wire_name {
                             new_pairs.push((k.to_string(), payload.clone()));
                             replaced = true;

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -256,18 +256,17 @@ pub async fn active_probe_param(
                 }
                 _ => parsed_method,
             };
-            // Resolve the probe destination: when this param came from form
-            // discovery (issue #424), `form_action_url` points at the form's
-            // action endpoint, which may differ from the page URL where the
-            // form was found. Body/JsonBody/Multipart all probe at the action;
-            // Query must do the same, otherwise we test the form-host page
-            // instead of the sink and produce a false negative.
-            let body_url = form_action_url
+            // When this param came from form discovery, `form_action_url`
+            // points at the form's action endpoint, which may differ from
+            // the page URL where the form was found. Every body-bearing
+            // location probes at the action; Query must do the same so we
+            // exercise the sink rather than the form-host page.
+            let action_resolved_url = form_action_url
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| url_original.clone());
             let mut url = match location {
-                Location::Query => body_url.clone(),
+                Location::Query => action_resolved_url.clone(),
                 _ => url_original.clone(),
             };
             let mut request_builder;
@@ -317,7 +316,7 @@ pub async fn active_probe_param(
                         body_string = format!("{}={}", param_name, payload);
                     }
                     request_builder = client_clone
-                        .request(req_method, body_url.clone())
+                        .request(req_method, action_resolved_url.clone())
                         .header("Content-Type", "application/x-www-form-urlencoded")
                         .body(body_string);
                 }
@@ -410,7 +409,7 @@ pub async fn active_probe_param(
                     let body_string = serde_json::to_string(&root)
                         .unwrap_or_else(|_| format!("{{\"{}\":\"{}\"}}", param_name, payload));
                     request_builder = client_clone
-                        .request(req_method, body_url.clone())
+                        .request(req_method, action_resolved_url.clone())
                         .header("Content-Type", "application/json")
                         .body(body_string);
                 }
@@ -444,7 +443,7 @@ pub async fn active_probe_param(
                         form = form.text(param_name.clone(), payload.clone());
                     }
                     request_builder = client_clone
-                        .request(req_method, body_url.clone())
+                        .request(req_method, action_resolved_url.clone())
                         .multipart(form);
                 }
                 Location::Fragment => {

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -747,7 +747,7 @@ fn build_url_inject_request(
     // Query params discovered through a `<form action=...>` must be verified
     // at the action URL — that's where the sink lives. Path params keep
     // target.url because path-segment injection depends on the original
-    // path layout (issue #424).
+    // path layout.
     let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
     let inject_url_str =
         crate::scanning::url_inject::build_injected_url(&base_url, param, encoded_payload);

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -744,9 +744,14 @@ fn build_url_inject_request(
     encoded_payload: &str,
     method: reqwest::Method,
 ) -> reqwest::RequestBuilder {
+    // Query params discovered through a `<form action=...>` must be verified
+    // at the action URL — that's where the sink lives. Path params keep
+    // target.url because path-segment injection depends on the original
+    // path layout (issue #424).
+    let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
     let inject_url_str =
-        crate::scanning::url_inject::build_injected_url(&target.url, param, encoded_payload);
-    let inject_url = url::Url::parse(&inject_url_str).unwrap_or_else(|_| target.url.clone());
+        crate::scanning::url_inject::build_injected_url(&base_url, param, encoded_payload);
+    let inject_url = url::Url::parse(&inject_url_str).unwrap_or_else(|_| base_url.clone());
     crate::utils::build_request(client, target, method, inject_url, target.data.clone())
 }
 

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1126,13 +1126,19 @@ async fn fetch_injection_response_with_client(
             crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
         }
         _ => {
-            // Query / Path: inject encoded payload into the URL
+            // Query / Path: inject encoded payload into the URL.
+            // `effective_query_base` rebases Query params discovered through
+            // a `<form action=...>` onto the action endpoint (issue #424);
+            // Path keeps target.url because path-segment injection depends
+            // on the original path layout.
+            let base_url =
+                crate::scanning::url_inject::effective_query_base(&target.url, param);
             let inject_url = crate::scanning::url_inject::build_injected_url(
-                &target.url,
+                &base_url,
                 param,
                 &encoded_payload,
             );
-            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| target.url.clone());
+            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
             crate::utils::build_request(
                 client,
                 target,

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1128,9 +1128,9 @@ async fn fetch_injection_response_with_client(
         _ => {
             // Query / Path: inject encoded payload into the URL.
             // `effective_query_base` rebases Query params discovered through
-            // a `<form action=...>` onto the action endpoint (issue #424);
-            // Path keeps target.url because path-segment injection depends
-            // on the original path layout.
+            // a `<form action=...>` onto the action endpoint; Path keeps
+            // target.url because path-segment injection depends on the
+            // original path layout.
             let base_url =
                 crate::scanning::url_inject::effective_query_base(&target.url, param);
             let inject_url = crate::scanning::url_inject::build_injected_url(

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1131,13 +1131,9 @@ async fn fetch_injection_response_with_client(
             // a `<form action=...>` onto the action endpoint; Path keeps
             // target.url because path-segment injection depends on the
             // original path layout.
-            let base_url =
-                crate::scanning::url_inject::effective_query_base(&target.url, param);
-            let inject_url = crate::scanning::url_inject::build_injected_url(
-                &base_url,
-                param,
-                &encoded_payload,
-            );
+            let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
+            let inject_url =
+                crate::scanning::url_inject::build_injected_url(&base_url, param, &encoded_payload);
             let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
             crate::utils::build_request(
                 client,

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -126,9 +126,14 @@ pub async fn verify_dom_xss_light_with_client(
             crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
         }
         _ => {
+            // GET form discovery sets form_action_url; light-verify must
+            // follow it to the action endpoint — otherwise the reflection
+            // we're confirming lives on a different URL (issue #424).
+            let base_url =
+                crate::scanning::url_inject::effective_query_base(&target.url, param);
             let inject_url =
-                crate::scanning::url_inject::build_injected_url(&target.url, param, payload);
-            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| target.url.clone());
+                crate::scanning::url_inject::build_injected_url(&base_url, param, payload);
+            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
             crate::utils::build_request(client, target, method, parsed_url, target.data.clone())
         }
     };

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -128,7 +128,7 @@ pub async fn verify_dom_xss_light_with_client(
         _ => {
             // GET form discovery sets form_action_url; light-verify must
             // follow it to the action endpoint — otherwise the reflection
-            // we're confirming lives on a different URL (issue #424).
+            // we're confirming lives on a different URL.
             let base_url =
                 crate::scanning::url_inject::effective_query_base(&target.url, param);
             let inject_url =

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -129,8 +129,7 @@ pub async fn verify_dom_xss_light_with_client(
             // GET form discovery sets form_action_url; light-verify must
             // follow it to the action endpoint — otherwise the reflection
             // we're confirming lives on a different URL.
-            let base_url =
-                crate::scanning::url_inject::effective_query_base(&target.url, param);
+            let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
             let inject_url =
                 crate::scanning::url_inject::build_injected_url(&base_url, param, payload);
             let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -457,7 +457,8 @@ async fn run_ast_dom_analysis(
                     &payload,
                 )
             } else {
-                crate::scanning::url_inject::build_injected_url(&target.url, param, &payload)
+                let base = crate::scanning::url_inject::effective_query_base(&target.url, param);
+                crate::scanning::url_inject::build_injected_url(&base, param, &payload)
             };
             let mut ast_result = crate::scanning::result::Result::new(
                 FindingType::AstDetected,
@@ -518,8 +519,12 @@ async fn run_ast_dom_analysis(
 fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
     let url = match param.location {
         crate::parameter_analysis::Location::Query => {
-            let mut pairs: Vec<(String, String)> = target
-                .url
+            // Show the request against the actual sink URL — form action when
+            // the param came from form discovery, otherwise target.url. The
+            // displayed PoC must match the URL that scanning actually hits
+            // (issue #424).
+            let base = crate::scanning::url_inject::effective_query_base(&target.url, param);
+            let mut pairs: Vec<(String, String)> = base
                 .query_pairs()
                 .map(|(k, v)| (k.to_string(), v.to_string()))
                 .collect();
@@ -537,7 +542,7 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
             let query = url::form_urlencoded::Serializer::new(String::new())
                 .extend_pairs(&pairs)
                 .finish();
-            let mut url = target.url.clone();
+            let mut url = base;
             url.set_query(Some(&query));
             url
         }
@@ -1081,9 +1086,15 @@ pub async fn run_scanning(
                     };
 
                     if should_add {
-                        // Build result URL with the reflected payload (via helper)
-                        let result_url = crate::scanning::url_inject::build_injected_url(
+                        // Build result URL with the reflected payload (via helper).
+                        // Use the form action URL when the param came from form
+                        // discovery, so the PoC URL points at the actual sink.
+                        let base = crate::scanning::url_inject::effective_query_base(
                             &target_clone.url,
+                            &param_clone,
+                        );
+                        let result_url = crate::scanning::url_inject::build_injected_url(
+                            &base,
                             &param_clone,
                             &reflection_payload,
                         );
@@ -1252,9 +1263,14 @@ pub async fn run_scanning(
                     };
 
                     if should_add {
-                        // Create result (via helper)
-                        let result_url = crate::scanning::url_inject::build_injected_url(
+                        // Create result (via helper). Use the form action URL
+                        // when the param came from form discovery.
+                        let base = crate::scanning::url_inject::effective_query_base(
                             &target_clone.url,
+                            &param_clone,
+                        );
+                        let result_url = crate::scanning::url_inject::build_injected_url(
+                            &base,
                             &param_clone,
                             &dom_payload,
                         );

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -521,8 +521,7 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
         crate::parameter_analysis::Location::Query => {
             // Show the request against the actual sink URL — form action when
             // the param came from form discovery, otherwise target.url. The
-            // displayed PoC must match the URL that scanning actually hits
-            // (issue #424).
+            // displayed PoC must match the URL that scanning actually hits.
             let base = crate::scanning::url_inject::effective_query_base(&target.url, param);
             let mut pairs: Vec<(String, String)> = base
                 .query_pairs()

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -81,6 +81,27 @@ fn selective_path_segment_encode(raw: &str) -> Cow<'_, str> {
     Cow::Owned(out)
 }
 
+/// Resolve the URL where a Query-location param should be probed.
+///
+/// When `param` was discovered through a `<form action=...>`, its
+/// `form_action_url` points at the form's action endpoint — that's the URL
+/// hosting the sink, not the page where the `<form>` tag was found. Without
+/// this redirection, GET-form scans probe the form-host page (no sink) and
+/// produce a false negative even though discovery flagged the field as
+/// reflecting at the action URL (issue #424).
+///
+/// For non-Query locations and for params without a form_action_url, the
+/// caller's `target_url` is returned unchanged.
+pub fn effective_query_base(target_url: &url::Url, param: &Param) -> url::Url {
+    if matches!(param.location, Location::Query)
+        && let Some(ref action) = param.form_action_url
+        && let Ok(parsed) = url::Url::parse(action)
+    {
+        return parsed;
+    }
+    target_url.clone()
+}
+
 /// Build a URL string with the given parameter injected/replaced by `injected`.
 /// For Location::Query it rewrites or appends the query pair.
 /// For Location::Path it replaces the indexed segment derived from param name pattern

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -88,9 +88,9 @@ fn selective_path_segment_encode(raw: &str) -> Cow<'_, str> {
 /// hosting the sink, not the page where the `<form>` tag was found. Without
 /// this redirection, GET-form scans probe the form-host page (no sink) and
 /// produce a false negative even though discovery flagged the field as
-/// reflecting at the action URL (issue #424).
+/// reflecting at the action URL.
 ///
-/// For non-Query locations and for params without a form_action_url, the
+/// For non-Query locations and for params without a `form_action_url`, the
 /// caller's `target_url` is returned unchanged.
 pub fn effective_query_base(target_url: &url::Url, param: &Param) -> url::Url {
     if matches!(param.location, Location::Query)

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -481,6 +481,35 @@ fn effective_query_base_ignores_form_action_for_non_query_locations() {
 }
 
 #[test]
+fn effective_query_base_preserves_existing_query_on_action() {
+    // `<form action="/app.php?ref=login">` — the action URL already has
+    // its own query params. Injecting our target field must keep them.
+    let target = make_url("https://example.com/page");
+    let param = Param {
+        name: "xss".into(),
+        value: "".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: Some("https://example.com/app.php?ref=login".to_string()),
+        form_origin_url: None,
+        framework_sink: None,
+    };
+    let base = effective_query_base(&target, &param);
+    let out = build_injected_url(&base, &param, "PAY");
+    assert!(
+        out.starts_with("https://example.com/app.php?"),
+        "expected app.php probe, got: {out}"
+    );
+    assert!(out.contains("ref=login"), "lost preexisting query: {out}");
+    assert!(out.contains("xss=PAY"), "missing injected param: {out}");
+}
+
+#[test]
 fn effective_query_base_falls_back_when_action_unparseable() {
     let target = make_url("https://example.com/page");
     let param = Param {

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -416,3 +416,89 @@ fn test_build_hpp_urls_returns_3_variants() {
     assert_eq!(variants[1].1, HppPosition::First);
     assert_eq!(variants[2].1, HppPosition::Both);
 }
+
+// Regression: issue #424 — Query param discovered via `<form action=...>`
+// must be probed at the action endpoint, not the page hosting the form.
+#[test]
+fn effective_query_base_uses_form_action_for_query_params() {
+    let target = make_url("https://example.com/page");
+    let mut param = Param {
+        name: "xss".into(),
+        value: "".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: Some("https://example.com/app.php".to_string()),
+        form_origin_url: Some("https://example.com/page".to_string()),
+        framework_sink: None,
+    };
+    let base = effective_query_base(&target, &param);
+    assert_eq!(base.as_str(), "https://example.com/app.php");
+
+    // Building the injected URL on top of the resolved base must hit /app.php
+    let out = build_injected_url(&base, &param, "PAY");
+    assert!(
+        out.starts_with("https://example.com/app.php?"),
+        "expected app.php probe, got: {out}"
+    );
+    assert!(out.contains("xss=PAY"));
+
+    // No form_action_url -> stays on target
+    param.form_action_url = None;
+    assert_eq!(
+        effective_query_base(&target, &param).as_str(),
+        target.as_str()
+    );
+}
+
+#[test]
+fn effective_query_base_ignores_form_action_for_non_query_locations() {
+    let target = make_url("https://example.com/page");
+    let param = Param {
+        name: "xss".into(),
+        value: "".into(),
+        location: Location::Body,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: Some("https://example.com/app.php".to_string()),
+        form_origin_url: None,
+        framework_sink: None,
+    };
+    // Body/JsonBody/Multipart resolve form_action_url at their own call site;
+    // the Query-specific helper must not steal that responsibility.
+    assert_eq!(
+        effective_query_base(&target, &param).as_str(),
+        target.as_str()
+    );
+}
+
+#[test]
+fn effective_query_base_falls_back_when_action_unparseable() {
+    let target = make_url("https://example.com/page");
+    let param = Param {
+        name: "xss".into(),
+        value: "".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: Some("::not a url::".to_string()),
+        form_origin_url: None,
+        framework_sink: None,
+    };
+    assert_eq!(
+        effective_query_base(&target, &param).as_str(),
+        target.as_str()
+    );
+}


### PR DESCRIPTION
## Summary
- Query params surfaced via `<form action=...>` discovery weren't being probed at the form's action endpoint — they stayed on the form-host page URL. Body / JsonBody / Multipart already used `form_action_url`; Query was the missing leg.
- For a target like `/page` hosting `<form action="/app.php"><input name="xss">`, the scan tested `/page?xss=...` and reported zero findings even though the action endpoint clearly reflected the payload — completing the v3 closure of #424.

## What changed
- New helper `scanning::url_inject::effective_query_base()` returns `form_action_url` for Query params, else `target.url`. Centralizes the redirection so future call sites can't drift.
- Routed through the helper:
  - `parameter_analysis::active_probe_param` (special-char probing)
  - `scanning::check_reflection` (reflection-phase payload injection)
  - `scanning::light_verify` (light verify)
  - `scanning::check_dom_verification::build_url_inject_request` (DOM verify)
  - `scanning::mod` PoC URL + request-text rendering (4 call sites) so the displayed `data` field matches the URL actually hit
- Body / JsonBody / Multipart paths are untouched (already resolved correctly). Path keeps `target.url` because path-segment injection is tied to the original path layout.

## Verification
- `cargo test --lib`: 1075 passed / 0 failed.
- 3 new regression tests in `url_inject::tests`:
  - `effective_query_base_uses_form_action_for_query_params`
  - `effective_query_base_ignores_form_action_for_non_query_locations`
  - `effective_query_base_falls_back_when_action_unparseable`
- End-to-end against a local surrogate (`/page` with `<form action="/app.php">`):
  - Before: `count=0`, no V/R/A.
  - After: `V | inHTML | http://127.0.0.1:8765/app.php?xss=<svg/onload=alert(1)>`.
- FP probes unchanged: `/safe` (escaped reflection) → 0, root → 0.

## Test plan
- [x] `cargo test --lib`
- [x] e2e: local node server with form whose action != page URL, verify V on action endpoint
- [x] regression: `/reflect?q=` still V, `/safe?q=` still 0
- [ ] CI green

Closes #424