### PR TITLE
fix(tls): use rustls ring backend to fix aws-lc-sys link failure (#1061)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -133,28 +133,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2032f911046de80f0a198e0901378627c33f59ea0ac00e363d481118bd70a53"
 
 [[package]]
-name = "aws-lc-rs"
-version = "1.17.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5ec2f1fc3ec205783a5da9a7e6c1509cc69dedf09a1949e412c1e18469326d00"
-dependencies = [
- "aws-lc-sys",
- "zeroize",
-]
-
-[[package]]
-name = "aws-lc-sys"
-version = "0.41.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1a2f9779ce85b93ab6170dd940ad0169b5766ff848247aff13bb788b832fe3f4"
-dependencies = [
- "cc",
- "cmake",
- "dunce",
- "fs_extra",
-]
-
-[[package]]
 name = "axum"
 version = "0.8.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -276,8 +254,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a1dce859f0832a7d088c4f1119888ab94ef4b5d6795d1ce05afb7fe159d79f98"
 dependencies = [
  "find-msvc-tools",
- "jobserver",
- "libc",
  "shlex",
 ]
 
@@ -286,12 +262,6 @@ name = "cfg-if"
 version = "1.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9330f8b2ff13f34540b44e946ef35111825727b38d33286ef986142615121801"
-
-[[package]]
-name = "cfg_aliases"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "613afe47fcd5fac7ccf1db93babcb082c5994d996f20b8b159f2ad1658eb5724"
 
 [[package]]
 name = "chrono"
@@ -346,15 +316,6 @@ name = "clap_lex"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c8d4a3bb8b1e0c1050499d1815f5ab16d04f0959b233085fb31653fbfc9d98f9"
-
-[[package]]
-name = "cmake"
-version = "0.1.58"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c0f78a02292a74a88ac736019ab962ece0bc380e3f977bf72e376c5d78ff0678"
-dependencies = [
- "cc",
-]
 
 [[package]]
 name = "colorchoice"
@@ -512,6 +473,7 @@ dependencies = [
  "regex",
  "reqwest",
  "rmcp",
+ "rustls",
  "schemars",
  "scraper",
  "serde",
@@ -622,12 +584,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "dunce"
-version = "1.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "92773504d58c093f6de2459af4af33faa518c13451eb8f2b5698ed3d36e7c813"
-
-[[package]]
 name = "dyn-clone"
 version = "1.0.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -691,12 +647,6 @@ checksum = "cb4cb245038516f5f85277875cdaa4f7d2c9a0fa0468de06ed190163b1581fcf"
 dependencies = [
  "percent-encoding",
 ]
-
-[[package]]
-name = "fs_extra"
-version = "1.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "42703706b716c37f96a77aea830392ad231f44c9e9a67872fa5548707e11b11c"
 
 [[package]]
 name = "futures"
@@ -802,24 +752,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
-]
-
-[[package]]
-name = "getrandom"
-version = "0.3.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "899def5c37c4fd7b2664648c28120ecec138e4d395b459e5ca34f9cce2dd77fd"
-dependencies = [
- "cfg-if",
- "js-sys",
- "libc",
- "r-efi",
- "wasip2",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -1190,16 +1124,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jobserver"
-version = "0.1.34"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9afb3de4395d6b3e67a780b6de64b51c978ecf11cb9a462c66be7d4ca9039d33"
-dependencies = [
- "getrandom 0.3.4",
- "libc",
-]
-
-[[package]]
 name = "js-sys"
 version = "0.3.99"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1237,12 +1161,6 @@ name = "log"
 version = "0.4.30"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "616ec5685824bcc94416c6d4a7a446eea774a31efd7062c8480ba6fd06d7a6e5"
-
-[[package]]
-name = "lru-slab"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "112b39cec0b298b6c1999fee3e31427f74f676e4cb9879ed1a121b43661a4154"
 
 [[package]]
 name = "markup5ever"
@@ -1682,15 +1600,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "ppv-lite86"
-version = "0.2.21"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85eae3c4ed2f50dcfe72643da4befc30deadb458a9b590d720cde2f2b1e97da9"
-dependencies = [
- "zerocopy",
-]
-
-[[package]]
 name = "precomputed-hash"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,103 +1615,12 @@ dependencies = [
 ]
 
 [[package]]
-name = "quinn"
-version = "0.11.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9e20a958963c291dc322d98411f541009df2ced7b5a4f2bd52337638cfccf20"
-dependencies = [
- "bytes",
- "cfg_aliases",
- "pin-project-lite",
- "quinn-proto",
- "quinn-udp",
- "rustc-hash",
- "rustls",
- "socket2",
- "thiserror",
- "tokio",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-proto"
-version = "0.11.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "434b42fec591c96ef50e21e886936e66d3cc3f737104fdb9b737c40ffb94c098"
-dependencies = [
- "aws-lc-rs",
- "bytes",
- "getrandom 0.3.4",
- "lru-slab",
- "rand",
- "ring",
- "rustc-hash",
- "rustls",
- "rustls-pki-types",
- "slab",
- "thiserror",
- "tinyvec",
- "tracing",
- "web-time",
-]
-
-[[package]]
-name = "quinn-udp"
-version = "0.5.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "addec6a0dcad8a8d96a771f815f0eaf55f9d1805756410b39f5fa81332574cbd"
-dependencies = [
- "cfg_aliases",
- "libc",
- "once_cell",
- "socket2",
- "tracing",
- "windows-sys 0.60.2",
-]
-
-[[package]]
 name = "quote"
 version = "1.0.45"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "41f2619966050689382d2b44f664f4bc593e129785a36d6ee376ddf37259b924"
 dependencies = [
  "proc-macro2",
-]
-
-[[package]]
-name = "r-efi"
-version = "5.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
-
-[[package]]
-name = "rand"
-version = "0.9.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "44c5af06bb1b7d3216d91932aed5265164bf384dc89cd6ba05cf59a35f5f76ea"
-dependencies = [
- "rand_chacha",
- "rand_core",
-]
-
-[[package]]
-name = "rand_chacha"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3022b5f1df60f26e1ffddd6c66e8aa15de382ae63b3a0c1bfc0e4d3e3f325cb"
-dependencies = [
- "ppv-lite86",
- "rand_core",
-]
-
-[[package]]
-name = "rand_core"
-version = "0.9.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "76afc826de14238e6e8c374ddcc1fa19e374fd8dd986b0d2af0d02377261d83c"
-dependencies = [
- "getrandom 0.3.4",
 ]
 
 [[package]]
@@ -1884,7 +1702,6 @@ dependencies = [
  "mime_guess",
  "percent-encoding",
  "pin-project-lite",
- "quinn",
  "rustls",
  "rustls-pki-types",
  "rustls-platform-verifier",
@@ -1911,7 +1728,7 @@ checksum = "a4689e6c2294d81e88dc6261c768b63bc4fcdb852be6d1352498b114f61383b7"
 dependencies = [
  "cc",
  "cfg-if",
- "getrandom 0.2.17",
+ "getrandom",
  "libc",
  "untrusted",
  "windows-sys 0.52.0",
@@ -1973,8 +1790,9 @@ version = "0.23.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ef86cd5876211988985292b91c96a8f2d298df24e75989a43a3c73f2d4d8168b"
 dependencies = [
- "aws-lc-rs",
+ "log",
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
@@ -1999,7 +1817,6 @@ version = "1.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "30a7197ae7eb376e574fe940d068c30fe0462554a3ddbe4eca7838e049c937a9"
 dependencies = [
- "web-time",
  "zeroize",
 ]
 
@@ -2036,7 +1853,6 @@ version = "0.103.13"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "61c429a8649f110dddef65e2a5ad240f747e85f7758a6bccc7e5777bd33f756e"
 dependencies = [
- "aws-lc-rs",
  "ring",
  "rustls-pki-types",
  "untrusted",
@@ -2482,21 +2298,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tinyvec"
-version = "1.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3e61e67053d25a4e82c844e8424039d9745781b3fc4f32b8d55ed50f5f667ef3"
-dependencies = [
- "tinyvec_macros",
-]
-
-[[package]]
-name = "tinyvec_macros"
-version = "0.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
-
-[[package]]
 name = "tokio"
 version = "1.52.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2791,15 +2592,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ccf3ec651a847eb01de73ccad15eb7d99f80485de043efb2f370cd654f4ea44b"
 
 [[package]]
-name = "wasip2"
-version = "1.0.3+wasi-0.2.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "20064672db26d7cdc89c7798c48a0fdfac8213434a1186e5ef29fd560ae223d6"
-dependencies = [
- "wit-bindgen",
-]
-
-[[package]]
 name = "wasm-bindgen"
 version = "0.2.122"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2969,16 +2761,7 @@ version = "0.52.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "282be5f36a8ce781fad8c8ae18fa3f9beff57ec1b52cb3de0789201425d9a33d"
 dependencies = [
- "windows-targets 0.52.6",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.60.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
-dependencies = [
- "windows-targets 0.53.5",
+ "windows-targets",
 ]
 
 [[package]]
@@ -2996,31 +2779,14 @@ version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9b724f72796e036ab90c1021d4780d4d3d648aca59e491e6b98e725b84e99973"
 dependencies = [
- "windows_aarch64_gnullvm 0.52.6",
- "windows_aarch64_msvc 0.52.6",
- "windows_i686_gnu 0.52.6",
- "windows_i686_gnullvm 0.52.6",
- "windows_i686_msvc 0.52.6",
- "windows_x86_64_gnu 0.52.6",
- "windows_x86_64_gnullvm 0.52.6",
- "windows_x86_64_msvc 0.52.6",
-]
-
-[[package]]
-name = "windows-targets"
-version = "0.53.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4945f9f551b88e0d65f3db0bc25c33b8acea4d9e41163edf90dcd0b19f9069f3"
-dependencies = [
- "windows-link",
- "windows_aarch64_gnullvm 0.53.1",
- "windows_aarch64_msvc 0.53.1",
- "windows_i686_gnu 0.53.1",
- "windows_i686_gnullvm 0.53.1",
- "windows_i686_msvc 0.53.1",
- "windows_x86_64_gnu 0.53.1",
- "windows_x86_64_gnullvm 0.53.1",
- "windows_x86_64_msvc 0.53.1",
+ "windows_aarch64_gnullvm",
+ "windows_aarch64_msvc",
+ "windows_i686_gnu",
+ "windows_i686_gnullvm",
+ "windows_i686_msvc",
+ "windows_x86_64_gnu",
+ "windows_x86_64_gnullvm",
+ "windows_x86_64_msvc",
 ]
 
 [[package]]
@@ -3030,22 +2796,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32a4622180e7a0ec044bb555404c800bc9fd9ec262ec147edd5989ccd0c02cd3"
 
 [[package]]
-name = "windows_aarch64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a9d8416fa8b42f5c947f8482c43e7d89e73a173cead56d044f6a56104a6d1b53"
-
-[[package]]
 name = "windows_aarch64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09ec2a7bb152e2252b53fa7803150007879548bc709c039df7627cabbd05d469"
-
-[[package]]
-name = "windows_aarch64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b9d782e804c2f632e395708e99a94275910eb9100b2114651e04744e9b125006"
 
 [[package]]
 name = "windows_i686_gnu"
@@ -3054,22 +2808,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e9b5ad5ab802e97eb8e295ac6720e509ee4c243f69d781394014ebfe8bbfa0b"
 
 [[package]]
-name = "windows_i686_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "960e6da069d81e09becb0ca57a65220ddff016ff2d6af6a223cf372a506593a3"
-
-[[package]]
 name = "windows_i686_gnullvm"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0eee52d38c090b3caa76c563b86c3a4bd71ef1a819287c19d586d7334ae8ed66"
-
-[[package]]
-name = "windows_i686_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fa7359d10048f68ab8b09fa71c3daccfb0e9b559aed648a8f95469c27057180c"
 
 [[package]]
 name = "windows_i686_msvc"
@@ -3078,22 +2820,10 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "240948bc05c5e7c6dabba28bf89d89ffce3e303022809e73deaefe4f6ec56c66"
 
 [[package]]
-name = "windows_i686_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e7ac75179f18232fe9c285163565a57ef8d3c89254a30685b57d83a38d326c2"
-
-[[package]]
 name = "windows_x86_64_gnu"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "147a5c80aabfbf0c7d901cb5895d1de30ef2907eb21fbbab29ca94c5b08b1a78"
-
-[[package]]
-name = "windows_x86_64_gnu"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9c3842cdd74a865a8066ab39c8a7a473c0778a3f29370b5fd6b4b9aa7df4a499"
 
 [[package]]
 name = "windows_x86_64_gnullvm"
@@ -3102,34 +2832,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "24d5b23dc417412679681396f2b49f3de8c1473deb516bd34410872eff51ed0d"
 
 [[package]]
-name = "windows_x86_64_gnullvm"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0ffa179e2d07eee8ad8f57493436566c7cc30ac536a3379fdf008f47f6bb7ae1"
-
-[[package]]
 name = "windows_x86_64_msvc"
 version = "0.52.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "589f6da84c646204747d1270a2a5661ea66ed1cced2631d546fdfb155959f9ec"
 
 [[package]]
-name = "windows_x86_64_msvc"
-version = "0.53.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6bbff5f0aada427a1e5a6da5f1f98158182f26556f345ac9e04d36d0ebed650"
-
-[[package]]
 name = "winnow"
 version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0592e1c9d151f854e6fd382574c3a0855250e1d9b2f99d9281c6e6391af352f1"
-
-[[package]]
-name = "wit-bindgen"
-version = "0.57.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1ebf944e87a7c253233ad6766e082e3cd714b5d03812acc24c318f549614536e"
 
 [[package]]
 name = "writeable"
@@ -3158,26 +2870,6 @@ dependencies = [
  "quote",
  "syn",
  "synstructure",
-]
-
-[[package]]
-name = "zerocopy"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bce33a6288fa3f072a8c2c7d0f2fdbb90e28298f0135c1f99b96c3db2efcc60b"
-dependencies = [
- "zerocopy-derive",
-]
-
-[[package]]
-name = "zerocopy-derive"
-version = "0.8.49"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8fd425244944f4ab65ccff928e7323354c5a018c75838362fdce749dfad2ee1e"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,9 +13,15 @@ repository = "https://github.com/hahwul/dalfox"
 clap = { version = "4.0", features = ["derive", "env"] }
 url = "2.0"
 reqwest = { version = "0.13", default-features = false, features = [
-    "rustls",
+    "rustls-no-provider",
     "socks", "multipart", "json", "form", "gzip", "deflate", "brotli"
 ] }
+# Pin rustls to the `ring` crypto backend instead of the default `aws-lc-rs`.
+# aws-lc-sys ships C/asm that fails to link on several distros (AUR, musl,
+# etc. — see #1061), whereas ring's prebuilt assembly is portable. reqwest's
+# `rustls-no-provider` feature leaves the crypto provider unset, so we install
+# ring's as the process default (see `dalfox::ensure_crypto_provider`).
+rustls = { version = "0.23", default-features = false, features = ["ring", "std", "tls12", "logging"] }
 scraper = "0.27"
 tokio = { version = "1", features = ["full"] }
 serde = { version = "1.0", features = ["derive"] }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -79,6 +79,26 @@ pub static WAF_CONSECUTIVE_BLOCKS: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(0);
 pub static NO_COLOR: AtomicBool = AtomicBool::new(false);
 
+/// Install the process-wide rustls crypto provider (ring).
+///
+/// reqwest is built with the `rustls-no-provider` feature so it bundles no
+/// crypto backend; we supply ring's instead of the default aws-lc-rs because
+/// aws-lc-sys fails to link on several distros (AUR, musl, …; see #1061).
+/// reqwest resolves the provider via `CryptoProvider::get_default()` when a
+/// `Client` is built, so this must run before the first client is constructed
+/// — it is called from `main()` and from every pooled client builder.
+///
+/// Idempotent and thread-safe: the first caller installs the provider, the
+/// rest are no-ops. If a downstream library consumer already installed a
+/// provider of their own, `install_default` returns `Err` and we leave their
+/// choice untouched.
+pub fn ensure_crypto_provider() {
+    static INSTALL: std::sync::Once = std::sync::Once::new();
+    INSTALL.call_once(|| {
+        let _ = rustls::crypto::ring::default_provider().install_default();
+    });
+}
+
 tokio::task_local! {
     /// Per-scan request counter, set by the MCP runner so concurrent scans
     /// don't pollute each other's progress tallies. Callers use

--- a/src/main.rs
+++ b/src/main.rs
@@ -77,6 +77,11 @@ use dalfox::utils::fs::read_bounded;
 
 #[tokio::main]
 async fn main() {
+    // Install the rustls crypto provider (ring) before anything builds a
+    // reqwest Client. reqwest uses `rustls-no-provider`, so without this the
+    // first Client::build() panics with "no crypto provider configured".
+    dalfox::ensure_crypto_provider();
+
     // Exit cleanly when a downstream consumer (e.g. `head`, `grep -q`) closes
     // the pipe. Rust ignores SIGPIPE by default, so the next `println!` panics
     // inside the stdio shim with `failed printing to stdout: Broken pipe` and

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -93,6 +93,7 @@ pub struct RemoteFetchOptions {
 
 /// Build a reqwest Client with the given remote fetch options (timeout, proxy).
 fn build_remote_client(opts: &RemoteFetchOptions) -> Result<Client, Box<dyn std::error::Error>> {
+    crate::ensure_crypto_provider();
     let mut builder = Client::builder()
         .timeout(Duration::from_secs(
             opts.timeout_secs.unwrap_or(DEFAULT_TIMEOUT_SECS),
@@ -174,6 +175,7 @@ pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn st
         return Ok(());
     }
 
+    crate::ensure_crypto_provider();
     let client = Client::builder()
         .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
         .danger_accept_invalid_certs(true)
@@ -209,6 +211,7 @@ pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn s
         return Ok(());
     }
 
+    crate::ensure_crypto_provider();
     let client = Client::builder()
         .timeout(Duration::from_secs(DEFAULT_TIMEOUT_SECS))
         .danger_accept_invalid_certs(true)

--- a/src/scanning/light_verify/tests.rs
+++ b/src/scanning/light_verify/tests.rs
@@ -13,6 +13,15 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio::time::{Duration, sleep};
 
+/// reqwest is built with `rustls-no-provider`, so the ring crypto provider
+/// must be installed before the first `Client::build()` or it panics.
+/// Production installs it in `main()` / the pooled builders; these unit tests
+/// construct bare clients, so route them through this helper.
+fn test_client() -> Client {
+    crate::ensure_crypto_provider();
+    Client::new()
+}
+
 #[derive(Clone)]
 struct TestState {
     class_marker: String,
@@ -155,7 +164,7 @@ async fn test_verify_dom_xss_light_raw_reflection_without_marker_evidence() {
     let target = make_target(addr, "/reflect", None, None);
     let param = make_param(Location::Query, "q");
     let payload = "<script>alert(1)</script>";
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, note) =
         verify_dom_xss_light_with_client(&client, &target, &param, payload).await;
@@ -175,7 +184,7 @@ async fn test_verify_dom_xss_light_marker_element_present_without_payload() {
     let target = make_target(addr, "/marker-only", None, None);
     let param = make_param(Location::Query, "q");
     let payload = format!("<div class=\"{}\">injected</div>", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
@@ -192,7 +201,7 @@ async fn test_verify_dom_xss_light_sets_csp_hint_when_inline_handlers_blocked() 
     let target = make_target(addr, "/csp", None, None);
     let param = make_param(Location::Query, "q");
     let payload = format!("payload-{}", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
@@ -214,7 +223,7 @@ async fn test_verify_dom_xss_light_returns_none_response_on_request_failure() {
     target.timeout = 1;
     let param = make_param(Location::Query, "q");
     let payload = "x";
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, note) =
         verify_dom_xss_light_with_client(&client, &target, &param, payload).await;
@@ -231,6 +240,7 @@ async fn test_verify_dom_xss_light_redirection() {
     let target = make_target(addr, "/redirect", None, None);
     let param = make_param(Location::Query, "q");
     let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
+    crate::ensure_crypto_provider();
     let client = Client::builder()
         .redirect(reqwest::redirect::Policy::none())
         .build()
@@ -251,7 +261,7 @@ async fn test_verify_dom_xss_light_location_header() {
     let target = make_target(addr, "/header", None, None);
     let param = make_param(Location::Header, "X-XSS");
     let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
@@ -268,7 +278,7 @@ async fn test_verify_dom_xss_light_location_body() {
     let target = make_target(addr, "/body", Some("POST"), Some("q=seed"));
     let param = make_param(Location::Body, "q");
     let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, _note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
@@ -284,7 +294,7 @@ async fn test_verify_dom_xss_light_location_json_body() {
     let target = make_target(addr, "/json", Some("POST"), Some("{\"q\":\"seed\"}"));
     let param = make_param(Location::JsonBody, "q");
     let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, _note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
@@ -300,7 +310,7 @@ async fn test_verify_dom_xss_light_location_multipart_body() {
     let target = make_target(addr, "/multipart", Some("POST"), Some("q=seed"));
     let param = make_param(Location::MultipartBody, "q");
     let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
-    let client = Client::new();
+    let client = test_client();
 
     let (verified, response, _note) =
         verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -89,6 +89,9 @@ impl Target {
     }
 
     pub fn build_client(&self) -> Result<Client, Box<dyn std::error::Error>> {
+        // Library consumers may build clients without going through `main()`,
+        // so make sure the ring crypto provider is installed first.
+        crate::ensure_crypto_provider();
         let key = self.client_cache_key();
         // Fast path: return a cached Client if one matches the key.
         if let Ok(guard) = client_cache().lock()

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -143,6 +143,7 @@ fn test_build_preflight_request_get_sets_range_and_headers() {
     target.user_agent = Some("Dalfox-Test-UA".to_string());
     target.cookies = vec![("sid".to_string(), "abc".to_string())];
 
+    crate::ensure_crypto_provider();
     let client = reqwest::Client::new();
     let req = build_preflight_request(&client, &target, false, Some(128))
         .build()
@@ -179,6 +180,7 @@ fn test_build_preflight_request_get_sets_range_and_headers() {
 #[test]
 fn test_build_preflight_request_head_ignores_range() {
     let target = parse_target("https://example.com/path").unwrap();
+    crate::ensure_crypto_provider();
     let client = reqwest::Client::new();
     let req = build_preflight_request(&client, &target, true, Some(128))
         .build()

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -1642,6 +1642,7 @@ async fn test_header_reflection_v2() {
         let header_name_lc = header_name.to_ascii_lowercase();
 
         // Simple functional check: server reflects the header value (transformed)
+        dalfox::ensure_crypto_provider();
         let client = reqwest::Client::new();
         let url = format!("http://{}:{}/header/{}", addr.ip(), addr.port(), case_id);
         let resp = client
@@ -1762,6 +1763,7 @@ async fn test_body_reflection_v2() {
         let param_name = case.param_name.as_deref().unwrap_or("query");
 
         // Simple functional check: server reflects the body param (transformed)
+        dalfox::ensure_crypto_provider();
         let client = reqwest::Client::new();
         let url = format!("http://{}:{}/body/{}", addr.ip(), addr.port(), case_id);
         let form = [(param_name.to_string(), "seed".to_string())];
@@ -1789,6 +1791,7 @@ async fn test_header_reflection_diverse_xss_contexts_v2() {
     // Representative header contexts: raw/script/attribute/js-string/style/encoded.
     let case_ids = vec![1, 9, 23, 32, 35, 41, 46, 49];
     let mut failed = Vec::new();
+    dalfox::ensure_crypto_provider();
     let client = reqwest::Client::new();
 
     for case_id in case_ids {
@@ -1834,6 +1837,7 @@ async fn test_header_reflection_advanced_xss_coverage_v2() {
     let case_ids = vec![42, 43, 45, 47, 48, 50, 34, 40];
     let mut reflected_count = 0usize;
     let mut mismatches = Vec::new();
+    dalfox::ensure_crypto_provider();
     let client = reqwest::Client::new();
 
     for case_id in case_ids {
@@ -2094,6 +2098,7 @@ async fn test_body_reflection_diverse_xss_contexts_v2() {
 
     let case_ids = vec![1, 9, 11, 14, 18, 21, 26, 31, 33];
     let mut failed = Vec::new();
+    dalfox::ensure_crypto_provider();
     let client = reqwest::Client::new();
 
     for case_id in case_ids {
@@ -2139,6 +2144,7 @@ async fn test_body_reflection_advanced_xss_coverage_v2() {
     let case_ids = vec![27, 28, 29, 30, 32, 34, 35, 36];
     let mut reflected_count = 0usize;
     let mut mismatches = Vec::new();
+    dalfox::ensure_crypto_provider();
     let client = reqwest::Client::new();
 
     for case_id in case_ids {


### PR DESCRIPTION
## Summary

Fixes #1061 — building dalfox v3.0.1 (e.g. via AUR/`paru`) fails at release linking with `ld.lld: error: undefined symbol: aws_lc_0_41_0_*`.

**Root cause:** reqwest's `rustls` feature forces the **aws-lc-rs** crypto backend, whose `aws-lc-sys` crate compiles a C/assembly library. That library fails to link on several toolchains (the AUR builder, musl, etc.), producing the undefined `aws_lc_0_41_0_*` symbols.

**Fix:** switch rustls to the portable **ring** backend, which ships prebuilt assembly and needs no C toolchain.

## Changes

- **`Cargo.toml`**: reqwest `rustls` → `rustls-no-provider`, and pin a direct `rustls` dependency to `["ring", "std", "tls12", "logging"]`. This removes `aws-lc-rs` / `aws-lc-sys` from the dependency tree entirely.
- **`src/lib.rs`**: add `dalfox::ensure_crypto_provider()` — idempotent, thread-safe, installs ring's `CryptoProvider` as the process default. `rustls-no-provider` ships no provider, so reqwest resolves it via `CryptoProvider::get_default()` at `Client::build()` time.
- **`src/main.rs`**: install the provider first thing in `main()`.
- **`src/target_parser/mod.rs`, `src/payload/remote.rs`**: install it in every pooled client builder so library consumers and the MCP server are covered even without going through `main()`.
- **tests**: route the unit/functional tests that construct bare reqwest `Client`s through the installer so they don't panic with "no crypto provider configured".

## Verification

- `cargo tree` — no `aws-lc-rs` / `aws-lc-sys`; ring is the backend across reqwest / hyper-rustls / tokio-rustls / rustls-platform-verifier.
- `cargo build --release` (LTO, `codegen-units = 1`, `strip`) **links cleanly** — the exact scenario that failed on AUR.
- **0 `aws_lc` symbols** in the release binary (`nm`); live HTTPS handshake succeeds over ring (HTTP/2 200).
- `cargo test --lib` → 1275 passed; `cargo clippy --all-targets` clean; remote-builder integration tests pass.

The in-repo `aur/PKGBUILD` needs no change — it builds against the committed `Cargo.lock` (now aws-lc-free); its `pkgver` is bumped by the maintainer at release time, so the AUR build will succeed once a release includes this commit.