### PR TITLE
fix(release): stop version_update.cr from truncating aur/PKGBUILD

### DIFF
--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -98,9 +98,12 @@ rescue ex
 end
 
 # snap convention here keeps the `v` prefix (matches release tags).
+# NOTE: Crystal's `/m` flag is MULTILINE *and* DOTALL, so `.` matches
+# newlines. Match the value with `[^\n]*` to stay on a single line —
+# `.*` would swallow the rest of the file.
 def update_snap(new_version : String) : Bool
   content = File.read(SNAP_YAML)
-  updated = content.sub(/^(version:\s*)['"]?v?[^'"\s]+['"]?\s*$/m, "\\1v#{new_version}")
+  updated = content.sub(/^(version:[ \t]*)[^\n]*/m, "\\1v#{new_version}")
   return false if updated == content
   File.write(SNAP_YAML, updated)
   true
@@ -111,11 +114,12 @@ end
 
 # AUR pkgver disallows hyphens; rewrite `-` as `_` so dev/rc tags remain
 # valid for `makepkg --printsrcinfo`. Also resets pkgrel=1 on bump.
+# `[^\n]*` (not `.*`) — see the DOTALL note on update_snap above.
 def update_aur(new_version : String) : Bool
   content = File.read(AUR_PKGBUILD)
   aur_ver = new_version.gsub('-', '_')
-  updated = content.sub(/^pkgver=.*/m, "pkgver=#{aur_ver}")
-                   .sub(/^pkgrel=.*/m, "pkgrel=1")
+  updated = content.sub(/^pkgver=[^\n]*/m, "pkgver=#{aur_ver}")
+                   .sub(/^pkgrel=[^\n]*/m, "pkgrel=1")
   return false if updated == content
   File.write(AUR_PKGBUILD, updated)
   true


### PR DESCRIPTION
## What

`scripts/version_update.cr` corrupts `aur/PKGBUILD` on the next `just vu`
version bump. Crystal's `/m` regex flag is **MULTILINE *and* DOTALL** (`.`
matches newlines), so `update_aur`'s `/^pkgver=.*/m` matches from `pkgver=`
to EOF — wiping `pkgrel`, `arch`, and every build function. The resulting
3-line PKGBUILD fails AUR publishing with `arch/pkgrel is not allowed to be
empty`.

This is currently latent in dalfox (no `just vu` bump has run since the AUR
scripts were added at 3.0.0), but it would break the next release. The same
bug already surfaced in [smugglex](https://github.com/hahwul/smugglex), which
shares these scripts.

## Change

- `update_aur`: match values with `[^\n]*` instead of `.*`
- `update_snap`: hardened the same way (its trailing `\s*$` relied on DOTALL
  backtracking); behavior unchanged, snap keeps its `v` prefix

Other writers (`update_cargo_toml`, `update_cargo_lock`, `update_flake`) use
quote-bounded `[^"]+` and were already safe.

## Verification

In-memory run against the real files (no writes):

```
PKGBUILD lines: 38 -> 38   (pkgver=9.9.9, pkgrel=1, arch=('x86_64' 'aarch64') preserved)
snapcraft lines: 24 -> 24  (version: v9.9.9)
```

`crystal build --no-codegen scripts/version_update.cr` passes.

Fixes #1029