### PR TITLE
feat(scan): animate spinner & progress with metallic shimmer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -502,6 +502,7 @@ dependencies = [
  "base64",
  "chrono",
  "clap",
+ "console",
  "hex",
  "indicatif",
  "oxc_allocator",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }
 serde_json = "1.0"
 indicatif = "0.18"
+console = "0.16"
 urlencoding = "2.1"
 base64 = "0.22"
 chrono = "0.4"

--- a/src/cmd/scan/logging.rs
+++ b/src/cmd/scan/logging.rs
@@ -45,6 +45,14 @@ pub(crate) fn log_dbg(msg: &str) {
 /// The carriage-return + erase-line redraw pattern is only useful on a real
 /// terminal; in a log file it leaves `\r⠋ preflight: ...\r⠙` strings — hence
 /// the `spinner_allowed` gate the caller computes once from stdout-is-tty.
+///
+/// The label is painted with the shared metallic [`shimmer`] (a bright band
+/// sweeping across silver text) and led by an accent-colored spinner glyph.
+/// Each frame is truncated to the live terminal width and terminated with
+/// `\x1b[K` (erase-to-end-of-line), so a long URL can never wrap onto a
+/// second row — wrapping would desync the `\r` redraw and strand debris.
+///
+/// [`shimmer`]: crate::utils::shimmer
 pub(crate) fn start_spinner(
     spinner_allowed: bool,
     enabled: bool,
@@ -56,17 +64,23 @@ pub(crate) fn start_spinner(
     let (tx, mut rx) = oneshot::channel::<()>();
     let (done_tx, done_rx) = oneshot::channel::<()>();
     tokio::spawn(async move {
-        let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-        let mut i = 0usize;
+        use crate::utils::shimmer;
+        let mut phase = 0usize;
         loop {
+            // Reserve 2 columns for the glyph + its trailing space; truncate
+            // the label (display-width aware, with an ellipsis) so the whole
+            // line fits on one row. `\x1b[K` clears any leftover from a
+            // previous, longer frame without a full-line repaint flicker.
+            let budget = crate::utils::term::term_cols().saturating_sub(2).max(8);
+            let visible = console::truncate_str(&label, budget, "…");
             crate::cprint!(
-                "\r\x1b[38;5;247m{} {}\x1b[0m",
-                frames[i % frames.len()],
-                label
+                "\r{} {}\x1b[K",
+                shimmer::spin_glyph(phase),
+                shimmer::shimmer(visible.as_ref(), phase)
             );
             let _ = io::stdout().flush();
             tokio::select! {
-                _ = tokio::time::sleep(Duration::from_millis(80)) => {},
+                _ = tokio::time::sleep(Duration::from_millis(shimmer::FRAME_MS as u64)) => {},
                 _ = &mut rx => {
                     crate::cprint!("\r\x1b[2K\r");
                     let _ = io::stdout().flush();
@@ -74,7 +88,7 @@ pub(crate) fn start_spinner(
                     break;
                 }
             }
-            i = (i + 1) % frames.len();
+            phase = phase.wrapping_add(1);
         }
     });
     Some((tx, done_rx))

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -385,23 +385,28 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         let (tx, mut rx) = oneshot::channel::<()>();
         let (done_tx, done_rx) = oneshot::channel::<()>();
         tokio::spawn(async move {
-            let frames = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
-            let mut i = 0usize;
+            use crate::utils::shimmer;
+            let mut phase = 0usize;
             loop {
                 let done = overall_done_clone.load(Ordering::Relaxed);
                 let percent = (done * 100) / std::cmp::max(1, total_targets_copy);
                 let findings = findings_count_clone.load(Ordering::Relaxed);
+                let text = format!(
+                    "overall  {done}/{total_targets_copy} targets · {percent}% · {findings} findings"
+                );
+                // Truncate to the terminal width (reserving the glyph + space)
+                // and clear to EOL so the metallic line never wraps onto a
+                // second row, which would desync the `\r` redraw.
+                let budget = crate::utils::term::term_cols().saturating_sub(2).max(8);
+                let visible = console::truncate_str(&text, budget, "…");
                 crate::cprint!(
-                    "\r\x1b[38;5;247m{} overall: targets={}  done={}  progress={}%  findings={}\x1b[0m",
-                    frames[i % frames.len()],
-                    total_targets_copy,
-                    done,
-                    percent,
-                    findings
+                    "\r{} {}\x1b[K",
+                    shimmer::spin_glyph(phase),
+                    shimmer::shimmer(visible.as_ref(), phase)
                 );
                 let _ = io::stdout().flush();
                 tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_millis(120)) => {},
+                    _ = tokio::time::sleep(Duration::from_millis(shimmer::FRAME_MS as u64)) => {},
                     _ = &mut rx => {
                         // clear the line and exit
                         crate::cprint!("\r\x1b[2K\r");
@@ -410,7 +415,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
                         break;
                     }
                 }
-                i = (i + 1) % frames.len();
+                phase = phase.wrapping_add(1);
             }
         });
         Some((tx, done_rx))

--- a/src/cmd/scan/scan_loop.rs
+++ b/src/cmd/scan/scan_loop.rs
@@ -140,15 +140,25 @@ pub(crate) async fn run_scan_loop(
                 let req_start = crate::REQUEST_COUNT.load(Ordering::Relaxed);
                 pb.set_style(
                     indicatif::ProgressStyle::default_bar()
-                        .template("{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({req_per_sec}, ETA {eta}) Overall scanning")
+                        .template("{spinner:.cyan} [{elapsed_precise}] [{bar:28.45/238}] {pos:>5}/{len:5} · {req_per_sec} · {wave}")
                         .expect("valid progress bar template")
+                        .tick_chars(crate::utils::shimmer::TICK_CHARS)
                         .with_key(
                             "req_per_sec",
                             crate::scanning::req_per_sec_tracker(req_start),
                         )
-                        .progress_chars("#>-"),
+                        .with_key(
+                            "wave",
+                            crate::utils::shimmer::wave_tracker(
+                                "Overall scanning".to_string(),
+                                crate::utils::shimmer::BAR_WAVE_RESERVE,
+                            ),
+                        )
+                        .progress_chars("█▉▊▋▌▍▎▏░"),
                 );
-                pb.enable_steady_tick(Duration::from_millis(120));
+                pb.enable_steady_tick(Duration::from_millis(
+                    crate::utils::shimmer::FRAME_MS as u64,
+                ));
                 Some(Arc::new(pb))
             } else {
                 None
@@ -259,7 +269,11 @@ pub(crate) async fn run_scan_loop(
             }
 
             if let Some(pb) = overall_pb {
-                pb.finish_with_message(format!("All scanning completed for {}", host));
+                crate::scanning::finish_scan_bar(
+                    &pb,
+                    console::style("✓").green().to_string(),
+                    format!("All scanning completed for {}", host),
+                );
             }
         });
         group_handles.push(group_handle);

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -20,7 +20,7 @@ use crate::cmd::scan::ScanArgs;
 use crate::parameter_analysis::{DelimiterType, InjectionContext, Location, Param};
 use crate::payload::mining::GF_PATTERNS_PARAMS;
 use crate::target_parser::Target;
-use indicatif::ProgressBar;
+use crate::utils::shimmer::ShimmerSpinner;
 use scraper;
 use std::sync::Arc;
 
@@ -457,7 +457,7 @@ pub async fn probe_dictionary_params(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
@@ -810,7 +810,7 @@ pub async fn probe_body_params(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
@@ -1025,7 +1025,7 @@ pub async fn probe_response_id_params(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
@@ -1280,7 +1280,7 @@ pub async fn probe_json_body_params(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
@@ -1529,7 +1529,7 @@ pub async fn probe_multipart_params(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     let Some(data) = &args.data else {
         return;
@@ -1651,7 +1651,7 @@ pub async fn mine_parameters(
     args: &ScanArgs,
     reflection_params: Arc<Mutex<Vec<Param>>>,
     semaphore: Arc<Semaphore>,
-    pb: Option<ProgressBar>,
+    pb: Option<ShimmerSpinner>,
 ) {
     // Body/JSON parameters supplied via `-d` are explicit user input, not
     // discovery. Seed them independent of the mining flags: query params are

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -756,14 +756,30 @@ pub async fn analyze_parameters(
     multi_pb: Option<Arc<MultiProgress>>,
 ) {
     let pb = if let Some(ref mp) = multi_pb {
-        let pb = mp.add(ProgressBar::new_spinner());
-        pb.set_style(
+        let bar = mp.add(ProgressBar::new_spinner());
+        // The message changes as mining moves between sources, and indicatif
+        // can't feed the live `{msg}` to a custom key, so the text lives in a
+        // shared cell that `{wave}` shimmers and `ShimmerSpinner::set_message`
+        // updates. Reserve 2 cols (glyph + space) so a long URL truncates
+        // instead of wrapping. The steady tick advances the shimmer.
+        let label = std::sync::Arc::new(std::sync::Mutex::new(format!(
+            "Analyzing parameters for {}",
+            target.url
+        )));
+        bar.set_style(
             ProgressStyle::default_spinner()
-                .template("{spinner:.green} {msg}")
-                .expect("valid progress style template"),
+                .template("{spinner:.cyan} {wave}")
+                .expect("valid progress style template")
+                .tick_chars(crate::utils::shimmer::TICK_CHARS)
+                .with_key(
+                    "wave",
+                    crate::utils::shimmer::wave_tracker_shared(label.clone(), 2),
+                ),
         );
-        pb.set_message(format!("Analyzing parameters for {}", target.url));
-        Some(pb)
+        bar.enable_steady_tick(std::time::Duration::from_millis(
+            crate::utils::shimmer::FRAME_MS as u64,
+        ));
+        Some(crate::utils::shimmer::ShimmerSpinner::new(bar, label))
     } else {
         None
     };
@@ -851,7 +867,11 @@ pub async fn analyze_parameters(
     }
 
     if let Some(pb) = pb {
-        pb.finish_with_message(format!("Completed analyzing parameters for {}", target.url));
+        crate::scanning::finish_scan_bar(
+            pb.bar(),
+            console::style("✓").green().to_string(),
+            format!("Completed analyzing parameters for {}", target.url),
+        );
     }
 }
 

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -951,6 +951,14 @@ fn build_scan_progress_bar(
 /// a status glyph (green `✓` / yellow `⚠`), the elapsed time, then the final
 /// message — replacing the wave rather than printing alongside it.
 pub(crate) fn finish_scan_bar(pb: &ProgressBar, prefix: String, msg: String) {
+    // Keep the completion line on one row too. The finished template is
+    // `{prefix} [elapsed] {msg}` — ~13 cols of furniture before `{msg}` — so
+    // trim the message to the leftover stderr width. It's a one-shot render
+    // (no `\r` redraw), but a wrapped completion line still reads ragged.
+    let avail = crate::utils::term::term_cols_stderr()
+        .saturating_sub(14)
+        .max(8);
+    let msg = console::truncate_str(&msg, avail, "…").into_owned();
     // Set the prefix + message *before* swapping the style: the in-progress
     // template ignores both slots, so this stays invisible until the style
     // swap, which then renders the final line in one shot. Doing it the other

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -914,19 +914,55 @@ fn build_scan_progress_bar(
     // found, payload skipped), which inflated the rate (e.g. 11.5k/s on
     // a 5k-payload scan that finished in 0.4s). See req_per_sec_tracker
     // for the displayed semantics and caveats.
+    //
+    // The trailing `{wave}` paints "Scanning <url>" with the shared metallic
+    // shimmer, re-evaluated on every steady tick from the bar's elapsed time
+    // (no extra timer task). `finish_scan_bar` swaps in a `{msg}` style at the
+    // end so the completion line replaces the wave instead of duplicating it.
     let req_start = crate::REQUEST_COUNT.load(Ordering::Relaxed);
     pb.set_style(
         ProgressStyle::default_bar()
             .template(
-                "{spinner:.green} [{elapsed_precise}] [{bar:40.cyan/blue}] {pos:>7}/{len:7} ({req_per_sec}, ETA {eta}) {msg}",
+                "{spinner:.cyan} [{elapsed_precise}] [{bar:28.45/238}] {pos:>5}/{len:5} · {req_per_sec} · {wave}",
             )
             .expect("valid progress bar template")
+            .tick_chars(crate::utils::shimmer::TICK_CHARS)
             .with_key("req_per_sec", req_per_sec_tracker(req_start))
-            .progress_chars("#>-"),
+            .with_key(
+                "wave",
+                crate::utils::shimmer::wave_tracker(
+                    format!("Scanning {}", target.url),
+                    crate::utils::shimmer::BAR_WAVE_RESERVE,
+                ),
+            )
+            .progress_chars("█▉▊▋▌▍▎▏░"),
     );
-    pb.enable_steady_tick(Duration::from_millis(120));
-    pb.set_message(format!("Scanning {}", target.url));
+    pb.enable_steady_tick(Duration::from_millis(
+        crate::utils::shimmer::FRAME_MS as u64,
+    ));
     Some(pb)
+}
+
+/// Render `pb` in its terminal "done" state and stop it.
+///
+/// The in-progress style paints the label through a `{wave}` shimmer and has
+/// no `{msg}` slot, so a plain `finish_with_message` would never show the
+/// completion text. Swap in a compact `{prefix} [elapsed] {msg}` style first:
+/// a status glyph (green `✓` / yellow `⚠`), the elapsed time, then the final
+/// message — replacing the wave rather than printing alongside it.
+pub(crate) fn finish_scan_bar(pb: &ProgressBar, prefix: String, msg: String) {
+    // Set the prefix + message *before* swapping the style: the in-progress
+    // template ignores both slots, so this stays invisible until the style
+    // swap, which then renders the final line in one shot. Doing it the other
+    // way round flashes a `✓ [elapsed]` frame with an empty message first.
+    pb.set_prefix(prefix);
+    pb.set_message(msg);
+    pb.set_style(
+        ProgressStyle::default_bar()
+            .template("{prefix} [{elapsed_precise}] {msg}")
+            .expect("valid finish template"),
+    );
+    pb.finish();
 }
 
 /// Log WAF block statistics gathered during the scan (debug builds only).
@@ -1656,7 +1692,11 @@ pub async fn run_scanning(
         // Check cancellation before spawning next param task
         if ctx.cancelled() {
             if let Some(ref pb) = pb {
-                pb.finish_with_message(format!("Cancelled scanning {}", target.url));
+                finish_scan_bar(
+                    pb,
+                    console::style("⚠").yellow().to_string(),
+                    format!("Cancelled scanning {}", target.url),
+                );
             }
             break;
         }
@@ -1672,7 +1712,11 @@ pub async fn run_scanning(
         // Early stop if global limit reached
         if ctx.limit_reached() {
             if let Some(ref pb) = pb {
-                pb.finish_with_message(format!("Completed scanning {}", target.url));
+                finish_scan_bar(
+                    pb,
+                    console::style("✓").green().to_string(),
+                    format!("Completed scanning {}", target.url),
+                );
             }
             return;
         }
@@ -1699,7 +1743,11 @@ pub async fn run_scanning(
     collapse_target_results(&results, &findings_count, target).await;
 
     if let Some(pb) = pb {
-        pb.finish_with_message(format!("Completed scanning {}", target.url));
+        finish_scan_bar(
+            &pb,
+            console::style("✓").green().to_string(),
+            format!("Completed scanning {}", target.url),
+        );
     }
 }
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -9,6 +9,7 @@ pub mod banner;
 pub mod fs;
 pub mod http;
 pub mod scan_id;
+pub mod shimmer;
 pub mod term;
 
 // Re-export banner helpers at `crate::utils::*`

--- a/src/utils/shimmer.rs
+++ b/src/utils/shimmer.rs
@@ -151,7 +151,8 @@ pub fn wave_tracker(
 ) -> impl Fn(&indicatif::ProgressState, &mut dyn std::fmt::Write) + Send + Sync + Clone + 'static {
     move |state, w| {
         let phase = (state.elapsed().as_millis() / FRAME_MS) as usize;
-        let avail = crate::utils::term::term_cols()
+        // indicatif draws to stderr, so measure stderr (see `term_cols_stderr`).
+        let avail = crate::utils::term::term_cols_stderr()
             .saturating_sub(reserve)
             .max(6);
         let shown = console::truncate_str(&label, avail, "…");
@@ -172,7 +173,8 @@ pub fn wave_tracker_shared(
     move |state, w| {
         let phase = (state.elapsed().as_millis() / FRAME_MS) as usize;
         let text = label.lock().map(|g| g.clone()).unwrap_or_default();
-        let avail = crate::utils::term::term_cols()
+        // indicatif draws to stderr, so measure stderr (see `term_cols_stderr`).
+        let avail = crate::utils::term::term_cols_stderr()
             .saturating_sub(reserve)
             .max(6);
         let shown = console::truncate_str(&text, avail, "…");
@@ -287,6 +289,23 @@ mod tests {
         for phase in 0..40 {
             assert_eq!(crate::utils::term::strip_ansi(&shimmer(text, phase)), text);
         }
+    }
+
+    #[test]
+    fn shimmer_spinner_set_message_updates_shared_cell() {
+        // The whole analyzer-shimmer feature rests on `set_message` writing
+        // through to the cell that `{wave}` reads. `ProgressBar::hidden()`
+        // needs no TTY, so this stays a pure unit test.
+        let sp = ShimmerSpinner::new(
+            indicatif::ProgressBar::hidden(),
+            Arc::new(Mutex::new("Analyzing…".to_string())),
+        );
+        assert_eq!(&*sp.label_cell().lock().unwrap(), "Analyzing…");
+        sp.set_message("Mining dictionary parameters");
+        assert_eq!(
+            &*sp.label_cell().lock().unwrap(),
+            "Mining dictionary parameters"
+        );
     }
 
     #[test]

--- a/src/utils/shimmer.rs
+++ b/src/utils/shimmer.rs
@@ -1,0 +1,301 @@
+//! Animated "metallic shimmer" text coloring plus the shared spinner glyph
+//! palette.
+//!
+//! The shimmer paints text in a 256-color grayscale ramp with a bright
+//! highlight band that sweeps left→right and loops — like light traveling
+//! across brushed metal. Every live indicator (the hand-rolled scan spinner,
+//! the multi-target overall ticker, and the indicatif progress messages)
+//! pulls its glyph and its text coloring from here so the whole CLI animates
+//! with one consistent look.
+//!
+//! All coloring honors the global `--no-color` / `NO_COLOR` toggle: when
+//! color is disabled every helper returns the input text verbatim, and the
+//! `cprint!` family additionally strips any escape that slips through.
+
+use std::fmt::Write as _;
+use std::sync::{Arc, Mutex};
+
+/// Smooth 10-frame braille spinner. Shared by the hand-rolled spinner
+/// (`start_spinner`, the overall ticker) and the indicatif bars (as
+/// `tick_chars`) so every spinner in the app rotates identically.
+pub const SPIN_FRAMES: [&str; 10] = ["⠋", "⠙", "⠹", "⠸", "⠼", "⠴", "⠦", "⠧", "⠇", "⠏"];
+
+/// `tick_chars` string for indicatif bars: the 10 running frames followed by
+/// the finished frame (indicatif shows the last entry once a bar completes).
+pub const TICK_CHARS: &str = "⠋⠙⠹⠸⠼⠴⠦⠧⠇⠏✓";
+
+/// Safe upper bound (in columns) of the fixed furniture on the shared scan-bar
+/// template — everything before the trailing `{wave}`: spinner, `[elapsed]`,
+/// `[bar:28]`, `pos/len`, and the `· req/s ·`. Passed to [`wave_tracker`] as
+/// the `reserve` so the shimmering target label is trimmed to the leftover
+/// width and the bar stays on one line (fits standard 80-column terminals).
+/// Keep this in sync (a little high) if the bar template changes width.
+pub const BAR_WAVE_RESERVE: usize = 80;
+
+/// Accent color (xterm-256) for the spinner glyph — a bright steel cyan that
+/// reads as "active" against the silver shimmer text.
+const ACCENT: u8 = 45;
+
+/// Milliseconds per animation frame. Used to derive a frame counter from a
+/// bar's elapsed time so the indicatif shimmer advances at the same cadence
+/// as the hand-rolled spinner's steady tick.
+pub const FRAME_MS: u128 = 80;
+
+/// Per-frame advance of the highlight band, in character cells. A touch
+/// faster than one cell so the shine visibly travels.
+const SWEEP_SPEED: f64 = 1.5;
+/// Half-width of the highlight band, in cells.
+const BAND_HALF: f64 = 4.5;
+/// Resting (base) brightness along the gray ramp, 0.0..=1.0. The band rises
+/// from here to full white at its center.
+const BASE_LEVEL: f64 = 0.42;
+/// Padding past each end so the band fully exits before the sweep loops.
+const SWEEP_PAD: f64 = BAND_HALF + 2.0;
+
+/// xterm-256 grayscale ramp endpoints: 232 (near-black) … 255 (near-white).
+const GRAY_MIN: u8 = 232;
+const GRAY_MAX: u8 = 255;
+
+/// Smoothstep easing for a soft band edge (no hard cutoff at the rim).
+#[inline]
+fn smoothstep(t: f64) -> f64 {
+    let t = t.clamp(0.0, 1.0);
+    t * t * (3.0 - 2.0 * t)
+}
+
+/// Map a 0.0..=1.0 brightness to an xterm-256 grayscale code.
+#[inline]
+fn gray_code(level: f64) -> u8 {
+    let span = (GRAY_MAX - GRAY_MIN) as f64;
+    GRAY_MIN + (level.clamp(0.0, 1.0) * span).round() as u8
+}
+
+/// Brightness (0..1) of the cell at `idx` given the highlight centered at
+/// `head`. Cells inside the band ramp up toward full white; cells outside
+/// sit at the resting base level.
+#[inline]
+fn cell_level(idx: f64, head: f64) -> f64 {
+    let dist = (idx - head).abs();
+    let t = (1.0 - dist / BAND_HALF).max(0.0);
+    BASE_LEVEL + (1.0 - BASE_LEVEL) * smoothstep(t)
+}
+
+/// Paint `text` with the highlight band centered at cell `head`. Runs of
+/// equal color are coalesced into a single escape (one `\x1b[38;5;Nm` per
+/// color change, not per character) so the rendered line stays compact.
+///
+/// Returns `text` unchanged when color output is disabled.
+pub fn shimmer_at(text: &str, head: f64) -> String {
+    if !crate::utils::term::color_enabled() {
+        return text.to_string();
+    }
+    let mut out = String::with_capacity(text.len() + 24);
+    let mut cur: Option<u8> = None;
+    for (i, ch) in text.chars().enumerate() {
+        let code = gray_code(cell_level(i as f64, head));
+        if cur != Some(code) {
+            let _ = write!(out, "\x1b[38;5;{code}m");
+            cur = Some(code);
+        }
+        out.push(ch);
+    }
+    if cur.is_some() {
+        out.push_str("\x1b[0m");
+    }
+    out
+}
+
+/// Paint `text` for animation frame `phase`. The highlight sweeps left→right
+/// and loops; `phase` is a monotonically increasing frame counter. Returns
+/// `text` unchanged when color output is disabled or the text is empty.
+pub fn shimmer(text: &str, phase: usize) -> String {
+    let n = text.chars().count();
+    if n == 0 {
+        return String::new();
+    }
+    if !crate::utils::term::color_enabled() {
+        return text.to_string();
+    }
+    let period = n as f64 + 2.0 * SWEEP_PAD;
+    let head = (phase as f64 * SWEEP_SPEED) % period - SWEEP_PAD;
+    shimmer_at(text, head)
+}
+
+/// The spinner glyph for animation frame `phase`, painted in the steel accent
+/// (or plain when color is disabled).
+pub fn spin_glyph(phase: usize) -> String {
+    let frame = SPIN_FRAMES[phase % SPIN_FRAMES.len()];
+    if crate::utils::term::color_enabled() {
+        format!("\x1b[38;5;{ACCENT}m{frame}\x1b[0m")
+    } else {
+        frame.to_string()
+    }
+}
+
+/// Build a `with_key("wave", …)` tracker that renders `label` with the
+/// metallic shimmer. The animation phase is derived from the bar's elapsed
+/// time, so the effect advances on every steady-tick redraw without spawning
+/// a separate timer task.
+///
+/// `reserve` is the column count consumed by the rest of the bar (every
+/// template element except `{wave}`, which sits last). The label is truncated
+/// to the leftover terminal width so the line never wraps — indicatif renders
+/// fixed-width bars at full length regardless of terminal size, so a long URL
+/// in an untruncated message is exactly what would spill onto a second row.
+/// Pass `reserve` as a safe *upper bound* of the furniture: over-estimating
+/// only trims a few extra characters off the label, while under-estimating is
+/// what risks a wrap.
+pub fn wave_tracker(
+    label: String,
+    reserve: usize,
+) -> impl Fn(&indicatif::ProgressState, &mut dyn std::fmt::Write) + Send + Sync + Clone + 'static {
+    move |state, w| {
+        let phase = (state.elapsed().as_millis() / FRAME_MS) as usize;
+        let avail = crate::utils::term::term_cols()
+            .saturating_sub(reserve)
+            .max(6);
+        let shown = console::truncate_str(&label, avail, "…");
+        let _ = write!(w, "{}", shimmer(shown.as_ref(), phase));
+    }
+}
+
+/// Like [`wave_tracker`] but reads its text from a shared cell on every render
+/// instead of a fixed string — for spinners whose message changes over time
+/// (e.g. the parameter analyzer moving "Analyzing…" → "Mining dictionary…" →
+/// "Mining DOM…"). indicatif's `ProgressState` can't expose the live `{msg}`
+/// to a custom key, so the displayed text is funneled through `label` (updated
+/// via [`ShimmerSpinner::set_message`]) and shimmered here.
+pub fn wave_tracker_shared(
+    label: Arc<Mutex<String>>,
+    reserve: usize,
+) -> impl Fn(&indicatif::ProgressState, &mut dyn std::fmt::Write) + Send + Sync + Clone + 'static {
+    move |state, w| {
+        let phase = (state.elapsed().as_millis() / FRAME_MS) as usize;
+        let text = label.lock().map(|g| g.clone()).unwrap_or_default();
+        let avail = crate::utils::term::term_cols()
+            .saturating_sub(reserve)
+            .max(6);
+        let shown = console::truncate_str(&text, avail, "…");
+        let _ = write!(w, "{}", shimmer(shown.as_ref(), phase));
+    }
+}
+
+/// A progress spinner whose message is painted with the metallic shimmer.
+///
+/// indicatif's `ProgressState` can't hand the live message to a `{wave}` key,
+/// so the displayed text lives in a shared cell here. Callers update it via
+/// [`set_message`](Self::set_message) — same name and shape as
+/// `ProgressBar::set_message`, so the parameter-mining code keeps working
+/// verbatim after swapping `Option<ProgressBar>` for `Option<ShimmerSpinner>`
+/// — and the `{wave}` key built by [`wave_tracker_shared`] over the same cell
+/// (see [`label_cell`](Self::label_cell)) shimmers whatever it holds. The
+/// remaining methods just delegate to the wrapped bar.
+#[derive(Clone)]
+pub struct ShimmerSpinner {
+    bar: indicatif::ProgressBar,
+    label: Arc<Mutex<String>>,
+}
+
+impl ShimmerSpinner {
+    /// Wrap `bar` with a shared `label` cell. The bar's style should reference
+    /// `{wave}` via [`wave_tracker_shared`] over this same cell.
+    pub fn new(bar: indicatif::ProgressBar, label: Arc<Mutex<String>>) -> Self {
+        Self { bar, label }
+    }
+
+    /// The shared label cell, for wiring the `{wave}` tracker to this spinner.
+    pub fn label_cell(&self) -> Arc<Mutex<String>> {
+        self.label.clone()
+    }
+
+    /// The wrapped bar, e.g. to finish it via `scanning::finish_scan_bar`.
+    pub fn bar(&self) -> &indicatif::ProgressBar {
+        &self.bar
+    }
+
+    /// Update the shimmered message (mirrors `ProgressBar::set_message`).
+    pub fn set_message(&self, msg: impl Into<String>) {
+        if let Ok(mut g) = self.label.lock() {
+            *g = msg.into();
+        }
+    }
+
+    /// Delegate to the wrapped bar (drives a redraw, refreshing the shimmer).
+    pub fn inc(&self, delta: u64) {
+        self.bar.inc(delta);
+    }
+
+    /// Delegate to the wrapped bar.
+    pub fn set_length(&self, len: u64) {
+        self.bar.set_length(len);
+    }
+
+    /// Delegate to the wrapped bar.
+    pub fn finish_and_clear(&self) {
+        self.bar.finish_and_clear();
+    }
+
+    /// Print a line above the spinner without shredding the live redraw.
+    pub fn println(&self, msg: impl AsRef<str>) {
+        self.bar.println(msg);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn gray_code_spans_the_ramp() {
+        assert_eq!(gray_code(0.0), GRAY_MIN);
+        assert_eq!(gray_code(1.0), GRAY_MAX);
+        // Clamps out-of-range input rather than wrapping.
+        assert_eq!(gray_code(-1.0), GRAY_MIN);
+        assert_eq!(gray_code(2.0), GRAY_MAX);
+    }
+
+    #[test]
+    fn cell_at_band_center_is_brightest() {
+        // A cell directly under the head is full brightness; far away it
+        // rests at the base level.
+        assert!((cell_level(10.0, 10.0) - 1.0).abs() < 1e-9);
+        assert!((cell_level(100.0, 10.0) - BASE_LEVEL).abs() < 1e-9);
+    }
+
+    #[test]
+    fn shimmer_preserves_visible_text() {
+        // Stripping the ANSI must recover the original text exactly — this is
+        // what keeps the rendered width correct and avoids wrap/newline bugs.
+        let painted = shimmer_at("scanning: https://example.com/x", 5.0);
+        assert_eq!(
+            crate::utils::term::strip_ansi(&painted),
+            "scanning: https://example.com/x"
+        );
+    }
+
+    #[test]
+    fn shimmer_empty_is_empty() {
+        assert_eq!(shimmer("", 3), "");
+        assert_eq!(shimmer_at("", 0.0), "");
+    }
+
+    #[test]
+    fn shimmer_visible_width_is_stable_across_frames() {
+        // The whole point of keeping width correct: every frame strips back
+        // to the same text, so the `\r` redraw never wraps or leaves debris.
+        let text = "analyzing: https://xss-game.appspot.com/level1/frame";
+        for phase in 0..40 {
+            assert_eq!(crate::utils::term::strip_ansi(&shimmer(text, phase)), text);
+        }
+    }
+
+    #[test]
+    fn spin_glyph_always_contains_its_frame() {
+        // Color-state agnostic (avoids mutating the global NO_COLOR toggle,
+        // which would flake other tests run in parallel): the glyph char is
+        // present whether or not ANSI wraps it.
+        for i in 0..SPIN_FRAMES.len() * 2 {
+            assert!(spin_glyph(i).contains(SPIN_FRAMES[i % SPIN_FRAMES.len()]));
+        }
+    }
+}

--- a/src/utils/term.rs
+++ b/src/utils/term.rs
@@ -28,17 +28,32 @@ pub fn stdout_is_tty() -> bool {
     std::io::IsTerminal::is_terminal(&std::io::stdout())
 }
 
-/// Current terminal width in columns, falling back to 80 when the size can't
-/// be queried (not a TTY, or the ioctl failed). The hand-rolled spinner /
-/// ticker use this to truncate their line so a long URL never wraps — a
-/// wrapped line breaks the `\r` redraw and strands a row of debris behind
-/// the cursor.
+/// Width in columns of `term`, falling back to 80 when the size can't be
+/// queried (not a TTY, or the ioctl failed).
 #[inline]
-pub fn term_cols() -> usize {
-    console::Term::stdout()
-        .size_checked()
+fn cols_of(term: console::Term) -> usize {
+    term.size_checked()
         .map(|(_, cols)| cols as usize)
         .unwrap_or(80)
+}
+
+/// Current **stdout** terminal width in columns. The hand-rolled spinner /
+/// overall ticker use this to truncate their line so a long URL never wraps —
+/// a wrapped line breaks the `\r` redraw and strands a row of debris behind
+/// the cursor. They write to stdout, so stdout is the stream to measure.
+#[inline]
+pub fn term_cols() -> usize {
+    cols_of(console::Term::stdout())
+}
+
+/// Current **stderr** terminal width in columns. indicatif renders its
+/// progress bars to stderr, so the `{wave}` shimmer truncation must measure
+/// stderr — measuring stdout would pick the wrong width (or the 80-col
+/// fallback) whenever stdout is piped while stderr is a TTY, e.g.
+/// `dalfox scan … | tee log`.
+#[inline]
+pub fn term_cols_stderr() -> usize {
+    cols_of(console::Term::stderr())
 }
 
 /// Strip ANSI CSI sequences (`\x1b[…m`, `\x1b[…K`, etc.) from `s`.

--- a/src/utils/term.rs
+++ b/src/utils/term.rs
@@ -28,6 +28,19 @@ pub fn stdout_is_tty() -> bool {
     std::io::IsTerminal::is_terminal(&std::io::stdout())
 }
 
+/// Current terminal width in columns, falling back to 80 when the size can't
+/// be queried (not a TTY, or the ioctl failed). The hand-rolled spinner /
+/// ticker use this to truncate their line so a long URL never wraps — a
+/// wrapped line breaks the `\r` redraw and strands a row of debris behind
+/// the cursor.
+#[inline]
+pub fn term_cols() -> usize {
+    console::Term::stdout()
+        .size_checked()
+        .map(|(_, cols)| cols as usize)
+        .unwrap_or(80)
+}
+
 /// Strip ANSI CSI sequences (`\x1b[…m`, `\x1b[…K`, etc.) from `s`.
 /// Conservative: only consumes sequences starting `ESC [` followed by
 /// `0-9;` parameters and a final byte in `0x40..=0x7E`. Anything else


### PR DESCRIPTION
## Summary

Polishes the interactive `dalfox scan` progress UI: a cohesive "light over brushed metal" shimmer across all live indicators, faster/smoother spinners, prettier progress bars, and width-safe rendering so nothing wraps or strands rows.

Triggered by: `dalfox scan "https://xss-game.appspot.com/level1/frame" --workers 1`

## What changed

- **New `src/utils/shimmer.rs`** — a 256-color grayscale highlight band that sweeps left→right across label text (the metallic shine), a shared 10-frame braille spinner palette with an accent-cyan glyph, and indicatif `{wave}` trackers. Honors `--no-color` / `NO_COLOR`.
- **Hand-rolled spinners** (preflight + multi-target overall ticker): shimmer the label, lead with the accent glyph, and **truncate to the live terminal width** (erase-to-EOL) so a long URL can never wrap and leave a stranded row.
- **indicatif bars** (per-target + overall): smooth block fill `█▉▊▋▌▍▎▏░` on a dim-gray track, cyan accent, **80 ms tick (was 120 ms)**, green `✓` completion. The trailing message shimmers via `{wave}` and truncates to the leftover width so the bar stays on **one line at ≥80 cols**.
- **Parameter-analysis spinner**: `ShimmerSpinner` wraps the bar + a shared label cell so its *changing* message ("Analyzing…" → "Mining dictionary…" → "Mining DOM…") shimmers. indicatif's `ProgressState` can't expose the live message to a custom key, so the handle mirrors `ProgressBar`'s method names — mining code is otherwise unchanged.
- Adds the `console` dependency (already compiled transitively via indicatif) for terminal-width detection.

## Verification

- `cargo build` / `cargo clippy` clean; **1256 lib tests pass** (+6 new shimmer tests).
- Captured animated output through a PTY at **40 / 80 / 100 / 120 cols** — confirmed the shimmer band travels, glyphs rotate, finish states are clean, and **zero live frames exceed the terminal width** (no wrap/newline artifacts).
- Confirmed the indicatif UI hiding under `NO_COLOR=1` is pre-existing `console`/indicatif behavior (verified against the original binary), not introduced here.

> Note: the scanning bar's shimmer animates from the bar's elapsed time, so for a target where the XSS is found on the first payload (scanning finishes sub-second) it barely moves by design; the long, user-visible analysis phase shimmers fully.