### PR TITLE
fix(scan): honor explicit -p header/cookie/multipart injection points

### DIFF
--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -46,6 +46,21 @@ fn json_key_regex() -> &'static regex::Regex {
     })
 }
 
+/// Names the operator explicitly targeted with `-p name:<wanted>` (e.g.
+/// `-p Referer:header`, `-p sid:cookie`, `-p file:multipart`). These are
+/// explicit injection points, so callers probe them even when the matching
+/// `--skip-reflection-*` sweep (or the mining phase) is disabled — mirroring
+/// how `-d` body params are honored under `--skip-mining`.
+pub(crate) fn explicit_param_names(param_specs: &[String], wanted: &str) -> Vec<String> {
+    param_specs
+        .iter()
+        .filter_map(|spec| {
+            let (name, ty) = spec.split_once(':')?;
+            (ty == wanted && !name.is_empty()).then(|| name.to_string())
+        })
+        .collect()
+}
+
 pub async fn check_discovery(
     target: &mut Target,
     args: &ScanArgs,
@@ -54,12 +69,13 @@ pub async fn check_discovery(
 ) {
     if !args.skip_discovery {
         check_query_discovery(target, reflection_params.clone(), semaphore.clone()).await;
-        if !args.skip_reflection_header {
-            check_header_discovery(target, reflection_params.clone(), semaphore.clone()).await;
-        }
-        if !args.skip_reflection_cookie {
-            check_cookie_discovery(target, reflection_params.clone(), semaphore.clone()).await;
-        }
+        // The header/cookie reflection *sweeps* are gated by
+        // `--skip-reflection-header` / `--skip-reflection-cookie`, but a
+        // header/cookie named explicitly via `-p name:header` / `:cookie` is an
+        // explicit injection point and is probed regardless. That gating now
+        // lives inside each function (see `explicit_param_names`).
+        check_header_discovery(target, args, reflection_params.clone(), semaphore.clone()).await;
+        check_cookie_discovery(target, args, reflection_params.clone(), semaphore.clone()).await;
         // Path discovery (respects --skip-reflection-path)
         if !args.skip_reflection_path {
             check_path_discovery(target, reflection_params.clone(), semaphore.clone()).await;
@@ -693,6 +709,7 @@ async fn detect_blanket_header_echo(target: &Target) -> bool {
 
 pub async fn check_header_discovery(
     target: &Target,
+    args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
 ) {
@@ -702,34 +719,52 @@ pub async fn check_header_discovery(
 
     let mut handles = vec![];
 
-    // Build a set of header names to test: explicit headers + common probes
+    // Headers to test, in priority order of "explicitness":
+    //   1. `-H` headers the user supplied (always)
+    //   2. headers the user named via `-p name:header` (always — explicit
+    //      injection points, honored even under --skip-reflection-header)
+    //   3. the common-probe sweep (only when reflection-header discovery is on)
     let mut headers_to_test: Vec<(String, String)> = target
         .headers
         .iter()
         .map(|(k, v)| (k.clone(), v.clone()))
         .collect();
-    let existing_names: std::collections::HashSet<String> = headers_to_test
+    let mut existing_names: std::collections::HashSet<String> = headers_to_test
         .iter()
         .map(|(k, _)| k.to_ascii_lowercase())
         .collect();
 
-    // Differential check: skip the default probe list when the target
-    // echoes any header name. User-supplied headers still get probed
-    // because the operator explicitly asked for them.
-    let blanket_echo = detect_blanket_header_echo(target).await;
-    if blanket_echo {
-        if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-            eprintln!(
-                "[DBG] blanket header echo detected (guard reflected); skipping {} common header probes",
-                COMMON_PROBE_HEADERS.len()
-            );
+    for name in explicit_param_names(&args.param, "header") {
+        if existing_names.insert(name.to_ascii_lowercase()) {
+            headers_to_test.push((name, String::new()));
         }
-    } else {
-        for &hdr in COMMON_PROBE_HEADERS {
-            if !existing_names.contains(&hdr.to_ascii_lowercase()) {
-                headers_to_test.push((hdr.to_string(), String::new()));
+    }
+
+    // The blanket common-header sweep is the only part gated by
+    // `--skip-reflection-header`. Explicitly-named headers above are not.
+    if !args.skip_reflection_header {
+        // Differential check: skip the default probe list when the target
+        // echoes any header name. User-supplied headers still get probed
+        // because the operator explicitly asked for them.
+        let blanket_echo = detect_blanket_header_echo(target).await;
+        if blanket_echo {
+            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
+                eprintln!(
+                    "[DBG] blanket header echo detected (guard reflected); skipping {} common header probes",
+                    COMMON_PROBE_HEADERS.len()
+                );
+            }
+        } else {
+            for &hdr in COMMON_PROBE_HEADERS {
+                if existing_names.insert(hdr.to_ascii_lowercase()) {
+                    headers_to_test.push((hdr.to_string(), String::new()));
+                }
             }
         }
+    }
+
+    if headers_to_test.is_empty() {
+        return;
     }
 
     for (header_name, header_value) in &headers_to_test {
@@ -995,6 +1030,7 @@ pub async fn check_path_discovery(
 
 pub async fn check_cookie_discovery(
     target: &Target,
+    args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
 ) {
@@ -1004,7 +1040,21 @@ pub async fn check_cookie_discovery(
 
     let mut handles = vec![];
 
+    // Under `--skip-reflection-cookie` the blanket sweep over supplied cookies
+    // is off, but cookies named explicitly via `-p name:cookie` are explicit
+    // injection points and still get probed.
+    let explicit_only: Option<Vec<String>> = if args.skip_reflection_cookie {
+        Some(explicit_param_names(&args.param, "cookie"))
+    } else {
+        None
+    };
+
     for (cookie_name, cookie_value) in &target.cookies {
+        if let Some(ref allow) = explicit_only
+            && !allow.iter().any(|n| n == cookie_name)
+        {
+            continue;
+        }
         let client_clone = client.clone();
         let url = target.url.clone();
         let cookies = target.cookies.clone();

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -55,8 +55,13 @@ pub(crate) fn explicit_param_names(param_specs: &[String], wanted: &str) -> Vec<
     param_specs
         .iter()
         .filter_map(|spec| {
-            let (name, ty) = spec.split_once(':')?;
-            (ty == wanted && !name.is_empty()).then(|| name.to_string())
+            // Parse "name:type" the same way `filter_params` does (parts[0] /
+            // parts[1]) so the two never disagree on what was targeted.
+            let parts: Vec<&str> = spec.split(':').collect();
+            match parts.as_slice() {
+                [name, ty, ..] if *ty == wanted && !name.is_empty() => Some(name.to_string()),
+                _ => None,
+            }
         })
         .collect()
 }

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -194,7 +194,7 @@ async fn test_check_header_discovery_blanket_echo_skips_default_probes() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, reflection_params.clone(), semaphore).await;
+    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
 
     let params = reflection_params.lock().await.clone();
     let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
@@ -223,7 +223,7 @@ async fn test_check_header_discovery_blanket_echo_keeps_user_supplied_headers() 
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, reflection_params.clone(), semaphore).await;
+    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
 
     let params = reflection_params.lock().await.clone();
     assert!(
@@ -243,7 +243,7 @@ async fn test_check_header_discovery_discovers_reflected_header() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, reflection_params.clone(), semaphore).await;
+    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
 
     let params = reflection_params.lock().await.clone();
     assert!(
@@ -270,7 +270,7 @@ async fn test_check_cookie_discovery_single_cookie_branch() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_cookie_discovery(&target, reflection_params.clone(), semaphore).await;
+    check_cookie_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
 
     let params = reflection_params.lock().await.clone();
     assert_eq!(params.len(), 1);
@@ -292,12 +292,83 @@ async fn test_check_cookie_discovery_multiple_cookies_branch() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_cookie_discovery(&target, reflection_params.clone(), semaphore).await;
+    check_cookie_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
 
     let params = reflection_params.lock().await.clone();
     assert_eq!(params.len(), 2);
     assert!(params.iter().any(|p| p.name == "session"));
     assert!(params.iter().any(|p| p.name == "theme"));
+}
+
+#[tokio::test]
+async fn test_check_header_discovery_explicit_param_survives_skip_flag() {
+    // Regression: `-p Name:header` is an explicit injection point and must be
+    // probed even under `--skip-reflection-header`, which only disables the
+    // blanket common-header sweep — not operator-named headers.
+    let addr = start_discovery_mock_server().await;
+    let target = parse_target(&format!("http://{}/reflect?q=1", addr)).unwrap();
+    let mut args = default_scan_args();
+    args.skip_reflection_header = true;
+    args.param = vec!["X-Reflect-Me:header".to_string()];
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(Semaphore::new(1));
+    check_header_discovery(&target, &args, reflection_params.clone(), semaphore).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "X-Reflect-Me" && p.location == Location::Header),
+        "explicit -p X-Reflect-Me:header must be probed under --skip-reflection-header, got {:?}",
+        params.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_check_header_discovery_skip_flag_without_explicit_is_noop() {
+    // Control: with the sweep off and nothing explicit, no headers are probed.
+    let addr = start_discovery_mock_server().await;
+    let target = parse_target(&format!("http://{}/reflect?q=1", addr)).unwrap();
+    let mut args = default_scan_args();
+    args.skip_reflection_header = true;
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(Semaphore::new(1));
+    check_header_discovery(&target, &args, reflection_params.clone(), semaphore).await;
+    assert!(reflection_params.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_check_cookie_discovery_explicit_param_survives_skip_flag() {
+    // Regression: `-p name:cookie` is probed even under
+    // `--skip-reflection-cookie`; other supplied cookies stay suppressed.
+    let addr = start_discovery_mock_server().await;
+    let mut target = parse_target(&format!("http://{}/reflect", addr)).unwrap();
+    target
+        .cookies
+        .push(("session".to_string(), "abc".to_string()));
+    target
+        .cookies
+        .push(("theme".to_string(), "dark".to_string()));
+    target.delay = 1;
+    let mut args = default_scan_args();
+    args.skip_reflection_cookie = true;
+    args.param = vec!["session:cookie".to_string()];
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(Semaphore::new(1));
+    check_cookie_discovery(&target, &args, reflection_params.clone(), semaphore).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params.iter().any(|p| p.name == "session"),
+        "explicit -p session:cookie must be probed under --skip-reflection-cookie"
+    );
+    assert!(
+        !params.iter().any(|p| p.name == "theme"),
+        "non-explicit cookie must stay suppressed under --skip-reflection-cookie"
+    );
 }
 
 #[tokio::test]

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -194,7 +194,13 @@ async fn test_check_header_discovery_blanket_echo_skips_default_probes() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
+    check_header_discovery(
+        &target,
+        &default_scan_args(),
+        reflection_params.clone(),
+        semaphore,
+    )
+    .await;
 
     let params = reflection_params.lock().await.clone();
     let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
@@ -223,7 +229,13 @@ async fn test_check_header_discovery_blanket_echo_keeps_user_supplied_headers() 
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
+    check_header_discovery(
+        &target,
+        &default_scan_args(),
+        reflection_params.clone(),
+        semaphore,
+    )
+    .await;
 
     let params = reflection_params.lock().await.clone();
     assert!(
@@ -243,7 +255,13 @@ async fn test_check_header_discovery_discovers_reflected_header() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_header_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
+    check_header_discovery(
+        &target,
+        &default_scan_args(),
+        reflection_params.clone(),
+        semaphore,
+    )
+    .await;
 
     let params = reflection_params.lock().await.clone();
     assert!(
@@ -270,7 +288,13 @@ async fn test_check_cookie_discovery_single_cookie_branch() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_cookie_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
+    check_cookie_discovery(
+        &target,
+        &default_scan_args(),
+        reflection_params.clone(),
+        semaphore,
+    )
+    .await;
 
     let params = reflection_params.lock().await.clone();
     assert_eq!(params.len(), 1);
@@ -292,7 +316,13 @@ async fn test_check_cookie_discovery_multiple_cookies_branch() {
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(Semaphore::new(1));
-    check_cookie_discovery(&target, &default_scan_args(), reflection_params.clone(), semaphore).await;
+    check_cookie_discovery(
+        &target,
+        &default_scan_args(),
+        reflection_params.clone(),
+        semaphore,
+    )
+    .await;
 
     let params = reflection_params.lock().await.clone();
     assert_eq!(params.len(), 2);

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -1515,6 +1515,137 @@ pub async fn probe_json_body_params(
     }
 }
 
+/// Seed multipart form-field params the operator named via `-p name:multipart`.
+///
+/// Like [`probe_body_params`], these come from explicit `-d` input rather than
+/// discovery — without this, `MultipartBody` params were only ever seeded from
+/// HTML `<form enctype=multipart/form-data>` discovery, so `-p file:multipart`
+/// (a known multipart sink) had no entry point and was silently never tested.
+/// Sends a real `multipart/form-data` probe and seeds the field as a
+/// `MultipartBody` param when the marker reflects. No-op without both `-d` and
+/// at least one `-p :multipart` spec.
+pub async fn probe_multipart_params(
+    target: &Target,
+    args: &ScanArgs,
+    reflection_params: Arc<Mutex<Vec<Param>>>,
+    semaphore: Arc<Semaphore>,
+    pb: Option<ProgressBar>,
+) {
+    let Some(data) = &args.data else {
+        return;
+    };
+    let wanted =
+        crate::parameter_analysis::discovery::explicit_param_names(&args.param, "multipart");
+    if wanted.is_empty() {
+        return;
+    }
+
+    if let Some(ref pb) = pb {
+        pb.set_length(wanted.len() as u64);
+        pb.set_message("Probing multipart fields");
+    }
+
+    let pairs: Vec<(String, String)> = form_urlencoded::parse(data.as_bytes())
+        .map(|(k, v)| (k.to_string(), v.to_string()))
+        .collect();
+    let client = target.build_client_or_default();
+    let marker = crate::scanning::markers::bracketed_marker();
+    let silence = args.silence;
+
+    let mut handles: Vec<tokio::task::JoinHandle<Option<Param>>> = Vec::new();
+    for field in wanted {
+        // Skip only if this name is already registered *as a multipart field*.
+        // A same-named body/query param (e.g. `probe_body_params` seeding
+        // `file` from the same `-d`) must not block the multipart slot —
+        // `-p file:multipart` filters by location, so the body entry would be
+        // dropped and we'd be left with nothing.
+        let exists = reflection_params
+            .lock()
+            .await
+            .iter()
+            .any(|p| p.name == field && p.location == Location::MultipartBody);
+        if exists {
+            continue;
+        }
+
+        let client_clone = client.clone();
+        let url = target.url.clone();
+        let target_clone = Arc::new(target.clone());
+        let semaphore_clone = semaphore.clone();
+        let pairs_clone = pairs.clone();
+        let field_name = field.clone();
+
+        let handle = tokio::spawn(async move {
+            let permit = semaphore_clone
+                .acquire()
+                .await
+                .expect("acquire semaphore permit");
+            let mut form = reqwest::multipart::Form::new();
+            let mut placed = false;
+            for (k, v) in &pairs_clone {
+                if *k == field_name {
+                    form = form.text(k.clone(), marker.to_string());
+                    placed = true;
+                } else {
+                    form = form.text(k.clone(), v.clone());
+                }
+            }
+            if !placed {
+                form = form.text(field_name.clone(), marker.to_string());
+            }
+
+            let request = crate::utils::build_request(
+                &client_clone,
+                &target_clone,
+                reqwest::Method::POST,
+                url,
+                None,
+            )
+            .multipart(form);
+            crate::tick_request_count();
+
+            let mut discovered: Option<Param> = None;
+            if let Ok(r) = request.send().await
+                && let Ok(text) = r.text().await
+                && crate::scanning::markers::classify_probe_reflection(&text).detected()
+            {
+                let context = detect_injection_context(&text);
+                let (valid, invalid) = crate::parameter_analysis::classify_special_chars(&text);
+                if !silence {
+                    eprintln!("Discovered multipart field: {}", field_name);
+                }
+                discovered = Some(Param {
+                    name: field_name,
+                    value: marker.to_string(),
+                    location: Location::MultipartBody,
+                    injection_context: Some(context),
+                    valid_specials: Some(valid),
+                    invalid_specials: Some(invalid),
+                    pre_encoding: None,
+                    pre_encoding_pipeline: None,
+                    wire_name: None,
+                    form_action_url: None,
+                    form_origin_url: None,
+                    framework_sink: None,
+                });
+            }
+            drop(permit);
+            discovered
+        });
+        handles.push(handle);
+    }
+
+    let mut batch: Vec<Param> = Vec::new();
+    for handle in handles {
+        if let Ok(Some(p)) = handle.await {
+            batch.push(p);
+        }
+    }
+    if !batch.is_empty() {
+        reflection_params.lock().await.extend(batch);
+    }
+}
+
 pub async fn mine_parameters(
     target: &mut Target,
     args: &ScanArgs,
@@ -1538,6 +1669,14 @@ pub async fn mine_parameters(
     )
     .await;
     probe_json_body_params(
+        target,
+        args,
+        reflection_params.clone(),
+        semaphore.clone(),
+        pb.clone(),
+    )
+    .await;
+    probe_multipart_params(
         target,
         args,
         reflection_params.clone(),

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -939,3 +939,108 @@ async fn test_mine_parameters_seeds_explicit_body_params_under_skip_mining_dict(
             .collect::<Vec<_>>()
     );
 }
+
+async fn reflect_raw_body_handler(body: axum::body::Bytes) -> Html<String> {
+    // Echo the raw request body. A multipart/form-data body carries each text
+    // field's value verbatim, so the probe marker shows up in the response.
+    Html(format!(
+        "<html><body>{}</body></html>",
+        String::from_utf8_lossy(&body)
+    ))
+}
+
+async fn start_raw_body_reflect_server() -> SocketAddr {
+    let app = Router::new().route("/r", axum::routing::post(reflect_raw_body_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+#[tokio::test]
+async fn test_probe_multipart_params_seeds_explicit_field() {
+    // `-p file:multipart` is a known multipart sink. Before, MultipartBody
+    // params were only seeded from discovered HTML forms, so this explicit
+    // injection point had no entry point. Now `-d` + `-p :multipart` seeds it.
+    let addr = start_raw_body_reflect_server().await;
+    let target =
+        parse_target(&format!("http://{}:{}/r", addr.ip(), addr.port())).expect("parse target");
+    let mut args = default_scan_args();
+    args.method = "POST".to_string();
+    args.data = Some("file=a&other=b".to_string());
+    args.param = vec!["file:multipart".to_string()];
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_multipart_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "file" && p.location == Location::MultipartBody),
+        "explicit -p file:multipart must seed a MultipartBody param, got {:?}",
+        params
+            .iter()
+            .map(|p| (&p.name, &p.location))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_probe_multipart_params_noop_without_multipart_spec() {
+    // Multipart is opt-in: with `-d` but no `-p :multipart`, this is a no-op
+    // (we don't re-send every body as multipart).
+    let target = parse_target("http://127.0.0.1:1").expect("parse target");
+    let mut args = default_scan_args();
+    args.data = Some("file=a".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(1));
+    probe_multipart_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+    assert!(reflection_params.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_mine_parameters_multipart_survives_same_named_body_param() {
+    // `-d file=a -p file:multipart`: `probe_body_params` seeds `file` as a Body
+    // param from the same `-d`, but the multipart slot must still be seeded —
+    // otherwise the `-p file:multipart` location filter drops the Body entry
+    // and nothing is left to scan.
+    let addr = start_raw_body_reflect_server().await;
+    let mut target =
+        parse_target(&format!("http://{}:{}/r", addr.ip(), addr.port())).expect("parse target");
+    let mut args = default_scan_args();
+    args.skip_mining = true;
+    args.method = "POST".to_string();
+    args.data = Some("file=a".to_string());
+    args.param = vec!["file:multipart".to_string()];
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    mine_parameters(
+        &mut target,
+        &args,
+        reflection_params.clone(),
+        semaphore,
+        None,
+    )
+    .await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "file" && p.location == Location::MultipartBody),
+        "multipart slot for `file` must be seeded even when a Body `file` exists, got {:?}",
+        params
+            .iter()
+            .map(|p| (&p.name, &p.location))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Follow-up to #1044. Same bug class — *a flag meant to skip **discovery** also suppresses an injection point the user named explicitly via `-p`* — found in two more places, plus a missing entry point:

1. **`fix(scan)`** — `-p name:header` / `-p name:cookie` were silently dropped under `--skip-reflection-header` / `--skip-reflection-cookie`.
2. **`feat(scan)`** — `-p name:multipart` never had a seeding path at all (multipart fields were only ever discovered from HTML forms).

`-p` is a *filter* over discovered params (`filter_params`), so it can't resurrect a param no discovery/mining phase seeded. When a location's only entry point sits behind a skip flag, explicit targeting of it does nothing — exactly the #1044 body bug.

## 1. Header / cookie under `--skip-reflection-*`

`check_header_discovery` / `check_cookie_discovery` are the only seeders for those locations and are gated by the matching skip flag. Confirmed against XSSMaze:

```
-p Referer:header                          → detected
-p Referer:header --skip-mining            → detected   # mining flag: no effect
-p Referer:header --skip-reflection-header → NOT detected   ← bug (now fixed)
```

A custom header not in `COMMON_PROBE_HEADERS` was also never probed even *without* a skip flag — the fix covers that too.

**Fix:** headers/cookies named via `-p` are explicit injection points and are probed regardless of the skip flag; the flag now only governs the blanket common-header / all-supplied-cookies sweep. Default (flag-off) behavior is unchanged, and flag-on with nothing explicit stays a no-op.

## 2. Multipart field injection

`MultipartBody` params were only seeded from discovered `<form enctype=multipart/form-data>`. The scanning/verification paths for multipart already existed — only the seeding was missing — so `-p file:multipart` (field via `-d`) had no entry point. Added `probe_multipart_params` (mirrors `probe_body_params`): sends a real multipart probe per `-p :multipart` field and seeds on reflection, independent of mining flags. Opt-in, so non-multipart POSTs are unaffected. The slot is keyed by `(name, MultipartBody)` so a same-named Body param from the same `-d` doesn't block it.

Verified: `multipart/level1 -p filename:multipart` went NOT-detected → detected.

## Out of scope (documented, not fixed)
- `--skip-reflection-path` disables path testing, but path segments have only synthetic names (`path_segment_N`) — there's no explicit `-p` to honor, so the flag is the sole knob. Working as intended.

## Testing
- `cargo test --lib` — **1181 passed, 0 failed** (6 new regression tests: header/cookie explicit-survives-skip + no-op controls, multipart seed + no-op + body/multipart same-name collision).
- Live XSSMaze checks for each fix (header NO→YES under skip flag; multipart NO→YES); default-flag scans still detect (no regression).