### PR TITLE
feat(skill): restructure dalfox skill with references/ directory for better maintainability

### DIFF
--- a/skills/dalfox/SKILL.md
+++ b/skills/dalfox/SKILL.md
@@ -1,137 +1,156 @@
 ---
 name: dalfox
-description: Use when scanning a URL or parameter for XSS (reflected, DOM, stored, blind), enumerating reflected parameters, or when the user explicitly mentions "dalfox". Runs as a CLI (`dalfox scan <URL>`) or as an MCP server exposing scan/preflight/cancel tools. Not for non-XSS vulnerabilities or general web fuzzing.
+description: >
+  Use when scanning a URL or parameter for XSS (reflected, DOM, stored, blind),
+  enumerating reflected parameters, or when the user explicitly mentions "dalfox"
+  or "XSS scan". Runs as CLI (`dalfox scan`) or MCP server (6 tools).
+  Authoritative workflows for dalfox v3 (Rust). Not for non-XSS vulnerabilities.
 ---
 
 # Dalfox: XSS Scanning Skill
 
-Dalfox is an XSS scanner. It discovers parameters, checks them for reflection, verifies DOM execution, and reports findings with types **V** (verified DOM execution), **A** (AST-detected), **R** (reflected-only).
+**Core principle**: XSS scanning sends attack payloads. Always start with authorization.
 
-## Authorization check — do this first
+## 1. Authorization (non-negotiable first step)
 
-**Always confirm authorization before scanning a target.** XSS scanning sends payloads to the target and is not safe on systems without permission. If the target is not clearly owned by the user (test lab, CTF, authorized engagement) or not a known test host (e.g., `http://testphp.vulnweb.com`, `https://xss-game.appspot.com`), ask:
+Before any scan:
 
-> "Confirm you're authorized to send XSS payloads to this target."
+- Confirm the target is owned by the user, a sanctioned test lab, CTF, or authorized engagement.
+- If the target is not obviously safe (e.g. not `testphp.vulnweb.com`, `xss-game.appspot.com`, or a clear lab host), ask explicitly:
 
-Do not proceed without an affirmative answer. For CTFs and authorized pentests, note the scope in a short acknowledgment and continue.
+  > "Confirm you are authorized to send XSS payloads to this target."
 
-## Pick a mode
+Do not proceed without a clear affirmative. Record the scope in one sentence when the user says yes.
 
-Check in order:
+## 2. Choose Execution Mode (check in order)
 
-1. **MCP tools visible** (tool names starting with `mcp__dalfox__` or `scan_with_dalfox` in the available tool list) → use MCP. It's asynchronous, supports concurrent scans, and returns structured results.
-2. **`dalfox` binary on PATH** (`command -v dalfox`) → use the CLI.
-3. **Neither** → tell the user how to install (`brew install dalfox`, `cargo install --path .`, or `nix run github:hahwul/dalfox`). Do not synthesize output.
+1. **MCP tools available** (`scan_with_dalfox`, `preflight_dalfox`, or tools prefixed `mcp__dalfox__`)  
+   → **Prefer MCP**. Async, cancellable, progress tracking, structured results.
 
-When both exist, prefer MCP — it decouples "start scan" from "read results" and the user can poll without blocking.
+2. **`dalfox` binary on PATH** (`command -v dalfox`)  
+   → Use CLI.
 
-## MCP usage
+3. **Neither**  
+   → Tell the user the install options: `brew install dalfox`, `cargo install --path .`, or `nix run github:hahwul/dalfox`.
 
-Six tools, intended pattern: `preflight` → `scan` → poll `get_results` → `delete` when done.
+When both are present, MCP is usually the better agent experience for anything longer than a quick smoke test.
 
-### Start a scan (non-blocking)
+See `references/mcp.md` for the exact 6 tools and parameter schemas.
 
-Call `scan_with_dalfox` with:
+## 3. Core Workflows
 
-- `target` (required) — full URL with scheme, e.g. `https://example.com/search?q=test`
-- `param` — restrict testing to listed names; accepts location hints like `q:query`, `user:body`, `auth:header`, `sid:cookie`
-- `method`, `data`, `headers` (`"Name: Value"`), `cookies` (`"name=value"`), `user_agent`, `proxy`
-- `encoders` — default `["url","html"]`; use `["none"]` to send payloads raw
-- `timeout` (1–299s), `delay` (0–9999ms), `workers` — out-of-range values are rejected
-- `deep_scan: true` for thorough testing, `skip_mining: true` + `skip_discovery: true` for fast sanity checks
-- `blind_callback_url` for blind-XSS (Burp Collaborator, interact.sh)
-- `include_request: true` / `include_response: true` only when you need forensic evidence — responses can be large
+### A. Safe Preflight (always do this on big or sensitive targets)
 
-Returns `{scan_id, target, status: "queued"}`. Store the `scan_id`.
+**MCP**:
+```json
+{"target": "https://target/?q=test", "skip_mining": true}
+```
+Use `preflight_dalfox`. Look at `estimated_total_requests` and `reachable`.
 
-### Poll results
-
-Call `get_results_dalfox` with `{scan_id}`. Also accepts `offset` / `limit` — use for results lists >50 items. The response includes a `progress` block with `suggested_poll_interval_ms`; honor it (~1–3s early, 1s near completion, 0 when done). Status goes through `queued → running → done | error | cancelled`.
-
-### Other tools
-
-- `preflight_dalfox` — synchronous. Counts discovered parameters and estimates total requests without sending payloads. Use this first when the user is worried about scan impact.
-- `list_scans_dalfox` — all tracked scans; filter by `status`.
-- `cancel_scan_dalfox` — signals the running task to stop at the next checkpoint. Partial results are preserved.
-- `delete_scan_dalfox` — removes a terminal scan from memory. Rejects running jobs — cancel first.
-
-Terminal jobs auto-purge after 1 hour, so short-lived workflows don't need to call delete.
-
-## CLI usage
-
-`dalfox` reads a target and prints findings. The minimal invocation:
-
+**CLI**:
 ```bash
-dalfox scan https://example.com/search?q=test
+dalfox scan https://target/?q=test --dry-run --skip-mining
 ```
 
-The `scan` subcommand is the default — `dalfox https://example.com/?q=1` works too. Other modes: `dalfox server` (REST API), `dalfox mcp` (stdio MCP), `dalfox payload list` (browse payloads).
+If the number is huge or `reachable == false`, report back to the user before sending real payloads.
 
-### Common scenarios
+### B. Standard Single-Target Scan (MCP preferred)
 
-| Goal | Command |
-|---|---|
-| Single URL, default coverage | `dalfox scan https://target/?q=1` |
-| POST body | `dalfox scan https://target/api -X POST -d 'user=a&pass=b'` |
-| Authenticated | `dalfox scan https://target/ -H 'Authorization: Bearer xxx' --cookies 'sid=abc'` |
-| Through a proxy (Burp) | `dalfox scan https://target/ --proxy http://127.0.0.1:8080` |
-| Specific params only | `dalfox scan https://target/?q=1 -p q -p page` |
-| Blind XSS | `dalfox scan https://target/ --blind-callback-url https://xyz.interact.sh` |
-| Stored XSS (reflected on a different URL) | `dalfox scan https://target/submit --sxss --sxss-url https://target/view` |
-| File of URLs | `dalfox scan targets.txt` (auto-detects, or `-i file`) |
-| Pipe from stdin | `cat urls.txt \| dalfox scan -i pipe` |
-| Fast smoke test (only the param you named) | `dalfox scan https://target/?q=1 -p q --skip-mining --skip-discovery` |
-| Fast smoke test (keep discovery, skip slow mining) | `dalfox scan https://target/?q=1 --skip-mining` |
-| Maximum coverage | `dalfox scan https://target/?q=1 --deep-scan --waf-bypass force` |
-| Machine-readable | `dalfox scan ... --format json -o result.json` (`jsonl`, `sarif`, `toml` also supported) |
-| Preflight only | `dalfox scan https://target/?q=1 --dry-run` |
-| Ignore noisy status codes | `dalfox scan https://target/ --ignore-return 302,403,404` |
+1. Preflight (see above).
+2. Start the scan:
+   - MCP: `scan_with_dalfox` (store the `scan_id`).
+   - CLI: `dalfox scan https://target/?q=test -p q ...`
+3. Poll (MCP) or watch output (CLI).
+4. Present findings using the rules in `references/results.md` (lead with V, surface `type_description` and `inject_type`).
+5. Clean up: `delete_scan_dalfox` (MCP) or just let the process end (CLI). Terminal jobs auto-expire after 1 h.
 
-### Useful flags
+### C. Authenticated / Proxied / Blind XSS
 
-- `--timeout 10` (default), `--delay 0` — add delay for rate-limited targets
-- `--workers 50` (default) — lower for politeness, higher for speed; no short alias
-- `--silence` / `-S` suppresses banner and noisy progress
-- `--include-request` / `--include-response` — embed raw HTTP in JSON output (large); `--include-all` is the shortcut for both
-- `--limit N` caps total findings; pair with `--limit-result-type v` to only count verified findings
-- `--waf-bypass auto | force | off` — `auto` probes first then bypasses, `force` applies bypass without probing (pair with `--force-waf cloudflare` etc. to pin a WAF), `off` disables the feature
-- `--sxss-retries 3` — how many times to poll the sxss-url (default 3); raise for slow-propagating apps
-- `--cookie-from-raw raw_request.http` — lift cookies from a captured request file
-- `--ignore-return 302,403,404` — drop responses with these status codes before reflection analysis (comma-separated)
+See the concrete flag combinations in `references/cli.md` (search for "Polite authenticated scan" and "Blind").
 
-Run `dalfox scan --help` for the full list.
+Common MCP pattern:
+- Supply `headers`, `cookies`, `proxy`, `blind_callback_url`, and explicit `param` with location hints.
 
-## Reading results
+### D. File / Many Targets
 
-Every finding includes:
+```bash
+dalfox scan targets.txt --skip-mining --workers 10 --delay 150
+```
 
-- **type**: `V` (verified DOM execution — highest confidence), `A` (AST-detected in inline JS), `R` (reflected but execution not confirmed)
-- `param`, `payload`, `evidence`
-- `inject_type` — the *reflection context*, not the parameter location. Values: `inHTML`, `inJS`, `inATTR`, `inURL`, `inCSS`. For the parameter location (query / body / header / cookie / path / JSON) look at `data` (the probe URL) and `method`.
-- `cwe` (usually `CWE-79`), `severity` — `High` for V and DOM-verified A, `Medium` for in-JS reflections, `Info` for plain R
-- `message_id`, `message_str` — stable numeric id and human summary
-- `data` — the URL actually probed (payload appears URL-encoded when injected in the query string)
+Combine with `--max-concurrent-targets` and `--max-targets-per-host` for safety.
 
-When presenting to the user, lead with V findings, then A, then R. Group by parameter when there are many. Raw `payload` and `evidence` are already sanitized for display but still contain attack strings — surround with backticks in markdown.
+### E. Raw Captured Request (raw-http)
 
-## Speed vs. coverage
+```bash
+dalfox scan -i raw-http captured-request.txt --blind https://your.interact.sh
+```
 
-Default settings test a reasonable payload budget (~hundreds of requests per parameter). For big scans:
+Excellent when the interesting parameters live in cookies, custom headers, or a complex JSON body. See `references/cli.md`.
 
-- Preflight first (`--dry-run` or `preflight_dalfox`) to see `estimated_total_requests`.
-- `--skip-mining` drops DOM / dictionary / GF-pattern param discovery. Usually the biggest request saving. Query params in the URL and HTML form fields are still discovered.
-- `--skip-discovery` turns off **all** discovery. Only parameters passed via `-p` are tested — do **not** pair this with an unparameterized URL or the scan will report zero targets.
-- `--deep-scan` roughly 3–5× cost. Use sparingly.
+### F. Stored XSS (SXSS)
 
-## Failure modes to recognize
+```bash
+dalfox scan https://target/submit --sxss --sxss-url https://target/view --sxss-retries 5
+```
 
-- **`reachable: false` in preflight** → target down, DNS issue, or WAF 403 at the front door. Try with `--proxy`, check with `curl` first.
-- **All findings type R, none V** → reflection detected but DOM didn't confirm. Common on JSON APIs (no HTML to parse) — expected, not a bug.
-- **Scan stuck in `running`** for many minutes → large parameter mining on a slow target. Either let it finish or `cancel_scan_dalfox` and re-run with `--skip-mining`.
-- **MCP returns `invalid_params` for timeout/delay** → value out of bounds (1–299s / 0–9999ms). Dalfox rejects rather than silently clamping.
+### G. Server Mode (when user wants a persistent API)
 
-## Not for
+```bash
+dalfox server --port 6664 --api-key "$TEAM_KEY" --allowed-origins "https://team.example.com"
+```
 
-- Non-XSS vulnerabilities (SQLi, SSRF, path traversal, auth bypass). Dalfox only tests for XSS.
-- Unauthenticated recon on targets the user hasn't confirmed they own / are permitted to test.
-- Replacing a manual code review for DOM-XSS hunting — the AST-detected findings still need a human to confirm.
+See `references/server-and-payload.md` for endpoints, CORS/JSONP details, and when to choose server vs MCP.
+
+## 4. Result Interpretation (read this every time)
+
+See the full guide in `references/results.md`.
+
+Key points for agents:
+- Every finding has `type` (`V`/`A`/`R`) **and** `type_description`.
+- `inject_type` tells you the reflection context (`inHTML`, `inJS`, `inATTR`, etc.).
+- The parameter *location* (query/body/header/...) is visible in `data` + `method`.
+- `include_request` / `include_response` are opt-in only — never enable them by default.
+
+## 5. Performance & Scope Recipes
+
+See `references/advanced.md` for the detailed recipes:
+
+- "Too many parameters / too slow" → preflight + `--skip-mining` + explicit `-p`
+- "WAF present" → the matrix of `--waf-bypass`, `--force-waf`, `--waf-evasion`
+- "Need custom payloads or markers" → `--custom-payload`, `--inject-marker`, `--custom-alert-*`
+- "Captured request testing" → `-i raw-http`
+- Concurrency / politeness caps
+
+## 6. Configuration & Environment
+
+See `references/config.md`.
+
+- `--config path` overrides everything.
+- Default location: `$XDG_CONFIG_HOME/dalfox/` or `~/.config/dalfox/`.
+- CLI flags always beat config values (enforced by `apply_to_scan_args_if_default`).
+- A `silence = true` in config suppresses the banner the same way `-S` does.
+
+## 7. Boundaries — What Dalfox Is Not For
+
+- Non-XSS issues (SQLi, SSRF, auth bypass, IDOR, etc.).
+- Unauthenticated mass recon on targets the user has not explicitly authorized.
+- Replacing human code review for complex DOM-XSS — AST findings (`A`) still need manual verification in many cases.
+
+## 8. Quick Reference — Where to Look Next
+
+- Exact CLI flags + safe combos → `references/cli.md`
+- MCP tool schemas + gotchas (including why `cookie_from_raw` is absent) → `references/mcp.md`
+- Finding types, output formats, POC types, error codes, exit codes → `references/results.md`
+- Config precedence, paths, banner behavior → `references/config.md`
+- Server API + `dalfox payload` selectors → `references/server-and-payload.md`
+- WAF recipes, mining control, raw-http, HPP, custom payloads → `references/advanced.md`
+
+## 9. AGENTS.md Invariants (this skill must respect)
+
+- `include_request` / `include_response` are opt-in only.
+- Config never overrides an explicit CLI/MCP value.
+- Concurrency is bounded (`workers`, `max_concurrent_targets`, `max_targets_per_host`).
+- Exit codes: 0 = clean, 1 = findings, 2 = error.
+- All three interfaces (CLI, server, MCP) share the error codes from `cmd::error_codes`.
+
+When in doubt, re-read the relevant reference file and the project `AGENTS.md` before acting.

--- a/skills/dalfox/references/INDEX.md
+++ b/skills/dalfox/references/INDEX.md
@@ -1,0 +1,47 @@
+# Dalfox Skill — References Index
+
+This directory holds detailed, lookup-oriented reference material so the main `SKILL.md` can stay focused on **agent workflows and decision-making**.
+
+## File Map
+
+| File | Purpose | Read when... |
+|------|---------|--------------|
+| `cli.md` | Complete CLI flag reference, grouped by concern, with defaults and agent notes | You need the exact spelling, default value, or safe combination for a flag |
+| `mcp.md` | The 6 MCP tools (`scan_with_dalfox` etc.) with full parameter schemas, validation rules, and security notes | Working via MCP tools (preferred for long/async scans) |
+| `results.md` | Finding shape (V/A/R + `type_description`), `inject_type`, output formats, `--poc-type`, `include_request/response` contract | Interpreting scan output or choosing `--format` / POC style |
+| `config.md` | Config file search paths, precedence (`apply_to_scan_args_if_default`), example, banner/silence interaction | User has (or should have) a `config.toml`; or you see unexpected defaults |
+| `server.md` | When and how to use `dalfox server`, auth, CORS, JSONP, endpoint summary | User wants to expose an API or the MCP tools are not available |
+| `payload.md` | `dalfox payload <selector>` usage and what each selector actually emits | User asks to list payloads or you need event-handler / tag names |
+| `advanced.md` | WAF bypass strategies, mining/discovery controls, scope filters, custom payloads, HPP, concurrency caps, `raw-http` input, `--max-payloads-per-param` | You hit WAF, huge parameter surfaces, need custom payloads, or captured request testing |
+
+## Design Principles for This Skill
+
+- **Main SKILL.md is the prompt** — short decision trees, concrete workflows ("preflight → scan → poll"), and "in this situation do X".
+- **References are for lookup** — exhaustive tables, exact schemas, and edge-case gotchas live here.
+- **AGENTS.md invariants are explicit**:
+  - `include_request` / `include_response` are opt-in only (`--include-all` is the convenience).
+  - Config never overrides explicit CLI flags (precedence is enforced in `apply_to_scan_args_if_default`).
+  - Concurrency is bounded (`workers`, `max_concurrent_targets`, `max_targets_per_host`).
+  - Exit codes: 0 = clean, 1 = findings, 2 = error.
+- **Safety first** — every workflow starts with the authorization check.
+- **MCP is preferred** for agent use when the tools are available (non-blocking, progress, cancellation).
+
+## How to Keep This Accurate
+
+When you change behavior in:
+- `src/cmd/scan.rs` (ScanArgs + defaults)
+- `src/mcp/mod.rs` (tool signatures)
+- `src/config.rs` (precedence + template)
+- `src/cmd/server.rs` or `src/cmd/payload.rs`
+
+...update the corresponding reference file **and** any workflow examples in the main `SKILL.md` in the same change.
+
+## Quick Agent Usage
+
+```markdown
+See references/mcp.md for the exact shape of scan_with_dalfox parameters.
+See references/results.md: "Interpreting V / A / R" when presenting findings.
+See references/advanced.md: "WAF present" recipe when you see Cloudflare / Akamai signatures.
+```
+
+Last updated: 2026 (reflects current Rust v3 codebase).

--- a/skills/dalfox/references/advanced.md
+++ b/skills/dalfox/references/advanced.md
@@ -1,0 +1,93 @@
+# Advanced Techniques & Recipes
+
+## WAF Handling
+
+### Recommended Combinations
+
+| Situation | Command / Flags |
+|-----------|-----------------|
+| Unknown / first pass | `--waf-bypass auto` (default) |
+| Known Cloudflare, want to force bypass mutations | `--waf-bypass force --force-waf cloudflare` |
+| Akamai or ModSecurity | `--waf-bypass force --force-waf akamai` (or `modsecurity`) |
+| Very noisy / aggressive WAF | `--waf-bypass force --waf-evasion` (forces workers=1 + 3s delay) |
+| Only fingerprint, no bypass mutations | `--waf-bypass off` |
+
+`--waf-min-confidence 0.3` (default) drops weak signals (Google Frontend, generic "request blocked" strings). Drop to `0.0` only when you are debugging fingerprinting.
+
+`--skip-waf-probe` skips the active "provocation" request that improves detection of some WAFs. Use when you want pure passive header inspection.
+
+## Parameter Discovery & Mining Control
+
+Biggest lever for request count is usually `--skip-mining` (or the more granular `--skip-mining-dom` / `--skip-mining-dict`).
+
+Discovery (`--skip-discovery`) turns off HTML parsing for forms, links, and inline JS. Only parameters you pass with `-p` will be tested — never use this on a bare URL without `-p`.
+
+`--only-discovery` is excellent for a quick "how many parameters will this scan actually hit?" check before committing to a long run.
+
+Remote wordlists (`--remote-wordlists burp,assetnote`) are cached with OnceLock for the lifetime of the process.
+
+## Scope & Filtering
+
+Use these in order of preference:
+
+1. `-p` + location hints (`id:query`, `user:body`) — most precise
+2. `--ignore-param` — drop noisy parameters you know are irrelevant
+3. `--include-url` / `--exclude-url` regex — when crawling many pages
+4. `--out-of-scope` + `--out-of-scope-file` — domain-level denylist (wildcards supported)
+
+`--max-targets-per-host` is a hard safety net when feeding a large file that contains many hosts.
+
+## Custom Payloads & Markers
+
+- `--custom-payload file.txt` — appends to the built-in set
+- `--only-custom-payload --custom-payload file.txt` — replaces the entire set
+- `--custom-blind-xss-payload file.txt` — only affects blind XSS mode
+- `--inject-marker 'FUZZ'` — lets you write `https://target/?q=FUZZ` and have payloads replace the literal `FUZZ` token (great for complex JSON bodies or non-standard locations)
+
+`--custom-alert-value 'document.domain'` + `--custom-alert-type str` is useful when the target has a CSP that blocks bare `alert(1)` but allows `alert(document.domain)`.
+
+## HTTP Parameter Pollution (HPP)
+
+`--hpp` duplicates query parameters (`?q=1&q=<payload>`). Some WAFs only inspect the first or last value. Rarely the first thing you reach for, but powerful against certain legacy or misconfigured WAFs.
+
+## Concurrency & Politeness
+
+- Normal interactive: default 50 workers is usually fine.
+- Shared / production target: `--workers 5-10 --delay 200-500`
+- WAF evasion mode: let `--waf-evasion` do the throttling for you.
+- Very large number of targets: combine `--max-concurrent-targets 10` with per-host caps.
+
+`--scan-timeout` (wall-clock seconds per target after preflight) is useful when a single endpoint is hanging and you don't want one bad target to stall the entire file.
+
+## raw-http Input (under-appreciated superpower)
+
+```bash
+# From Burp "Copy request to file"
+dalfox scan -i raw-http captured.req --blind https://collab/
+
+# Or paste a literal request (rare but works for one-off)
+dalfox scan -i raw-http $'POST /login HTTP/1.1\r\nHost: ...\r\n...'
+```
+
+dalfox parses the method, path, headers (including Cookie), and body. Extremely effective when the interesting parameters are in cookies, custom headers, or a non-standard JSON structure that normal URL discovery would miss.
+
+## When to Use --deep-scan
+
+Only when you have evidence that the first finding on a parameter is not the only (or most severe) one. It disables the early-exit optimization after the first verified hit. Expensive — use deliberately.
+
+## Common "I have too many requests" recipes
+
+1. Preflight first (`--dry-run` or MCP `preflight_dalfox`).
+2. Add `--skip-mining`.
+3. Add explicit `-p` for the 5–10 parameters you actually care about.
+4. Cap with `--max-payloads-per-param 30`.
+5. If still too much: lower `--workers` and add `--delay`.
+
+## MCP vs CLI for advanced scenarios
+
+Most of the flags above have direct equivalents in `scan_with_dalfox` parameters. The main absences on the MCP side are:
+- `--cookie-from-raw` (security)
+- `--remote-payloads` / `--remote-wordlists` (you can still pass custom lists via other means if needed)
+- Some of the more exotic mining/scope filters (they exist in the engine but are not yet exposed on the MCP surface)
+
+When you need the full power, fall back to spawning the CLI with carefully constructed arguments (or extend the MCP tool surface in a future change).

--- a/skills/dalfox/references/cli.md
+++ b/skills/dalfox/references/cli.md
@@ -1,0 +1,150 @@
+# CLI Reference (dalfox scan)
+
+All flags are defined in `src/cmd/scan.rs:ScanArgs`. Defaults are centralized in the same file (`DEFAULT_*` constants).
+
+## Input
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `-i, --input-type` | `auto` | `auto`, `url`, `file`, `pipe`, `raw-http` |
+| `TARGET` (positional) | — | URL, file path, or raw HTTP when `-i raw-http` |
+
+**`raw-http`** is powerful: you can feed a complete captured request (from Burp "Copy to file" or `curl -v` output) and dalfox will parse method, path, headers, cookies, and body.
+
+## Output & POC
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `-f, --format` | `plain` | `plain`, `json`, `jsonl`, `markdown`, `sarif`, `toml` |
+| `-o, --output` | (stdout) | Write to file |
+| `--poc-type` | `plain` | `plain`, `curl`, `httpie`, `http-request` |
+| `--include-request` | false | Opt-in only |
+| `--include-response` | false | Opt-in only |
+| `--include-all` | — | Sets both of the above |
+| `--stream-findings` | false | Emit each verified finding immediately |
+| `--limit N` | unlimited | Cap displayed findings |
+| `--limit-result-type` | `all` | `all`, `v`, `r`, `a` (case-insensitive) |
+| `--only-poc "v,r"` | all types | Comma-separated filter for which types to show |
+| `-S, --silence` | false | Suppress everything except POC lines |
+| `--no-color` | (auto) | Also respects `NO_COLOR` env var |
+
+**Machine-readable formats** auto-silence the banner.
+
+## Target & Scope Control (very useful, often under-used)
+
+| Flag | Purpose |
+|------|---------|
+| `-p, --param` | Restrict to specific params (supports `name:location` hints) |
+| `--include-url` | Regex whitelist (multiple) |
+| `--exclude-url` | Regex blacklist (multiple) |
+| `--ignore-param` | Skip these parameter names entirely |
+| `--out-of-scope` | Wildcard domain patterns (e.g. `*.dev.example.com`) |
+| `--out-of-scope-file` | File containing one pattern per line |
+
+## Discovery & Mining
+
+| Flag | Effect |
+|------|--------|
+| `--only-discovery` | Stop after parameter discovery (no XSS payloads) |
+| `--skip-discovery` | Turn off HTML form / link / JS discovery completely |
+| `--skip-mining` | Skip DOM mining + dictionary mining (biggest single win for speed) |
+| `--skip-mining-dom` | Skip only DOM-based mining |
+| `--skip-mining-dict` | Skip only wordlist/dictionary mining |
+| `-W, --mining-dict-word` | Path to custom wordlist for dictionary mining |
+| `--remote-wordlists` | `burp,assetnote` (comma-separated) |
+
+**Common fast-mode combo**: `--skip-mining` (or `--skip-mining-dom`) + explicit `-p` params you care about.
+
+## Network & Concurrency
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--timeout` | 10s | Per-request |
+| `--scan-timeout` | 0 (disabled) | Hard wall-clock cap **per target** after preflight |
+| `--delay` | 0 ms | |
+| `-F, --follow-redirects` | false | |
+| `--proxy` | — | `http://...` or `socks5://...` |
+| `--ignore-return` | (none) | Comma-separated status codes to drop before analysis (e.g. `302,403,404`) |
+| `--workers` | 50 | Concurrent workers |
+| `--max-concurrent-targets` | 50 | For file/pipe input |
+| `--max-targets-per-host` | 100 | Safety cap per host |
+
+## XSS Engine
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `-e, --encoders` | `url,html` | `none,url,2url,3url,4url,html,base64` (comma-separated) |
+| `--remote-payloads` | (none) | `portswigger,payloadbox` |
+| `--custom-payload` | — | File of extra payloads |
+| `--only-custom-payload` | false | Ignore built-in set |
+| `--custom-blind-xss-payload` | — | File for blind XSS |
+| `-b, --blind` | — | Callback URL (interact.sh, Burp Collab, etc.) |
+| `--custom-alert-value` | `1` | Value used inside `alert(...)` etc. |
+| `--custom-alert-type` | `none` | `none` or `str` (wraps in quotes) |
+| `--inject-marker` | — | Replace this literal string with payloads |
+| `--deep-scan` | false | Keep testing even after first finding |
+| `--max-payloads-per-param` | 0 (unlimited) | Hard cap on payloads per parameter |
+| `--skip-xss-scanning` | false | Discovery only (different from `--only-discovery`) |
+| `--skip-ast-analysis` | false | Disable oxc-based DOM XSS detection |
+| `--hpp` | false | HTTP Parameter Pollution (duplicate query params) |
+
+## Stored XSS (SXSS)
+
+| Flag | Notes |
+|------|-------|
+| `--sxss` | Enable stored XSS mode |
+| `--sxss-url` | Where to look for the stored reflection (auto-detect if omitted) |
+| `--sxss-method` | GET/POST for the check |
+| `--sxss-retries` | 3 (increase for slow propagation) |
+
+## WAF
+
+| Flag | Default | Notes |
+|------|---------|-------|
+| `--waf-bypass` | `auto` | `auto` (probe then bypass), `force`, `off` |
+| `--force-waf` | — | Pin a specific engine (`cloudflare`, `akamai`, `modsecurity`, `aws`, ...) |
+| `--skip-waf-probe` | false | Skip the active provocation request |
+| `--waf-evasion` | false | Auto-throttle (workers=1, delay=3000 ms) when WAF detected |
+| `--waf-min-confidence` | 0.3 | Discard weak fingerprints (Google Frontend, generic "blocked" messages) |
+
+See `references/advanced.md` for recommended WAF combinations.
+
+## Other Useful / Diagnostic
+
+- `--cookie-from-raw request.txt` — lift cookies from a captured raw request file (CLI only)
+- `--dry-run` — preflight summary only (same as MCP `preflight_dalfox`)
+- `--debug` — show DBG lines
+- Global root flags: `--config`, `--debug`, `--no-color`, `--silence`
+
+## Exit Codes
+
+See `references/results.md`.
+
+## Common High-Value Combinations
+
+**Fast smoke test on one param**:
+```bash
+dalfox scan https://target/?q=1 -p q --skip-mining --skip-discovery
+```
+
+**Polite authenticated scan through Burp**:
+```bash
+dalfox scan https://target/ -H 'Authorization: Bearer ...' \
+  --cookies 'sid=...' --proxy http://127.0.0.1:8080 \
+  --delay 300 --workers 5
+```
+
+**WAF-heavy target (Cloudflare)**:
+```bash
+dalfox scan https://target/ --waf-bypass force --force-waf cloudflare --waf-evasion
+```
+
+**Maximum coverage (expensive)**:
+```bash
+dalfox scan targets.txt --deep-scan --remote-payloads portswigger,payloadbox -e url,html,base64
+```
+
+**Raw captured request**:
+```bash
+dalfox scan -i raw-http captured-request.txt --blind https://your.interact.sh
+```

--- a/skills/dalfox/references/config.md
+++ b/skills/dalfox/references/config.md
@@ -1,0 +1,76 @@
+# Configuration System
+
+## Search Order & Precedence
+
+1. Explicit `--config /path/to/file.toml` (or `.json`) — highest priority, fails visibly on parse error.
+2. Default user config (no `--config` flag):
+   - `$XDG_CONFIG_HOME/dalfox/config.toml` (or `.json`) if `XDG_CONFIG_HOME` is set and non-empty
+   - Otherwise `$HOME/.config/dalfox/config.toml` (preferred) or `config.json`
+3. If no file exists at the default location, dalfox **creates** a `config.toml` with a heavily commented template containing all keys at their defaults.
+
+There is **no automatic project-local** `.dalfox/config.toml` discovery in the current design (unlike some other tools). Use `--config ./dalfox-scan.toml` or commit a config in the repo and point at it.
+
+## Precedence Rule (critical invariant)
+
+**CLI flags always win.**
+
+The function `Config::apply_to_scan_args_if_default` only fills fields that are still at their built-in default values. Any flag the user actually typed on the command line overrides the config file.
+
+This is the same rule used by the server and (indirectly) by MCP callers who pass explicit parameters.
+
+## What Lives in a Config File
+
+See the auto-generated template for the full schema. Common useful keys under `[scan]`:
+
+- `silence = true`
+- `format = "jsonl"`
+- `encoders = ["url", "html", "base64"]`
+- `workers = 20`
+- `timeout = 15`
+- `delay = 150`
+- `waf_bypass = "force"`
+- `force_waf = "cloudflare"`
+- `deep_scan = true`
+- `skip_mining = true`
+
+The config also supports top-level keys for server defaults in future versions, but today most server behavior is passed on the `dalfox server` command line.
+
+## Banner & Silence Interaction
+
+Banner suppression is decided from three places (OR-ed):
+
+- Root `--silence` / `-S`
+- `scan.silence` under the subcommand
+- `silence = true` in the loaded config file
+
+Machine-readable output formats also force silence automatically.
+
+## When to Recommend a Config File to the User
+
+- Repeated custom encoder sets
+- Corporate proxy + auth headers that must be present on every scan
+- Team-standard WAF bypass policy (`waf_bypass = "force"`, `force_waf = "akamai"`)
+- Lower worker count for politeness on a shared target range
+- Consistent `silence = true` + `format = "json"` for automation
+
+Example minimal team config:
+
+```toml
+[scan]
+workers = 10
+delay = 200
+encoders = ["url", "html"]
+waf_bypass = "auto"
+waf_min_confidence = 0.4
+```
+
+## MCP and Server vs Config
+
+- MCP calls go through the same `ScanArgs` construction path but most fields come from the JSON-RPC parameters (no automatic config merge for MCP at the moment — the caller is expected to supply what they want).
+- The HTTP server (`dalfox server`) also accepts per-scan options in the request body and applies the same conservative default-merging logic where relevant.
+
+## Debugging "why is my setting not taking effect?"
+
+1. Run with `--debug` — look for config load messages.
+2. `dalfox --config /path/to/your.toml scan ... --help` (or just parse the args).
+3. Remember: if you typed the flag at all, the config value is ignored for that field.

--- a/skills/dalfox/references/mcp.md
+++ b/skills/dalfox/references/mcp.md
@@ -1,0 +1,109 @@
+# MCP Tools Reference
+
+Dalfox exposes exactly **six tools** via the MCP stdio server (`dalfox mcp` or the built-in MCP mode).
+
+Preferred agent pattern: `preflight_dalfox` → `scan_with_dalfox` → poll `get_results_dalfox` (respect `suggested_poll_interval_ms`) → `delete_scan_dalfox` when terminal.
+
+## Tool Summary
+
+| Tool | Purpose | Blocking? | Returns |
+|------|---------|-----------|---------|
+| `preflight_dalfox` | Parameter discovery + request count estimate, no payloads sent | Yes (fast) | `reachable`, `params_discovered`, `estimated_total_requests`, per-param breakdown |
+| `scan_with_dalfox` | Start async scan | No (returns immediately) | `{scan_id, target, status: "queued"}` |
+| `get_results_dalfox` | Poll status + results (supports offset/limit) | No | Full job with `progress`, `results[]` when done |
+| `list_scans_dalfox` | List all in-memory jobs (filter by status) | No | Array of job summaries |
+| `cancel_scan_dalfox` | Signal cancellation (next checkpoint) | No | Job moves to `cancelled` (partial results kept) |
+| `delete_scan_dalfox` | Remove terminal job from memory | No | Job record deleted (running jobs rejected) |
+
+Terminal jobs auto-purge after 1 hour.
+
+## scan_with_dalfox — Full Parameters
+
+```json
+{
+  "target": "https://example.com/search?q=test",   // required, must have scheme
+  "param": ["q", "id:query", "user:body", "auth:header"],
+  "method": "POST",
+  "data": "user=admin&pass=test",                  // or JSON string
+  "headers": ["Authorization: Bearer xxx"],
+  "cookies": ["session=abc123"],
+  "user_agent": "Mozilla/5.0...",
+  "encoders": ["url", "html", "base64"],           // "none" means raw only
+  "timeout": 10,                                   // 1-299 (hard validated)
+  "delay": 0,                                      // 0-9999 ms (hard validated)
+  "follow_redirects": false,
+  "proxy": "http://127.0.0.1:8080",
+  "include_request": false,                        // opt-in only — responses can be huge
+  "include_response": false,
+  "skip_mining": false,
+  "skip_discovery": false,
+  "deep_scan": false,
+  "skip_ast_analysis": false,
+  "blind_callback_url": "https://xyz.interact.sh",
+  "workers": 50                                    // 1-500 (hard validated)
+}
+```
+
+**Hard validation (returns `invalid_params` on violation):**
+- `timeout` ∈ [1, 299]
+- `delay` ∈ [0, 9999]
+- `workers` ∈ [1, 500]
+
+**Encoder normalization**: If `"none"` is present anywhere, the list becomes `["none"]` only.
+
+**Security note — `cookie_from_raw` is deliberately absent** from the MCP surface. Exposing it would allow an MCP caller to cause the host to read an arbitrary file on disk and forward its cookies to an attacker-controlled target (same class of issue that produced GHSA-35wr-x7v6-9fv2 in v2). MCP callers must supply cookies directly via the `cookies` array.
+
+## preflight_dalfox — Parameters
+
+Fewer options (no encoders, no `include_*`, no blind, no deep scan, no workers — it only does discovery).
+
+```json
+{
+  "target": "...",
+  "param": [...],
+  "method": "GET",
+  "data": "...",
+  "headers": [...],
+  "cookies": [...],
+  "user_agent": "...",
+  "timeout": 10,
+  "proxy": "...",
+  "follow_redirects": false,
+  "skip_mining": false,
+  "skip_discovery": false
+}
+```
+
+Use this before expensive scans when the user is concerned about request volume.
+
+## get_results_dalfox — Pagination & Progress
+
+- `offset` / `limit` for large result sets.
+- Response always includes a `progress` object with `suggested_poll_interval_ms`.
+  - Early scan: 1000–3000 ms
+  - Near completion: ~1000 ms
+  - Done / error / cancelled: 0
+- Honor the suggested interval to avoid hammering the in-memory job store.
+
+## Job Lifecycle (shared with server)
+
+`queued` → `running` → `done` | `error` | `cancelled`
+
+`cancel_scan_dalfox` flips an `AtomicBool`; the scan loop checks it at safe points. Partial findings are returned.
+
+## Error Handling in MCP
+
+- Out-of-range numbers → `invalid_params` with exact message.
+- Unreachable target in preflight → `reachable: false` + `error_code`.
+- Use the shared error codes from `cmd::error_codes` (see `results.md`).
+
+## Recommended Agent Loop (MCP)
+
+1. Call `preflight_dalfox` (or `dry-run` in CLI).
+2. If `estimated_total_requests` is huge or `reachable == false`, report to user before proceeding.
+3. `scan_with_dalfox` → store `scan_id`.
+4. Loop: `get_results_dalfox` (respect interval) until terminal status.
+5. Present findings (lead with V, then A, then R — see `results.md`).
+6. `delete_scan_dalfox` (optional — terminal jobs auto-expire).
+
+When both MCP tools and the `dalfox` binary exist, **prefer MCP** for agent-driven work. It decouples start from wait and gives structured progress.

--- a/skills/dalfox/references/results.md
+++ b/skills/dalfox/references/results.md
@@ -1,0 +1,108 @@
+# Results, Findings & Output Formats
+
+## Finding Types (the V / A / R model)
+
+Every finding has both a single-letter `type` and a human `type_description`.
+
+| Type | Code | Meaning | Typical Severity | When it appears |
+|------|------|---------|------------------|-----------------|
+| **Verified** | `V` | Payload executed in a real DOM context (confirmed by headless or AST+verification pipeline) | High | DOM sinks (innerHTML, document.write, etc.) that actually ran |
+| **AST-detected** | `A` | Static analysis of inline JavaScript found a dangerous sink with attacker-controlled data | High (if DOM-verified) / Medium | `inJS` reflections where the AST engine sees dangerous patterns |
+| **Reflected** | `R` | Payload appears in the HTTP response body or headers, but execution was not confirmed | Medium / Info | Pure reflection without DOM execution path, JSON APIs, etc. |
+
+**Agent rule**: When presenting results to the user, **lead with V, then A, then R**. Group by parameter. Always surface `type_description` alongside the letter.
+
+## Full Finding Shape (JSON / MCP / server)
+
+```json
+{
+  "type": "V",
+  "type_description": "Verified DOM-based XSS",
+  "inject_type": "inHTML",
+  "method": "GET",
+  "data": "https://target/?q=<script>alert(1)</script>",
+  "param": "q",
+  "payload": "<script>alert(1)</script>",
+  "evidence": "...snippet...",
+  "cwe": "CWE-79",
+  "severity": "High",
+  "message_id": 1234,
+  "message_str": "Reflected XSS via parameter 'q' in HTML context",
+  "message": "..."
+}
+```
+
+### inject_type values (reflection context, not parameter location)
+
+- `inHTML` — inside HTML text / tag content
+- `inJS` — inside a script block or event handler
+- `inATTR` — inside an attribute value
+- `inURL` — inside a URL attribute (href, src, etc.)
+- `inCSS` — inside style / CSS context (rare)
+
+For the **parameter location** (query / body / header / cookie / path / JSON), look at the `data` field (the actual probed URL) + `method`.
+
+## Output Formats (`--format`)
+
+| Format | Best for | Notes |
+|--------|----------|-------|
+| `plain` (default) | Human reading, interactive | Color + banner unless silenced |
+| `json` | Parsing, piping, server/MCP | Full envelope with `meta.target_summary` |
+| `jsonl` | Streaming / log ingestion | One finding per line + final meta line |
+| `markdown` | Reports, PR comments | Human-friendly with sections |
+| `sarif` | GitHub Code Scanning, SARIF tools | Standard static-analysis interchange |
+| `toml` | Config-like consumption | Rarely used |
+
+**Machine-readable formats** (`json`, `jsonl`, `sarif`, `toml`) automatically suppress the banner so stdout stays parseable.
+
+## POC Output (`--poc-type`)
+
+- `plain` — the default one-line `[POC][V][param] ...` style
+- `curl` — ready-to-run `curl '...'` command
+- `httpie` — `http GET '...'` style
+- `http-request` — raw HTTP request text
+
+Use `--poc-type curl` (or httpie) when the user wants something they can copy-paste immediately.
+
+## Request / Response Inclusion (strict opt-in)
+
+**AGENTS.md invariant**:
+- `--include-request` and `--include-response` are **opt-in only**.
+- `--include-all` is the convenience flag that sets both.
+- These fields are intentionally **not** on by default because responses can be enormous and may contain sensitive data.
+
+Never turn them on "just in case" during automated scans. Only enable when the user explicitly needs forensic evidence.
+
+In MCP: `include_request` / `include_response` default to `false` and must be set explicitly.
+
+## Streaming Findings
+
+`--stream-findings` emits each verified finding the moment it is confirmed instead of waiting for the final summary. Useful for very long scans where you want early signal. Off by default.
+
+## Error Codes (appear in JSON `meta`, MCP, server)
+
+See `cmd/mod.rs` for the canonical list. Common ones:
+
+- `NO_TARGETS`, `NO_FILE`, `INVALID_INPUT_TYPE`
+- `PARSE_ERROR`, `FILE_READ_ERROR`, `STDIN_ERROR`
+- `INPUT_TOO_LARGE`, `STDIN_NOT_PIPED`
+- `CONNECTION_FAILED`, `DNS_RESOLUTION_FAILED`, `TLS_HANDSHAKE_FAILED`, `REQUEST_TIMEOUT`
+- `CONTENT_TYPE_MISMATCH`
+- `TRUNCATED_PER_HOST_CAP`
+
+In JSON output the per-target summary contains `error_code` when the target failed before any payloads were sent.
+
+## Exit Codes (CLI)
+
+- `0` — Scan finished cleanly, zero findings
+- `1` — Scan finished with one or more findings (V/A/R)
+- `2` — Hard error (bad input, config, runtime failure)
+
+MCP and server surface the same information via `status` and `error_code` fields instead of process exit codes.
+
+## How to Present Results to Users (agent guidance)
+
+1. Lead with count and highest-confidence findings.
+2. For each interesting finding: `type` + `type_description`, `param`, `inject_type`, short evidence, and a POC (ideally `--poc-type curl`).
+3. If many R-only findings on a JSON API, explain that this is expected (no HTML DOM to verify execution).
+4. Offer to re-run with `--deep-scan`, specific `--poc-type`, or WAF bypass options if the first pass was noisy or blocked.

--- a/skills/dalfox/references/server-and-payload.md
+++ b/skills/dalfox/references/server-and-payload.md
@@ -1,0 +1,68 @@
+# Server Mode & Payload Subcommand
+
+## dalfox server
+
+Runs an async HTTP API (axum) that exposes the same scanning engine.
+
+### Key Flags
+
+| Flag | Default | Purpose |
+|------|---------|---------|
+| `-p, --port` | 6664 | Listen port |
+| `-H, --host` | 127.0.0.1 | Bind address (use 0.0.0.0 carefully) |
+| `--api-key` | (none) | Required value for `X-API-KEY` header (or `DALFOX_API_KEY` env) |
+| `--log-file` | (none) | Plain-text log file (no ANSI) |
+| `--allowed-origins` | (none) | Comma-separated. Supports `*`, exact origins, `regex:<pattern>` |
+| `--jsonp` | false | Enable JSONP (wraps responses in callback function) |
+| `--callback-param-name` | `callback` | JSONP callback query parameter |
+| `--cors-allow-methods` | GET,POST,... | |
+| `--cors-allow-headers` | Content-Type,X-API-KEY,... | |
+
+### Endpoints (axum paths)
+
+- `POST /scan` — submit scan (body = scan options)
+- `GET /scan` — submit via query params (JSONP friendly)
+- `GET /scan/{id}` — status + results
+- `DELETE /scan/{id}` — cancel
+- `GET /scans` — list jobs (supports `?status=running`)
+- `GET /result/{id}` — alias of `/scan/{id}`
+- `POST /preflight` — discovery only
+- `GET /health` — liveness
+
+Jobs are in-memory only. Same `queued / running / done / error / cancelled` lifecycle as MCP.
+
+**Authentication**: when `--api-key` is set, every mutating endpoint requires the key. Read endpoints can be open or also protected depending on deployment choice.
+
+**JSONP**: only works for GET endpoints and requires the callback parameter. The server is strict about the callback name to avoid XSS in the JSONP wrapper itself.
+
+Use the server when:
+- You want a long-lived scan service for a team / pipeline
+- You need JSONP because the caller is a browser
+- You prefer REST over stdio MCP
+
+Prefer MCP tools when you are an agent that can speak JSON-RPC over stdio.
+
+## dalfox payload <selector>
+
+Lightweight enumeration / remote fetch command. No scanning.
+
+Supported selectors:
+
+| Selector | What it does |
+|----------|--------------|
+| (no arg) | Prints short help + summary of built-in JS payload count |
+| `event-handlers` | All common DOM event handler attribute names (`onclick`, `onload`, `onerror`, ...) |
+| `useful-tags` | HTML tags frequently useful for XSS (`script`, `img`, `svg`, `iframe`, `object`, ...) |
+| `payloadbox` | Fetches current remote XSS payloads from PayloadBox provider (requires network) |
+| `portswigger` | Fetches current remote XSS payloads from PortSwigger cheat sheet |
+| `uri-scheme` | Scheme-based payloads (`javascript:`, `data:text/html,...`, base64 variants, etc.) |
+
+These are primarily diagnostic / research helpers. The real payload selection and mutation logic lives inside the scanning engine.
+
+Example:
+```bash
+dalfox payload event-handlers | head -20
+dalfox payload portswigger > portswigger.txt
+```
+
+You can feed custom lists back into scans with `--custom-payload` or `--custom-blind-xss-payload`.


### PR DESCRIPTION
## Summary

Major redesign of the `dalfox` skill following **approach B** (structural redesign + heavy use of `references/`).

### Motivation
The previous `SKILL.md` had several gaps and was becoming hard to maintain:
- Config system completely undocumented
- Outdated `payload` subcommand usage (`dalfox payload list` didn't exist)
- `dalfox server` barely mentioned
- Many important flags missing (`--poc-type`, `raw-http`, advanced WAF/mining/scope controls, etc.)
- MCP parameters incomplete
- No clear separation between "agent prompt" and detailed reference material

### Changes

**Main `SKILL.md`** (now 156 lines, much higher signal):
- Strong workflow-oriented structure (authorization → mode decision → core workflows → result interpretation → recipes → boundaries)
- All depth delegated to `references/`
- Explicit callout of AGENTS.md invariants at the bottom

**New `references/` directory** (7 files):
- `INDEX.md` – navigation + design principles + maintenance guidance
- `mcp.md` – complete 6-tool schemas + validation rules + security note on `cookie_from_raw`
- `results.md` – V/A/R model, output formats, POC types, error codes, exit codes, `include_*` opt-in contract
- `cli.md` – all flags grouped by concern with practical combinations
- `config.md` – search paths, `apply_to_scan_args_if_default` precedence, examples
- `server-and-payload.md` – server flags/endpoints + correct `payload` selectors
- `advanced.md` – WAF strategies, mining/scope, raw-http, HPP, custom payloads, concurrency recipes

### Benefits
- Much easier for agents to follow correct workflows
- Far more accurate and complete coverage of current v3 codebase
- Sustainable: future changes only need updates in the relevant reference file
- Strong alignment with project `AGENTS.md` rules

**Total**: +~650 lines of high-quality, focused reference material.

---

This PR is ready for review. Happy to iterate on any section.