### PR TITLE
ci: add cargo-audit (RUSTSEC) security workflow

### DIFF
--- a/.github/workflows/ci-security.yml
+++ b/.github/workflows/ci-security.yml
@@ -1,0 +1,28 @@
+---
+name: Security Audit
+on:
+  push:
+    branches: [main]
+    paths: [Cargo.toml, Cargo.lock, .github/workflows/ci-security.yml]
+  pull_request:
+    branches: [main]
+    paths: [Cargo.toml, Cargo.lock, .github/workflows/ci-security.yml]
+  schedule:
+    # Weekly: catch newly-disclosed RUSTSEC advisories even when the
+    # dependency tree itself has not changed.
+    - cron: "0 6 * * 1"
+  workflow_dispatch:
+permissions:
+  contents: read
+  issues: write
+  checks: write
+jobs:
+  audit:
+    name: cargo audit (RUSTSEC)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+      - name: Run security audit
+        uses: rustsec/audit-check@v2
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
## Summary
Closes #1014. Adds a dependency-vulnerability gate — the one piece of CI a security tool was missing. Dependabot already opens dependency-bump PRs, but nothing was *failing the build* on a known RUSTSEC advisory.

## What it does
New `.github/workflows/ci-security.yml` runs the official `rustsec/audit-check` action against `Cargo.lock`. Triggers:
- **push/PR to `main`** that touch `Cargo.toml` / `Cargo.lock` / the workflow itself
- **weekly cron** (`0 6 * * 1`) — catches *newly-disclosed* advisories even when the dependency tree hasn't changed (the main reason a code-path-filtered job in `ci.yml` wouldn't suffice)
- **`workflow_dispatch`** for manual runs

The action fails the build on known vulnerabilities and annotates unmaintained/yanked crates.

## Why a separate workflow
`ci.yml` is filtered to `**/*.rs`, `Cargo.toml`, `Dockerfile`, and a fresh advisory with no code change would never trigger it. A standalone cron-driven workflow is the standard pattern (and matches the existing `ci-contributors.yml` naming).

## Verification (local)
Ran the same audit locally with the just-published advisory DB (1099 advisories):
- `cargo audit` -> exit 0
- `cargo audit --deny warnings` -> exit 0
- **0 vulnerabilities, 0 warnings across 332 crate dependencies**

So the job is green on day one.