### PR TITLE
feat(dom-xss): recognize jQuery $(), dynamic import(), and fetch/XHR response flows

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -1776,6 +1776,7 @@ impl<'a> DomXssVisitor<'a> {
         let saved_aliases = self.var_aliases.clone();
         let saved_instance_classes = self.instance_classes.clone();
         let saved_bound_aliases = self.bound_function_aliases.clone();
+        let saved_response_vars = self.response_object_vars.clone();
         let saved_vuln_len = self.vulnerabilities.len();
         let saved_collecting_tainted_returns = self.collecting_tainted_returns;
         let saved_tainted_return_sources = std::mem::take(&mut self.tainted_return_sources);
@@ -1829,6 +1830,7 @@ impl<'a> DomXssVisitor<'a> {
         self.var_aliases = saved_aliases;
         self.instance_classes = saved_instance_classes;
         self.bound_function_aliases = saved_bound_aliases;
+        self.response_object_vars = saved_response_vars;
         self.vulnerabilities.truncate(saved_vuln_len);
         self.collecting_tainted_returns = saved_collecting_tainted_returns;
         self.tainted_return_sources = saved_tainted_return_sources;
@@ -1962,12 +1964,16 @@ impl<'a> DomXssVisitor<'a> {
                     // Save current tainted vars state
                     let saved_tainted = self.tainted_vars.clone();
                     let saved_aliases = self.var_aliases.clone();
+                    let saved_response_vars = self.response_object_vars.clone();
 
                     self.walk_statements(&body.statements);
 
-                    // Restore state after function (parameters are local scope)
+                    // Restore state after function (locals don't leak out —
+                    // e.g. a `const r = await fetch()` Response binding must
+                    // not taint an unrelated outer `r.text()`).
                     self.tainted_vars = saved_tainted;
                     self.var_aliases = saved_aliases;
+                    self.response_object_vars = saved_response_vars;
                 }
             }
             Statement::ClassDeclaration(class_decl) => {
@@ -2687,7 +2693,7 @@ impl<'a> DomXssVisitor<'a> {
             }
             // Named callback, e.g. `.then(render)`.
             Expression::Identifier(id) => {
-                return self.named_promise_callback_kind(id.name.as_str(), &incoming);
+                return self.named_promise_callback_kind(id.name.as_str(), id.span, &incoming);
             }
             _ => return PromiseValueKind::Unknown,
         };
@@ -2730,15 +2736,37 @@ impl<'a> DomXssVisitor<'a> {
         result_kind
     }
 
-    /// Best-effort threading for `.then(namedFn)`: if the summarized callback
-    /// returns tainted data, propagate it to the next `.then`. Sinks *inside*
-    /// the named callback are reported by the normal function-summary
-    /// call-site path, not here.
+    /// Handle a named `.then(namedFn)` callback against the resolved promise
+    /// value. When the incoming value is tainted and the callback's summary
+    /// says its first parameter reaches a sink (e.g.
+    /// `fetch().then(r => r.text()).then(render)` with
+    /// `function render(t){ el.innerHTML = t; }`), report it — the
+    /// fetch-chain driver consumed the call, so the normal function-summary
+    /// call-site path never runs for this reference. Also propagate the
+    /// callback's tainted return so the next `.then` sees it.
     fn named_promise_callback_kind(
-        &self,
+        &mut self,
         fn_name: &str,
+        span: oxc_span::Span,
         incoming: &PromiseValueKind,
     ) -> PromiseValueKind {
+        // Sink reached by the callback's first parameter, when the resolved
+        // value flowing into it is tainted.
+        if let PromiseValueKind::Tainted(source) = incoming
+            && let Some(sink_name) = self
+                .function_summaries
+                .get(fn_name)
+                .and_then(|summary| summary.tainted_param_sinks.get(&0))
+                .cloned()
+        {
+            self.report_vulnerability_with_source(
+                span,
+                &sink_name,
+                "Tainted fetch response reaches sink through named .then() callback",
+                Some(source.clone()),
+            );
+        }
+
         if let Some(summary) = self.function_summaries.get(fn_name) {
             if matches!(
                 incoming,

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -48,6 +48,19 @@ struct BoundCallableAlias {
     bound_args: Vec<BoundArgInfo>,
 }
 
+/// What a Promise in a `fetch().then(…).then(…)` chain resolves to, threaded
+/// from one `.then` callback's return value to the next callback's parameter.
+#[derive(Clone)]
+enum PromiseValueKind {
+    /// The value is a `fetch()` `Response` object — its `.text()`/`.json()`
+    /// reads are tainted network data.
+    Response,
+    /// The value is tainted, carrying the given source label.
+    Tainted(String),
+    /// The value is not (known to be) tainted.
+    Unknown,
+}
+
 /// AST visitor for DOM XSS analysis
 struct DomXssVisitor<'a> {
     /// Set of tainted variable names
@@ -101,6 +114,13 @@ struct DomXssVisitor<'a> {
     /// never bound to a variable. Populated by the HTML pre-scan in
     /// `ast_integration::extract_script_element_ids`.
     script_element_ids: HashSet<String>,
+    /// Callback parameters currently bound to a `fetch()` `Response`
+    /// object — the first `.then(resp => …)` of a fetch chain. While such
+    /// a parameter is in scope, `resp.text()` / `resp.json()` read the
+    /// network response body, which is an untrusted DOM-XSS source. The
+    /// set is pushed/popped as the promise-chain driver enters and leaves
+    /// each callback so the binding never leaks past its callback.
+    response_object_vars: HashSet<String>,
 }
 
 // Module-level DOM source/sink/sanitizer constants
@@ -492,6 +512,7 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_field_sources: HashMap::new(),
             script_element_vars: HashSet::new(),
             script_element_ids: HashSet::new(),
+            response_object_vars: HashSet::new(),
         }
     }
 
@@ -881,6 +902,141 @@ impl<'a> DomXssVisitor<'a> {
         }
     }
 
+    /// The constant string that must appear at the *start* of `expr`'s value,
+    /// when statically determinable. Used to decide whether a jQuery `$()`
+    /// argument is forced into selector mode (a leading `#`/`.`/tag char) or
+    /// can be parsed as HTML (no static prefix, or a leading `<`).
+    ///
+    /// Returns `Some("")` when the leading segment is dynamic but provably
+    /// empty-prefixed (e.g. a template literal that opens with `${expr}`),
+    /// `None` when no static leading text can be determined.
+    fn static_leading_string(&self, expr: &Expression<'a>) -> Option<String> {
+        match expr {
+            Expression::StringLiteral(s) => Some(s.value.to_string()),
+            Expression::TemplateLiteral(t) => {
+                // A template opening with `${…}` has an empty first quasi, so
+                // the runtime prefix is whatever that expression yields — no
+                // static leading text we can rely on.
+                let first = t.quasis.first()?;
+                let raw = first.value.cooked.as_ref().map(Str::as_str).unwrap_or("");
+                if raw.is_empty() {
+                    None
+                } else {
+                    Some(raw.to_string())
+                }
+            }
+            Expression::BinaryExpression(b) if b.operator == BinaryOperator::Addition => {
+                self.static_leading_string(&b.left)
+            }
+            Expression::ParenthesizedExpression(p) => self.static_leading_string(&p.expression),
+            _ => None,
+        }
+    }
+
+    /// True when a jQuery `$()` / `jQuery()` argument is pinned into *selector*
+    /// mode by a constant leading character (`#id`, `.class`, `tag`, `[attr]`,
+    /// …). jQuery only builds DOM nodes (the XSS-relevant path) when the first
+    /// non-whitespace character of the string is `<`, so a constant non-`<`
+    /// prefix means the tainted tail can never start an HTML tag — suppress.
+    ///
+    /// No static prefix (`$(taint)`, `$(decodeURIComponent(...))`) or a
+    /// leading `<` (`$('<div>' + taint)`) does NOT force selector mode, so the
+    /// constructor can create elements and we keep the finding.
+    fn jquery_arg_forces_selector(&self, expr: &Expression<'a>) -> bool {
+        match self.static_leading_string(expr) {
+            Some(prefix) => {
+                let trimmed = prefix.trim_start();
+                !trimmed.is_empty() && !trimmed.starts_with('<')
+            }
+            None => false,
+        }
+    }
+
+    /// Recognise the `fetch(...)` global call (bare, or via `window`/`self`/
+    /// `globalThis`). Its returned Promise resolves to a `Response`.
+    fn is_fetch_call(&self, call: &CallExpression<'a>) -> bool {
+        match &call.callee {
+            Expression::Identifier(id) => id.name == "fetch",
+            Expression::StaticMemberExpression(_) => matches!(
+                self.get_expr_string(&call.callee).as_deref(),
+                Some("window.fetch" | "self.fetch" | "globalThis.fetch")
+            ),
+            _ => false,
+        }
+    }
+
+    /// True when `expr` is `await fetch(...)` (through parentheses) — the
+    /// awaited value is a `Response`, so a variable bound to it has
+    /// `.text()`/`.json()` reads that are tainted network data (issue #1024).
+    fn awaited_fetch_var(&self, expr: &Expression<'a>) -> bool {
+        let inner = match expr {
+            Expression::AwaitExpression(a) => &a.argument,
+            Expression::ParenthesizedExpression(p) => return self.awaited_fetch_var(&p.expression),
+            _ => return false,
+        };
+        let mut current = inner;
+        loop {
+            match current {
+                Expression::ParenthesizedExpression(p) => current = &p.expression,
+                Expression::CallExpression(call) => return self.is_fetch_call(call),
+                _ => return false,
+            }
+        }
+    }
+
+    /// If `call` invokes a Promise combinator (`.then` / `.catch` / `.finally`),
+    /// return the method name.
+    fn promise_method_name(call: &CallExpression<'a>) -> Option<&'static str> {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return None;
+        };
+        match member.property.name.as_str() {
+            "then" => Some("then"),
+            "catch" => Some("catch"),
+            "finally" => Some("finally"),
+            _ => None,
+        }
+    }
+
+    /// True when this `.then`/`.catch`/`.finally` call sits on a Promise chain
+    /// whose root is a `fetch(...)` call. Walks the receiver chain down through
+    /// nested combinators.
+    fn promise_chain_roots_at_fetch(&self, call: &CallExpression<'a>) -> bool {
+        let mut current: &Expression<'a> = match &call.callee {
+            Expression::StaticMemberExpression(m) => &m.object,
+            _ => return false,
+        };
+        loop {
+            match current {
+                Expression::ParenthesizedExpression(p) => current = &p.expression,
+                Expression::CallExpression(inner) => {
+                    if self.is_fetch_call(inner) {
+                        return true;
+                    }
+                    if Self::promise_method_name(inner).is_some()
+                        && let Expression::StaticMemberExpression(m) = &inner.callee
+                    {
+                        current = &m.object;
+                        continue;
+                    }
+                    return false;
+                }
+                _ => return false,
+            }
+        }
+    }
+
+    /// First `return <expr>;` argument in a callback's block body, used to
+    /// thread the resolved value of one `.then` callback into the next.
+    fn first_return_expr<'b>(stmts: &'b [Statement<'a>]) -> Option<&'b Expression<'a>> {
+        for stmt in stmts {
+            if let Statement::ReturnStatement(ret) = stmt {
+                return ret.argument.as_ref();
+            }
+        }
+        None
+    }
+
     fn build_bound_alias_from_bind_call(
         &self,
         bind_call: &CallExpression<'a>,
@@ -1190,6 +1346,20 @@ impl<'a> DomXssVisitor<'a> {
 
     /// Determine whether a call expression yields tainted data and provide source hint.
     fn call_taint_and_source(&self, call: &CallExpression<'a>) -> (bool, Option<String>) {
+        // `responseVar.text()` / `responseVar.json()` on a `fetch()` Response
+        // reads untrusted network data (issue #1024). The receiver is bound by
+        // the promise-chain driver; the resolved string is the DOM-XSS source.
+        if let Expression::StaticMemberExpression(member) = &call.callee
+            && let Expression::Identifier(id) = &member.object
+            && self.response_object_vars.contains(id.name.as_str())
+        {
+            match member.property.name.as_str() {
+                "text" => return (true, Some("Response.text".to_string())),
+                "json" => return (true, Some("Response.json".to_string())),
+                _ => {}
+            }
+        }
+
         // Sanitizers produce de-tainted values
         if let Some(func_name) = self.get_expr_string(&call.callee)
             && (self.sanitizers.contains(func_name.as_str())
@@ -1376,6 +1546,33 @@ impl<'a> DomXssVisitor<'a> {
         (false, None)
     }
 
+    /// Source label when `member` reads an `XMLHttpRequest` response body
+    /// (`xhr.responseText` / `xhr.response`) on a variable known to hold a
+    /// `new XMLHttpRequest()` instance (issue #1024). The Ajax response is
+    /// server/network-controlled and routinely echoes a reflected/stored
+    /// param, so reading it is an untrusted DOM-XSS source.
+    fn xhr_response_source_for_member(
+        &self,
+        member: &StaticMemberExpression<'a>,
+    ) -> Option<String> {
+        let Expression::Identifier(id) = &member.object else {
+            return None;
+        };
+        if self
+            .instance_classes
+            .get(id.name.as_str())
+            .map(String::as_str)
+            != Some("XMLHttpRequest")
+        {
+            return None;
+        }
+        match member.property.name.as_str() {
+            "responseText" => Some("XMLHttpRequest.responseText".to_string()),
+            "response" => Some("XMLHttpRequest.response".to_string()),
+            _ => None,
+        }
+    }
+
     /// Check if expression is tainted
     fn is_tainted(&self, expr: &Expression) -> bool {
         match expr {
@@ -1385,6 +1582,9 @@ impl<'a> DomXssVisitor<'a> {
             }
             Expression::StaticMemberExpression(member) => {
                 if self.url_search_params_source_for_member(member).is_some() {
+                    return true;
+                }
+                if self.xhr_response_source_for_member(member).is_some() {
                     return true;
                 }
                 if let Some(full_path) = self.get_member_string(member) {
@@ -1466,6 +1666,9 @@ impl<'a> DomXssVisitor<'a> {
                     false
                 }
             }
+            // `await taintedPromise` yields the resolved tainted value — e.g.
+            // `await r.text()` on a fetch Response (issue #1024).
+            Expression::AwaitExpression(await_expr) => self.is_tainted(&await_expr.argument),
             _ => false,
         }
     }
@@ -1852,6 +2055,13 @@ impl<'a> DomXssVisitor<'a> {
                 if !assigned_instance_class {
                     self.instance_classes.remove(var_name);
                 }
+                // `const r = await fetch(url)` — r holds a Response, so later
+                // `r.text()` / `r.json()` reads are tainted (issue #1024).
+                if self.awaited_fetch_var(init) {
+                    self.response_object_vars.insert(var_name.to_string());
+                } else {
+                    self.response_object_vars.remove(var_name);
+                }
                 // Track aliases created by `.bind()` so subsequent calls can resolve
                 // to sink functions or function summaries.
                 let mut assigned_bind_alias = false;
@@ -2113,6 +2323,9 @@ impl<'a> DomXssVisitor<'a> {
                 if let Some(source) = self.url_search_params_source_for_member(member) {
                     return Some(source);
                 }
+                if let Some(source) = self.xhr_response_source_for_member(member) {
+                    return Some(source);
+                }
                 if let Some(full_path) = self.get_member_string(member) {
                     if matches!(
                         full_path.as_str(),
@@ -2239,6 +2452,9 @@ impl<'a> DomXssVisitor<'a> {
                 .expressions
                 .last()
                 .and_then(|expr| self.find_source_in_expr(expr)),
+            Expression::AwaitExpression(await_expr) => {
+                self.find_source_in_expr(&await_expr.argument)
+            }
             _ => None,
         }
     }
@@ -2321,9 +2537,227 @@ impl<'a> DomXssVisitor<'a> {
             Expression::ArrowFunctionExpression(arrow) => {
                 self.walk_statements(&arrow.body.statements);
             }
+            // Dynamic `import(tainted)` runs an attacker-controlled module
+            // (issue #1022). Detect it here; reached both as a bare statement
+            // (`import(t);`) and as the object of a chain (`import(t).then(…)`)
+            // via the member-object recursion below.
+            Expression::ImportExpression(import_expr) => {
+                self.walk_import_expression(import_expr);
+            }
+            Expression::AwaitExpression(await_expr) => {
+                self.walk_expression(&await_expr.argument);
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.walk_expression(&paren.expression);
+            }
+            Expression::SequenceExpression(seq) => {
+                for e in &seq.expressions {
+                    self.walk_expression(e);
+                }
+            }
+            // Reach call / import expressions that sit as the *object* of a
+            // member access — e.g. `$(tainted).appendTo(...)`,
+            // `import(tainted).then(...)`, `eval(tainted).x`. A member-callee
+            // chain otherwise never visits its leftmost operand.
+            Expression::StaticMemberExpression(member) => {
+                self.walk_expression(&member.object);
+            }
+            Expression::ComputedMemberExpression(member) => {
+                self.walk_expression(&member.object);
+                self.walk_expression(&member.expression);
+            }
 
             _ => {}
         }
+    }
+
+    /// Report `import(tainted)` as a code-execution sink and walk the
+    /// specifier for any nested sinks. A tainted module specifier (a
+    /// `data:text/javascript,…` URL or a remote/`//host` URL derived from
+    /// `location.*`, `URLSearchParams`, `name`, `document.referrer`, …) loads
+    /// and runs an attacker-controlled ES module — a real DOM XSS.
+    fn walk_import_expression(&mut self, import_expr: &ImportExpression<'a>) {
+        if self.is_tainted(&import_expr.source) {
+            let source = self.find_source_in_expr(&import_expr.source);
+            self.report_vulnerability_with_source(
+                import_expr.span,
+                "import",
+                "Tainted module specifier passed to dynamic import() runs attacker-controlled module code",
+                source,
+            );
+        }
+        self.walk_expression(&import_expr.source);
+    }
+
+    /// Drive a `fetch().then(...)…` Promise chain (issue #1024): walk each
+    /// callback body so nested sinks fire, threading the resolved value
+    /// (`Response`, then the awaited text/json) from one callback's return
+    /// into the next callback's parameter. Returns the kind the chain
+    /// ultimately resolves to (unused at the top level).
+    fn promise_kind_of_call(&mut self, call: &CallExpression<'a>) -> PromiseValueKind {
+        if self.is_fetch_call(call) {
+            // The URL argument is rarely a sink, but walk it so any nested
+            // source/sink inside the request expression is still visited.
+            for arg in &call.arguments {
+                if let Some(expr) = arg.as_expression() {
+                    self.walk_expression(expr);
+                }
+            }
+            return PromiseValueKind::Response;
+        }
+
+        let Some(method) = Self::promise_method_name(call) else {
+            return PromiseValueKind::Unknown;
+        };
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return PromiseValueKind::Unknown;
+        };
+        let receiver_kind = self.promise_kind_of_expr(&member.object);
+
+        match method {
+            "then" => {
+                // arg0 = onFulfilled (the resolved value); arg1 = onRejected
+                // (an error — never the tainted response body).
+                if let Some(on_rejected) = call.arguments.get(1) {
+                    self.process_promise_callback(on_rejected, PromiseValueKind::Unknown);
+                }
+                match call.arguments.first() {
+                    Some(on_fulfilled) => {
+                        self.process_promise_callback(on_fulfilled, receiver_kind)
+                    }
+                    None => receiver_kind,
+                }
+            }
+            // `.catch` / `.finally`: still walk the callback, but on the
+            // success path the resolved value flows through unchanged.
+            _ => {
+                if let Some(cb) = call.arguments.first() {
+                    self.process_promise_callback(cb, PromiseValueKind::Unknown);
+                }
+                receiver_kind
+            }
+        }
+    }
+
+    fn promise_kind_of_expr(&mut self, expr: &Expression<'a>) -> PromiseValueKind {
+        match expr {
+            Expression::ParenthesizedExpression(p) => self.promise_kind_of_expr(&p.expression),
+            Expression::CallExpression(call) => self.promise_kind_of_call(call),
+            _ => PromiseValueKind::Unknown,
+        }
+    }
+
+    /// Walk a `.then`/`.catch`/`.finally` callback with its first parameter
+    /// bound to the incoming Promise value, then report the value its body
+    /// returns so the next `.then` in the chain sees it.
+    fn process_promise_callback(
+        &mut self,
+        cb_arg: &Argument<'a>,
+        incoming: PromiseValueKind,
+    ) -> PromiseValueKind {
+        let Some(expr) = cb_arg.as_expression() else {
+            return PromiseValueKind::Unknown;
+        };
+
+        let (param_name, statements, return_expr): (
+            Option<String>,
+            &oxc_allocator::Vec<'a, Statement<'a>>,
+            Option<&Expression<'a>>,
+        ) = match expr {
+            Expression::FunctionExpression(func) => {
+                let Some(body) = &func.body else {
+                    return PromiseValueKind::Unknown;
+                };
+                let pname = Self::first_param_name(&func.params);
+                let ret = Self::first_return_expr(&body.statements);
+                (pname, &body.statements, ret)
+            }
+            Expression::ArrowFunctionExpression(arrow) => {
+                let pname = Self::first_param_name(&arrow.params);
+                let ret = if arrow.expression {
+                    match arrow.body.statements.first() {
+                        Some(Statement::ExpressionStatement(stmt)) => Some(&stmt.expression),
+                        _ => None,
+                    }
+                } else {
+                    Self::first_return_expr(&arrow.body.statements)
+                };
+                (pname, &arrow.body.statements, ret)
+            }
+            // Named callback, e.g. `.then(render)`.
+            Expression::Identifier(id) => {
+                return self.named_promise_callback_kind(id.name.as_str(), &incoming);
+            }
+            _ => return PromiseValueKind::Unknown,
+        };
+
+        let saved_tainted = self.tainted_vars.clone();
+        let saved_aliases = self.var_aliases.clone();
+        let saved_response_vars = self.response_object_vars.clone();
+
+        if let Some(name) = &param_name {
+            // A fresh parameter binding shadows any same-named outer state.
+            self.tainted_vars.remove(name);
+            self.var_aliases.remove(name);
+            self.response_object_vars.remove(name);
+            match &incoming {
+                PromiseValueKind::Response => {
+                    self.response_object_vars.insert(name.clone());
+                }
+                PromiseValueKind::Tainted(source) => {
+                    self.tainted_vars.insert(name.clone());
+                    self.var_aliases.insert(name.clone(), source.clone());
+                }
+                PromiseValueKind::Unknown => {}
+            }
+        }
+
+        self.walk_statements(statements);
+
+        let result_kind = match return_expr {
+            Some(re) if self.is_tainted(re) => PromiseValueKind::Tainted(
+                self.find_source_in_expr(re)
+                    .unwrap_or_else(|| "Response.text".to_string()),
+            ),
+            _ => PromiseValueKind::Unknown,
+        };
+
+        self.tainted_vars = saved_tainted;
+        self.var_aliases = saved_aliases;
+        self.response_object_vars = saved_response_vars;
+
+        result_kind
+    }
+
+    /// Best-effort threading for `.then(namedFn)`: if the summarized callback
+    /// returns tainted data, propagate it to the next `.then`. Sinks *inside*
+    /// the named callback are reported by the normal function-summary
+    /// call-site path, not here.
+    fn named_promise_callback_kind(
+        &self,
+        fn_name: &str,
+        incoming: &PromiseValueKind,
+    ) -> PromiseValueKind {
+        if let Some(summary) = self.function_summaries.get(fn_name) {
+            if matches!(
+                incoming,
+                PromiseValueKind::Tainted(_) | PromiseValueKind::Response
+            ) && let Some(src) = summary.tainted_param_returns.get(&0)
+            {
+                return PromiseValueKind::Tainted(src.clone());
+            }
+            if let Some(src) = &summary.return_without_tainted_params {
+                return PromiseValueKind::Tainted(src.clone());
+            }
+        }
+        PromiseValueKind::Unknown
+    }
+
+    fn first_param_name(params: &FormalParameters<'a>) -> Option<String> {
+        params.items.first().and_then(|p| match &p.pattern {
+            BindingPattern::BindingIdentifier(id) => Some(id.name.to_string()),
+            _ => None,
+        })
     }
 
     fn walk_event_handler_body(
@@ -2687,6 +3121,37 @@ impl<'a> DomXssVisitor<'a> {
 
     /// Walk through a call expression
     fn walk_call_expression(&mut self, call: &CallExpression<'a>) {
+        // fetch().then(...) response-source chains (issue #1024). Drive the
+        // whole chain here so each callback body is walked with the resolved
+        // Response / tainted value bound to its parameter, then return.
+        if Self::promise_method_name(call).is_some() && self.promise_chain_roots_at_fetch(call) {
+            self.promise_kind_of_call(call);
+            return;
+        }
+
+        // jQuery `$(tainted)` / `jQuery(tainted)` selector-to-HTML constructor
+        // (issue #1021). A string whose first non-whitespace char is `<` makes
+        // jQuery build live DOM nodes (running onerror/onload). Fire only when
+        // the argument is tainted AND not pinned into selector mode by a
+        // constant `#`/`.`/tag prefix — see `jquery_arg_forces_selector`.
+        if let Expression::Identifier(id) = &call.callee
+            && (id.name == "$" || id.name == "jQuery")
+            && let Some(arg0) = call.arguments.first()
+            && let Some(arg_expr) = arg0.as_expression()
+            && self.is_tainted(arg_expr)
+            && !self.jquery_arg_forces_selector(arg_expr)
+        {
+            let source = self.find_source_in_expr(arg_expr);
+            self.report_vulnerability_with_source(
+                call.span(),
+                "jQuery$",
+                "Tainted HTML string passed to jQuery $() constructor builds DOM nodes (selector-to-HTML)",
+                source,
+            );
+            // Continue walking so inner sinks/sources in the argument are still
+            // visited (the argument expression itself may chain further).
+        }
+
         if let Expression::StaticMemberExpression(member) = &call.callee
             && member.property.name.as_str() == "set"
             && call.arguments.len() >= 2

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -902,14 +902,15 @@ impl<'a> DomXssVisitor<'a> {
         }
     }
 
-    /// The constant string that must appear at the *start* of `expr`'s value,
-    /// when statically determinable. Used to decide whether a jQuery `$()`
-    /// argument is forced into selector mode (a leading `#`/`.`/tag char) or
-    /// can be parsed as HTML (no static prefix, or a leading `<`).
+    /// The non-empty constant string that must appear at the *start* of
+    /// `expr`'s value, when statically determinable. Used to decide whether a
+    /// jQuery `$()` argument is forced into selector mode (a leading
+    /// `#`/`.`/tag char) or can be parsed as HTML (no static prefix, or a
+    /// leading `<`).
     ///
-    /// Returns `Some("")` when the leading segment is dynamic but provably
-    /// empty-prefixed (e.g. a template literal that opens with `${expr}`),
-    /// `None` when no static leading text can be determined.
+    /// Returns `None` when no non-empty static leading text can be determined
+    /// — including a template literal that opens with `${expr}` (empty first
+    /// quasi), where the runtime prefix is dynamic.
     fn static_leading_string(&self, expr: &Expression<'a>) -> Option<String> {
         match expr {
             Expression::StringLiteral(s) => Some(s.value.to_string()),
@@ -3148,8 +3149,11 @@ impl<'a> DomXssVisitor<'a> {
                 "Tainted HTML string passed to jQuery $() constructor builds DOM nodes (selector-to-HTML)",
                 source,
             );
-            // Continue walking so inner sinks/sources in the argument are still
-            // visited (the argument expression itself may chain further).
+            // Walk the (tainted) argument so a nested sink inside it — e.g.
+            // `$(eval(location.hash))` — is also reported; the trailing
+            // `walk_expression(&call.callee)` only descends the `$` callee,
+            // never the call's arguments.
+            self.walk_expression(arg_expr);
         }
 
         if let Expression::StaticMemberExpression(member) = &call.callee

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3627,3 +3627,22 @@ async function load() {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn jquery_constructor_walks_nested_sink_in_argument() {
+    // A nested sink inside the (tainted) `$()` argument must also be visited.
+    // `$(eval(location.hash))` is both a jQuery$ finding and an eval finding.
+    let js = r#"$(eval(location.hash));"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    let sinks: Vec<String> = r.iter().map(|v| v.sink.clone()).collect();
+    assert!(
+        sinks.iter().any(|s| s == "eval"),
+        "nested eval sink inside $() argument must be visited; got {:?}",
+        sinks
+    );
+    assert!(
+        sinks.iter().any(|s| s == "jQuery$"),
+        "jQuery$ constructor on the tainted argument must also fire; got {:?}",
+        sinks
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3271,3 +3271,359 @@ $('#root').find('.target').append(q);
         r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
     );
 }
+
+// ===== Issue #1021: jQuery $() / jQuery() selector-to-HTML constructor =====
+
+#[test]
+fn jquery_constructor_hash_to_html_is_sink() {
+    // xssmaze /jquery/level1/ — $(location.hash) builds DOM nodes.
+    let js = r#"
+var target = decodeURIComponent(location.hash.slice(1));
+if (target) { $(target).appendTo('#content'); }
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "jQuery$" && v.source.contains("location.hash")),
+        "jQuery $() constructor on tainted hash must be a sink; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_jquery_alias_is_sink() {
+    let js = r#"
+var t = location.search;
+jQuery(t);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "jQuery$"),
+        "jQuery() alias constructor must be a sink; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_name_source_is_sink() {
+    let js = r#"$(window.name);"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "jQuery$"),
+        "jQuery $() on window.name must be a sink; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_id_selector_prefix_suppressed() {
+    // `$('#' + tainted)` is pinned into selector mode by the leading '#',
+    // so the tainted tail can never open an HTML tag — no finding.
+    let js = r#"
+var t = location.hash.slice(1);
+$('#' + t);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "jQuery$"),
+        "selector-prefixed $('#'+t) must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_class_selector_prefix_suppressed() {
+    let js = r#"
+var t = location.search;
+$('.item-' + t);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "jQuery$"),
+        "selector-prefixed $('.x'+t) must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_html_prefix_still_sink() {
+    // A leading '<' means HTML-build mode even with a constant prefix.
+    let js = r#"
+var t = location.hash.slice(1);
+$('<div>' + t);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "jQuery$"),
+        "$('<div>'+t) opens an HTML tag and must fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn jquery_constructor_untainted_selector_no_finding() {
+    let js = r#"$('#content').hide(); $('.menu').show();"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "constant jQuery selectors must not produce findings; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+// ===== Issue #1022: dynamic import() code-execution sink =====
+
+#[test]
+fn dynamic_import_hash_is_sink() {
+    let js = r#"
+var t = decodeURIComponent(location.hash.slice(1));
+if (t) { import(t); }
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "import" && v.source.contains("location.hash")),
+        "dynamic import(tainted hash) must be a sink; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dynamic_import_searchparams_is_sink() {
+    // xssmaze /codeexec/level1/.
+    let js = r#"
+var name = new URLSearchParams(location.search).get('query') || '';
+if (name) {
+  import(name).then(function () {}).catch(function () {});
+}
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "import"),
+        "dynamic import() of URLSearchParams value must be a sink; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dynamic_import_constant_specifier_no_finding() {
+    let js = r#"import('./plugins/chart.js').then(function (m) { m.init(); });"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "import"),
+        "import() of a constant module path must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+// ===== Issue #1024: fetch()/XMLHttpRequest response source =====
+
+#[test]
+fn fetch_text_response_to_innerhtml() {
+    // xssmaze /apidom/level1/.
+    let js = r#"
+fetch('/data.txt').then(function (r) { return r.text(); })
+  .then(function (t) { document.getElementById('o').innerHTML = t; });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("Response")),
+        "fetch().then(r=>r.text()).then(t=>innerHTML=t) must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_json_field_to_innerhtml() {
+    // xssmaze /apidom/level2/.
+    let js = r#"
+fetch('/api').then(function (r) { return r.json(); })
+  .then(function (d) { document.getElementById('card').innerHTML = d.html; });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "innerHTML"),
+        "fetch().then(r=>r.json()).then(d=>innerHTML=d.html) must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_arrow_chain_to_document_write() {
+    // xssmaze /apidom/level5/ with arrow callbacks.
+    let js = r#"
+fetch('/api').then(r => r.text()).then(t => document.write(t));
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "document.write"),
+        "fetch arrow chain into document.write must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_json_to_insert_adjacent_html() {
+    // xssmaze /apidom/level4/.
+    let js = r#"
+fetch('/api').then(function (r) { return r.json(); })
+  .then(function (d) {
+    document.getElementById('feed').insertAdjacentHTML('beforeend', '<li>' + d.msg + '</li>');
+  });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "insertAdjacentHTML"),
+        "fetch json -> insertAdjacentHTML must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_text_to_contextual_fragment() {
+    // xssmaze /apidom/level6/.
+    let js = r#"
+fetch('/api').then(function (r) { return r.text(); })
+  .then(function (t) {
+    var frag = document.createRange().createContextualFragment(t);
+    document.getElementById('out').appendChild(frag);
+  });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "createContextualFragment"),
+        "fetch text -> createContextualFragment must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn xhr_response_text_to_innerhtml() {
+    // xssmaze /apidom/level3/.
+    let js = r#"
+var xhr = new XMLHttpRequest();
+xhr.open('GET', '/data.txt');
+xhr.onload = function () { document.getElementById('o').innerHTML = xhr.responseText; };
+xhr.send();
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("XMLHttpRequest")),
+        "xhr.responseText -> innerHTML must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn xhr_response_to_document_write() {
+    let js = r#"
+var xhr = new XMLHttpRequest();
+xhr.onload = function () { document.write(xhr.response); };
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "document.write" && v.source.contains("XMLHttpRequest")),
+        "xhr.response -> document.write must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_text_to_safe_textcontent_no_finding() {
+    // textContent is not an HTML sink, so even tainted response text is safe.
+    let js = r#"
+fetch('/data.txt').then(function (r) { return r.text(); })
+  .then(function (t) { document.getElementById('o').textContent = t; });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "fetch response into textContent must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn non_fetch_promise_chain_no_false_positive() {
+    // A non-fetch promise resolving an arbitrary value must not be treated
+    // as a tainted response source.
+    let js = r#"
+somePromise.then(function (r) { return r.text(); })
+  .then(function (t) { document.getElementById('o').innerHTML = t; });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "non-fetch promise chain must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_await_form_response_to_innerhtml() {
+    // async/await fetch: `const r = await fetch(); const t = await r.text();`
+    let js = r#"
+async function load() {
+  const r = await fetch('/api');
+  const t = await r.text();
+  document.getElementById('o').innerHTML = t;
+}
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("Response")),
+        "awaited fetch response -> innerHTML must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_await_json_form_response_to_innerhtml() {
+    let js = r#"
+async function load() {
+  const res = await fetch('/api');
+  const data = await res.json();
+  document.querySelector('#x').innerHTML = data.body;
+}
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "innerHTML"),
+        "awaited fetch json -> innerHTML must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3646,3 +3646,41 @@ fn jquery_constructor_walks_nested_sink_in_argument() {
         sinks
     );
 }
+
+#[test]
+fn fetch_named_then_callback_reaches_sink() {
+    // Named .then() callback: the fetch-chain driver consumes the call, so
+    // the sink inside `render` must be reported via the callback's summary.
+    let js = r#"
+function render(t) { document.getElementById('o').innerHTML = t; }
+fetch('/api').then(function (r) { return r.text(); }).then(render);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("Response")),
+        "named .then(render) sink must surface; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn awaited_fetch_var_does_not_leak_out_of_function_summary() {
+    // A summarized function with `const r = await fetch(...)` must not leave
+    // its response-var binding in the outer analysis, or an unrelated outer
+    // `rsp.text()` would be wrongly treated as a tainted source.
+    let js = r#"
+async function loader() { var rsp = await fetch('/api'); return rsp; }
+document.getElementById('o').innerHTML = rsp.text();
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "response-var binding must not leak out of the function summary; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -133,9 +133,19 @@ pub fn generate_dom_xss_poc(source: &str, sink: &str) -> (String, String) {
     //   * Everything else (`innerHTML`, jQuery `html()`, `document.write`,
     //     …) renders the payload as HTML, so a tag + event-handler combo
     //     wins.
+    // `import` takes a module *specifier* (a URL), so the same executable
+    // `data:text/javascript,…` payload as a URL-attribute sink loads and runs
+    // an attacker module — group it with the URL-attribute shape.
     let is_url_attr_sink = matches!(
         sink,
-        "src" | "href" | "xlink:href" | "action" | "formaction" | "poster" | "background"
+        "src"
+            | "href"
+            | "xlink:href"
+            | "action"
+            | "formaction"
+            | "poster"
+            | "background"
+            | "import"
     );
     // Sinks whose value is fed directly to a JS evaluator. `script.text` /
     // `script.textContent` / `script.innerText` are listed alongside the

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -695,3 +695,128 @@ fn test_extract_script_element_ids_ignores_blank_ids() {
     assert_eq!(ids.len(), 1);
     assert!(ids.contains("ok"));
 }
+
+// ===== End-to-end pipeline coverage for issues #1021 / #1022 / #1024 =====
+// Each test feeds the actual xssmaze page HTML through the same path the
+// scanner uses (extract JS from HTML -> AST analyze -> POC generation).
+
+#[test]
+fn e2e_jquery_level1_constructor_finding_and_hash_poc() {
+    // xssmaze /jquery/level1/
+    let html = r#"<html><head><script src='https://cdnjs.cloudflare.com/ajax/libs/jquery/3.7.1/jquery.min.js'></script></head>
+    <body>
+    <div id='content'></div>
+    <script>
+      var target = decodeURIComponent(location.hash.slice(1));
+      if (target) { $(target).appendTo('#content'); }
+    </script>
+    </body></html>"#;
+    let results = run_initial_ast_dom_analysis(html, "http://t/jquery/level1/", "GET");
+    assert!(
+        results.iter().any(|r| r.evidence.contains("jQuery$")),
+        "jQuery $() constructor must surface a finding; got {:?}",
+        results
+            .iter()
+            .map(|r| r.evidence.clone())
+            .collect::<Vec<_>>()
+    );
+    // location.hash source -> HTML payload carried in the fragment (the PoC
+    // URL is stored in the `data` field).
+    assert!(
+        results
+            .iter()
+            .any(|r| r.data.contains('#') && r.payload.contains("onerror=alert(1)")),
+        "expected a hash-fragment HTML PoC; got {:?}",
+        results
+            .iter()
+            .map(|r| (r.data.clone(), r.payload.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn e2e_codeexec_level1_dynamic_import_finding_and_data_uri_poc() {
+    // xssmaze /codeexec/level1/
+    let html = r#"<html><body>
+    <div id='status'>loading plugin...</div>
+    <script>
+      var name = new URLSearchParams(location.search).get('query') || '';
+      if (name) {
+        import(name).then(function () {}).catch(function () {});
+      }
+    </script>
+    </body></html>"#;
+    let results = run_initial_ast_dom_analysis(html, "http://t/codeexec/level1/?query=a", "GET");
+    assert!(
+        results.iter().any(|r| r.evidence.contains("Sink: import")),
+        "dynamic import() must surface a finding; got {:?}",
+        results
+            .iter()
+            .map(|r| r.evidence.clone())
+            .collect::<Vec<_>>()
+    );
+    // import takes a module specifier -> executable data: URL payload on `query`.
+    assert!(
+        results
+            .iter()
+            .any(|r| r.payload.contains("query=data:text/javascript,alert(1)")),
+        "expected a data: URL module PoC on query; got {:?}",
+        results
+            .iter()
+            .map(|r| r.payload.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn e2e_apidom_level1_fetch_innerhtml_finding() {
+    // xssmaze /apidom/level1/
+    let html = r#"<html><body>
+    <div id='out'>loading...</div>
+    <script>
+      var q = new URLSearchParams(location.search).get('q') || '';
+      fetch('/apidom/level1/api?q=' + encodeURIComponent(q))
+        .then(function (r) { return r.text(); })
+        .then(function (t) { document.getElementById('out').innerHTML = t; });
+    </script>
+    </body></html>"#;
+    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level1/?q=a", "GET");
+    assert!(
+        results
+            .iter()
+            .any(|r| r.evidence.contains("Source: Response.text")
+                && r.evidence.contains("Sink: innerHTML")),
+        "fetch text response -> innerHTML must surface; got {:?}",
+        results
+            .iter()
+            .map(|r| r.evidence.clone())
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn e2e_apidom_level3_xhr_innerhtml_finding() {
+    // xssmaze /apidom/level3/
+    let html = r#"<html><body>
+    <div id='out'>loading...</div>
+    <script>
+      var q = new URLSearchParams(location.search).get('q') || '';
+      var xhr = new XMLHttpRequest();
+      xhr.open('GET', '/apidom/level3/api?q=' + encodeURIComponent(q));
+      xhr.onload = function () { document.getElementById('out').innerHTML = xhr.responseText; };
+      xhr.send();
+    </script>
+    </body></html>"#;
+    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level3/?q=a", "GET");
+    assert!(
+        results.iter().any(
+            |r| r.evidence.contains("Source: XMLHttpRequest.responseText")
+                && r.evidence.contains("Sink: innerHTML")
+        ),
+        "xhr.responseText -> innerHTML must surface; got {:?}",
+        results
+            .iter()
+            .map(|r| r.evidence.clone())
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Closes three AST DOM-XSS coverage gaps found while expanding [XSSMaze](https://github.com/hahwul/xssmaze) DOM-sink coverage. Each was a real exploitable flow that the static engine silently missed.

| Issue | Gap | Now |
|-------|-----|-----|
| #1021 | jQuery `$()` / `jQuery()` selector-to-HTML constructor sink | ✅ detected |
| #1022 | dynamic `import()` code-execution sink | ✅ detected |
| #1024 | `fetch()` / `XMLHttpRequest` response **source** | ✅ detected |

## Details

### #1021 — jQuery `$()` / `jQuery()` constructor
`$(tainted)` builds live DOM nodes (running `onerror`/`onload`) when the string's first non-whitespace char is `<`. Now flagged as a sink (`jQuery$`), with FP gating per the issue:
- fires for `$(t)`, `$(decodeURIComponent(...))`, `$('<div>' + t)`;
- suppressed when a constant prefix pins selector mode (`$('#' + t)`, `$('.item-' + t)`).

### #1022 — dynamic `import()`
`import(tainted)` loads and runs an attacker-controlled ES module. Flagged as a code-execution sink (reached as a bare statement and through `import(t).then(...)`), with an executable `data:text/javascript,alert(1)` module-specifier PoC.

### #1024 — `fetch()` / `XMLHttpRequest` response source
The `Response.text`/`Response.json`/`XMLHttpRequest.response*` source labels were declared but inert. Now wired up:
- a `PromiseValueKind` driver threads the `Response` → awaited text/json value through each `.then()` callback parameter, walking every callback body (also `.catch`/`.finally`, named callbacks, and the `await fetch()` / `await r.text()` form);
- `xhr.responseText` / `xhr.response` recognized via `new XMLHttpRequest()` instance tracking.

A finding here is naturally "verification needed" (Medium), matching the existing storage/cookie source class.

### Supporting change
`walk_expression` now recurses into member objects / `await` / parens / sequences so chained operands like `$(t).appendTo(...)` and `import(t).then(...)` are reached. This is purely additive coverage (no double-reporting).

## Coverage
XSSMaze `jquery/level1`, `codeexec/level1`, and `apidom/level1`–`level6`.

## Testing
- 27 new unit + end-to-end tests (incl. FP-suppression and non-fetch-promise no-false-positive cases), routed through `run_initial_ast_dom_analysis` — the same path the scanner uses.
- Full suite: **1126 passed, 0 failed**; `cargo clippy` clean; `cargo fmt --check` clean.
- Verified live against served maze-style pages: all four emit `[A][DOM-XSS]` with correct sink-aware PoCs.

Closes #1021
Closes #1022
Closes #1024