### PR TITLE
fix(scan): always test explicit -p targets regardless of --skip-* flags

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -800,6 +800,10 @@ pub async fn analyze_parameters(
     }
     if !args.param.is_empty() {
         params = filter_params(params, &args.param, target);
+        // Discovery/mining may have been skipped for the location an explicit
+        // `-p name:type` targets; synthesize those so a named injection point
+        // is always tested regardless of `--skip-*` flags.
+        ensure_explicit_params(&mut params, &args.param, target);
     }
     target.reflection_params = params;
 
@@ -851,6 +855,28 @@ pub async fn analyze_parameters(
     }
 }
 
+/// The `-p name:<type>` label for a param's location, matching the `-p`
+/// spec grammar. `Location::Header` resolves to `"cookie"` when the name is one
+/// of the target's cookies, else `"header"`. Single source of truth shared by
+/// `filter_params` and `ensure_explicit_params`.
+fn param_type_label(p: &Param, target: &Target) -> &'static str {
+    match p.location {
+        Location::Query => "query",
+        Location::Body => "body",
+        Location::JsonBody => "json",
+        Location::MultipartBody => "multipart",
+        Location::Path => "path",
+        Location::Fragment => "fragment",
+        Location::Header => {
+            if target.cookies.iter().any(|(n, _)| n == &p.name) {
+                "cookie"
+            } else {
+                "header"
+            }
+        }
+    }
+}
+
 fn filter_params(params: Vec<Param>, param_specs: &[String], target: &Target) -> Vec<Param> {
     if param_specs.is_empty() {
         return params;
@@ -860,47 +886,72 @@ fn filter_params(params: Vec<Param>, param_specs: &[String], target: &Target) ->
         .into_iter()
         .filter(|p| {
             for spec in param_specs {
-                if spec.contains(':') {
-                    let parts: Vec<&str> = spec.split(':').collect();
-                    if parts.len() >= 2 {
-                        let name = parts[0];
-                        let type_str = parts[1];
-                        if p.name == name {
-                            let param_type = match p.location {
-                                Location::Query => "query",
-                                Location::Body => "body",
-                                Location::JsonBody => "json",
-                                Location::MultipartBody => "multipart",
-                                Location::Path => "path",
-                                Location::Fragment => "fragment",
-                                Location::Header => {
-                                    if target.cookies.iter().any(|(n, _)| n == &p.name) {
-                                        "cookie"
-                                    } else {
-                                        "header"
-                                    }
-                                }
-                            };
-                            if param_type == type_str {
-                                return true;
-                            }
-                        }
-                    } else {
-                        // Invalid format, treat as name only
-                        if p.name == *spec {
-                            return true;
-                        }
-                    }
-                } else {
-                    // 이름만 지정
-                    if p.name == *spec {
+                // "name:type" → match name + location; extra colons are ignored
+                // (parts[0]/parts[1]). A bare "name" matches any location.
+                let parts: Vec<&str> = spec.split(':').collect();
+                if parts.len() >= 2 {
+                    if p.name == parts[0] && param_type_label(p, target) == parts[1] {
                         return true;
                     }
+                } else if p.name == *spec {
+                    return true;
                 }
             }
             false
         })
         .collect()
+}
+
+/// Guarantee that every explicit `-p name:<type>` injection point is present
+/// in `params`, synthesizing any that discovery/mining did not seed.
+///
+/// `-p` is otherwise just a *filter* over discovered params, so a `--skip-*`
+/// flag that suppresses the phase which would have seeded a location silently
+/// drops the operator's explicit target (the #1044 / #1045 bug class). This is
+/// the general guard: a named target is always tested, whatever was skipped.
+///
+/// Synthesized params carry no `injection_context` (scanning then uses the
+/// context-agnostic fallback payloads) and no special-char profile (the active
+/// probing stage fills that in). `path` and `fragment` are excluded: path
+/// segments are positional (`path_segment_N`, not name-addressable) and
+/// fragments are never sent to the server, so neither can be seeded by name.
+fn ensure_explicit_params(params: &mut Vec<Param>, param_specs: &[String], target: &Target) {
+    for spec in param_specs {
+        // Parse "name:type" as parts[0]/parts[1] to match `filter_params`.
+        let parts: Vec<&str> = spec.split(':').collect();
+        let (name, type_str) = match parts.as_slice() {
+            [name, ty, ..] if !name.is_empty() => (*name, *ty),
+            _ => continue, // name-only → filtering, nothing to synthesize
+        };
+        let location = match type_str {
+            "query" => Location::Query,
+            "body" => Location::Body,
+            "json" => Location::JsonBody,
+            "multipart" => Location::MultipartBody,
+            "header" | "cookie" => Location::Header,
+            _ => continue,
+        };
+        let already = params
+            .iter()
+            .any(|p| p.name == name && param_type_label(p, target) == type_str);
+        if already {
+            continue;
+        }
+        params.push(Param {
+            name: name.to_string(),
+            value: String::new(),
+            location,
+            injection_context: None,
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: None,
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: None,
+            framework_sink: None,
+        });
+    }
 }
 
 #[cfg(test)]

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -766,6 +766,77 @@ fn test_filter_params_invalid_filter_format() {
     assert_eq!(filtered[0].name, "sort");
 }
 
+fn bare_param(name: &str, location: Location) -> Param {
+    Param {
+        name: name.to_string(),
+        value: String::new(),
+        location,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+    }
+}
+
+#[test]
+fn test_ensure_explicit_params_synthesizes_missing_targets() {
+    let target = parse_target("https://example.com/?present=1").unwrap();
+    // Discovery seeded only `present`; the other explicit targets were dropped
+    // (e.g. a --skip-* flag suppressed their phase).
+    let mut params = vec![bare_param("present", Location::Query)];
+    let specs = vec![
+        "present:query".to_string(),      // already seeded → not duplicated
+        "id:query".to_string(),           // synthesized
+        "X-Api-Token:header".to_string(), // synthesized
+        "sid:cookie".to_string(),         // synthesized (Header location)
+    ];
+    ensure_explicit_params(&mut params, &specs, &target);
+
+    assert_eq!(
+        params.iter().filter(|p| p.name == "present").count(),
+        1,
+        "existing target must not be duplicated"
+    );
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "id" && p.location == Location::Query)
+    );
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "X-Api-Token" && p.location == Location::Header)
+    );
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "sid" && p.location == Location::Header)
+    );
+}
+
+#[test]
+fn test_ensure_explicit_params_skips_unsynthesizable_specs() {
+    let target = parse_target("https://example.com").unwrap();
+    let mut params: Vec<Param> = vec![];
+    // name-only (ambiguous), path (positional), fragment (never scanned)
+    let specs = vec![
+        "foo".to_string(),
+        "seg:path".to_string(),
+        "h:fragment".to_string(),
+    ];
+    ensure_explicit_params(&mut params, &specs, &target);
+    assert!(
+        params.is_empty(),
+        "name-only / path / fragment specs must not be synthesized, got {:?}",
+        params.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+}
+
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
         input_type: "url".to_string(),


### PR DESCRIPTION
## Summary

Generalizes #1044 and #1045. We kept finding the same shape of bug: `-p name:type` is only a **filter** over discovered params (`filter_params`), so any `--skip-*` flag that suppresses the phase which would have *seeded* that location silently drops the operator's explicitly-named injection point.

Rather than patch each flag/location pair again, this adds one central guard.

## The remaining hole

`--skip-discovery` gates query/header/cookie/path seeding together, so it dropped explicit targets across the board — and even defeated the #1045 header/cookie fix (those functions run *inside* the `if !skip_discovery` block). Confirmed on XSSMaze:

```
?query=a                                   → detected
?query=a --skip-discovery -p query:query   → NOT detected   ← bug
header/level1 -p Referer:header --skip-discovery → NOT detected   ← bug
```

## Fix

A central guard in `analyze_parameters`, after discovery → mining → filtering:
synthesize any explicit `-p name:type` injection point that no phase seeded. The
synthesized param carries no `injection_context` (scanning falls back to the
context-agnostic payload set) and gets its special-char profile from the
existing active-probing stage — so it flows through the normal pipeline.

- Excludes `path` (positional `path_segment_N`, not name-addressable) and
  `fragment` (never sent to the server; already skipped in `run_scanning`).
- Factors the `-p` type label out of `filter_params` into `param_type_label`
  so the filter and the synthesizer can't drift.

After this, **no `--skip-*` flag can drop an explicit `-p` target** — the
general form of the previous two fixes.

## Verification (XSSMaze, live)

| invocation | before | after |
|---|---|---|
| `--skip-discovery -p query:query` | NOT detected | detected |
| `-p Referer:header --skip-discovery` | NOT detected | detected |
| `-p Referer:header --skip-reflection-header` (#1045) | detected | detected |
| `-X POST -p query:body -d .. --skip-mining` (#1044) | detected | detected |
| normal scan, no `-p` | detected | detected (no regression) |
| `--skip-discovery` with no `-p` | off | off (unchanged) |

## Testing
- `cargo test --lib` — **1183 passed, 0 failed** (2 new: synthesis seeds missing targets / doesn't duplicate existing; name-only + path + fragment are not synthesized).
- rustfmt + clippy clean.

## Out of scope (separate follow-up)
- Nested JSON body keys (`-p b:json` for `{"a":{"b":..}}`) are still not mined — `probe_json_body_params` only walks top-level keys and JsonBody substitution is flat. Deferred; needs recursive mining + nested-path substitution across mining/active-probe/check_reflection.