### PR TITLE
fix(release): repair deb/rpm packaging and harden the release matrix

### DIFF
--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -23,6 +23,9 @@ jobs:
     permissions:
       contents: write # Required to upload release assets
     strategy:
+      # Keep building every target even if one fails, so a single
+      # target (e.g. a broken .deb) never cancels the others' uploads.
+      fail-fast: false
       matrix:
         include:
           # Linux targets
@@ -104,64 +107,8 @@ jobs:
             cargo build --verbose --release --target ${{ matrix.target }}
           fi
 
-      # --- Debian / RPM packaging (only for glibc Linux targets) ---
-      - name: Install cargo-deb and cargo-generate-rpm
-        if: |
-          matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          cargo install cargo-deb --locked
-          cargo install cargo-generate-rpm --locked
-
-      # Copy the cross-compiled binary to the default location that cargo-deb expects
-      - name: Prepare binary for packaging tools
-        if: |
-          matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          mkdir -p target/release
-          cp "target/${{ matrix.target }}/release/dalfox" target/release/dalfox
-
-      - name: Build Debian package
-        if: |
-          matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          cargo deb --no-build
-
-      - name: Build RPM package
-        if: |
-          matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'aarch64-unknown-linux-gnu'
-        run: |
-          cargo generate-rpm --target ${{ matrix.target }}
-
-      - name: Rename and checksum packages
-        if: |
-          matrix.target == 'x86_64-unknown-linux-gnu' ||
-          matrix.target == 'aarch64-unknown-linux-gnu'
-        shell: bash
-        run: |
-          cd target/${{ matrix.target }}/release
-
-          # Rename .deb
-          for deb in *.deb; do
-            if [ -f "$deb" ]; then
-              mv "$deb" "dalfox-$VERSION-linux-${{ matrix.build }}.deb"
-            fi
-          done
-
-          # Rename .rpm
-          for rpm in *.rpm; do
-            if [ -f "$rpm" ]; then
-              mv "$rpm" "dalfox-$VERSION-linux-${{ matrix.build }}.rpm"
-            fi
-          done
-
-          # Create checksums
-          shasum -a 256 *.deb *.rpm 2>/dev/null | sed 's|  |  |' > /tmp/pkg-checksums.txt || true
-          mv /tmp/pkg-checksums.txt . 2>/dev/null || true
-      # ---------------------------------------------------------------
+      # Build and upload the binary archive first, so a packaging-tool
+      # failure (.deb/.rpm) can never block the primary release artifact.
       - name: Build archive
         shell: bash
         run: |
@@ -169,11 +116,11 @@ jobs:
           dirname="$binary_name-$VERSION-${{ matrix.build }}"
           mkdir "$dirname"
 
-          # Move the appropriate binary into the archive directory
+          # Copy (not move) the binary so the Debian/RPM steps can still find it
           if [ "${{ matrix.os }}" = "windows-latest" ]; then
-            mv "target/${{ matrix.target }}/release/$binary_name.exe" "$dirname"
+            cp "target/${{ matrix.target }}/release/$binary_name.exe" "$dirname"
           else
-            mv "target/${{ matrix.target }}/release/$binary_name" "$dirname"
+            cp "target/${{ matrix.target }}/release/$binary_name" "$dirname"
           fi
 
           # Create the appropriate archive format for each OS
@@ -200,6 +147,57 @@ jobs:
             ${{ env.ASSET }}
             ${{ env.ASSET }}.sha256
 
+      # --- Debian / RPM packaging (only for glibc Linux targets) ---
+      - name: Install cargo-deb and cargo-generate-rpm
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo install cargo-deb --locked
+          cargo install cargo-generate-rpm --locked
+
+      # Copy the cross-compiled binary to the default location the packaging tools expect
+      - name: Prepare binary for packaging tools
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          mkdir -p target/release
+          cp "target/${{ matrix.target }}/release/dalfox" target/release/dalfox
+
+      - name: Build Debian package
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo deb --no-build
+
+      - name: Build RPM package
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        run: |
+          cargo generate-rpm --target ${{ matrix.target }}
+
+      # cargo-deb writes to target/debian/, cargo-generate-rpm to
+      # target/<target>/generate-rpm/ — collect both into target/packages/.
+      - name: Rename and checksum packages
+        if: |
+          matrix.target == 'x86_64-unknown-linux-gnu' ||
+          matrix.target == 'aarch64-unknown-linux-gnu'
+        shell: bash
+        run: |
+          mkdir -p target/packages
+          deb=$(find target/debian -name '*.deb' | head -n1)
+          rpm=$(find "target/${{ matrix.target }}/generate-rpm" -name '*.rpm' | head -n1)
+          deb_name="dalfox-$VERSION-${{ matrix.build }}.deb"
+          rpm_name="dalfox-$VERSION-${{ matrix.build }}.rpm"
+          cp "$deb" "target/packages/$deb_name"
+          cp "$rpm" "target/packages/$rpm_name"
+          cd target/packages
+          shasum -a 256 "$deb_name" > "$deb_name.sha256"
+          shasum -a 256 "$rpm_name" > "$rpm_name.sha256"
+
       - name: Upload Debian and RPM packages
         if: |
           (github.event_name == 'release' || github.event.inputs.upload == 'true') &&
@@ -207,7 +205,7 @@ jobs:
         uses: softprops/action-gh-release@v3
         with:
           files: |
-            target/${{ matrix.target }}/release/dalfox-*.deb
-            target/${{ matrix.target }}/release/dalfox-*.rpm
-            target/${{ matrix.target }}/release/dalfox-*.deb.sha256
-            target/${{ matrix.target }}/release/dalfox-*.rpm.sha256
+            target/packages/*.deb
+            target/packages/*.rpm
+            target/packages/*.deb.sha256
+            target/packages/*.rpm.sha256

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -143,6 +143,9 @@ jobs:
         if: github.event_name == 'release' || github.event.inputs.upload == 'true'
         uses: softprops/action-gh-release@v3
         with:
+          # Pin the target release so manual workflow_dispatch runs (where
+          # github.ref is a branch, not a tag) still upload to VERSION.
+          tag_name: ${{ env.VERSION }}
           files: |-
             ${{ env.ASSET }}
             ${{ env.ASSET }}.sha256
@@ -204,6 +207,7 @@ jobs:
           (matrix.target == 'x86_64-unknown-linux-gnu' || matrix.target == 'aarch64-unknown-linux-gnu')
         uses: softprops/action-gh-release@v3
         with:
+          tag_name: ${{ env.VERSION }}
           files: |
             target/packages/*.deb
             target/packages/*.rpm

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -6,6 +6,8 @@ rust-version = "1.93"
 authors = ["hahwul"]
 description = "Dalfox is a powerful open-source XSS scanner and utility focused on automation"
 license = "MIT"
+homepage = "https://github.com/hahwul/dalfox"
+repository = "https://github.com/hahwul/dalfox"
 
 [dependencies]
 clap = { version = "4.0", features = ["derive", "env"] }
@@ -44,8 +46,6 @@ strip = "symbols"
 maintainer = "hahwul <hahwul@gmail.com>"
 copyright = "2024, hahwul"
 license-file = "LICENSE.txt"
-homepage = "https://github.com/hahwul/dalfox"
-description = "Powerful open-source XSS scanner"
 extended-description = """Dalfox is a powerful open-source XSS scanner and automation utility.
 It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
 depends = ["ca-certificates"]


### PR DESCRIPTION
## Why

The [v3.0.1 release run](https://github.com/hahwul/dalfox/actions/runs/26794227332) failed. Root cause was a single `Cargo.toml` error that cascaded across the matrix.

`cargo-deb` rejects `description` and `homepage` inside `[package.metadata.deb]` (it reads the short description from `[package].description` and the homepage from `[package].homepage`), so `cargo deb --no-build` died with a TOML parse error. That one failure cascaded:

- glibc Linux targets ran deb/rpm packaging **before** the archive upload, so the parse error also blocked the `linux-x86_64` / `linux-aarch64` tarballs.
- the matrix had no `fail-fast: false`, so the failure cancelled the in-flight `windows` and `linux-x86_64` jobs.

Net effect: only the musl and macOS binaries reached the v3.0.1 release — `windows .zip`, both glibc `.tar.gz`, and **all** `.deb`/`.rpm` were missing.

A second latent bug: even with the parse fixed, the rename/upload steps looked for packages under `target/<target>/release/`, but the tools actually emit to `target/debian/` (deb) and `target/<target>/generate-rpm/` (rpm), and the package names double-prefixed `linux-`.

## Changes

**Cargo.toml**
- Drop invalid `description`/`homepage` from `[package.metadata.deb]`.
- Add `homepage` + `repository` to `[package]` (where cargo-deb reads them).

**.github/workflows/cd-release.yml**
- Add `fail-fast: false` so one target never cancels the others.
- Build + upload the binary archive **before** deb/rpm packaging (`cp`, not `mv`) so a packaging-tool failure can no longer drop the primary artifact.
- Collect packages from their real output paths into `target/packages/` for upload.
- Fix duplicated `linux-` in package names to match the archive naming (`dalfox-vX.Y.Z-linux-x86_64.deb`).

## Verification

Reproduced and fixed locally with `cargo-deb 3.7.0` and `cargo-generate-rpm 0.21.0` against a real release binary:
- `cargo deb --no-build` now builds `dalfox_3.0.1-1_arm64.deb` containing `/usr/bin/dalfox`.
- `cargo generate-rpm` emits the `.rpm`, and the rename/checksum step resolves both packages into `target/packages/`.
- Workflow YAML validates.