### PR TITLE
perf(scan): make WAF bypass payload expansion orthogonal

### DIFF
--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -746,6 +746,82 @@ fn build_shared_payloads(target: &Target) -> Vec<String> {
     shared
 }
 
+/// Expand a parameter's base payload set into its WAF-bypass variants,
+/// keeping the two bypass axes orthogonal instead of multiplying them.
+///
+/// Output order (front to back), de-duplicated while preserving first
+/// occurrence:
+///   1. the originals — cheapest, browser-native; they reflect first so a
+///      param whose base shape isn't filtered short-circuits immediately;
+///   2. raw structural mutations (`<scr<!---->ipt>`, `<ScRiPt>`, …) — the
+///      highest-probability WAF bypass that needs no server-side decode,
+///      front-loaded so an actively-blocking WAF surfaces a working bypass
+///      before we spend requests on the heavier encoder variants;
+///   3. encoder variants of the originals (`%3C…`, fullwidth, zwsp, …) —
+///      transport-style evasion that relies on the app decoding the wire
+///      bytes back into an executable payload.
+///
+/// Crucially this does *not* emit `encode(mutate(p))`: cross-encoding a
+/// structural mutation buries its bypass under transport encoding and needs
+/// both an app-side decode *and* browser tolerance of the mutated shape — a
+/// compound condition that rarely lands while costing one request apiece.
+/// Skipping it shrinks the per-param request count from `N·(1+m)·(1+k)` to
+/// `N·(1+m+k)` with no loss of reach on either axis.
+///
+/// `stats`, when present, records each generated mutation variant against
+/// its `MutationType` for `target_summary.waf.bypass.mutations_applied[]`
+/// (counted pre-dedup against the encoder set, matching the prior
+/// "did the mutation apply" semantics).
+fn expand_waf_payloads(
+    base: &[String],
+    strategy: &crate::waf::bypass::BypassStrategy,
+    stats: Option<&crate::waf::bypass::MutationStats>,
+) -> Vec<String> {
+    let mut seen: HashSet<String> = HashSet::with_capacity(base.len());
+    let mut out: Vec<String> = Vec::with_capacity(base.len());
+
+    // 1. Originals (de-duplicated), kept at the front.
+    for p in base {
+        if seen.insert(p.clone()) {
+            out.push(p.clone());
+        }
+    }
+
+    // 2. Raw structural mutations — no transport encoding applied.
+    if !strategy.mutations.is_empty() {
+        let tagged = crate::waf::bypass::apply_mutations_tagged(
+            base,
+            &strategy.mutations,
+            MAX_WAF_MUTATION_VARIANTS_PER_PAYLOAD,
+        );
+        for (p, origin) in tagged {
+            // `None` is the unmodified base, already emitted in step 1.
+            if let Some(m) = origin {
+                if let Some(stats) = stats {
+                    stats.record_variant(m);
+                }
+                if seen.insert(p.clone()) {
+                    out.push(p);
+                }
+            }
+        }
+    }
+
+    // 3. Encoder variants of the originals. `apply_encoders_to_payloads`
+    //    re-emits each original as the first variant of its base; those
+    //    collide with step 1 and are dropped by `seen`, leaving only the
+    //    genuinely encoded forms.
+    if !strategy.extra_encoders.is_empty() {
+        for v in crate::encoding::apply_encoders_to_payloads(base, &strategy.extra_encoders) {
+            if seen.insert(v.clone()) {
+                out.push(v);
+            }
+        }
+    }
+
+    out
+}
+
 /// === Stage 4: Payload Generation — build per-parameter payload sets ===
 ///
 /// For each (non-fragment) reflection parameter, build a [`ParamPayloadJob`]
@@ -789,56 +865,18 @@ fn generate_param_jobs(
         reflection_payloads.extend(shared_payloads.iter().cloned());
         dom_payloads.extend(shared_payloads.iter().cloned());
 
-        // Apply WAF bypass mutations and extra encoders if WAF was detected
+        // Apply WAF bypass expansion if a WAF was detected. The two bypass
+        // axes are kept orthogonal rather than multiplied together (see
+        // `expand_waf_payloads`): structural mutations are sent raw and
+        // encoder variants are applied to the originals only, so we never
+        // emit the low-yield `encode(mutate(p))` cross product. The tagged
+        // mutation pass still feeds `record_variant`, which powers the
+        // per-target effectiveness counter in
+        // target_summary.waf.bypass.mutations_applied[].
         if let Some(strategy) = waf_strategy {
-            // Apply mutations (capped per base payload to prevent explosion).
-            // Use the tagged variant so we can attribute each generated
-            // variant to its mutation type — record_variant feeds the
-            // per-target effectiveness counter that surfaces in
-            // target_summary.waf.bypass.mutations_applied[].
-            if !strategy.mutations.is_empty() {
-                let stats = target.mutation_stats.as_ref();
-                let tagged_reflect = crate::waf::bypass::apply_mutations_tagged(
-                    &reflection_payloads,
-                    &strategy.mutations,
-                    MAX_WAF_MUTATION_VARIANTS_PER_PAYLOAD,
-                );
-                reflection_payloads = tagged_reflect
-                    .into_iter()
-                    .map(|(p, origin)| {
-                        if let (Some(stats), Some(m)) = (stats, origin) {
-                            stats.record_variant(m);
-                        }
-                        p
-                    })
-                    .collect();
-                let tagged_dom = crate::waf::bypass::apply_mutations_tagged(
-                    &dom_payloads,
-                    &strategy.mutations,
-                    MAX_WAF_MUTATION_VARIANTS_PER_PAYLOAD,
-                );
-                dom_payloads = tagged_dom
-                    .into_iter()
-                    .map(|(p, origin)| {
-                        if let (Some(stats), Some(m)) = (stats, origin) {
-                            stats.record_variant(m);
-                        }
-                        p
-                    })
-                    .collect();
-            }
-
-            // Apply extra WAF bypass encoders to payloads
-            if !strategy.extra_encoders.is_empty() {
-                reflection_payloads = crate::encoding::apply_encoders_to_payloads(
-                    &reflection_payloads,
-                    &strategy.extra_encoders,
-                );
-                dom_payloads = crate::encoding::apply_encoders_to_payloads(
-                    &dom_payloads,
-                    &strategy.extra_encoders,
-                );
-            }
+            let stats = target.mutation_stats.as_deref();
+            reflection_payloads = expand_waf_payloads(&reflection_payloads, strategy, stats);
+            dom_payloads = expand_waf_payloads(&dom_payloads, strategy, stats);
         }
 
         // Adaptive prune + reorder: when active probing recorded that the

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -777,8 +777,14 @@ fn expand_waf_payloads(
     strategy: &crate::waf::bypass::BypassStrategy,
     stats: Option<&crate::waf::bypass::MutationStats>,
 ) -> Vec<String> {
-    let mut seen: HashSet<String> = HashSet::with_capacity(base.len());
-    let mut out: Vec<String> = Vec::with_capacity(base.len());
+    // Size both collections to the orthogonal output estimate
+    // (`N·(1+m+k)`) so the mutation/encoder passes don't repeatedly rehash
+    // and realloc — `base.len()` alone under-allocates by that whole factor.
+    let est = base
+        .len()
+        .saturating_mul(1 + strategy.mutations.len() + strategy.extra_encoders.len());
+    let mut seen: HashSet<String> = HashSet::with_capacity(est);
+    let mut out: Vec<String> = Vec::with_capacity(est);
 
     // 1. Originals (de-duplicated), kept at the front.
     for p in base {

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -659,6 +659,130 @@ fn test_hoist_angle_free_payloads_no_op_without_block() {
     assert_eq!(hoisted, original, "non-angle invalids must not reorder");
 }
 
+// ── expand_waf_payloads: orthogonal mutation/encoder expansion ───────
+
+#[test]
+fn test_expand_waf_payloads_keeps_axes_orthogonal_no_cross_product() {
+    use crate::waf::bypass::{BypassStrategy, MutationType};
+    let base = vec!["<script>alert(1)</script>".to_string()];
+    let strategy = BypassStrategy {
+        extra_encoders: vec!["url".to_string()],
+        mutations: vec![MutationType::CaseAlternation],
+        extra_delay_hint_ms: 0,
+    };
+    let out = expand_waf_payloads(&base, &strategy, None);
+
+    // The raw mutation is present, un-encoded.
+    let mutated = crate::waf::bypass::apply_mutations(&base, &[MutationType::CaseAlternation], 1)
+        .into_iter()
+        .find(|p| p != &base[0])
+        .expect("case-alternation should produce a variant");
+    assert!(out.contains(&mutated), "raw mutation must be present");
+
+    // The url-encoded *original* is present.
+    let enc = crate::encoding::url_encode(&base[0]);
+    assert!(out.contains(&enc), "encoded original must be present");
+
+    // But the cross product encode(mutate(p)) must NOT be generated.
+    let cross = crate::encoding::url_encode(&mutated);
+    assert!(
+        !out.contains(&cross),
+        "encode(mutation) cross product must not be emitted"
+    );
+}
+
+#[test]
+fn test_expand_waf_payloads_ordering_originals_then_mutations_then_encoders() {
+    use crate::waf::bypass::{BypassStrategy, MutationType};
+    let base = vec!["<svg onload=alert(1)>".to_string()];
+    let strategy = BypassStrategy {
+        extra_encoders: vec!["url".to_string()],
+        mutations: vec![MutationType::SlashSeparator],
+        extra_delay_hint_ms: 0,
+    };
+    let out = expand_waf_payloads(&base, &strategy, None);
+
+    assert_eq!(out[0], base[0], "original must come first");
+    let slash = "<svg/onload=alert(1)>".to_string();
+    let enc = crate::encoding::url_encode(&base[0]);
+    let i_slash = out
+        .iter()
+        .position(|p| p == &slash)
+        .expect("raw mutation present");
+    let i_enc = out
+        .iter()
+        .position(|p| p == &enc)
+        .expect("encoder variant present");
+    assert!(
+        i_slash < i_enc,
+        "raw mutation must precede encoder variants (got slash@{i_slash}, enc@{i_enc})"
+    );
+}
+
+#[test]
+fn test_expand_waf_payloads_records_mutation_telemetry() {
+    use crate::waf::bypass::{BypassStrategy, MutationStats, MutationType};
+    let base = vec!["<svg onload=alert(1)>".to_string()];
+    let strategy = BypassStrategy {
+        extra_encoders: vec![],
+        mutations: vec![MutationType::SlashSeparator],
+        extra_delay_hint_ms: 0,
+    };
+    let stats = MutationStats::default();
+    let _ = expand_waf_payloads(&base, &strategy, Some(&stats));
+    let snap = stats.snapshot();
+    assert_eq!(
+        snap.variants.get(&MutationType::SlashSeparator).copied(),
+        Some(1),
+        "the applied mutation must be recorded once"
+    );
+}
+
+#[test]
+fn test_expand_waf_payloads_reduces_request_count_vs_cross_product() {
+    use crate::waf::bypass::{BypassStrategy, MutationType};
+    // Demonstrates the request-volume win: the orthogonal expansion is
+    // strictly smaller than the old multiply-everything cross product.
+    let base = vec![
+        "<script>alert(1)</script>".to_string(),
+        "<svg onload=alert(1)>".to_string(),
+    ];
+    let strategy = BypassStrategy {
+        extra_encoders: vec!["url".to_string(), "2url".to_string(), "unicode".to_string()],
+        mutations: vec![
+            MutationType::HtmlCommentSplit,
+            MutationType::CaseAlternation,
+            MutationType::BacktickParens,
+        ],
+        extra_delay_hint_ms: 0,
+    };
+    let new = expand_waf_payloads(&base, &strategy, None);
+
+    // Old behavior: mutate first, then encode the *whole* set.
+    let mutated = crate::waf::bypass::apply_mutations(
+        &base,
+        &strategy.mutations,
+        MAX_WAF_MUTATION_VARIANTS_PER_PAYLOAD,
+    );
+    let old = crate::encoding::apply_encoders_to_payloads(&mutated, &strategy.extra_encoders);
+
+    assert!(
+        new.len() < old.len(),
+        "orthogonal expansion ({}) must send fewer payloads than the cross product ({})",
+        new.len(),
+        old.len()
+    );
+}
+
+#[test]
+fn test_expand_waf_payloads_empty_strategy_dedups_originals() {
+    use crate::waf::bypass::BypassStrategy;
+    let base = vec!["<x>".to_string(), "<x>".to_string(), "<y>".to_string()];
+    let strategy = BypassStrategy::default();
+    let out = expand_waf_payloads(&base, &strategy, None);
+    assert_eq!(out, vec!["<x>".to_string(), "<y>".to_string()]);
+}
+
 #[test]
 fn test_get_fallback_reflection_payloads_none_encoder_keeps_raw_only() {
     let mut args = default_scan_args();


### PR DESCRIPTION
## Summary

WAF bypass payload generation multiplied its two bypass axes together — mutations were applied first, then every variant (originals + mutations) was run through the extra encoders, producing `N·(1+m)·(1+k)` payloads per parameter.

The expensive part is the `encode(mutate(p))` **cross product**. Cross-encoding a structural mutation (`<scr<!---->ipt>`, `<ScRiPt>`) buries the bypass under transport encoding, so landing it needs both an app-side decode **and** browser tolerance of the mutated shape — a compound condition that rarely succeeds while costing one HTTP request apiece. Looking at the functional bypass cases (`waf_bypass_scenarios.toml`), real bypasses resolve via the **pure-encoder axis** or the **pure-mutation axis**, never the cross product.

## What changed

New `expand_waf_payloads()` keeps the two axes **orthogonal**:

1. **originals** — front of the list, browser-native; short-circuit early when the base shape isn't filtered
2. **raw structural mutations** — front-loaded; highest-probability bypass, needs no server-side decode
3. **encoder variants of the originals only**

This drops the cross product, shrinking per-param request volume from `N·(1+m)·(1+k)` to `N·(1+m+k)`.

## Impact

- **~56% fewer payloads** on the real Cloudflare strategy (320 → 140 for 20 base payloads)
- Fewer requests under an actively-blocking WAF → less block pressure → less exponential backoff → faster scans
- **No loss of reach** on either bypass axis
- Mutation telemetry (`target_summary.waf.bypass.mutations_applied[]`) preserved

## Tests

- 5 new unit tests: no cross product emitted, axis ordering, telemetry recording, request-count reduction, empty-strategy dedup
- Full lib suite green (1262 passed), `cargo fmt` / `clippy` clean
- Verified end-to-end against a reflecting server with `--waf-bypass force --force-waf cloudflare` (mutation telemetry recorded correctly)