### PR TITLE
chore: collapse Option/Result combinators to clearer forms

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -460,7 +460,7 @@ async fn preflight_content_type(
     let ct_opt = head_headers
         .get(CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
-        .map(std::string::ToString::to_string);
+        .map(ToString::to_string);
     let mut csp_header = head_headers
         .get("content-security-policy")
         .and_then(|v| v.to_str().ok())
@@ -1377,7 +1377,10 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 }
                 let file_path = &args.targets[0];
                 match fs::read_to_string(file_path) {
-                    Ok(content) => content.lines().map(std::string::ToString::to_string).collect(),
+                    Ok(content) => content
+                        .lines()
+                        .map(ToString::to_string)
+                        .collect(),
                     Err(e) => {
                         if !args.silence {
                             emit_error(
@@ -1756,7 +1759,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         host_groups.entry(host).or_default().push(target);
     }
 
-    let total_targets = host_groups.values().map(std::vec::Vec::len).sum::<usize>();
+    let total_targets = host_groups.values().map(Vec::len).sum::<usize>();
     let preflight_idx = Arc::new(AtomicUsize::new(0));
     let analyze_idx = Arc::new(AtomicUsize::new(0));
     let scan_idx = Arc::new(AtomicUsize::new(0));

--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -460,7 +460,7 @@ async fn preflight_content_type(
     let ct_opt = head_headers
         .get(CONTENT_TYPE)
         .and_then(|v| v.to_str().ok())
-        .map(|s| s.to_string());
+        .map(std::string::ToString::to_string);
     let mut csp_header = head_headers
         .get("content-security-policy")
         .and_then(|v| v.to_str().ok())
@@ -1377,7 +1377,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                 }
                 let file_path = &args.targets[0];
                 match fs::read_to_string(file_path) {
-                    Ok(content) => content.lines().map(|s| s.to_string()).collect(),
+                    Ok(content) => content.lines().map(std::string::ToString::to_string).collect(),
                     Err(e) => {
                         if !args.silence {
                             emit_error(
@@ -1756,7 +1756,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         host_groups.entry(host).or_default().push(target);
     }
 
-    let total_targets = host_groups.values().map(|g| g.len()).sum::<usize>();
+    let total_targets = host_groups.values().map(std::vec::Vec::len).sum::<usize>();
     let preflight_idx = Arc::new(AtomicUsize::new(0));
     let analyze_idx = Arc::new(AtomicUsize::new(0));
     let scan_idx = Arc::new(AtomicUsize::new(0));
@@ -2301,14 +2301,10 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                         let bullet = if i + 1 == n { "└──" } else { "├──" };
                         let valid = p
                             .valid_specials
-                            .as_ref()
-                            .map(|v| v.iter().collect::<String>())
-                            .unwrap_or_else(|| "-".to_string());
+                            .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
                         let invalid = p
                             .invalid_specials
-                            .as_ref()
-                            .map(|v| v.iter().collect::<String>())
-                            .unwrap_or_else(|| "-".to_string());
+                            .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
                         crate::cprintln!(
                             "  \x1b[90m{}\x1b[0m \x1b[38;5;247m{}\x1b[0m \x1b[38;5;247mvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\" \x1b[38;5;247minvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\"",
                             bullet, p.name, valid, invalid

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -351,11 +351,10 @@ fn build_cors_headers(state: &AppState, req_headers: &HeaderMap) -> HeaderMap {
         let exact_allowed = state
             .allowed_origins
             .as_ref()
-            .map(|v| {
+            .is_some_and(|v| {
                 v.iter()
                     .any(|o| !o.starts_with("regex:") && o != "*" && o == origin_str)
-            })
-            .unwrap_or(false);
+            });
         let regex_allowed = state
             .allowed_origin_regexes
             .iter()
@@ -1186,12 +1185,10 @@ async fn get_scan_handler(
     let user_agent = params.get("user_agent").cloned();
     let include_request = params
         .get("include_request")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
     let include_response = params
         .get("include_response")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
 
     let param_list: Option<Vec<String>> = params.get("param").map(|s| {
         s.split(',')
@@ -1202,24 +1199,19 @@ async fn get_scan_handler(
     let proxy = params.get("proxy").cloned();
     let follow_redirects = params
         .get("follow_redirects")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
     let skip_mining = params
         .get("skip_mining")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
     let skip_discovery = params
         .get("skip_discovery")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
     let deep_scan = params
         .get("deep_scan")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
     let skip_ast_analysis = params
         .get("skip_ast_analysis")
-        .map(|s| s == "true")
-        .unwrap_or(false);
+        .is_some_and(|s| s == "true");
 
     let opts = ScanOptions {
         cookie,
@@ -1365,8 +1357,7 @@ async fn cancel_scan_handler(
     // must first cancel a running scan and wait for it to settle.
     let purge_requested = params
         .get("purge")
-        .map(|v| v == "1" || v.eq_ignore_ascii_case("true"))
-        .unwrap_or(false);
+        .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
 
     let mut jobs = state.jobs.lock().await;
     match jobs.get_mut(&id) {
@@ -1520,7 +1511,7 @@ async fn list_scans_handler(
                 "scan_id": id,
                 "target": job.target_url,
                 "status": job.status,
-                "result_count": job.results.as_ref().map(|r| r.len()).unwrap_or(0),
+                "result_count": job.results.as_ref().map_or(0, |r| r.len()),
                 "queued_at_ms": job.queued_at_ms,
                 "started_at_ms": job.started_at_ms,
                 "finished_at_ms": job.finished_at_ms,

--- a/src/cmd/server.rs
+++ b/src/cmd/server.rs
@@ -348,13 +348,10 @@ fn build_cors_headers(state: &AppState, req_headers: &HeaderMap) -> HeaderMap {
     if let Some(origin_val) = req_headers.get("Origin")
         && let Ok(origin_str) = origin_val.to_str()
     {
-        let exact_allowed = state
-            .allowed_origins
-            .as_ref()
-            .is_some_and(|v| {
-                v.iter()
-                    .any(|o| !o.starts_with("regex:") && o != "*" && o == origin_str)
-            });
+        let exact_allowed = state.allowed_origins.as_ref().is_some_and(|v| {
+            v.iter()
+                .any(|o| !o.starts_with("regex:") && o != "*" && o == origin_str)
+        });
         let regex_allowed = state
             .allowed_origin_regexes
             .iter()
@@ -1183,12 +1180,8 @@ async fn get_scan_handler(
         .unwrap_or_else(|| "GET".to_string());
     let data_opt = params.get("data").cloned();
     let user_agent = params.get("user_agent").cloned();
-    let include_request = params
-        .get("include_request")
-        .is_some_and(|s| s == "true");
-    let include_response = params
-        .get("include_response")
-        .is_some_and(|s| s == "true");
+    let include_request = params.get("include_request").is_some_and(|s| s == "true");
+    let include_response = params.get("include_response").is_some_and(|s| s == "true");
 
     let param_list: Option<Vec<String>> = params.get("param").map(|s| {
         s.split(',')
@@ -1197,21 +1190,11 @@ async fn get_scan_handler(
             .collect()
     });
     let proxy = params.get("proxy").cloned();
-    let follow_redirects = params
-        .get("follow_redirects")
-        .is_some_and(|s| s == "true");
-    let skip_mining = params
-        .get("skip_mining")
-        .is_some_and(|s| s == "true");
-    let skip_discovery = params
-        .get("skip_discovery")
-        .is_some_and(|s| s == "true");
-    let deep_scan = params
-        .get("deep_scan")
-        .is_some_and(|s| s == "true");
-    let skip_ast_analysis = params
-        .get("skip_ast_analysis")
-        .is_some_and(|s| s == "true");
+    let follow_redirects = params.get("follow_redirects").is_some_and(|s| s == "true");
+    let skip_mining = params.get("skip_mining").is_some_and(|s| s == "true");
+    let skip_discovery = params.get("skip_discovery").is_some_and(|s| s == "true");
+    let deep_scan = params.get("deep_scan").is_some_and(|s| s == "true");
+    let skip_ast_analysis = params.get("skip_ast_analysis").is_some_and(|s| s == "true");
 
     let opts = ScanOptions {
         cookie,

--- a/src/config.rs
+++ b/src/config.rs
@@ -651,7 +651,7 @@ impl Config {
             if let Some(v) = &scan.encoders {
                 // Override only if current encoders equal the canonical defaults (user did not supply CLI override).
                 // Canonical defaults are defined in cmd::scan::DEFAULT_ENCODERS (["url","html"]).
-                if args.encoders.iter().map(|s| s.as_str()).collect::<Vec<_>>()
+                if args.encoders.iter().map(std::string::String::as_str).collect::<Vec<_>>()
                     == crate::cmd::scan::DEFAULT_ENCODERS
                 {
                     args.encoders = v.clone();

--- a/src/config.rs
+++ b/src/config.rs
@@ -651,7 +651,11 @@ impl Config {
             if let Some(v) = &scan.encoders {
                 // Override only if current encoders equal the canonical defaults (user did not supply CLI override).
                 // Canonical defaults are defined in cmd::scan::DEFAULT_ENCODERS (["url","html"]).
-                if args.encoders.iter().map(std::string::String::as_str).collect::<Vec<_>>()
+                if args
+                    .encoders
+                    .iter()
+                    .map(String::as_str)
+                    .collect::<Vec<_>>()
                     == crate::cmd::scan::DEFAULT_ENCODERS
                 {
                     args.encoders = v.clone();

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -26,7 +26,7 @@ pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String])
 
     // Use a HashSet for O(1) encoder lookup instead of O(n) linear scan
     let encoder_set: std::collections::HashSet<&str> =
-        encoders.iter().map(|s| s.as_str()).collect();
+        encoders.iter().map(std::string::String::as_str).collect();
 
     // Expansion order
     let prio = [

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -26,7 +26,7 @@ pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String])
 
     // Use a HashSet for O(1) encoder lookup instead of O(n) linear scan
     let encoder_set: std::collections::HashSet<&str> =
-        encoders.iter().map(std::string::String::as_str).collect();
+        encoders.iter().map(String::as_str).collect();
 
     // Expansion order
     let prio = [

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -508,7 +508,7 @@ fn default_method() -> String {
 fn default_encoders() -> Vec<String> {
     crate::cmd::scan::DEFAULT_ENCODERS
         .iter()
-        .map(std::string::ToString::to_string)
+        .map(ToString::to_string)
         .collect()
 }
 fn default_timeout() -> u64 {
@@ -1103,7 +1103,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             skip_discovery: params.skip_discovery,
             encoders: crate::cmd::scan::DEFAULT_ENCODERS
                 .iter()
-                .map(std::string::ToString::to_string)
+                .map(ToString::to_string)
                 .collect(),
         });
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -244,8 +244,7 @@ impl DalfoxMcp {
         let url = scan_args
             .targets
             .first()
-            .map(String::as_str)
-            .unwrap_or("<missing>");
+            .map_or("<missing>", String::as_str);
         let include_request = scan_args.include_request;
         let include_response = scan_args.include_response;
 
@@ -509,7 +508,7 @@ fn default_method() -> String {
 fn default_encoders() -> Vec<String> {
     crate::cmd::scan::DEFAULT_ENCODERS
         .iter()
-        .map(|s| s.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 fn default_timeout() -> u64 {
@@ -999,7 +998,7 @@ status, and result_count."
                         "scan_id": id,
                         "target": job.target_url,
                         "status": job.status,
-                        "result_count": job.results.as_ref().map(|r| r.len()).unwrap_or(0)
+                        "result_count": job.results.as_ref().map_or(0, |r| r.len())
                     });
                     if let Some(obj) = entry.as_object_mut() {
                         write_timestamps(job, obj);
@@ -1104,7 +1103,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             skip_discovery: params.skip_discovery,
             encoders: crate::cmd::scan::DEFAULT_ENCODERS
                 .iter()
-                .map(|s| s.to_string())
+                .map(std::string::ToString::to_string)
                 .collect(),
         });
 

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -357,7 +357,7 @@ pub async fn check_query_discovery(
                         &text,
                         crate::scanning::markers::bracketed_marker(),
                     )
-                    .map(std::string::ToString::to_string);
+                    .map(ToString::to_string);
                     discovered = Some(Param {
                         name,
                         value,
@@ -760,7 +760,7 @@ pub async fn check_header_discovery(
                     &text,
                     crate::scanning::markers::bracketed_marker(),
                 )
-                .map(std::string::ToString::to_string);
+                .map(ToString::to_string);
                 discovered = Some(Param {
                     name: header_name,
                     value: header_value,
@@ -823,7 +823,10 @@ pub async fn check_path_discovery(
 
     let mut handles = Vec::new();
 
-    let mut new_segments: Vec<String> = segments.iter().map(std::string::ToString::to_string).collect();
+    let mut new_segments: Vec<String> = segments
+        .iter()
+        .map(ToString::to_string)
+        .collect();
     for (idx, original) in segments.iter().enumerate() {
         let saved = std::mem::replace(&mut new_segments[idx], test_value.to_string());
         let new_path = format!("/{}", new_segments.join("/"));

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -323,10 +323,9 @@ pub async fn check_query_discovery(
                     resp.headers()
                         .get("location")
                         .and_then(|v| v.to_str().ok())
-                        .map(|loc| {
+                        .is_some_and(|loc| {
                             crate::scanning::markers::classify_probe_reflection(loc).detected()
                         })
-                        .unwrap_or(false)
                 } else {
                     false
                 };
@@ -358,7 +357,7 @@ pub async fn check_query_discovery(
                         &text,
                         crate::scanning::markers::bracketed_marker(),
                     )
-                    .map(|s| s.to_string());
+                    .map(std::string::ToString::to_string);
                     discovered = Some(Param {
                         name,
                         value,
@@ -761,7 +760,7 @@ pub async fn check_header_discovery(
                     &text,
                     crate::scanning::markers::bracketed_marker(),
                 )
-                .map(|s| s.to_string());
+                .map(std::string::ToString::to_string);
                 discovered = Some(Param {
                     name: header_name,
                     value: header_value,
@@ -824,7 +823,7 @@ pub async fn check_path_discovery(
 
     let mut handles = Vec::new();
 
-    let mut new_segments: Vec<String> = segments.iter().map(|s| s.to_string()).collect();
+    let mut new_segments: Vec<String> = segments.iter().map(std::string::ToString::to_string).collect();
     for (idx, original) in segments.iter().enumerate() {
         let saved = std::mem::replace(&mut new_segments[idx], test_value.to_string());
         let new_path = format!("/{}", new_segments.join("/"));
@@ -1385,7 +1384,7 @@ pub async fn check_form_discovery(
                 .expect("inline JSON regex is valid")
         });
         for caps in inline_re.captures_iter(&html) {
-            let full = caps.get(0).map(|m| m.as_str()).unwrap_or("");
+            let full = caps.get(0).map_or("", |m| m.as_str());
             // Try to parse as JSON
             if let Ok(serde_json::Value::Object(obj)) =
                 serde_json::from_str::<serde_json::Value>(full)

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -489,7 +489,10 @@ pub async fn probe_dictionary_params(
     }
 
     if !loaded {
-        params = GF_PATTERNS_PARAMS.iter().map(std::string::ToString::to_string).collect();
+        params = GF_PATTERNS_PARAMS
+            .iter()
+            .map(ToString::to_string)
+            .collect();
     }
 
     // Sentinel pre-probe: 3 unique random param names. If every one reflects,

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -77,8 +77,7 @@ async fn pre_collapse_query_probe(client: &reqwest::Client, target: &Target) -> 
                 .headers()
                 .get("location")
                 .and_then(|v| v.to_str().ok())
-                .map(|loc| loc.contains(marker))
-                .unwrap_or(false);
+                .is_some_and(|loc| loc.contains(marker));
         let text = resp.text().await.ok()?;
         if !location_has_marker && !text.contains(marker) {
             return None;
@@ -490,7 +489,7 @@ pub async fn probe_dictionary_params(
     }
 
     if !loaded {
-        params = GF_PATTERNS_PARAMS.iter().map(|s| s.to_string()).collect();
+        params = GF_PATTERNS_PARAMS.iter().map(std::string::ToString::to_string).collect();
     }
 
     // Sentinel pre-probe: 3 unique random param names. If every one reflects,
@@ -614,10 +613,9 @@ pub async fn probe_dictionary_params(
                         r.headers()
                             .get("location")
                             .and_then(|v| v.to_str().ok())
-                            .map(|loc| {
+                            .is_some_and(|loc| {
                                 crate::scanning::markers::classify_probe_reflection(loc).detected()
                             })
-                            .unwrap_or(false)
                     } else {
                         false
                     };

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -373,7 +373,7 @@ pub async fn active_probe_param(
                                 .trim_matches('/')
                                 .split('/')
                                 .filter(|s| !s.is_empty())
-                                .map(std::string::ToString::to_string)
+                                .map(ToString::to_string)
                                 .collect()
                         };
                         if idx < segments.len() {
@@ -519,7 +519,7 @@ pub async fn active_probe_param(
                         resp.headers()
                             .get(reqwest::header::LOCATION)
                             .and_then(|v| v.to_str().ok())
-                            .map(std::string::ToString::to_string)
+                            .map(ToString::to_string)
                     } else {
                         None
                     };
@@ -771,10 +771,12 @@ pub async fn analyze_parameters(
         for p in &target.reflection_params {
             let valid = p
                 .valid_specials
-                .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
+                .as_ref()
+                .map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
             let invalid = p
                 .invalid_specials
-                .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
+                .as_ref()
+                .map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
             let line = format!(
                 "[param-analysis] name={} type={:?} reflected=true context={:?} valid_specials=\"{}\" invalid_specials=\"{}\"",
                 p.name, p.location, p.injection_context, valid, invalid

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -373,7 +373,7 @@ pub async fn active_probe_param(
                                 .trim_matches('/')
                                 .split('/')
                                 .filter(|s| !s.is_empty())
-                                .map(|s| s.to_string())
+                                .map(std::string::ToString::to_string)
                                 .collect()
                         };
                         if idx < segments.len() {
@@ -519,7 +519,7 @@ pub async fn active_probe_param(
                         resp.headers()
                             .get(reqwest::header::LOCATION)
                             .and_then(|v| v.to_str().ok())
-                            .map(|s| s.to_string())
+                            .map(std::string::ToString::to_string)
                     } else {
                         None
                     };
@@ -771,14 +771,10 @@ pub async fn analyze_parameters(
         for p in &target.reflection_params {
             let valid = p
                 .valid_specials
-                .as_ref()
-                .map(|v| v.iter().collect::<String>())
-                .unwrap_or_else(|| "-".to_string());
+                .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
             let invalid = p
                 .invalid_specials
-                .as_ref()
-                .map(|v| v.iter().collect::<String>())
-                .unwrap_or_else(|| "-".to_string());
+                .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
             let line = format!(
                 "[param-analysis] name={} type={:?} reflected=true context={:?} valid_specials=\"{}\" invalid_specials=\"{}\"",
                 p.name, p.location, p.injection_context, valid, invalid

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -22,7 +22,7 @@ fn ensure_default_registries() {
     // Seed payload providers if empty
     {
         let reg = PAYLOAD_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut m = reg.lock().unwrap_or_else(|e| e.into_inner());
+        let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if m.is_empty() {
             m.insert(
                 "payloadbox".to_string(),
@@ -37,7 +37,7 @@ fn ensure_default_registries() {
     // Seed wordlist providers if empty
     {
         let reg = WORDLIST_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut m = reg.lock().unwrap_or_else(|e| e.into_inner());
+        let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
         if m.is_empty() {
             m.insert(
                 "assetnote".to_string(),
@@ -55,14 +55,14 @@ fn ensure_default_registries() {
 pub fn register_payload_provider<N: AsRef<str>>(name: N, urls: Vec<String>) {
     let reg = PAYLOAD_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
     let key = name.as_ref().to_ascii_lowercase();
-    let mut m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     m.insert(key, urls);
 }
 
 pub fn register_wordlist_provider<N: AsRef<str>>(name: N, urls: Vec<String>) {
     let reg = WORDLIST_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
     let key = name.as_ref().to_ascii_lowercase();
-    let mut m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     m.insert(key, urls);
 }
 
@@ -72,7 +72,7 @@ pub fn list_payload_providers() -> Vec<String> {
     let Some(reg) = PAYLOAD_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     m.keys().cloned().collect()
 }
 
@@ -81,7 +81,7 @@ pub fn list_wordlist_providers() -> Vec<String> {
     let Some(reg) = WORDLIST_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     m.keys().cloned().collect()
 }
 
@@ -244,7 +244,7 @@ fn collect_payload_provider_urls(providers: &[String]) -> Vec<String> {
     let Some(reg) = PAYLOAD_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut urls: Vec<String> = Vec::new();
     for p in providers {
         if let Some(lst) = m.get(&p.to_ascii_lowercase()) {
@@ -260,7 +260,7 @@ fn collect_wordlist_provider_urls(providers: &[String]) -> Vec<String> {
     let Some(reg) = WORDLIST_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(|e| e.into_inner());
+    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
     let mut urls: Vec<String> = Vec::new();
     for p in providers {
         if let Some(lst) = m.get(&p.to_ascii_lowercase()) {
@@ -311,12 +311,12 @@ async fn fetch_multiple_text_lists(client: &Client, urls: &[String]) -> String {
 /// - drop comment lines starting with '#', '//', or ';'
 fn sanitize_lines(text: &str) -> Vec<String> {
     text.lines()
-        .map(|l| l.trim())
+        .map(str::trim)
         .filter(|l| !l.is_empty())
         .filter(|l| !l.starts_with('#'))
         .filter(|l| !l.starts_with("//"))
         .filter(|l| !l.starts_with(';'))
-        .map(|l| l.to_string())
+        .map(std::string::ToString::to_string)
         .collect()
 }
 

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -1,5 +1,5 @@
 use std::collections::HashMap;
-use std::sync::{Arc, Mutex, OnceLock};
+use std::sync::{Arc, Mutex, OnceLock, PoisonError};
 use std::time::Duration;
 
 use reqwest::Client;
@@ -22,7 +22,9 @@ fn ensure_default_registries() {
     // Seed payload providers if empty
     {
         let reg = PAYLOAD_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut m = reg
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         if m.is_empty() {
             m.insert(
                 "payloadbox".to_string(),
@@ -37,7 +39,9 @@ fn ensure_default_registries() {
     // Seed wordlist providers if empty
     {
         let reg = WORDLIST_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
-        let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+        let mut m = reg
+            .lock()
+            .unwrap_or_else(PoisonError::into_inner);
         if m.is_empty() {
             m.insert(
                 "assetnote".to_string(),
@@ -55,14 +59,18 @@ fn ensure_default_registries() {
 pub fn register_payload_provider<N: AsRef<str>>(name: N, urls: Vec<String>) {
     let reg = PAYLOAD_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
     let key = name.as_ref().to_ascii_lowercase();
-    let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     m.insert(key, urls);
 }
 
 pub fn register_wordlist_provider<N: AsRef<str>>(name: N, urls: Vec<String>) {
     let reg = WORDLIST_PROVIDER_REGISTRY.get_or_init(|| Mutex::new(HashMap::new()));
     let key = name.as_ref().to_ascii_lowercase();
-    let mut m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let mut m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     m.insert(key, urls);
 }
 
@@ -72,7 +80,9 @@ pub fn list_payload_providers() -> Vec<String> {
     let Some(reg) = PAYLOAD_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     m.keys().cloned().collect()
 }
 
@@ -81,7 +91,9 @@ pub fn list_wordlist_providers() -> Vec<String> {
     let Some(reg) = WORDLIST_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     m.keys().cloned().collect()
 }
 
@@ -244,7 +256,9 @@ fn collect_payload_provider_urls(providers: &[String]) -> Vec<String> {
     let Some(reg) = PAYLOAD_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let mut urls: Vec<String> = Vec::new();
     for p in providers {
         if let Some(lst) = m.get(&p.to_ascii_lowercase()) {
@@ -260,7 +274,9 @@ fn collect_wordlist_provider_urls(providers: &[String]) -> Vec<String> {
     let Some(reg) = WORDLIST_PROVIDER_REGISTRY.get() else {
         return Vec::new();
     };
-    let m = reg.lock().unwrap_or_else(std::sync::PoisonError::into_inner);
+    let m = reg
+        .lock()
+        .unwrap_or_else(PoisonError::into_inner);
     let mut urls: Vec<String> = Vec::new();
     for p in providers {
         if let Some(lst) = m.get(&p.to_ascii_lowercase()) {

--- a/src/payload/xss_csp_bypass.rs
+++ b/src/payload/xss_csp_bypass.rs
@@ -29,7 +29,7 @@ pub struct CspAnalysis {
 pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
     let mut analysis = CspAnalysis::default();
 
-    let directives: Vec<&str> = csp_value.split(';').map(|s| s.trim()).collect();
+    let directives: Vec<&str> = csp_value.split(';').map(str::trim).collect();
 
     let mut has_script_src = false;
     let mut has_default_src = false;

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -526,7 +526,7 @@ impl<'a> DomXssVisitor<'a> {
                 t.quasis
                     .first()
                     .and_then(|q| q.value.cooked.as_ref())
-                    .map(|c| c.as_str())
+                    .map(oxc_ast::ast::Str::as_str)
             }
             _ => None,
         };
@@ -639,8 +639,7 @@ impl<'a> DomXssVisitor<'a> {
 
     fn call_first_arg_eq_ignore_case(call: &CallExpression<'a>, expected: &str) -> bool {
         Self::extract_static_string_argument(call, 0)
-            .map(|s| s.eq_ignore_ascii_case(expected))
-            .unwrap_or(false)
+            .is_some_and(|s| s.eq_ignore_ascii_case(expected))
     }
 
     /// Static-selector matcher for "this picks a `<script>`."
@@ -790,7 +789,7 @@ impl<'a> DomXssVisitor<'a> {
     }
 
     fn get_property_key_name(&self, key: &PropertyKey<'a>) -> Option<String> {
-        key.name().map(|n| n.into_owned())
+        key.name().map(std::borrow::Cow::into_owned)
     }
 
     fn get_summary_object_prefix(&self, expr: &Expression<'a>) -> Option<String> {
@@ -1280,8 +1279,7 @@ impl<'a> DomXssVisitor<'a> {
             let mut target_name = self.get_expr_string(target_expr);
             if target_name
                 .as_ref()
-                .map(|name| !self.sources.contains(name.as_str()))
-                .unwrap_or(true)
+                .is_none_or(|name| !self.sources.contains(name.as_str()))
                 && let Some(alias) = target_alias
             {
                 target_name = Some(alias.target.clone());
@@ -1967,8 +1965,7 @@ impl<'a> DomXssVisitor<'a> {
                         Argument::SpreadElement(spread) => self.is_tainted(&spread.argument),
                         _ => arg
                             .as_expression()
-                            .map(|e| self.is_tainted(e))
-                            .unwrap_or(false),
+                            .is_some_and(|e| self.is_tainted(e)),
                     };
                     if is_arg_tainted {
                         self.tainted_vars.insert(var_name.to_string());
@@ -1977,15 +1974,13 @@ impl<'a> DomXssVisitor<'a> {
                             _ => arg.as_expression(),
                         };
                         let source = source_expr
-                            .and_then(|e| self.find_source_in_expr(e))
-                            .map(|source| {
+                            .and_then(|e| self.find_source_in_expr(e)).map_or_else(|| "location.search".to_string(), |source| {
                                 if id.name.as_str() == "URLSearchParams" {
                                     self.normalize_search_param_source(&source)
                                 } else {
                                     source
                                 }
-                            })
-                            .unwrap_or_else(|| "location.search".to_string());
+                            });
                         self.var_aliases
                             .insert(var_name.to_string(), source.clone());
                         if id.name.as_str() == "URLSearchParams" {
@@ -2038,8 +2033,7 @@ impl<'a> DomXssVisitor<'a> {
                             Argument::SpreadElement(spread) => self.is_tainted(&spread.argument),
                             _ => arg
                                 .as_expression()
-                                .map(|e| self.is_tainted(e))
-                                .unwrap_or(false),
+                                .is_some_and(|e| self.is_tainted(e)),
                         };
                         if is_arg_tainted {
                             self.tainted_vars.insert(var_name.to_string());
@@ -2294,8 +2288,7 @@ impl<'a> DomXssVisitor<'a> {
                                 }
                                 _ => arg
                                     .as_expression()
-                                    .map(|e| self.is_tainted(e))
-                                    .unwrap_or(false),
+                                    .is_some_and(|e| self.is_tainted(e)),
                             };
                             if is_arg_tainted {
                                 self.report_vulnerability(
@@ -2405,7 +2398,7 @@ impl<'a> DomXssVisitor<'a> {
                     && matches!(
                         self.instance_classes
                             .get(id.name.as_str())
-                            .map(|name| name.as_str()),
+                            .map(std::string::String::as_str),
                         Some("MessageChannel")
                     )
                 {
@@ -2417,7 +2410,7 @@ impl<'a> DomXssVisitor<'a> {
                     && matches!(
                         self.instance_classes
                             .get(id.name.as_str())
-                            .map(|name| name.as_str()),
+                            .map(std::string::String::as_str),
                         Some("SharedWorker")
                     )
                 {
@@ -2612,12 +2605,10 @@ impl<'a> DomXssVisitor<'a> {
                 }
                 let is_sink = prop_name
                     .as_deref()
-                    .map(|name| self.is_assignment_sink_property(name))
-                    .unwrap_or(false);
+                    .is_some_and(|name| self.is_assignment_sink_property(name));
                 let full_path_is_sink = self
                     .get_computed_member_string(member)
-                    .map(|full_path| self.sinks.contains(full_path.as_str()))
-                    .unwrap_or(false);
+                    .is_some_and(|full_path| self.sinks.contains(full_path.as_str()));
 
                 if (is_sink || full_path_is_sink) && right_tainted {
                     let sink_name = if full_path_is_sink {
@@ -2998,8 +2989,7 @@ impl<'a> DomXssVisitor<'a> {
             let mut target_func_name = self.get_expr_string(target_expr);
             if target_func_name
                 .as_ref()
-                .map(|name| !self.sinks.contains(name.as_str()))
-                .unwrap_or(true)
+                .is_none_or(|name| !self.sinks.contains(name.as_str()))
                 && let Some(alias) = target_alias_owned.as_ref()
                 && self.sinks.contains(alias.target.as_str())
             {
@@ -3341,7 +3331,7 @@ impl AstDomAnalyzer {
         let ret = Parser::new(&allocator, source_code, source_type).parse();
 
         if !ret.errors.is_empty() {
-            let error_messages: Vec<String> = ret.errors.iter().map(|e| e.to_string()).collect();
+            let error_messages: Vec<String> = ret.errors.iter().map(std::string::ToString::to_string).collect();
             return Err(format!("Parse errors: {}", error_messages.join(", ")));
         }
 

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -526,7 +526,7 @@ impl<'a> DomXssVisitor<'a> {
                 t.quasis
                     .first()
                     .and_then(|q| q.value.cooked.as_ref())
-                    .map(oxc_ast::ast::Str::as_str)
+                    .map(Str::as_str)
             }
             _ => None,
         };
@@ -1963,9 +1963,7 @@ impl<'a> DomXssVisitor<'a> {
                 {
                     let is_arg_tainted = match arg {
                         Argument::SpreadElement(spread) => self.is_tainted(&spread.argument),
-                        _ => arg
-                            .as_expression()
-                            .is_some_and(|e| self.is_tainted(e)),
+                        _ => arg.as_expression().is_some_and(|e| self.is_tainted(e)),
                     };
                     if is_arg_tainted {
                         self.tainted_vars.insert(var_name.to_string());
@@ -1974,13 +1972,17 @@ impl<'a> DomXssVisitor<'a> {
                             _ => arg.as_expression(),
                         };
                         let source = source_expr
-                            .and_then(|e| self.find_source_in_expr(e)).map_or_else(|| "location.search".to_string(), |source| {
-                                if id.name.as_str() == "URLSearchParams" {
-                                    self.normalize_search_param_source(&source)
-                                } else {
-                                    source
-                                }
-                            });
+                            .and_then(|e| self.find_source_in_expr(e))
+                            .map_or_else(
+                                || "location.search".to_string(),
+                                |source| {
+                                    if id.name.as_str() == "URLSearchParams" {
+                                        self.normalize_search_param_source(&source)
+                                    } else {
+                                        source
+                                    }
+                                },
+                            );
                         self.var_aliases
                             .insert(var_name.to_string(), source.clone());
                         if id.name.as_str() == "URLSearchParams" {
@@ -2031,9 +2033,7 @@ impl<'a> DomXssVisitor<'a> {
                     if let Some(arg) = call.arguments.first() {
                         let is_arg_tainted = match arg {
                             Argument::SpreadElement(spread) => self.is_tainted(&spread.argument),
-                            _ => arg
-                                .as_expression()
-                                .is_some_and(|e| self.is_tainted(e)),
+                            _ => arg.as_expression().is_some_and(|e| self.is_tainted(e)),
                         };
                         if is_arg_tainted {
                             self.tainted_vars.insert(var_name.to_string());
@@ -2286,9 +2286,7 @@ impl<'a> DomXssVisitor<'a> {
                                 Argument::SpreadElement(spread) => {
                                     self.is_tainted(&spread.argument)
                                 }
-                                _ => arg
-                                    .as_expression()
-                                    .is_some_and(|e| self.is_tainted(e)),
+                                _ => arg.as_expression().is_some_and(|e| self.is_tainted(e)),
                             };
                             if is_arg_tainted {
                                 self.report_vulnerability(
@@ -2398,7 +2396,7 @@ impl<'a> DomXssVisitor<'a> {
                     && matches!(
                         self.instance_classes
                             .get(id.name.as_str())
-                            .map(std::string::String::as_str),
+                            .map(String::as_str),
                         Some("MessageChannel")
                     )
                 {
@@ -2410,7 +2408,7 @@ impl<'a> DomXssVisitor<'a> {
                     && matches!(
                         self.instance_classes
                             .get(id.name.as_str())
-                            .map(std::string::String::as_str),
+                            .map(String::as_str),
                         Some("SharedWorker")
                     )
                 {
@@ -3331,7 +3329,11 @@ impl AstDomAnalyzer {
         let ret = Parser::new(&allocator, source_code, source_type).parse();
 
         if !ret.errors.is_empty() {
-            let error_messages: Vec<String> = ret.errors.iter().map(std::string::ToString::to_string).collect();
+            let error_messages: Vec<String> = ret
+                .errors
+                .iter()
+                .map(ToString::to_string)
+                .collect();
             return Err(format!("Parse errors: {}", error_messages.join(", ")));
         }
 

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -85,12 +85,10 @@ fn payload_has_any_marker(payload: &str) -> bool {
 fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     let selector = super::selectors::universal();
     document.select(selector).any(|node| {
-        node.value()
-            .attr("class")
-            .is_some_and(|cls| {
-                cls.split_ascii_whitespace()
-                    .any(|c| c.eq_ignore_ascii_case(marker))
-            })
+        node.value().attr("class").is_some_and(|cls| {
+            cls.split_ascii_whitespace()
+                .any(|c| c.eq_ignore_ascii_case(marker))
+        })
     })
 }
 

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -87,11 +87,10 @@ fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> boo
     document.select(selector).any(|node| {
         node.value()
             .attr("class")
-            .map(|cls| {
+            .is_some_and(|cls| {
                 cls.split_ascii_whitespace()
                     .any(|c| c.eq_ignore_ascii_case(marker))
             })
-            .unwrap_or(false)
     })
 }
 
@@ -103,8 +102,7 @@ fn any_element_has_id_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     document.select(selector).any(|node| {
         node.value()
             .attr("id")
-            .map(|id| id.trim().eq_ignore_ascii_case(marker))
-            .unwrap_or(false)
+            .is_some_and(|id| id.trim().eq_ignore_ascii_case(marker))
     })
 }
 

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -283,8 +283,7 @@ fn callee_identifier_is_sink(callee: &Expression<'_>) -> bool {
         Expression::SequenceExpression(seq) => seq
             .expressions
             .last()
-            .map(callee_identifier_is_sink)
-            .unwrap_or(false),
+            .is_some_and(callee_identifier_is_sink),
         _ => false,
     }
 }

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -162,7 +162,7 @@ pub async fn verify_dom_xss_light_with_client(
             .headers()
             .get("Content-Security-Policy")
             .and_then(|v| v.to_str().ok())
-            .map(|s| s.to_string());
+            .map(std::string::ToString::to_string);
         if let Ok(text) = resp.text().await {
             // 1) Payload reflection present after normalization
             if crate::utils::is_htmlish_content_type(&ct)

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -162,7 +162,7 @@ pub async fn verify_dom_xss_light_with_client(
             .headers()
             .get("Content-Security-Policy")
             .and_then(|v| v.to_str().ok())
-            .map(std::string::ToString::to_string);
+            .map(ToString::to_string);
         if let Ok(text) = resp.text().await {
             // 1) Payload reflection present after normalization
             if crate::utils::is_htmlish_content_type(&ct)

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1284,8 +1284,7 @@ pub async fn run_scanning(
                                     body,
                                 )
                             })
-                            .map(|k| k.label())
-                            .unwrap_or("DOM evidence");
+                            .map_or("DOM evidence", |k| k.label());
 
                         let mut result = crate::scanning::result::Result::new(
                             FindingType::Verified, // DOM-verified => Vulnerability

--- a/src/scanning/tech_detect.rs
+++ b/src/scanning/tech_detect.rs
@@ -141,8 +141,7 @@ pub fn detect_technologies(headers: &HeaderMap, body: Option<&str>) -> TechDetec
                 Some(substr) => val
                     .to_str()
                     .ok()
-                    .map(|v| v.to_ascii_lowercase().contains(substr))
-                    .unwrap_or(false),
+                    .is_some_and(|v| v.to_ascii_lowercase().contains(substr)),
             };
             if matched {
                 merge_detection(

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -330,7 +330,10 @@ pub fn load_custom_payloads(path: &str) -> Result<Vec<String>, Box<dyn std::erro
     }
 
     let content = std::fs::read_to_string(path)?;
-    let payloads: Vec<String> = content.lines().map(std::string::ToString::to_string).collect();
+    let payloads: Vec<String> = content
+        .lines()
+        .map(ToString::to_string)
+        .collect();
 
     if let Ok(mut guard) = cache.lock() {
         guard.insert(path.to_string(), payloads.clone());

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -330,7 +330,7 @@ pub fn load_custom_payloads(path: &str) -> Result<Vec<String>, Box<dyn std::erro
     }
 
     let content = std::fs::read_to_string(path)?;
-    let payloads: Vec<String> = content.lines().map(|s| s.to_string()).collect();
+    let payloads: Vec<String> = content.lines().map(std::string::ToString::to_string).collect();
 
     if let Ok(mut guard) = cache.lock() {
         guard.insert(path.to_string(), payloads.clone());

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -169,7 +169,7 @@ pub fn parse_method_url_body(s: &str) -> (String, String, Option<String>) {
             let body = parts
                 .get(2)
                 .filter(|s| !s.is_empty())
-                .map(|s| s.to_string());
+                .map(std::string::ToString::to_string);
             return (potential_method, url, body);
         }
     }

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -169,7 +169,7 @@ pub fn parse_method_url_body(s: &str) -> (String, String, Option<String>) {
             let body = parts
                 .get(2)
                 .filter(|s| !s.is_empty())
-                .map(std::string::ToString::to_string);
+                .map(ToString::to_string);
             return (potential_method, url, body);
         }
     }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -315,12 +315,10 @@ pub async fn send_with_retry(
             .headers()
             .get("retry-after")
             .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok())
-            .map(|secs| (secs * 1000).min(max_retry_delay_ms))
-            .unwrap_or_else(|| {
+            .and_then(|s| s.parse::<u64>().ok()).map_or_else(|| {
                 // Exponential backoff: 1s, 2s, 4s
                 (1000 * (1u64 << attempts.min(3))).min(max_retry_delay_ms)
-            });
+            }, |secs| (secs * 1000).min(max_retry_delay_ms));
 
         let Some(rb) = next_rb else {
             // Cannot retry (request body was streamed), return the 429

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -315,10 +315,14 @@ pub async fn send_with_retry(
             .headers()
             .get("retry-after")
             .and_then(|v| v.to_str().ok())
-            .and_then(|s| s.parse::<u64>().ok()).map_or_else(|| {
-                // Exponential backoff: 1s, 2s, 4s
-                (1000 * (1u64 << attempts.min(3))).min(max_retry_delay_ms)
-            }, |secs| (secs * 1000).min(max_retry_delay_ms));
+            .and_then(|s| s.parse::<u64>().ok())
+            .map_or_else(
+                || {
+                    // Exponential backoff: 1s, 2s, 4s
+                    (1000 * (1u64 << attempts.min(3))).min(max_retry_delay_ms)
+                },
+                |secs| (secs * 1000).min(max_retry_delay_ms),
+            );
 
         let Some(rb) = next_rb else {
             // Cannot retry (request body was streamed), return the 429

--- a/src/utils/scan_id.rs
+++ b/src/utils/scan_id.rs
@@ -19,8 +19,7 @@ use std::time::{SystemTime, UNIX_EPOCH};
 pub fn make_scan_id(seed: &str) -> String {
     let now = SystemTime::now()
         .duration_since(UNIX_EPOCH)
-        .map(|d| d.as_nanos())
-        .unwrap_or(0);
+        .map_or(0, |d| d.as_nanos());
 
     make_scan_id_with_nonce(seed, now)
 }

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -185,8 +185,7 @@ pub fn fingerprint_from_response(
                 Some(substr) => val
                     .to_str()
                     .ok()
-                    .map(|v| v.to_ascii_lowercase().contains(substr))
-                    .unwrap_or(false),
+                    .is_some_and(|v| v.to_ascii_lowercase().contains(substr)),
             };
             if matched {
                 merge_fingerprint(


### PR DESCRIPTION
## Summary
- Behavior-preserving `clippy::pedantic` cleanups across 21 production files
- Replace deprecated/verbose Option combinator patterns with their idiomatic equivalents

### Patterns applied
- `.map(f).unwrap_or(x)` → `.map_or(x, f)`
- `.map(f).unwrap_or(false)` → `.is_some_and(f)`
- `.map_or(true, |x| !cond)` → `.is_none_or(|x| !cond)`
- `.unwrap_or_else(|e| e.into_inner())` → `.unwrap_or_else(PoisonError::into_inner)`
- Redundant method-call closures (`|s| s.to_string()`, `|s| s.as_str()`, …) → method references

No control-flow, side effects, or output contracts were changed. Test code, format strings, and intentional duplicate-arm dispatch tables were left alone.

## Test plan
- [x] `cargo build --all-targets` — clean
- [x] `cargo clippy --all-targets` — clean
- [x] `cargo test` — 1274 tests, 0 failed (1076 lib + 186 integration + others)