### PR TITLE
fix(docs): rank title matches above content matches in search

### DIFF
--- a/docs/static/js/search.js
+++ b/docs/static/js/search.js
@@ -80,7 +80,9 @@
       var titleIdx = item.title.toLowerCase().indexOf(q);
       var contentIdx = item.content.toLowerCase().indexOf(q);
       if (titleIdx !== -1 || contentIdx !== -1) {
-        var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
+        // Title matches always rank above content-only matches; within each
+        // group an earlier match position ranks higher.
+        var score = titleIdx !== -1 ? 10000 - titleIdx : -contentIdx;
         results.push({ item: item, score: score });
       }
     }


### PR DESCRIPTION
## Summary

Fixes documentation search ranking so that pages matching the **query in their title** always sort above pages that only match in their body content.

## Problem

In `docs/static/js/search.js` the scoring was:

```js
var score = titleIdx !== -1 ? 100 - titleIdx : contentIdx;
```

Two issues:
1. **Title matches could be outranked by content matches** — a title match scored `100 - titleIdx`, while a content-only match used the raw `contentIdx`. A deep content match (e.g. index 60+) could score higher than a title match.
2. **Content matches sorted in reverse** — larger `contentIdx` (later in the body) scored higher, so earlier matches ranked lower.

## Fix

```js
var score = titleIdx !== -1 ? 10000 - titleIdx : -contentIdx;
```

- Title matches land near `10000` (always positive) → always above content-only matches.
- Content-only matches use `-contentIdx` (≤ 0) → always below title matches.
- Within each group, an earlier match position ranks higher.

No other logic changes; the sort and rendering still consume `score` only.