### PR TITLE
fix(docs): add alt to header logo image for accessibility

### DIFF
--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -29,7 +29,7 @@
           <span></span><span></span><span></span>
         </button>
         <a href="{{ base_url }}/" class="header-logo">
-          <img src="/images/logo_solo.webp" style="width: 30px;">
+          <img src="/images/logo_solo.webp" style="width: 30px;" alt="" aria-hidden="true">
           <span class="header-logo-text">DALFOX</span>
         </a>
         <nav class="header-nav">


### PR DESCRIPTION
## Summary

The docs header logo `<img>` had no `alt` attribute, which triggered the **"Image elements do not have `[alt]` attributes"** accessibility audit.

Since the visible **DALFOX** wordmark sits right next to the logo inside the same link, the image is redundant with adjacent text. Marked it decorative with `alt="" aria-hidden="true"` — this satisfies the audit and avoids a redundant "Dalfox logo DALFOX" screen-reader announcement, matching the existing decorative pattern at `content/index.md:233`.

## Verification

All rendered `<img>` elements in the docs now have `alt`:
- `templates/header.html` — logo, now `alt="" aria-hidden="true"` (this change)
- `templates/landing.html` — author avatar, `alt="hahwul"` (already present)
- `content/index.md` — contributors SVG, `alt="" aria-hidden="true"` (already present)

No JS-injected images exist (`static/js` checked). The `payloads.md` / `config.toml` `<img` hits are literal payload text and a comment, not rendered images.