### PR TITLE
fix(scanning): graceful worker shutdown instead of panicking on closed semaphore

### DIFF
--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -971,10 +971,18 @@ pub async fn run_scanning(
         let finding_tx_clone = finding_tx.clone();
 
         let handle = tokio::spawn(async move {
-            let _permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("semaphore closed unexpectedly");
+            // `acquire()` only errors if the semaphore has been closed. Nothing
+            // closes this one today (it lives for the whole scan), so the error
+            // path is currently unreachable — but `expect` would turn any future
+            // cooperative-shutdown change into a panic across every waiting
+            // worker, which is especially bad when dalfox runs embedded as a
+            // library / server / MCP backend. A closed semaphore means there is
+            // no work left to do, so wind the worker down cleanly (the task
+            // batches results into the shared `results_clone`, so there is
+            // nothing to return).
+            let Ok(_permit) = semaphore_clone.acquire().await else {
+                return;
+            };
             // Batch local results to reduce mutex contention
             let mut local_results: Vec<crate::scanning::result::Result> = Vec::new();
             // Stream every new finding through the channel (if provided) before


### PR DESCRIPTION
## Summary
Closes #1012. Defensive hardening in the per-parameter scan worker (`src/scanning/mod.rs`).

The worker acquired its concurrency permit with:
```rust
let _permit = semaphore_clone.acquire().await
    .expect("semaphore closed unexpectedly");
```
`Semaphore::acquire()` only returns `Err` once the semaphore is **closed**. Nothing closes this one today — it's an `Arc` held for the whole scan (created at `mod.rs:720`, zero `.close()` calls in the crate) — so the error path is currently **unreachable**. But `expect` means any future cooperative-shutdown change (e.g. closing the semaphore to cancel in-flight work) would panic *every* waiting worker at once. That's especially harmful when dalfox runs embedded as a library / REST server / MCP backend, where a worker panic is much worse than a clean exit.

## Change
```rust
let Ok(_permit) = semaphore_clone.acquire().await else {
    return;
};
```
The spawned task returns `()` and batches its results into the shared `results_clone` mutex (not via a return value), so a bare `return;` is the correct early-exit — matching the closure's existing `return;` checkpoints. A closed semaphore means there's no work left.

## Scope
One-line behavioral guard + explanatory comment. No change in behavior today (the branch is unreachable until something closes the semaphore).

## Verification (local)
- `cargo build` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅ (0 diagnostics)
- `cargo fmt --all -- --check` ✅
- `cargo test` ✅ — 1302 passed, 0 failed, 19 ignored