### PR TITLE
ci(packaging): add Arch/musl/snap source-build gates

### DIFF
--- a/.github/workflows/ci-packaging.yml
+++ b/.github/workflows/ci-packaging.yml
@@ -1,0 +1,83 @@
+---
+name: Packaging Build
+# Source-build gates for the distro packaging paths that the default CI
+# (glibc + GNU ld on ubuntu/macos/windows) never exercises. These would have
+# caught #1061, where aws-lc-sys failed to link under Arch's rust toolchain
+# (lld). Each job builds dalfox from source the way a downstream packager
+# does, then smoke-runs the binary.
+on:
+  push:
+    branches: [main]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "**/*.rs"
+      - aur/PKGBUILD
+      - snap/snapcraft.yaml
+      - .github/workflows/ci-packaging.yml
+  pull_request:
+    branches: [main]
+    paths:
+      - Cargo.toml
+      - Cargo.lock
+      - "**/*.rs"
+      - aur/PKGBUILD
+      - snap/snapcraft.yaml
+      - .github/workflows/ci-packaging.yml
+  workflow_dispatch:
+env:
+  CARGO_TERM_COLOR: always
+jobs:
+  arch-aur:
+    name: AUR source build (Arch, lld)
+    runs-on: ubuntu-latest
+    container: archlinux:base-devel
+    # Reproduces the reporter's environment from #1061: Arch's rust package
+    # linking with lld. We run the same cargo invocation the AUR PKGBUILD
+    # uses, against this PR's working tree. We deliberately do NOT call
+    # makepkg: its source=() points at the published v<pkgver> release
+    # tarball, so it would build the released source instead of this PR.
+    env:
+      # Force the lld link path the AUR failure surfaced under, so any
+      # regression of the aws-lc-sys class fails here too.
+      RUSTFLAGS: "-C link-arg=-fuse-ld=lld"
+    steps:
+      - name: Install toolchain
+        run: pacman -Syu --noconfirm --needed base-devel rust git lld
+      - uses: actions/checkout@v6
+      - name: Build like the AUR PKGBUILD
+        run: |
+          cargo fetch --locked
+          cargo build --frozen --release --all-features
+      - name: Smoke test the binary
+        run: ./target/release/dalfox --version
+
+  musl:
+    name: Static musl build
+    runs-on: ubuntu-latest
+    # musl is where C-FFI crates (the aws-lc-sys class) most often break, so a
+    # static build is a cheap canary that the dependency graph stays
+    # pure-Rust / musl-friendly.
+    steps:
+      - uses: actions/checkout@v6
+      - uses: dtolnay/rust-toolchain@stable
+        with:
+          targets: x86_64-unknown-linux-musl
+      - name: Install musl tools
+        run: sudo apt-get update && sudo apt-get install -y musl-tools
+      - name: Build (static musl)
+        run: cargo build --locked --release --target x86_64-unknown-linux-musl
+      - name: Smoke test the binary
+        run: ./target/x86_64-unknown-linux-musl/release/dalfox --version
+
+  snap:
+    name: Snap source build
+    runs-on: ubuntu-latest
+    # Builds snap/snapcraft.yaml the way the Snap Store does (snapcraft + LXD),
+    # validating the amd64 source build before publish. The arm64/armhf/i386
+    # entries in snapcraft.yaml build only on a matching host, so they are
+    # covered separately via `snapcraft remote-build` at release time.
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build snap
+        uses: snapcore/action-build@v1


### PR DESCRIPTION
## Motivation

#1061 (the aws-lc-sys link failure on AUR) shipped in v3.0.1 because **the default CI only builds on glibc + GNU ld** (ubuntu/macos/windows). The break only surfaces under Arch's rust toolchain, which links with **lld** — an environment nothing in CI exercised before publishing.

This adds a `Packaging Build` workflow that builds dalfox from source the way downstream packagers do, then smoke-runs the binary, so this class of failure is caught on the PR instead of in a release.

## Jobs

- **arch-aur** — `archlinux:base-devel`, `RUSTFLAGS=-C link-arg=-fuse-ld=lld`, mirrors the AUR PKGBUILD's `cargo build --frozen --release` against the working tree. Reproduces #1061's exact environment (would have failed red on the pre-fix tree). It runs cargo directly rather than `makepkg`, because the PKGBUILD's `source=()` points at the published release tarball — `makepkg` would build the released source, not the PR.
- **musl** — `x86_64-unknown-linux-musl` static build. musl is where C-FFI crates (the aws-lc-sys class) most often break, so this is the cheapest canary that the dependency graph stays pure-Rust / musl-friendly.
- **snap** — builds `snap/snapcraft.yaml` via `snapcore/action-build` (amd64), as the Snap Store does. The arm64/armhf/i386 entries build only on a matching host and are covered via `snapcraft remote-build` at release time.

Triggers on PRs/pushes touching `Cargo.{toml,lock}`, `**/*.rs`, `aur/PKGBUILD`, `snap/snapcraft.yaml`, or the workflow itself.

## Local verification

Reproduced the gate locally via Docker (`--platform linux/amd64`, Arch + lld): the **v3.0.1** tree fails with the `undefined symbol: aws_lc_0_41_0_*` link error, while **main** (post #1063 ring fix) builds clean and the binary runs. Results pasted in the thread.