### PR TITLE
style(landing): show hero illustration full-bleed on narrow screens

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -2235,11 +2235,37 @@ body:has(.docs-layout) .site-footer {
         grid-template-columns: 1fr;
         gap: 2.5rem;
     }
-    /* Hide the full illustration treatment below 1024px.
-       The rich "cover the headline" version only makes sense in true two-column desktop.
-       In the awkward intermediate sizes it ends up looking isolated in the middle. */
+    /* Below 1024px the layout collapses to a single column, so the rich
+       "cover the headline from the right" treatment no longer fits. Instead of
+       hiding the scene, switch it to a full-bleed cover that fills the whole
+       hero — bleeding past every edge so no rectangular border of the webp is
+       ever visible — and fade it with a soft vertical mask so the headline and
+       copy stay readable on top. */
     .hero-illustration {
-        display: none;
+        display: block;
+        background-position: center 30%;
+        background-size: cover;
+        opacity: 0.16;
+        mask-image: linear-gradient(
+            to bottom,
+            transparent 0%,
+            rgba(0, 0, 0, 0.45) 20%,
+            black 48%,
+            black 74%,
+            rgba(0, 0, 0, 0.35) 92%,
+            transparent 100%
+        );
+        -webkit-mask-image: linear-gradient(
+            to bottom,
+            transparent 0%,
+            rgba(0, 0, 0, 0.45) 20%,
+            black 48%,
+            black 74%,
+            rgba(0, 0, 0, 0.35) 92%,
+            transparent 100%
+        );
+        mask-composite: add;
+        -webkit-mask-composite: source-over;
     }
     .features-grid {
         grid-template-columns: repeat(2, 1fr);


### PR DESCRIPTION
## Summary

On the docs landing page, the hero illustration (`illust.webp`) was hidden entirely below 1024px (`.hero-illustration { display: none }`), because the desktop "cover the headline from the right" treatment only fits the two-column layout.

This change keeps the scene visible on narrow screens by switching it to a **full-bleed cover** that fills the whole hero and bleeds past every edge — so no rectangular border of the webp is ever visible — with a soft vertical mask so the headline and copy stay readable on top.

## Changes

- `docs/static/css/style.css` — in the `@media (max-width: 1024px)` block, replace `display: none` for `.hero-illustration` with `display: block` + `background-size: cover` + a vertical fade mask (`opacity: 0.16`).

## Notes

- Pure CSS / responsive-only change; desktop (≥1024px) treatment is untouched.
- 768px / 480px blocks inherit this rule (no longer re-hidden).