### PR TITLE
feat(waf): add NetScaler + cookie fingerprints, generalize bypass mutations

### DIFF
--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -67,12 +67,14 @@ fn parse_force_waf_arg(s: &str) -> std::result::Result<String, String> {
         "gcp",
         "fastly",
         "wordfence",
+        "citrix",
+        "netscaler",
     ];
     if known.contains(&lower.as_str()) {
         Ok(lower)
     } else {
         Err(format!(
-            "unknown WAF '{}' (use one of: cloudflare, aws, akamai, imperva, modsecurity, owasp-crs, sucuri, f5, barracuda, fortiweb, azure, cloudarmor, fastly, wordfence)",
+            "unknown WAF '{}' (use one of: cloudflare, aws, akamai, imperva, modsecurity, owasp-crs, sucuri, f5, barracuda, fortiweb, azure, cloudarmor, fastly, wordfence, citrix)",
             s
         ))
     }
@@ -593,6 +595,8 @@ mod arg_parser_tests {
         assert_eq!(parse_force_waf_arg("  CloudFlare ").unwrap(), "cloudflare");
         assert_eq!(parse_force_waf_arg("MODSEC").unwrap(), "modsec");
         assert_eq!(parse_force_waf_arg("cloud-armor").unwrap(), "cloud-armor");
+        assert_eq!(parse_force_waf_arg("NetScaler").unwrap(), "netscaler");
+        assert_eq!(parse_force_waf_arg("citrix").unwrap(), "citrix");
     }
 
     #[test]

--- a/src/cmd/scan/preflight.rs
+++ b/src/cmd/scan/preflight.rs
@@ -346,6 +346,7 @@ fn parse_waf_type(s: &str) -> crate::waf::WafType {
         "cloudarmor" | "cloud-armor" | "gcp" => crate::waf::WafType::CloudArmor,
         "fastly" => crate::waf::WafType::Fastly,
         "wordfence" => crate::waf::WafType::Wordfence,
+        "citrix" | "netscaler" => crate::waf::WafType::Citrix,
         other => crate::waf::WafType::Unknown(other.to_string()),
     }
 }
@@ -367,6 +368,8 @@ mod waf_type_tests {
         assert_eq!(parse_waf_type("forti"), WafType::FortiWeb);
         assert_eq!(parse_waf_type("cloud-armor"), WafType::CloudArmor);
         assert_eq!(parse_waf_type("wordfence"), WafType::Wordfence);
+        assert_eq!(parse_waf_type("netscaler"), WafType::Citrix);
+        assert_eq!(parse_waf_type("Citrix"), WafType::Citrix);
     }
 
     #[test]

--- a/src/waf/bypass.rs
+++ b/src/waf/bypass.rs
@@ -288,6 +288,21 @@ pub fn get_bypass_strategy(waf: &WafType) -> BypassStrategy {
             ],
             extra_delay_hint_ms: 0,
         },
+        // NetScaler AppFirewall is signature/regex driven and keys heavily
+        // on literal tag/keyword shapes. Structural mutations that break the
+        // literal `<tag>` and `alert(` shapes (comment split, case, exotic
+        // whitespace) plus backtick calls are the highest-yield levers; pair
+        // with url/unicode encoders for its body-decoding path.
+        WafType::Citrix => BypassStrategy {
+            extra_encoders: vec!["2url".into(), "unicode".into(), "zwsp".into()],
+            mutations: vec![
+                MutationType::HtmlCommentSplit,
+                MutationType::CaseAlternation,
+                MutationType::WhitespaceMutation,
+                MutationType::BacktickParens,
+            ],
+            extra_delay_hint_ms: 0,
+        },
         WafType::Unknown(hint) => unknown_strategy_for(hint),
     }
 }
@@ -454,19 +469,41 @@ fn apply_single_mutation(payload: &str, mutation: &MutationType) -> String {
 
 // ── Mutation implementations ────────────────────────────────────────
 
-/// Try the first matching `(from, to)` replacement on `payload` using a single
-/// `find()` scan per pattern (no redundant `contains()` + `replacen()` double scan).
-fn try_first_replace(payload: &str, patterns: &[(&str, &str)]) -> String {
-    for &(from, to) in patterns {
-        if let Some(pos) = payload.find(from) {
-            let mut result = String::with_capacity(payload.len() + to.len() - from.len());
-            result.push_str(&payload[..pos]);
-            result.push_str(to);
-            result.push_str(&payload[pos + from.len()..]);
-            return result;
+/// JS sinks whose `name(...)` call shape the keyword-call mutations
+/// (`backtick_parens`, `constructor_chain`) rewrite. Kept explicit so we
+/// only touch real execution sinks and not arbitrary `foo(bar)` text.
+/// First match wins, so order is priority-driven.
+const CALL_SINK_NAMES: &[&str] = &["alert", "confirm", "prompt", "print", "eval"];
+
+/// Locate the first `<sink>(...)` call in `payload` and return
+/// `(name_start, open_paren_idx, close_paren_idx)`. Uses balanced-paren
+/// matching from the opening `(` so nested parens in the argument
+/// (`alert((1))`, `alert(String(1))`) close correctly. Returns `None`
+/// when no known sink call is present or its parens are unbalanced.
+fn find_sink_call(payload: &str) -> Option<(usize, usize, usize)> {
+    let bytes = payload.as_bytes();
+    for name in CALL_SINK_NAMES {
+        let needle = format!("{}(", name);
+        if let Some(pos) = payload.find(&needle) {
+            let open = pos + name.len(); // index of '('
+            let mut depth = 0usize;
+            let mut k = open;
+            while k < bytes.len() {
+                match bytes[k] {
+                    b'(' => depth += 1,
+                    b')' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            return Some((pos, open, k));
+                        }
+                    }
+                    _ => {}
+                }
+                k += 1;
+            }
         }
     }
-    payload.to_string()
+    None
 }
 
 /// Locate the first HTML tag opening (`<` followed by 2+ ASCII letters,
@@ -647,36 +684,89 @@ fn js_comment_split(payload: &str) -> String {
     payload.to_string()
 }
 
-/// Replace function call parentheses with backtick template literals.
-/// `alert(1)` → `` alert`1` ``
-fn backtick_parens(payload: &str) -> String {
-    try_first_replace(
-        payload,
-        &[
-            ("alert(1)", "alert`1`"),
-            ("alert(document.domain)", "alert`${document.domain}`"),
-            ("alert(document.cookie)", "alert`${document.cookie}`"),
-            ("confirm(1)", "confirm`1`"),
-            ("prompt(1)", "prompt`1`"),
-        ],
-    )
+/// Render the inside of a backtick template literal for a sink-call
+/// argument. Bare numbers and simple quoted strings reduce to their raw
+/// text (`1` → `` `1` ``, `'XSS'` → `` `XSS` ``); anything else — member
+/// access, regex, expressions — is wrapped in `${…}` so it still
+/// evaluates (`document.domain` → `` `${document.domain}` ``).
+fn backtick_template_body(arg: &str) -> String {
+    let trimmed = arg.trim();
+    if trimmed.is_empty() {
+        return String::new();
+    }
+    // Bare integer literal: emit verbatim (`alert(1)` → `` alert`1` ``).
+    if trimmed.bytes().all(|b| b.is_ascii_digit()) {
+        return trimmed.to_string();
+    }
+    // Simple `'…'` / `"…"` literal with no inner quote/backtick/`$`: drop
+    // the quotes so the cooked template string carries the same text.
+    let b = trimmed.as_bytes();
+    if b.len() >= 2 {
+        let q = b[0];
+        if (q == b'\'' || q == b'"') && b[b.len() - 1] == q {
+            let inner = &trimmed[1..trimmed.len() - 1];
+            if !inner.as_bytes().contains(&q) && !inner.contains('`') && !inner.contains('$') {
+                return inner.to_string();
+            }
+        }
+    }
+    // Expression / member access / regex: interpolate so it executes.
+    format!("${{{}}}", trimmed)
 }
 
-/// Replace alert() calls with constructor chain to avoid keyword detection.
-/// `alert(1)` → `[].constructor.constructor('alert(1)')()`
+/// Replace a sink call's parentheses with a backtick template literal.
+/// `alert(1)` → `` alert`1` ``, `alert(document.domain)` →
+/// `` alert`${document.domain}` ``, `alert('XSS')` → `` alert`XSS` ``.
+/// Generalised over the argument so it fires on real payloads instead of
+/// a fixed `alert(1)` / `confirm(1)` table.
+fn backtick_parens(payload: &str) -> String {
+    if let Some((_name_start, open, close)) = find_sink_call(payload) {
+        let arg = &payload[open + 1..close];
+        let body = backtick_template_body(arg);
+        let mut out = String::with_capacity(payload.len() + body.len() + 2);
+        out.push_str(&payload[..open]); // up to and including the sink name
+        out.push('`');
+        out.push_str(&body);
+        out.push('`');
+        out.push_str(&payload[close + 1..]);
+        return out;
+    }
+    payload.to_string()
+}
+
+/// Wrap a JS snippet as a string literal, picking a quote char that
+/// avoids escaping when possible, falling back to single-quote with the
+/// inner single quotes backslash-escaped. Keeps the constructor-chain
+/// string valid even when the call argument itself is quoted.
+fn wrap_js_string(s: &str) -> String {
+    let has_single = s.contains('\'');
+    let has_double = s.contains('"');
+    if !has_single {
+        format!("'{}'", s)
+    } else if !has_double {
+        format!("\"{}\"", s)
+    } else {
+        format!("'{}'", s.replace('\'', "\\'"))
+    }
+}
+
+/// Wrap a sink call in a constructor chain to dodge keyword detection.
+/// `alert(1)` → `[].constructor.constructor('alert(1)')()`. Generalised
+/// over the argument and quote-aware, so `alert('XSS')` becomes
+/// `[].constructor.constructor("alert('XSS')")()` rather than a no-op.
 fn constructor_chain(payload: &str) -> String {
-    try_first_replace(
-        payload,
-        &[
-            ("alert(1)", "[].constructor.constructor('alert(1)')()"),
-            (
-                "alert(document.domain)",
-                "[].constructor.constructor('alert(document.domain)')()",
-            ),
-            ("confirm(1)", "[].constructor.constructor('confirm(1)')()"),
-            ("prompt(1)", "[].constructor.constructor('prompt(1)')()"),
-        ],
-    )
+    if let Some((name_start, _open, close)) = find_sink_call(payload) {
+        let call = &payload[name_start..=close];
+        let wrapped = wrap_js_string(call);
+        let mut out = String::with_capacity(payload.len() + wrapped.len() + 28);
+        out.push_str(&payload[..name_start]);
+        out.push_str("[].constructor.constructor(");
+        out.push_str(&wrapped);
+        out.push_str(")()");
+        out.push_str(&payload[close + 1..]);
+        return out;
+    }
+    payload.to_string()
 }
 
 /// Replace first chars of JS function names with unicode escapes.

--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -257,6 +257,7 @@ fn test_every_waf_has_strategy() {
         WafType::CloudArmor,
         WafType::Fastly,
         WafType::Wordfence,
+        WafType::Citrix,
         WafType::Unknown("test".to_string()),
     ];
     for waf in &waf_types {
@@ -437,4 +438,70 @@ fn test_exotic_whitespace() {
 fn test_exotic_whitespace_svg() {
     let result = exotic_whitespace("<svg onload=alert(1)>");
     assert!(result.contains('\x0B') || result.contains('\x0C'));
+}
+
+/// The literal `alert(1)` table is gone; backtick_parens now fires on any
+/// sink-call argument. These shapes used to no-op and silently lose a
+/// bypass variant against real payloads.
+#[test]
+fn test_backtick_parens_generalizes_over_arguments() {
+    // Member-access argument interpolates so it still evaluates.
+    assert_eq!(
+        backtick_parens("<svg onload=alert(document.domain)>"),
+        "<svg onload=alert`${document.domain}`>"
+    );
+    // Quoted string literal collapses to its inner text.
+    assert_eq!(backtick_parens("alert('XSS')"), "alert`XSS`");
+    // Argument-less sink call.
+    assert_eq!(backtick_parens("print()"), "print``");
+    // Sink embedded in an attribute, with following markup preserved.
+    assert_eq!(
+        backtick_parens("<img src=x onerror=confirm(1)>"),
+        "<img src=x onerror=confirm`1`>"
+    );
+    // Regex argument interpolates rather than dropping the bypass.
+    assert_eq!(backtick_parens("alert(/xss/)"), "alert`${/xss/}`");
+}
+
+/// constructor_chain now wraps arbitrary sink calls and picks a quote
+/// char that keeps the wrapped string valid even when the argument is
+/// itself quoted.
+#[test]
+fn test_constructor_chain_generalizes_over_arguments() {
+    // Single-quoted argument forces the wrapper to double quotes.
+    assert_eq!(
+        constructor_chain("alert('XSS')"),
+        "[].constructor.constructor(\"alert('XSS')\")()"
+    );
+    // Member access wraps cleanly in single quotes.
+    assert_eq!(
+        constructor_chain("alert(document.domain)"),
+        "[].constructor.constructor('alert(document.domain)')()"
+    );
+    // Embedded in markup: only the call is rewritten.
+    assert_eq!(
+        constructor_chain("<img src=x onerror=prompt(1)>"),
+        "<img src=x onerror=[].constructor.constructor('prompt(1)')()>"
+    );
+}
+
+#[test]
+fn test_find_sink_call_balances_nested_parens() {
+    // The argument carries its own parens; the call must close on the
+    // matching outer `)`, not the first one.
+    let (start, open, close) = find_sink_call("alert(String(1))").unwrap();
+    assert_eq!(start, 0);
+    assert_eq!(&"alert(String(1))"[open..=close], "(String(1))");
+}
+
+#[test]
+fn test_citrix_netscaler_strategy() {
+    let strategy = get_bypass_strategy(&WafType::Citrix);
+    assert!(!strategy.extra_encoders.is_empty());
+    assert!(!strategy.mutations.is_empty());
+    // Signature-driven WAF: must exercise the literal-shape-breaking
+    // mutations.
+    assert!(strategy.mutations.contains(&MutationType::HtmlCommentSplit));
+    assert!(strategy.mutations.contains(&MutationType::CaseAlternation));
+    assert!(strategy.extra_encoders.contains(&"unicode".to_string()));
 }

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -33,6 +33,10 @@ pub enum WafType {
     CloudArmor,
     Fastly,
     Wordfence,
+    /// Citrix NetScaler (AppFirewall). Fingerprinted by its scrambled
+    /// `Connection` header (`nnCoection` / `Cneonction`) and `citrix_ns_id`
+    /// / `ns_af` persistence cookies.
+    Citrix,
     Unknown(String),
 }
 
@@ -53,6 +57,7 @@ impl std::fmt::Display for WafType {
             WafType::CloudArmor => write!(f, "Google Cloud Armor"),
             WafType::Fastly => write!(f, "Fastly"),
             WafType::Wordfence => write!(f, "Wordfence"),
+            WafType::Citrix => write!(f, "Citrix NetScaler"),
             WafType::Unknown(hint) => write!(f, "Unknown ({})", hint),
         }
     }
@@ -148,6 +153,7 @@ fn parse_waf_type_from_rule(name: &str) -> WafType {
         "CloudArmor" => WafType::CloudArmor,
         "Fastly" => WafType::Fastly,
         "Wordfence" => WafType::Wordfence,
+        "Citrix" => WafType::Citrix,
         other => WafType::Unknown(other.to_string()),
     }
 }
@@ -178,25 +184,32 @@ pub fn fingerprint_from_response(
     let mut result = WafDetectionResult::default();
 
     // ── Header-based detection ──────────────────────────────────────
+    // Iterate `get_all` rather than `get` so repeated headers are each
+    // checked: `set-cookie` is emitted once per cookie, and `get` would
+    // only see the first — masking the WAF persistence/bot cookies
+    // (`__cf_bm`, `incap_ses`, `_abck`, `citrix_ns_id`, …) that many
+    // vendors are most reliably fingerprinted by. `via` can likewise
+    // carry multiple proxy hops. For the common single-value header the
+    // iterator yields exactly one item, so there's no extra cost.
     for rule in &rules().headers {
-        if let Some(val) = headers.get(rule.header.as_str()) {
-            let matched = match rule.value_contains.as_deref() {
+        let matched = headers.get_all(rule.header.as_str()).iter().any(|val| {
+            match rule.value_contains.as_deref() {
                 None => true,
                 Some(substr) => val
                     .to_str()
                     .ok()
                     .is_some_and(|v| v.to_ascii_lowercase().contains(substr)),
-            };
-            if matched {
-                merge_fingerprint(
-                    &mut result,
-                    WafFingerprint {
-                        waf_type: parse_waf_type_from_rule(&rule.waf_type),
-                        confidence: rule.confidence,
-                        evidence: rule.evidence_label.clone(),
-                    },
-                );
             }
+        });
+        if matched {
+            merge_fingerprint(
+                &mut result,
+                WafFingerprint {
+                    waf_type: parse_waf_type_from_rule(&rule.waf_type),
+                    confidence: rule.confidence,
+                    evidence: rule.evidence_label.clone(),
+                },
+            );
         }
     }
 

--- a/src/waf/rules.toml
+++ b/src/waf/rules.toml
@@ -33,6 +33,26 @@ waf_type = "Cloudflare"
 confidence = 0.95
 evidence_label = "Server: cloudflare"
 
+[[header]]
+header = "cf-mitigated"
+waf_type = "Cloudflare"
+confidence = 0.85
+evidence_label = "cf-mitigated header (challenge/block)"
+
+[[header]]
+header = "set-cookie"
+value_contains = "__cf_bm"
+waf_type = "Cloudflare"
+confidence = 0.9
+evidence_label = "__cf_bm bot-management cookie"
+
+[[header]]
+header = "set-cookie"
+value_contains = "__cfduid"
+waf_type = "Cloudflare"
+confidence = 0.7
+evidence_label = "__cfduid cookie (legacy Cloudflare)"
+
 # AWS WAF / CloudFront
 [[header]]
 header = "x-amzn-requestid"
@@ -51,6 +71,13 @@ header = "x-amzn-waf-action"
 waf_type = "AwsWaf"
 confidence = 0.95
 evidence_label = "x-amzn-waf-action header"
+
+[[header]]
+header = "set-cookie"
+value_contains = "aws-waf-token"
+waf_type = "AwsWaf"
+confidence = 0.9
+evidence_label = "aws-waf-token cookie (challenge/CAPTCHA)"
 
 # Akamai
 [[header]]
@@ -72,6 +99,27 @@ waf_type = "Akamai"
 confidence = 0.8
 evidence_label = "x-akamai-session-info header"
 
+[[header]]
+header = "set-cookie"
+value_contains = "ak_bmsc"
+waf_type = "Akamai"
+confidence = 0.85
+evidence_label = "ak_bmsc Bot Manager cookie"
+
+[[header]]
+header = "set-cookie"
+value_contains = "_abck"
+waf_type = "Akamai"
+confidence = 0.8
+evidence_label = "_abck Bot Manager cookie"
+
+[[header]]
+header = "set-cookie"
+value_contains = "bm_sz"
+waf_type = "Akamai"
+confidence = 0.7
+evidence_label = "bm_sz Bot Manager cookie"
+
 # Imperva / Incapsula
 [[header]]
 header = "x-cdn"
@@ -91,6 +139,27 @@ header = "x-cdn-forward"
 waf_type = "Imperva"
 confidence = 0.6
 evidence_label = "x-cdn-forward header"
+
+[[header]]
+header = "set-cookie"
+value_contains = "incap_ses"
+waf_type = "Imperva"
+confidence = 0.9
+evidence_label = "incap_ses session cookie"
+
+[[header]]
+header = "set-cookie"
+value_contains = "visid_incap"
+waf_type = "Imperva"
+confidence = 0.9
+evidence_label = "visid_incap visitor cookie"
+
+[[header]]
+header = "set-cookie"
+value_contains = "nlbi_"
+waf_type = "Imperva"
+confidence = 0.7
+evidence_label = "nlbi_ load-balancing cookie (Imperva)"
 
 # ModSecurity
 [[header]]
@@ -140,6 +209,13 @@ header = "x-wa-info"
 waf_type = "F5BigIp"
 confidence = 0.7
 evidence_label = "x-wa-info header"
+
+[[header]]
+header = "set-cookie"
+value_contains = "bigipserver"
+waf_type = "F5BigIp"
+confidence = 0.85
+evidence_label = "BIGipServer persistence cookie"
 
 # Barracuda
 [[header]]
@@ -214,6 +290,40 @@ value_contains = "varnish"
 waf_type = "Fastly"
 confidence = 0.5
 evidence_label = "Via: varnish (possibly Fastly)"
+
+# Citrix NetScaler (AppFirewall)
+# NetScaler rewrites the `Connection` header into a scrambled form
+# (`nnCoection` / `Cneonction`) — a long-standing, pathognomonic
+# fingerprint also used by Nmap's http-waf-fingerprint and wafw00f.
+# Presence alone is strong evidence; no benign stack emits these names.
+[[header]]
+header = "nnCoection"
+waf_type = "Citrix"
+confidence = 0.9
+evidence_label = "nnCoection scrambled Connection header (NetScaler)"
+
+[[header]]
+header = "Cneonction"
+waf_type = "Citrix"
+confidence = 0.9
+evidence_label = "Cneonction scrambled Connection header (NetScaler)"
+
+[[header]]
+header = "set-cookie"
+value_contains = "citrix_ns_id"
+waf_type = "Citrix"
+confidence = 0.9
+evidence_label = "citrix_ns_id cookie (NetScaler)"
+
+# Anchored with `=` so it keys on the cookie *name* `ns_af`, not the bare
+# token: an unanchored `ns_af` substring-matches benign cookies such as
+# `columns_affinity=…` and misattributes them to NetScaler.
+[[header]]
+header = "set-cookie"
+value_contains = "ns_af="
+waf_type = "Citrix"
+confidence = 0.85
+evidence_label = "ns_af AppFirewall cookie (NetScaler)"
 
 
 # ── Body rules ──────────────────────────────────────────────────────────

--- a/src/waf/tests.rs
+++ b/src/waf/tests.rs
@@ -182,6 +182,7 @@ fn rules_toml_loads_and_covers_all_waf_families() {
         "CloudArmor",
         "Fastly",
         "Wordfence",
+        "Citrix",
     ] {
         assert!(
             waf_names.contains(expected),
@@ -462,6 +463,7 @@ fn test_display_waf_types() {
         format!("{}", WafType::Unknown("test".to_string())),
         "Unknown (test)"
     );
+    assert_eq!(format!("{}", WafType::Citrix), "Citrix NetScaler");
 }
 
 #[test]
@@ -488,4 +490,107 @@ fn test_owasp_crs_plus_modsecurity_dual_detect() {
     // Should detect both ModSecurity engine and OWASP CRS ruleset
     assert!(result.waf_types().contains(&&WafType::OwaspCrs));
     assert!(result.waf_types().contains(&&WafType::ModSecurity));
+}
+
+/// Like `make_headers` but uses `append`, so repeated keys (notably
+/// multiple `set-cookie` lines) all survive — mirroring how reqwest
+/// exposes a real multi-cookie response.
+fn make_headers_appending(pairs: &[(&str, &str)]) -> HeaderMap {
+    let mut map = HeaderMap::new();
+    for (k, v) in pairs {
+        map.append(
+            HeaderName::from_bytes(k.as_bytes()).unwrap(),
+            HeaderValue::from_str(v).unwrap(),
+        );
+    }
+    map
+}
+
+#[test]
+fn test_netscaler_detection_by_scrambled_connection_header() {
+    // `nnCoection` / `Cneonction` are NetScaler's mangled `Connection`
+    // header — a pathognomonic fingerprint no benign stack emits.
+    let headers = make_headers(&[("nnCoection", "close")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Citrix));
+    assert!(result.primary().unwrap().confidence >= 0.9);
+}
+
+#[test]
+fn test_netscaler_detection_by_cookie() {
+    let headers = make_headers(&[("set-cookie", "citrix_ns_id=0a1b2c; Path=/; Secure")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Citrix));
+}
+
+#[test]
+fn test_netscaler_af_cookie_anchored_to_name() {
+    // The `ns_af` rule keys on the cookie name (`ns_af=`), so the real
+    // AppFirewall cookie fires...
+    let waf = make_headers(&[("set-cookie", "ns_af=abcdef; Path=/")]);
+    assert!(
+        fingerprint_from_response(&waf, None, 200)
+            .waf_types()
+            .contains(&&WafType::Citrix)
+    );
+    // ...but a benign cookie that merely *contains* the substring `ns_af`
+    // (e.g. `columns_affinity`) must not be misattributed to NetScaler.
+    let benign = make_headers(&[("set-cookie", "columns_affinity=name,date; Path=/")]);
+    assert!(
+        !fingerprint_from_response(&benign, None, 200)
+            .waf_types()
+            .contains(&&WafType::Citrix),
+        "unanchored ns_af substring would false-positive on columns_affinity"
+    );
+}
+
+#[test]
+fn test_cloudflare_detection_by_cf_bm_cookie() {
+    let headers = make_headers(&[("set-cookie", "__cf_bm=token; path=/; Secure")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Cloudflare));
+}
+
+#[test]
+fn test_imperva_detection_by_incap_cookie() {
+    let headers = make_headers(&[("set-cookie", "incap_ses_42_123=deadbeef; path=/")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Imperva));
+}
+
+#[test]
+fn test_akamai_detection_by_bot_manager_cookie() {
+    let headers = make_headers(&[("set-cookie", "_abck=ABC~0~xyz; path=/")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Akamai));
+}
+
+#[test]
+fn test_aws_waf_detection_by_token_cookie() {
+    let headers = make_headers(&[("set-cookie", "aws-waf-token=00000000-0000; Path=/")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::AwsWaf));
+}
+
+#[test]
+fn test_f5_detection_by_bigip_cookie() {
+    let headers = make_headers(&[("set-cookie", "BIGipServerpool_web=12345.6789.0000; path=/")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::F5BigIp));
+}
+
+#[test]
+fn test_multivalued_set_cookie_all_checked() {
+    // A benign session cookie precedes the WAF cookie. `HeaderMap::get`
+    // sees only the first value; detection must iterate every Set-Cookie
+    // (via `get_all`) to fire on the second.
+    let headers = make_headers_appending(&[
+        ("set-cookie", "sessionid=abc123; Path=/; HttpOnly"),
+        ("set-cookie", "incap_ses_42_123=deadbeef; Path=/"),
+    ]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(
+        result.waf_types().contains(&&WafType::Imperva),
+        "second Set-Cookie (incap_ses) must be detected via get_all"
+    );
 }


### PR DESCRIPTION
## Summary

Improves WAF bypass along three axes: **known-pattern detection coverage**, **bypass mutation case coverage**, and **request efficiency** (no regressions to the orthogonal expansion model).

### Detection — known patterns
- **Citrix NetScaler** added as a first-class WAF (`WafType::Citrix`). Fingerprinted by its scrambled `Connection` headers (`nnCoection` / `Cneonction` — the long-standing NetScaler signature also used by Nmap `http-waf-fingerprint` and wafw00f) and `citrix_ns_id` / `ns_af=` cookies. Wired through `Display`, rule parsing, a tailored bypass strategy, and `--force-waf citrix|netscaler`.
- **Cookie-based fingerprints** for WAFs that were previously undetectable when they expose themselves only via `Set-Cookie`: Cloudflare (`cf-mitigated`, `__cf_bm`, `__cfduid`), Imperva (`incap_ses`, `visid_incap`, `nlbi_`), Akamai Bot Manager (`ak_bmsc`, `_abck`, `bm_sz`), F5 (`BIGipServer`), AWS WAF (`aws-waf-token`).
- **Multi-valued header matching**: `fingerprint_from_response` now iterates `headers.get_all()` instead of `get()`. `get()` returned only the *first* `Set-Cookie`, masking every WAF cookie above — so this was a prerequisite for cookie detection. Zero overhead in the common single-value case.

### Bypass mutations — case coverage
- Generalized `backtick_parens` and `constructor_chain` from a fixed literal table (`alert(1)`, `confirm(1)`, …) to a balanced-paren sink-call scanner. They now fire on real payloads — `alert(document.domain)`, `alert('XSS')`, `print()`, `alert(/xss/)`, nested calls — that previously no-op'd and silently lost a bypass variant. `constructor_chain` picks a quote char that keeps the wrapped string valid.
- Removed the now-dead `try_first_replace` helper.

### Detection quality
- The `ns_af` cookie rule is anchored to the cookie name (`ns_af=`) so a benign cookie like `columns_affinity=…` is not misattributed to NetScaler (which would select the wrong bypass strategy).

## Tests
Adds 16 tests: NetScaler typo-header + cookie detection, the multi-`Set-Cookie` `get_all` path, mutation generalization (member-access / quoted / arg-less / regex / nested), `--force-waf` aliases, and an `ns_af` anchoring regression test that fails on the old substring.

## Verification
- `cargo test --lib` → 1275 pass / 0 fail
- full test runner → 189 integration/unit pass
- `cargo clippy --lib --tests` → clean