### PR TITLE
fix(scan): validate --custom-payload content up front, not just file existence

### DIFF
--- a/src/cmd/scan.rs
+++ b/src/cmd/scan.rs
@@ -1727,7 +1727,27 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                     path, e
                 ));
             }
-            Ok(_) => {}
+            Ok(_) => {
+                // The stat above only proves a regular file exists. An empty,
+                // comment-only, non-UTF-8, or over-budget file passes it yet
+                // yields zero usable payloads — load_custom_payloads rejects
+                // those, but the scan driver swallows that error via
+                // `.unwrap_or_else(|_| vec![])`, so --only-custom-payload would
+                // "succeed" having scanned nothing. Validate the content here
+                // (this also warms the shared cache the scan reuses): fatal
+                // under --only-custom-payload, a warning in additive mode.
+                if let Err(e) = crate::scanning::xss_common::load_custom_payloads(path) {
+                    if args.only_custom_payload {
+                        emit_error(
+                            &args.format,
+                            crate::cmd::error_codes::FILE_READ_ERROR,
+                            &e.to_string(),
+                        );
+                        return ScanOutcome::Error;
+                    }
+                    log_warn(&format!("{} — built-in payloads only", e));
+                }
+            }
         }
     }
 


### PR DESCRIPTION
## Summary
Refs #1013. The pre-scan validation for `--custom-payload` (`src/cmd/scan.rs`) only checked file **existence/type** via `fs::metadata`. An empty, comment-only, non-UTF-8, or over-budget file passes that stat but produces **zero usable payloads**. `load_custom_payloads` already rejects those cases, but the scan driver swallows the error with `.unwrap_or_else(|_| vec![])` (`src/scanning/mod.rs:783-787`), so `--only-custom-payload` would report a **clean success having scanned nothing** — the "0 payloads -> exit 0" footgun.

## Change
Extend the existing regular-file arm to validate **content** by calling `load_custom_payloads` up front:
- fatal (`ScanOutcome::Error`) under `--only-custom-payload`
- warning + built-ins in additive mode

This mirrors the missing/not-a-file handling right above it, and warms the shared payload cache the scan later reuses (no extra I/O cost).

## Scope note
The error-swallowing inside `get_dom_payloads`' `None` branch (`mod.rs:385/397`) is left as-is — it's intentional ("Avoid erroring when custom payload file is missing", falls back to built-in DOM payloads). This PR closes the gap at the CLI entry point, where the exit-code contract matters.

## Verification
- `cargo build` (pass)
- `cargo clippy --all-targets --all-features -- -D warnings` (pass, 0 diagnostics)
- `cargo fmt --all -- --check` (pass)
- `cargo test` (pass — 1302 passed, 0 failed)