### PR TITLE
style(docs): refine buttons with outline→fill primary, drop gradients

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1364,26 +1364,34 @@ body:has(.docs-layout) .site-footer {
     font-weight: 600;
     text-decoration: none;
     transition:
-        transform 0.15s,
-        background 0.15s,
-        border-color 0.15s,
-        box-shadow 0.15s;
+        transform 0.15s ease,
+        background 0.15s ease,
+        color 0.15s ease,
+        border-color 0.15s ease,
+        box-shadow 0.15s ease;
     border: 1px solid transparent;
     cursor: pointer;
     font-family: inherit;
 }
+.btn:focus-visible {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+.btn:active {
+    transform: translateY(0);
+}
+/* Outline → fill: clean accent edge at rest, floods periwinkle on hover */
 .btn-primary {
-    background: linear-gradient(180deg, var(--brand-3) 0%, var(--brand) 100%);
-    color: #fff;
-    box-shadow:
-        0 6px 20px rgba(48, 54, 94, 0.45),
-        inset 0 1px 0 rgba(255, 255, 255, 0.12);
+    background: transparent;
+    color: var(--accent);
+    border-color: var(--accent);
 }
 .btn-primary:hover {
+    background: var(--accent);
+    color: var(--bg-content);
+    border-color: var(--accent);
     transform: translateY(-1px);
-    box-shadow:
-        0 10px 26px rgba(48, 54, 94, 0.55),
-        inset 0 1px 0 rgba(255, 255, 255, 0.18);
+    box-shadow: 0 6px 18px rgba(139, 148, 232, 0.3);
 }
 .btn-secondary {
     background: var(--bg-surface);
@@ -1391,8 +1399,9 @@ body:has(.docs-layout) .site-footer {
     border-color: var(--border-light);
 }
 .btn-secondary:hover {
-    border-color: var(--brand-3);
+    border-color: var(--accent);
     background: var(--bg-hover);
+    transform: translateY(-1px);
 }
 .btn-ghost {
     background: transparent;


### PR DESCRIPTION
## Summary
Removes the gradient-based button styling in the docs site and replaces it with a clean, flat **outline → fill** treatment that better matches the inky periwinkle theme.

### `btn-primary`
- Drops the `linear-gradient` + heavy brand-glow shadow
- **Rest:** transparent background with an accent (`#8b94e8`) border and text — restrained, on-theme
- **Hover:** floods with the periwinkle accent and switches to ink-dark text (`--bg-content`), with a subtle lift and soft glow

### Across all buttons
- New `:focus-visible` accent ring (accessibility) and `:active` press reset
- `color` added to the `.btn` transition so the fill animates smoothly
- `btn-secondary` hover border unified to `--accent` + matching subtle lift

Button hierarchy is now clearer: **primary is the only colored button**, secondary uses a neutral border, ghost stays borderless.

Verified locally with `hwaro build` + `hwaro serve`; checked both the rest and hover render of the hero CTA.