### PR TITLE
docs: hide mobile hamburger on landing/404 + make toggle robust

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -868,6 +868,8 @@ body:has(.docs-layout) .site-footer {
     overflow-x: hidden;
 }
 
+
+
 /* Hero */
 .hero {
     position: relative;
@@ -1716,6 +1718,11 @@ body:has(.docs-layout) .site-footer {
     }
     .hamburger {
         display: flex;
+    }
+    /* Hide mobile hamburger on pages without sidebar (landing + 404) */
+    body:has(.landing) .hamburger,
+    body:has(.error-page) .hamburger {
+        display: none;
     }
     .header-nav {
         display: none;

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -36,6 +36,43 @@
         var href = (a.getAttribute('href') || '').replace(/^https?:\/\/[^/]+/, '').replace(/\/$/, '') || '/';
         if (href === path) a.classList.add('active');
       });
+
+      // Mobile hamburger menu (robust click handling, no inline onclick)
+      var hamburger = document.querySelector('.hamburger');
+      var sidebar = document.querySelector('.docs-sidebar');
+      var overlay = document.querySelector('.site-overlay');
+
+      if (hamburger && sidebar && overlay) {
+        function setExpanded(expanded) {
+          hamburger.setAttribute('aria-expanded', expanded ? 'true' : 'false');
+          sidebar.classList.toggle('open', expanded);
+          overlay.classList.toggle('active', expanded);
+        }
+
+        hamburger.addEventListener('click', function(e){
+          e.preventDefault();
+          var isOpen = sidebar.classList.contains('open');
+          setExpanded(!isOpen);
+        });
+
+        overlay.addEventListener('click', function(){
+          setExpanded(false);
+        });
+
+        // Close drawer when clicking any sidebar link (good UX on mobile)
+        sidebar.querySelectorAll('a').forEach(function(link){
+          link.addEventListener('click', function(){
+            setExpanded(false);
+          });
+        });
+
+        // Close on Escape key for accessibility
+        document.addEventListener('keydown', function(e){
+          if (e.key === 'Escape' && sidebar.classList.contains('open')) {
+            setExpanded(false);
+          }
+        });
+      }
     })();
   </script>
   {{ highlight_js }}

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -25,7 +25,7 @@
   <header class="site-header">
     <div class="header-inner">
       <div class="header-left">
-        <button class="hamburger" aria-label="Menu" onclick="document.querySelector('.docs-sidebar')?.classList.toggle('open');document.querySelector('.site-overlay')?.classList.toggle('active');">
+        <button class="hamburger" aria-label="Menu" aria-controls="docs-sidebar" aria-expanded="false">
           <span></span><span></span><span></span>
         </button>
         <a href="{{ base_url }}/" class="header-logo">
@@ -50,4 +50,4 @@
       </div>
     </div>
   </header>
-  <div class="site-overlay" onclick="document.querySelector('.docs-sidebar')?.classList.remove('open');this.classList.remove('active');"></div>
+  <div class="site-overlay" aria-hidden="true"></div>

--- a/docs/templates/page.html
+++ b/docs/templates/page.html
@@ -1,6 +1,6 @@
 {% include "header.html" %}
   <div class="docs-layout">
-    <aside class="docs-sidebar">
+    <aside class="docs-sidebar" id="docs-sidebar">
       <nav class="sidebar-nav">
         <div class="sidebar-section">
           <div class="sidebar-title">

--- a/docs/templates/section.html
+++ b/docs/templates/section.html
@@ -1,6 +1,6 @@
 {% include "header.html" %}
   <div class="docs-layout">
-    <aside class="docs-sidebar">
+    <aside class="docs-sidebar" id="docs-sidebar">
       <nav class="sidebar-nav">
         <div class="sidebar-section">
           <div class="sidebar-title">


### PR DESCRIPTION
**Problem**

On mobile view, the hamburger menu button was visible on the landing page (homepage) and 404 page, but clicking it did nothing because those pages do not render a `.docs-sidebar`.

Additionally, the original implementation used complex inline `onclick` handlers containing optional chaining (`?.`), which could silently fail to attach in some mobile browser contexts.

**Changes**

- Hide the hamburger button entirely on landing (`.landing`) and 404 (`.error-page`) pages using `body:has(...)` (inside the existing 768px media query).
- Refactored the mobile menu toggle logic:
  - Removed inline `onclick` from header template
  - Added proper `addEventListener` in the footer script with:
    - `aria-expanded` management
    - Close on overlay click
    - Close when tapping any sidebar link (good mobile UX)
    - Close on Escape key
  - Added `id="docs-sidebar"` and `aria-controls` for accessibility
- Updated both `page.html` and `section.html` templates

**Result**

- Landing page and 404 page no longer show a non-functional hamburger on mobile.
- Docs pages retain full working mobile navigation drawer.
- More robust and accessible implementation.

This is a docs-only change (no Rust code).