### PR TITLE
docs(landing): add package-manager dropdown to hero install

### DIFF
--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -25,7 +25,21 @@ template = "landing"
           Star on GitHub
         </a>
       </div>
-      <div class="hero-install">
+      <div class="hero-install" data-install>
+        <div class="hero-install-pm">
+          <button class="hero-install-pm-btn" type="button" aria-haspopup="listbox" aria-expanded="false" aria-label="Choose install method">
+            <span class="hero-install-pm-label">brew</span>
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          <ul class="hero-install-pm-menu" role="listbox" aria-label="Install method">
+            <li role="option" class="is-selected" aria-selected="true" data-label="brew" data-cmd="brew install dalfox">Homebrew</li>
+            <li role="option" aria-selected="false" data-label="snap" data-cmd="sudo snap install dalfox">Snap</li>
+            <li role="option" aria-selected="false" data-label="aur" data-cmd="yay -S dalfox">Arch (AUR)</li>
+            <li role="option" aria-selected="false" data-label="nix" data-cmd="nix profile install github:hahwul/dalfox">Nix</li>
+            <li role="option" aria-selected="false" data-label="cargo" data-cmd="cargo install dalfox">Cargo</li>
+          </ul>
+        </div>
+        <span class="hero-install-sep" aria-hidden="true"></span>
         <span class="dollar">$</span>
         <code>brew install dalfox</code>
         <button class="hero-install-copy" type="button">copy</button>

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1450,6 +1450,91 @@ body:has(.docs-layout) .site-footer {
     border-color: var(--success);
 }
 
+/* Hero install — package-manager selector */
+.hero-install-pm {
+    position: relative;
+    flex-shrink: 0;
+}
+.hero-install-pm-btn {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.3rem;
+    background: none;
+    border: none;
+    padding: 0.1rem 0.1rem;
+    color: var(--accent);
+    font-family: inherit;
+    font-size: inherit;
+    cursor: pointer;
+    transition: color 0.15s;
+}
+.hero-install-pm-btn:hover {
+    color: var(--accent-hover);
+}
+.hero-install-pm-btn svg {
+    opacity: 0.75;
+    transition: transform 0.18s ease;
+}
+.hero-install-pm.open .hero-install-pm-btn svg {
+    transform: rotate(180deg);
+}
+.hero-install-sep {
+    align-self: stretch;
+    width: 1px;
+    margin: -0.2rem 0;
+    background: var(--ink-line);
+}
+.hero-install-pm-menu {
+    /* opens upward — the hero clips overflow, so a drop-down would be cut off */
+    position: absolute;
+    bottom: calc(100% + 0.55rem);
+    left: 0;
+    z-index: 30;
+    min-width: 160px;
+    margin: 0;
+    padding: 0.3rem;
+    list-style: none;
+    background: var(--bg-hover);
+    border: 1px solid var(--border-light);
+    border-radius: 7px;
+    box-shadow: 0 -12px 30px rgba(0, 0, 0, 0.45);
+    opacity: 0;
+    transform: translateY(4px);
+    pointer-events: none;
+    transition:
+        opacity 0.15s ease,
+        transform 0.15s ease;
+}
+.hero-install-pm.open .hero-install-pm-menu {
+    opacity: 1;
+    transform: translateY(0);
+    pointer-events: auto;
+}
+.hero-install-pm-menu li {
+    padding: 0.4rem 0.6rem;
+    border-radius: 4px;
+    color: var(--text-secondary);
+    font-size: 0.78rem;
+    white-space: nowrap;
+    cursor: pointer;
+    transition:
+        background 0.12s,
+        color 0.12s;
+}
+.hero-install-pm-menu li:hover {
+    background: var(--accent-dim);
+    color: var(--text-primary);
+}
+.hero-install-pm-menu li.is-selected {
+    color: var(--accent);
+}
+.hero-install-pm-menu li.is-selected::after {
+    content: "✓";
+    float: right;
+    margin-left: 1rem;
+    opacity: 0.8;
+}
+
 /* Hero terminal */
 .hero-visual {
     min-width: 0;

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -22,18 +22,50 @@
   </footer>
   <script>
     (function(){
-      var btn = document.querySelector('.hero-install-copy');
-      if (!btn) return;
-      btn.addEventListener('click', function(){
-        var code = document.querySelector('.hero-install code');
-        if (!code) return;
-        navigator.clipboard.writeText(code.textContent.trim()).then(function(){
-          btn.classList.add('copied');
-          var prev = btn.textContent;
-          btn.textContent = 'copied';
-          setTimeout(function(){ btn.classList.remove('copied'); btn.textContent = prev; }, 1500);
+      var wrap = document.querySelector('.hero-install');
+      if (!wrap) return;
+      var code = wrap.querySelector('code');
+
+      var copyBtn = wrap.querySelector('.hero-install-copy');
+      if (copyBtn && code) {
+        copyBtn.addEventListener('click', function(){
+          navigator.clipboard.writeText(code.textContent.trim()).then(function(){
+            copyBtn.classList.add('copied');
+            var prev = copyBtn.textContent;
+            copyBtn.textContent = 'copied';
+            setTimeout(function(){ copyBtn.classList.remove('copied'); copyBtn.textContent = prev; }, 1500);
+          });
         });
-      });
+      }
+
+      var pm = wrap.querySelector('.hero-install-pm');
+      if (pm && code) {
+        var btn = pm.querySelector('.hero-install-pm-btn');
+        var label = pm.querySelector('.hero-install-pm-label');
+        var options = pm.querySelectorAll('[role="option"]');
+
+        function close(){ pm.classList.remove('open'); btn.setAttribute('aria-expanded', 'false'); }
+
+        btn.addEventListener('click', function(e){
+          e.stopPropagation();
+          if (pm.classList.contains('open')) { close(); }
+          else { pm.classList.add('open'); btn.setAttribute('aria-expanded', 'true'); }
+        });
+
+        options.forEach(function(opt){
+          opt.addEventListener('click', function(){
+            options.forEach(function(o){ o.classList.remove('is-selected'); o.setAttribute('aria-selected', 'false'); });
+            opt.classList.add('is-selected');
+            opt.setAttribute('aria-selected', 'true');
+            code.textContent = opt.getAttribute('data-cmd');
+            if (label) { label.textContent = opt.getAttribute('data-label'); }
+            close();
+          });
+        });
+
+        document.addEventListener('click', function(e){ if (!pm.contains(e.target)) close(); });
+        document.addEventListener('keydown', function(e){ if (e.key === 'Escape') close(); });
+      }
     })();
   </script>
   {{ highlight_js }}


### PR DESCRIPTION
## Summary

The landing hero only advertised `brew install dalfox`. This adds a small package-manager selector so visitors can pick the installer that fits their platform, swapping the displayed command.

Methods (the single-command installers from the Installation guide):

| Item | Command |
|---|---|
| Homebrew (default) | `brew install dalfox` |
| Snap | `sudo snap install dalfox` |
| Arch (AUR) | `yay -S dalfox` |
| Nix | `nix profile install github:hahwul/dalfox` |
| Cargo | `cargo install dalfox` |

Selecting an option updates the `$` command and the selector label; the existing copy button still copies the current command.

## Notes

- The menu opens **upward** because `.hero` uses `overflow: hidden` (to clip the background illustration), which would otherwise cut off a drop-down. There's ample room above the install bar.
- Styling reuses existing dark / 東洋風 theme tokens (`--bg-hover`, `--ink-line`, `--accent`); selected item is marked with a ✓.
- Degrades gracefully without JS (default `brew install dalfox` stays visible).

## Test plan

- [x] `hwaro build` passes; markup renders without stray `<p>` wrapping
- [x] Verified default / open / selected states via headless Chrome
- [x] Selecting Cargo updates command to `cargo install dalfox`, label to `cargo`, and closes the menu