### PR TITLE
feat(ci): add .deb and .rpm packaging using cargo-deb and cargo-generate-rpm

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -103,6 +103,56 @@ jobs:
           else
             cargo build --verbose --release --target ${{ matrix.target }}
           fi
+
+      # --- Debian / RPM packaging (only for glibc Linux targets) ---
+      - name: Install cargo-deb and cargo-generate-rpm
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo install cargo-deb --locked
+          cargo install cargo-generate-rpm --locked
+
+      - name: Build Debian package
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo deb --target ${{ matrix.target }} --no-build --output target/${{ matrix.target }}/release/
+
+      - name: Build RPM package
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo generate-rpm --target ${{ matrix.target }} --no-build --output target/${{ matrix.target }}/release/
+
+      - name: Rename and checksum packages
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          cd target/${{ matrix.target }}/release
+
+          # Rename .deb
+          for deb in *.deb; do
+            if [ -f "$deb" ]; then
+              mv "$deb" "dalfox-$VERSION-linux-${{ matrix.build }}.deb"
+            fi
+          done
+
+          # Rename .rpm
+          for rpm in *.rpm; do
+            if [ -f "$rpm" ]; then
+              mv "$rpm" "dalfox-$VERSION-linux-${{ matrix.build }}.rpm"
+            fi
+          done
+
+          # Create checksums
+          shasum -a 256 *.deb *.rpm 2>/dev/null | sed 's|  |  |' > /tmp/pkg-checksums.txt || true
+          mv /tmp/pkg-checksums.txt . 2>/dev/null || true
+      # ---------------------------------------------------------------
       - name: Build archive
         shell: bash
         run: |
@@ -140,3 +190,15 @@ jobs:
           files: |-
             ${{ env.ASSET }}
             ${{ env.ASSET }}.sha256
+
+      - name: Upload Debian and RPM packages
+        if: |
+          (github.event_name == 'release' || github.event.inputs.upload == 'true') &&
+          (matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu')
+        uses: softprops/action-gh-release@v3
+        with:
+          files: |
+            target/${{ matrix.target }}/release/dalfox-*.deb
+            target/${{ matrix.target }}/release/dalfox-*.rpm
+            target/${{ matrix.target }}/release/dalfox-*.deb.sha256
+            target/${{ matrix.target }}/release/dalfox-*.rpm.sha256

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -134,7 +134,7 @@ jobs:
           matrix.target == 'x86_64-unknown-linux-gnu' ||
           matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          cargo generate-rpm --no-build
+          cargo generate-rpm --target ${{ matrix.target }}
 
       - name: Rename and checksum packages
         if: |

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -113,19 +113,28 @@ jobs:
           cargo install cargo-deb --locked
           cargo install cargo-generate-rpm --locked
 
+      # Copy the cross-compiled binary to the default location that cargo-deb expects
+      - name: Prepare binary for packaging tools
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/dalfox" target/release/dalfox
+
       - name: Build Debian package
         if: |
           matrix.target == 'x86_64-unknown-linux-gnu' ||
           matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          cargo deb --target ${{ matrix.target }} --no-build --output target/${{ matrix.target }}/release/
+          cargo deb --no-build
 
       - name: Build RPM package
         if: |
           matrix.target == 'x86_64-unknown-linux-gnu' ||
           matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
-          cargo generate-rpm --target ${{ matrix.target }} --no-build --output target/${{ matrix.target }}/release/
+          cargo generate-rpm --no-build
 
       - name: Rename and checksum packages
         if: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -42,6 +42,8 @@ strip = "symbols"
 maintainer = "hahwul <hahwul@gmail.com>"
 copyright = "2024, hahwul"
 license-file = "LICENSE.txt"
+homepage = "https://github.com/hahwul/dalfox"
+description = "Powerful open-source XSS scanner"
 extended-description = """Dalfox is a powerful open-source XSS scanner and automation utility.
 It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
 depends = ["ca-certificates"]
@@ -52,6 +54,12 @@ assets = [
 ]
 
 [package.metadata.generate-rpm]
+license = "MIT"
+summary = "Powerful open-source XSS scanner"
+group = "Applications/System"
+homepage = "https://github.com/hahwul/dalfox"
+description = """Dalfox is a powerful open-source XSS scanner and automation utility.
+It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
 assets = [
     { source = "target/release/dalfox", dest = "/usr/bin/dalfox", mode = "755" },
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,3 +37,21 @@ oxc_span = "0.131.0"
 lto = true
 codegen-units = 1
 strip = "symbols"
+
+[package.metadata.deb]
+maintainer = "hahwul <hahwul@gmail.com>"
+copyright = "2024, hahwul"
+license-file = ["LICENSE", "4"]
+extended-description = """Dalfox is a powerful open-source XSS scanner and automation utility.
+It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
+depends = ["ca-certificates"]
+section = "utils"
+priority = "optional"
+assets = [
+    { source = "target/release/dalfox", dest = "/usr/bin/dalfox", mode = "755" },
+]
+
+[package.metadata.generate-rpm]
+assets = [
+    { source = "target/release/dalfox", dest = "/usr/bin/dalfox", mode = "755" },
+]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -41,7 +41,7 @@ strip = "symbols"
 [package.metadata.deb]
 maintainer = "hahwul <hahwul@gmail.com>"
 copyright = "2024, hahwul"
-license-file = ["LICENSE", "4"]
+license-file = "LICENSE.txt"
 extended-description = """Dalfox is a powerful open-source XSS scanner and automation utility.
 It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
 depends = ["ca-certificates"]


### PR DESCRIPTION
**Summary**

This PR adds proper Linux package support (`.deb` and `.rpm`) to Dalfox releases.

**Background**
- Previously we only provided raw tarballs/zips.
- Many users (especially on Debian/Ubuntu/Fedora/RHEL) prefer native packages.
- We already added musl binaries in earlier work; this PR focuses on easy-to-install system packages for glibc-based Linux.

**Changes**
- Integrated `cargo-deb` and `cargo-generate-rpm` directly into the release workflow.
- Packaging runs automatically for `linux-x86_64` and `linux-aarch64` (glibc) builds during releases.
- Packages are uploaded as separate assets alongside the existing tarballs.
- Improved package metadata in `Cargo.toml`.

**Why cargo-deb + cargo-generate-rpm?**
- User preference (previous negative experience with GoReleaser/nfpm ecosystem).
- Stays within the Rust ecosystem.
- Relatively simple integration with the existing build matrix.

**Current Scope**
- Only glibc x86_64 and aarch64 are packaged (most common use case).
- musl binaries are still provided as tarballs (as before).

**Testing**
- Verified via `workflow_dispatch` on the feature branch.
- Both `.deb` and `.rpm` are successfully generated for x86_64 and aarch64.

**Future Work (out of scope for this PR)**
- Packaging for musl binaries (if demand appears)
- APT/YUM repository setup
- More advanced package features (completions, man pages, etc.)

Closes parts of #1005