### PR TITLE
refactor(scanning): name magic numbers and dedupe reflection helpers (#1016)

### DIFF
--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -23,7 +23,7 @@ pub(crate) async fn resolve_targets(
     // bounded` enforce the cap during the read itself, so a pseudo-
     // file that lies about its size (`/dev/zero` reports 0 bytes via
     // metadata) is still stopped.
-    const MAX_TARGET_LIST_BYTES: u64 = 256 << 20; // 256 MiB
+    const MAX_TARGET_LIST_BYTES: u64 = crate::utils::fs::MAX_FILE_READ_BYTES;
 
     // Auto-detect raw-http on positional args. Read each candidate
     // file *once* into a cache so the later "auto" branch can reuse

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -260,19 +260,18 @@ fn test_extract_context_none() {
 
 #[test]
 fn test_dedupe_ast_results_prefers_verified_variant() {
-    let mut ast_a = ScanResult::new(
-        FindingType::AstDetected,
-        "DOM-XSS".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<img src=x onerror=alert(1)>".to_string(),
-        "https://example.com:1:1 - desc (Source: location.search, Sink: innerHTML)".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        0,
-        "desc (검증 필요) [경량 확인: 미검증]".to_string(),
-    );
+    let mut ast_a = ScanResult::builder(FindingType::AstDetected)
+        .inject_type("DOM-XSS")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<img src=x onerror=alert(1)>")
+        .evidence("https://example.com:1:1 - desc (Source: location.search, Sink: innerHTML)")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(0)
+        .message_str("desc (검증 필요) [경량 확인: 미검증]")
+        .build();
     ast_a.request = Some("GET /?q=... HTTP/1.1".to_string());
 
     let mut ast_v = ast_a.clone();
@@ -290,32 +289,30 @@ fn test_dedupe_ast_results_prefers_verified_variant() {
 fn test_dedupe_ast_results_collapses_cross_stage_duplicates() {
     let evidence =
         "https://example.com:3:9 - DOM-based XSS via location.search to innerHTML (Source: location.search, Sink: innerHTML)".to_string();
-    let ast_preflight = ScanResult::new(
-        FindingType::AstDetected,
-        "DOM-XSS".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "-".to_string(),
-        "<img src=x onerror=alert(1) class=dlxaaa111>".to_string(),
-        evidence.clone(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        0,
-        "preflight".to_string(),
-    );
-    let mut ast_param_verified = ScanResult::new(
-        FindingType::Verified,
-        "DOM-XSS".to_string(),
-        "GET".to_string(),
-        "https://example.com/?q=%3Cimg...%3E".to_string(),
-        "q".to_string(),
-        "<img src=x onerror=alert(1) class=dlxaaa111>".to_string(),
-        evidence,
-        "CWE-79".to_string(),
-        "High".to_string(),
-        0,
-        "verified".to_string(),
-    );
+    let ast_preflight = ScanResult::builder(FindingType::AstDetected)
+        .inject_type("DOM-XSS")
+        .method("GET")
+        .data("https://example.com")
+        .param("-")
+        .payload("<img src=x onerror=alert(1) class=dlxaaa111>")
+        .evidence(evidence.clone())
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(0)
+        .message_str("preflight")
+        .build();
+    let mut ast_param_verified = ScanResult::builder(FindingType::Verified)
+        .inject_type("DOM-XSS")
+        .method("GET")
+        .data("https://example.com/?q=%3Cimg...%3E")
+        .param("q")
+        .payload("<img src=x onerror=alert(1) class=dlxaaa111>")
+        .evidence(evidence)
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(0)
+        .message_str("verified")
+        .build();
     ast_param_verified.request = Some("GET /?q=... HTTP/1.1".to_string());
 
     let deduped = dedupe_ast_results(vec![ast_preflight, ast_param_verified.clone()]);
@@ -326,19 +323,18 @@ fn test_dedupe_ast_results_collapses_cross_stage_duplicates() {
 
 #[test]
 fn test_dedupe_ast_results_keeps_non_ast_entries() {
-    let r1 = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "PAY".to_string(),
-        "e1".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        606,
-        "m1".to_string(),
-    );
+    let r1 = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("PAY")
+        .evidence("e1")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(606)
+        .message_str("m1")
+        .build();
     let r2 = r1.clone();
     let deduped = dedupe_ast_results(vec![r1, r2]);
     assert_eq!(deduped.len(), 2);
@@ -346,19 +342,18 @@ fn test_dedupe_ast_results_keeps_non_ast_entries() {
 
 #[test]
 fn test_generate_poc_plain_query() {
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "plain");
     assert!(out.contains("[POC][R][GET][inHTML]"));
     assert!(out.contains("?q=%3Cx%3E"));
@@ -366,19 +361,18 @@ fn test_generate_poc_plain_query() {
 
 #[test]
 fn test_generate_poc_curl() {
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "curl");
     assert!(out.starts_with("curl -X GET "));
     assert!(out.contains("?q=%3Cx%3E"));
@@ -386,19 +380,18 @@ fn test_generate_poc_curl() {
 
 #[test]
 fn test_generate_poc_http_request_prefers_request_block() {
-    let mut r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let mut r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     r.request = Some("GET / HTTP/1.1\nHost: example.com".to_string());
     let out = generate_poc(&r, "http-request");
     assert!(out.contains("GET / HTTP/1.1"));
@@ -410,19 +403,18 @@ fn test_generate_poc_plain_header_does_not_synthesize_query() {
     // rendered as `?X-Custom-Header=<svg…>` (an invented query param),
     // which couldn't reproduce the finding. The plain POC must now leave
     // the URL untouched and tag the line with `[hdr]`.
-    let mut r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "http://example.com/".to_string(),
-        "X-Custom-Header".to_string(),
-        "<svg/onload=alert(1)>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let mut r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("http://example.com/")
+        .param("X-Custom-Header")
+        .payload("<svg/onload=alert(1)>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     r.location = "Header".to_string();
     let out = generate_poc(&r, "plain");
     assert!(
@@ -440,19 +432,18 @@ fn test_generate_poc_plain_header_does_not_synthesize_query() {
 
 #[test]
 fn test_generate_poc_curl_header_uses_dash_h_flag() {
-    let mut r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "http://example.com/".to_string(),
-        "X-Custom-Header".to_string(),
-        "<svg/onload=alert(1)>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let mut r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("http://example.com/")
+        .param("X-Custom-Header")
+        .payload("<svg/onload=alert(1)>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     r.location = "Header".to_string();
     let out = generate_poc(&r, "curl");
     assert!(
@@ -465,19 +456,18 @@ fn test_generate_poc_curl_header_uses_dash_h_flag() {
 
 #[test]
 fn test_generate_poc_cookie_uses_cookie_tag_and_dash_b() {
-    let mut r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "http://example.com/".to_string(),
-        "Cookie".to_string(),
-        "<svg/onload=alert(1)>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let mut r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("http://example.com/")
+        .param("Cookie")
+        .payload("<svg/onload=alert(1)>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     r.location = "Header".to_string();
     let plain = generate_poc(&r, "plain");
     assert!(
@@ -495,19 +485,18 @@ fn test_generate_poc_cookie_uses_cookie_tag_and_dash_b() {
 
 #[test]
 fn test_generate_poc_body_emits_data_flag() {
-    let mut r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "POST".to_string(),
-        "http://example.com/login".to_string(),
-        "username".to_string(),
-        "<svg/onload=alert(1)>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let mut r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("POST")
+        .data("http://example.com/login")
+        .param("username")
+        .payload("<svg/onload=alert(1)>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     r.location = "Body".to_string();
     let plain = generate_poc(&r, "plain");
     assert!(
@@ -533,19 +522,18 @@ fn test_generate_poc_query_unchanged_when_location_empty() {
     // Older Result producers don't set `location` yet. The plain POC must
     // stay byte-identical to the pre-bug-5 format so unrelated downstream
     // parsers (CI, reporting scripts) don't break.
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "plain");
     assert!(
         out.contains("[POC][R][GET][inHTML]"),
@@ -557,57 +545,54 @@ fn test_generate_poc_query_unchanged_when_location_empty() {
 
 #[test]
 fn test_generate_poc_path_segment_append() {
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://ex.com/foo/bar".to_string(),
-        "path_segment_1".to_string(),
-        "PAY".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://ex.com/foo/bar")
+        .param("path_segment_1")
+        .payload("PAY")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "plain");
     assert!(out.contains("https://ex.com/foo/bar/PAY"));
 }
 
 #[test]
 fn test_generate_poc_http_request_without_request_falls_back_to_url() {
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "http-request");
     assert!(out.contains("https://example.com?q=%3Cx%3E"));
 }
 
 #[test]
 fn test_generate_poc_unknown_type_defaults_to_plain_format() {
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "PAY".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("PAY")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "custom");
     assert!(out.starts_with("[POC][R][GET][inHTML]"));
 }
@@ -615,19 +600,18 @@ fn test_generate_poc_unknown_type_defaults_to_plain_format() {
 #[test]
 fn test_generate_poc_path_segment_selective_encoding_for_special_chars() {
     let payload = "A B#?%".to_string();
-    let r = ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        format!("https://ex.com/base/{}", payload),
-        "path_segment_2".to_string(),
-        payload,
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    );
+    let r = ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data(format!("https://ex.com/base/{}", payload))
+        .param("path_segment_2")
+        .payload(payload)
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build();
     let out = generate_poc(&r, "plain");
     assert!(out.contains("A%20B%23%3F%25"));
 }
@@ -794,19 +778,18 @@ fn host_group(targets: Vec<Target>) -> HashMap<String, Vec<Target>> {
 
 /// A `Reflected` finding with the common boilerplate filled in.
 fn reflected_result(url: &str, param: &str, payload: &str) -> ScanResult {
-    ScanResult::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        url.to_string(),
-        param.to_string(),
-        payload.to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        0,
-        "msg".to_string(),
-    )
+    ScanResult::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data(url.to_string())
+        .param(param.to_string())
+        .payload(payload.to_string())
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(0)
+        .message_str("msg")
+        .build()
 }
 
 /// A `ScanState` with empty shared handles and the supplied results preloaded.

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -556,7 +556,7 @@ pub async fn check_query_discovery(
     // send a purely numeric marker to detect filters that strip a-zA-Z.
     // This catches injection points like `<script>#{input.gsub(/[a-zA-Z]/, "")}</script>`.
     {
-        let numeric_marker = "90197752"; // unique numeric-only probe
+        let numeric_marker = crate::scanning::check_reflection::NUMERIC_PROBE_MARKER;
         for (name, value) in target.url.query_pairs() {
             let name = name.to_string();
             if discovered_names.contains(&name) {

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -484,7 +484,7 @@ pub async fn probe_dictionary_params(
     if !loaded && let Some(wordlist_path) = &args.mining_dict_word {
         match crate::utils::fs::read_bounded(
             std::path::Path::new(wordlist_path),
-            256 << 20, // 256 MiB budget
+            crate::utils::fs::MAX_FILE_READ_BYTES,
             "parameter wordlist",
         ) {
             Ok(content) => {

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -723,22 +723,23 @@ pub fn run_initial_ast_dom_analysis(
             } else {
                 format!("{description} (검증 필요) [경량 확인: 파라미터 없음]")
             };
-            let mut ast_result = crate::scanning::result::Result::new(
+            let mut ast_result = crate::scanning::result::Result::builder(
                 crate::scanning::result::FindingType::AstDetected,
-                "DOM-XSS".to_string(),
-                target_method.to_string(),
-                poc_url,
-                "-".to_string(),
-                payload,
-                format!(
-                    "{}:{}:{} - {} (Source: {}, Sink: {})",
-                    target_url, vuln.line, vuln.column, description, vuln.source, vuln.sink
-                ),
-                "CWE-79".to_string(),
-                "Medium".to_string(),
-                0,
-                message,
-            );
+            )
+            .inject_type("DOM-XSS")
+            .method(target_method.to_string())
+            .data(poc_url)
+            .param("-")
+            .payload(payload)
+            .evidence(format!(
+                "{}:{}:{} - {} (Source: {}, Sink: {})",
+                target_url, vuln.line, vuln.column, description, vuln.source, vuln.sink
+            ))
+            .cwe("CWE-79")
+            .severity("Medium")
+            .message_id(0)
+            .message_str(message)
+            .build();
             if self_bootstrap_verified {
                 ast_result.result_type = crate::scanning::result::FindingType::Verified;
                 ast_result.severity = "High".to_string();

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1402,10 +1402,12 @@ pub async fn check_reflection_with_response(
     }
 }
 
-/// Convenience wrapper over [`check_reflection_with_response`] that discards
-/// the body and reports only whether a (non-safe-context) reflection was
-/// found. Always builds a default client (CLI path).
-pub async fn check_reflection(
+/// Test-only convenience wrapper over [`check_reflection_with_response`]:
+/// discards the body and reports only whether a (non-safe-context) reflection
+/// was found, always building a default client. Production code calls
+/// [`check_reflection_with_response`] directly with a pooled client.
+#[cfg(test)]
+async fn check_reflection(
     target: &Target,
     param: &Param,
     payload: &str,

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -28,6 +28,25 @@ pub use crate::encoding::pre_encoding::apply_pre_encoding;
 /// Maximum number of iterative URL-decode passes when building payload variants.
 const MAX_URL_DECODE_ITERATIONS: usize = 4;
 
+/// Purely numeric reflection probe. Sent for parameters that showed no
+/// reflection with the normal alphanumeric markers, to catch injection
+/// points behind letter-stripping filters (e.g. `gsub(/[a-zA-Z]/, "")`),
+/// which would erase a normal marker but leave digits intact. Shared with
+/// `parameter_analysis::discovery` so both probe paths stay in sync.
+pub const NUMERIC_PROBE_MARKER: &str = "90197752";
+
+/// Consecutive WAF block responses (HTTP 403/406/429/503) tolerated before
+/// adaptive backoff engages. Below this, blocks are assumed transient.
+const WAF_BACKOFF_THRESHOLD: u32 = 3;
+/// Maximum exponential-backoff escalation step. Caps the doubling so the
+/// raw delay plateaus at `WAF_BACKOFF_BASE_MS << WAF_BACKOFF_MAX_ESCALATION`
+/// before the absolute `WAF_BACKOFF_CAP_MS` ceiling is applied.
+const WAF_BACKOFF_MAX_ESCALATION: u32 = 4;
+/// Base backoff delay (milliseconds), doubled once per escalation step.
+const WAF_BACKOFF_BASE_MS: u64 = 2000;
+/// Absolute ceiling (milliseconds) on a single adaptive-backoff sleep.
+const WAF_BACKOFF_CAP_MS: u64 = 30_000;
+
 /// Check whether *all* occurrences of `payload` in `html` fall inside safe tags
 /// (textarea, noscript, style, xmp, plaintext, title).  If the payload appears
 /// at least once outside a safe tag, returns `false`.
@@ -1233,10 +1252,11 @@ async fn fetch_injection_response_with_client(
             if is_waf_block {
                 let consecutive = crate::tick_waf_block();
                 // Apply adaptive backoff when consecutive blocks exceed threshold
-                if consecutive >= 3 {
-                    let escalation = (consecutive - 3).min(4) as u64;
-                    let backoff_ms = 2000u64 * (1u64 << escalation);
-                    let backoff_ms = backoff_ms.min(30_000);
+                if consecutive >= WAF_BACKOFF_THRESHOLD {
+                    let escalation =
+                        (consecutive - WAF_BACKOFF_THRESHOLD).min(WAF_BACKOFF_MAX_ESCALATION);
+                    let backoff_ms = WAF_BACKOFF_BASE_MS * (1u64 << escalation);
+                    let backoff_ms = backoff_ms.min(WAF_BACKOFF_CAP_MS);
                     sleep(Duration::from_millis(backoff_ms)).await;
                 }
             } else {
@@ -1350,60 +1370,51 @@ async fn fetch_injection_response_with_client(
     }
 }
 
+/// Inject `payload`, then classify reflection in the response.
+///
+/// Pass `Some(client)` to reuse a pooled HTTP client (MCP / REST runners);
+/// pass `None` on the CLI path to build a default client per request from
+/// the target. Returns the reflection kind (suppressed to `None` when the
+/// match lands only in a known-safe context) together with the response
+/// body, or `(None, None)` when no response was obtained.
+pub async fn check_reflection_with_response(
+    client: Option<&Client>,
+    target: &Target,
+    param: &Param,
+    payload: &str,
+    args: &crate::cmd::scan::ScanArgs,
+) -> (Option<ReflectionKind>, Option<String>) {
+    let text = match client {
+        Some(client) => {
+            fetch_injection_response_with_client(client, target, param, payload, args).await
+        }
+        None => fetch_injection_response(target, param, payload, args).await,
+    };
+    if let Some(text) = text {
+        let kind = classify_reflection(&text, payload);
+        let kind = match kind {
+            Some(_) if is_in_safe_context_decoded(&text, payload) => None,
+            other => other,
+        };
+        (kind, Some(text))
+    } else {
+        (None, None)
+    }
+}
+
+/// Convenience wrapper over [`check_reflection_with_response`] that discards
+/// the body and reports only whether a (non-safe-context) reflection was
+/// found. Always builds a default client (CLI path).
 pub async fn check_reflection(
     target: &Target,
     param: &Param,
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
 ) -> bool {
-    if let Some(text) = fetch_injection_response(target, param, payload, args).await {
-        match classify_reflection(&text, payload) {
-            Some(_) if is_in_safe_context_decoded(&text, payload) => false,
-            Some(_) => true,
-            None => false,
-        }
-    } else {
-        false
-    }
-}
-
-pub async fn check_reflection_with_response(
-    target: &Target,
-    param: &Param,
-    payload: &str,
-    args: &crate::cmd::scan::ScanArgs,
-) -> (Option<ReflectionKind>, Option<String>) {
-    if let Some(text) = fetch_injection_response(target, param, payload, args).await {
-        let kind = classify_reflection(&text, payload);
-        let kind = match kind {
-            Some(_) if is_in_safe_context_decoded(&text, payload) => None,
-            other => other,
-        };
-        (kind, Some(text))
-    } else {
-        (None, None)
-    }
-}
-
-pub async fn check_reflection_with_response_client(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    payload: &str,
-    args: &crate::cmd::scan::ScanArgs,
-) -> (Option<ReflectionKind>, Option<String>) {
-    if let Some(text) =
-        fetch_injection_response_with_client(client, target, param, payload, args).await
-    {
-        let kind = classify_reflection(&text, payload);
-        let kind = match kind {
-            Some(_) if is_in_safe_context_decoded(&text, payload) => None,
-            other => other,
-        };
-        (kind, Some(text))
-    } else {
-        (None, None)
-    }
+    check_reflection_with_response(None, target, param, payload, args)
+        .await
+        .0
+        .is_some()
 }
 
 /// HPP reflection check: send a request using a pre-built HPP URL (with duplicate params)

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -234,7 +234,7 @@ async fn test_check_reflection_with_response_early_return_when_skip() {
     let param = make_param();
     let mut args = default_scan_args();
     args.skip_xss_scanning = true;
-    let res = check_reflection_with_response(&target, &param, "PAY", &args).await;
+    let res = check_reflection_with_response(None, &target, &param, "PAY", &args).await;
     assert_eq!(
         res,
         (None, None),
@@ -743,7 +743,7 @@ async fn test_check_reflection_suppresses_inert_js_string_apos_reflection() {
     let param = make_param();
     let args = default_scan_args();
 
-    let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
+    let (kind, body) = check_reflection_with_response(None, &target, &param, payload, &args).await;
     assert_eq!(
         kind, None,
         "apos-encoded JS-string reflection should be classified inert (no R)"
@@ -774,7 +774,7 @@ async fn test_check_reflection_detects_form_urlencoded_response_runtime() {
     let param = make_param();
     let args = default_scan_args();
 
-    let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
+    let (kind, body) = check_reflection_with_response(None, &target, &param, payload, &args).await;
     assert_eq!(kind, Some(ReflectionKind::UrlDecoded));
     assert!(
         body.unwrap_or_default()
@@ -807,7 +807,7 @@ async fn test_check_reflection_with_response_demotes_safe_html_entity_reflection
     let param = make_param();
     let args = default_scan_args();
 
-    let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
+    let (kind, body) = check_reflection_with_response(None, &target, &param, payload, &args).await;
     assert_eq!(
         kind, None,
         "safe-context entity reflection must not produce a reflection kind"
@@ -826,7 +826,7 @@ async fn test_check_reflection_with_response_not_reflected() {
     let param = make_param();
     let args = default_scan_args();
 
-    let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
+    let (kind, body) = check_reflection_with_response(None, &target, &param, payload, &args).await;
     assert_eq!(kind, None);
     assert!(
         body.is_some(),
@@ -950,7 +950,7 @@ async fn test_check_reflection_with_response_handles_json_raw_reflection() {
     let param = make_param();
     let args = default_scan_args();
 
-    let (kind, body) = check_reflection_with_response(&target, &param, payload, &args).await;
+    let (kind, body) = check_reflection_with_response(None, &target, &param, payload, &args).await;
     assert_eq!(kind, Some(ReflectionKind::Raw));
     assert!(body.unwrap_or_default().contains("echo"));
 }
@@ -1415,7 +1415,8 @@ async fn test_path_reflection_suppressed_on_non_html_content_type() {
     let args = default_scan_args();
 
     let (kind, _body) =
-        check_reflection_with_response(&target, &param, "<script>alert(1)</script>", &args).await;
+        check_reflection_with_response(None, &target, &param, "<script>alert(1)</script>", &args)
+            .await;
     assert_eq!(
         kind, None,
         "path-injection reflection on application/javascript should be suppressed"

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -36,7 +36,7 @@ pub mod xss_common;
 use crate::cmd::scan::ScanArgs;
 use crate::parameter_analysis::Param;
 use crate::scanning::check_dom_verification::check_dom_verification_with_client;
-use crate::scanning::check_reflection::check_reflection_with_response_client;
+use crate::scanning::check_reflection::check_reflection_with_response;
 use crate::scanning::result::FindingType;
 use crate::target_parser::Target;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -464,14 +464,16 @@ async fn run_ast_dom_analysis(
                 let base = crate::scanning::url_inject::effective_query_base(&target.url, param);
                 crate::scanning::url_inject::build_injected_url(&base, param, &payload)
             };
-            let mut ast_result = crate::scanning::result::Result::new(
-                FindingType::AstDetected,
-                "DOM-XSS".to_string(),
-                crate::scanning::url_inject::effective_method(&target.method, param),
-                result_url.clone(),
-                param.name.clone(),
-                payload.clone(),
-                format!(
+            let mut ast_result = crate::scanning::result::Result::builder(FindingType::AstDetected)
+                .inject_type("DOM-XSS")
+                .method(crate::scanning::url_inject::effective_method(
+                    &target.method,
+                    param,
+                ))
+                .data(result_url.clone())
+                .param(param.name.clone())
+                .payload(payload.clone())
+                .evidence(format!(
                     "{}:{}:{} - {} (Source: {}, Sink: {})",
                     target.url.as_str(),
                     vuln.line,
@@ -479,12 +481,12 @@ async fn run_ast_dom_analysis(
                     description,
                     vuln.source,
                     vuln.sink
-                ),
-                "CWE-79".to_string(),
-                "Medium".to_string(),
-                0,
-                format!("{} (검증 필요)", description),
-            );
+                ))
+                .cwe("CWE-79")
+                .severity("Medium")
+                .message_id(0)
+                .message_str(format!("{} (검증 필요)", description))
+                .build();
             ast_result.location = format!("{:?}", param.location);
             if !source_uses_url_surface {
                 ast_result.request = Some(build_request_text(target, param, &payload));
@@ -1220,7 +1222,7 @@ impl ScanWorkerCtx {
         let mut probe_response_text: Option<String> = None;
         for pp in probe_payloads {
             let (kind, response_text) =
-                check_reflection_with_response_client(client, &self.target, param, pp, &self.args)
+                check_reflection_with_response(Some(client), &self.target, param, pp, &self.args)
                     .await;
             if kind.is_some() {
                 probe_reflected = true;
@@ -1263,9 +1265,9 @@ impl ScanWorkerCtx {
         // If probe found no reflection, try a numeric-only probe to detect
         // letter-stripping filters (e.g., /[a-zA-Z]/ removal).
         if !probe_reflected {
-            let numeric_probe = "90197752";
-            let (kind, _) = check_reflection_with_response_client(
-                client,
+            let numeric_probe = crate::scanning::check_reflection::NUMERIC_PROBE_MARKER;
+            let (kind, _) = check_reflection_with_response(
+                Some(client),
                 &self.target,
                 param,
                 numeric_probe,
@@ -1316,8 +1318,8 @@ impl ScanWorkerCtx {
                     state.reflection_found_locally = true;
                     (None, None)
                 } else {
-                    check_reflection_with_response_client(
-                        self.client.as_ref(),
+                    check_reflection_with_response(
+                        Some(self.client.as_ref()),
                         &self.target,
                         param,
                         &reflection_payload,
@@ -1452,23 +1454,25 @@ impl ScanWorkerCtx {
                     // Template-shaped payloads (`{{…}}`) further refine the
                     // label to `*-CSTI` so users can tell client-side
                     // template injection apart from generic HTML reflection.
-                    let mut result = crate::scanning::result::Result::new(
-                        finding_type,
-                        inject_type_for_payload_with_sink(
+                    let mut result = crate::scanning::result::Result::builder(finding_type)
+                        .inject_type(inject_type_for_payload_with_sink(
                             self.args.sxss,
                             &reflection_payload,
                             param.framework_sink.as_deref(),
-                        ),
-                        crate::scanning::url_inject::effective_method(&self.target.method, param),
-                        result_url,
-                        param.name.clone(),
-                        reflection_payload.clone(),
-                        summary,
-                        "CWE-79".to_string(),
-                        severity,
-                        606,
-                        poc_msg,
-                    );
+                        ))
+                        .method(crate::scanning::url_inject::effective_method(
+                            &self.target.method,
+                            param,
+                        ))
+                        .data(result_url)
+                        .param(param.name.clone())
+                        .payload(reflection_payload.clone())
+                        .evidence(summary)
+                        .cwe("CWE-79")
+                        .severity(severity)
+                        .message_id(606)
+                        .message_str(poc_msg)
+                        .build();
                     result.location = format!("{:?}", param.location);
                     result.request =
                         Some(build_request_text(&self.target, param, &reflection_payload));
@@ -1564,29 +1568,33 @@ impl ScanWorkerCtx {
                         })
                         .map_or("DOM evidence", |k| k.label());
 
-                    let mut result = crate::scanning::result::Result::new(
-                        FindingType::Verified, // DOM-verified => Vulnerability
-                        inject_type_for_payload_with_sink(
-                            self.args.sxss,
-                            &dom_payload,
-                            param.framework_sink.as_deref(),
-                        ),
-                        crate::scanning::url_inject::effective_method(&self.target.method, param),
-                        result_url,
-                        param.name.clone(),
-                        dom_payload.clone(),
-                        format!(
-                            "DOM verification successful for param {} ({})",
-                            param.name, evidence_label
-                        ),
-                        "CWE-79".to_string(),
-                        "High".to_string(),
-                        606,
-                        format!(
-                            "Triggered XSS Payload ({}): {}={}",
-                            evidence_label, param.name, dom_payload
-                        ),
-                    );
+                    // DOM-verified => Vulnerability
+                    let mut result =
+                        crate::scanning::result::Result::builder(FindingType::Verified)
+                            .inject_type(inject_type_for_payload_with_sink(
+                                self.args.sxss,
+                                &dom_payload,
+                                param.framework_sink.as_deref(),
+                            ))
+                            .method(crate::scanning::url_inject::effective_method(
+                                &self.target.method,
+                                param,
+                            ))
+                            .data(result_url)
+                            .param(param.name.clone())
+                            .payload(dom_payload.clone())
+                            .evidence(format!(
+                                "DOM verification successful for param {} ({})",
+                                param.name, evidence_label
+                            ))
+                            .cwe("CWE-79")
+                            .severity("High")
+                            .message_id(606)
+                            .message_str(format!(
+                                "Triggered XSS Payload ({}): {}={}",
+                                evidence_label, param.name, dom_payload
+                            ))
+                            .build();
                     result.location = format!("{:?}", param.location);
                     result.request = Some(build_request_text(&self.target, param, &dom_payload));
                     result.response = response_text;
@@ -1652,25 +1660,25 @@ impl ScanWorkerCtx {
                         };
                         let reflection_note = reflection_kind_note(kind);
 
-                        let mut result = crate::scanning::result::Result::new(
-                            FindingType::Reflected,
-                            "inHTML-HPP".to_string(),
-                            self.target.method.clone(),
-                            hpp_url.clone(),
-                            param.name.clone(),
-                            hpp_payload.clone(),
-                            format!(
-                                "HPP bypass: reflected XSS for param {} (position={}, {})",
-                                param.name, pos_label, reflection_note
-                            ),
-                            "CWE-79".to_string(),
-                            "Medium".to_string(),
-                            606,
-                            format!(
-                                "[R] HPP Bypass ({}): {}={} (position={})",
-                                reflection_note, param.name, hpp_payload, pos_label
-                            ),
-                        );
+                        let mut result =
+                            crate::scanning::result::Result::builder(FindingType::Reflected)
+                                .inject_type("inHTML-HPP")
+                                .method(self.target.method.clone())
+                                .data(hpp_url.clone())
+                                .param(param.name.clone())
+                                .payload(hpp_payload.clone())
+                                .evidence(format!(
+                                    "HPP bypass: reflected XSS for param {} (position={}, {})",
+                                    param.name, pos_label, reflection_note
+                                ))
+                                .cwe("CWE-79")
+                                .severity("Medium")
+                                .message_id(606)
+                                .message_str(format!(
+                                    "[R] HPP Bypass ({}): {}={} (position={})",
+                                    reflection_note, param.name, hpp_payload, pos_label
+                                ))
+                                .build();
                         result.location = format!("{:?}", param.location);
                         result.response = response_text;
                         self.stream_finding(&result);

--- a/src/scanning/result.rs
+++ b/src/scanning/result.rs
@@ -89,36 +89,109 @@ pub struct Result {
 }
 
 impl Result {
-    #[allow(clippy::too_many_arguments)]
-    pub fn new(
-        result_type: FindingType,
-        inject_type: String,
-        method: String,
-        data: String,
-        param: String,
-        payload: String,
-        evidence: String,
-        cwe: String,
-        severity: String,
-        message_id: u32,
-        message_str: String,
-    ) -> Self {
-        Self {
-            result_type,
-            inject_type,
-            method,
-            data,
-            param,
-            payload,
-            evidence,
-            cwe,
-            severity,
-            message_id,
-            message_str,
-            location: String::new(),
-            request: None,
-            response: None,
+    /// Start building a finding. `result_type` is the only required field;
+    /// every other field starts empty (`""` / `0` / `None`) and is filled in
+    /// with the chained setters on [`ResultBuilder`], finishing with
+    /// [`ResultBuilder::build`].
+    ///
+    /// Replaces the former 11-argument `Result::new`, which tripped
+    /// `clippy::too_many_arguments`. The `location` / `request` / `response`
+    /// fields remain public and are set directly on the built value when a
+    /// caller needs them (often conditionally).
+    pub fn builder(result_type: FindingType) -> ResultBuilder {
+        ResultBuilder {
+            inner: Result {
+                result_type,
+                inject_type: String::new(),
+                method: String::new(),
+                data: String::new(),
+                param: String::new(),
+                payload: String::new(),
+                evidence: String::new(),
+                cwe: String::new(),
+                severity: String::new(),
+                message_id: 0,
+                message_str: String::new(),
+                location: String::new(),
+                request: None,
+                response: None,
+            },
         }
+    }
+}
+
+/// Fluent builder for [`Result`]. Each setter consumes and returns `self` so
+/// calls chain; setters take `impl Into<String>` so both `&str` and `String`
+/// work at the call site.
+#[derive(Debug, Clone)]
+pub struct ResultBuilder {
+    inner: Result,
+}
+
+impl ResultBuilder {
+    /// Injection technique label (e.g. `"inHTML-URL"`, `"DOM-XSS"`).
+    pub fn inject_type(mut self, v: impl Into<String>) -> Self {
+        self.inner.inject_type = v.into();
+        self
+    }
+
+    /// HTTP method used for the request that produced the finding.
+    pub fn method(mut self, v: impl Into<String>) -> Self {
+        self.inner.method = v.into();
+        self
+    }
+
+    /// Request data / URL associated with the finding.
+    pub fn data(mut self, v: impl Into<String>) -> Self {
+        self.inner.data = v.into();
+        self
+    }
+
+    /// Name of the affected parameter.
+    pub fn param(mut self, v: impl Into<String>) -> Self {
+        self.inner.param = v.into();
+        self
+    }
+
+    /// The payload that triggered the finding.
+    pub fn payload(mut self, v: impl Into<String>) -> Self {
+        self.inner.payload = v.into();
+        self
+    }
+
+    /// Human-readable evidence string.
+    pub fn evidence(mut self, v: impl Into<String>) -> Self {
+        self.inner.evidence = v.into();
+        self
+    }
+
+    /// CWE identifier (e.g. `"CWE-79"`).
+    pub fn cwe(mut self, v: impl Into<String>) -> Self {
+        self.inner.cwe = v.into();
+        self
+    }
+
+    /// Severity label (e.g. `"High"`, `"Medium"`).
+    pub fn severity(mut self, v: impl Into<String>) -> Self {
+        self.inner.severity = v.into();
+        self
+    }
+
+    /// Numeric message identifier.
+    pub fn message_id(mut self, v: u32) -> Self {
+        self.inner.message_id = v;
+        self
+    }
+
+    /// Message string shown to the user.
+    pub fn message_str(mut self, v: impl Into<String>) -> Self {
+        self.inner.message_str = v.into();
+        self
+    }
+
+    /// Finalize the builder into a [`Result`].
+    pub fn build(self) -> Result {
+        self.inner
     }
 }
 

--- a/src/scanning/result/tests.rs
+++ b/src/scanning/result/tests.rs
@@ -3,19 +3,18 @@ use serde_json;
 
 #[test]
 fn test_result_creation() {
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "Found script tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("Found script tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
     assert_eq!(result.result_type, FindingType::Verified);
     assert_eq!(result.inject_type, "inHTML");
@@ -34,19 +33,18 @@ fn test_result_creation() {
 
 #[test]
 fn test_result_creation_with_request_response() {
-    let mut result = Result::new(
-        FindingType::Verified,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com".to_string(),
-        "data".to_string(),
-        "alert(1)".to_string(),
-        "JavaScript execution".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        200,
-        "Potential XSS".to_string(),
-    );
+    let mut result = Result::builder(FindingType::Verified)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com")
+        .param("data")
+        .payload("alert(1)")
+        .evidence("JavaScript execution")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(200)
+        .message_str("Potential XSS")
+        .build();
 
     result.request = Some("POST / HTTP/1.1\nHost: example.com\n\nkey=value".to_string());
     result.response = Some("HTTP/1.1 200 OK\n\n<html>alert(1)</html>".to_string());
@@ -61,19 +59,18 @@ fn test_result_creation_with_request_response() {
 
 #[test]
 fn test_result_serialization() {
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "query".to_string(),
-        "payload".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "message".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("query")
+        .payload("payload")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("message")
+        .build();
 
     let json = serde_json::to_string(&result).unwrap();
     assert!(json.contains("\"type\":\"V\""));
@@ -158,33 +155,31 @@ fn test_result_deserialization_ast_detected() {
 
 #[test]
 fn test_result_different_types() {
-    let reflected = Result::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "param".to_string(),
-        "test".to_string(),
-        "Reflected".to_string(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        200,
-        "Parameter reflected".to_string(),
-    );
+    let reflected = Result::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("param")
+        .payload("test")
+        .evidence("Reflected")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(200)
+        .message_str("Parameter reflected")
+        .build();
 
-    let vulnerable = Result::new(
-        FindingType::Verified,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com".to_string(),
-        "data".to_string(),
-        "alert(1)".to_string(),
-        "Executed".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        200,
-        "XSS confirmed".to_string(),
-    );
+    let vulnerable = Result::builder(FindingType::Verified)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com")
+        .param("data")
+        .payload("alert(1)")
+        .evidence("Executed")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(200)
+        .message_str("XSS confirmed")
+        .build();
 
     assert_eq!(reflected.result_type, FindingType::Reflected);
     assert_eq!(reflected.severity, "Info");
@@ -196,37 +191,35 @@ fn test_result_different_types() {
 #[test]
 fn test_result_edge_cases() {
     // Empty strings (except result_type which is now an enum)
-    let result = Result::new(
-        FindingType::Reflected,
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        "".to_string(),
-        0,
-        "".to_string(),
-    );
+    let result = Result::builder(FindingType::Reflected)
+        .inject_type("")
+        .method("")
+        .data("")
+        .param("")
+        .payload("")
+        .evidence("")
+        .cwe("")
+        .severity("")
+        .message_id(0)
+        .message_str("")
+        .build();
 
     assert_eq!(result.result_type, FindingType::Reflected);
     assert_eq!(result.message_id, 0);
 
     // Special characters
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "param".to_string(),
-        "<>\"'&".to_string(),
-        "Special chars".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        200,
-        "Test".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("param")
+        .payload("<>\"'&")
+        .evidence("Special chars")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(200)
+        .message_str("Test")
+        .build();
 
     assert_eq!(result.payload, "<>\"'&");
     let json = serde_json::to_string(&result).unwrap();
@@ -236,33 +229,31 @@ fn test_result_edge_cases() {
 
 #[test]
 fn test_results_to_markdown() {
-    let result1 = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "Found script tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result1 = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("Found script tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
-    let result2 = Result::new(
-        FindingType::Reflected,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com/api".to_string(),
-        "data".to_string(),
-        "alert(2)".to_string(),
-        "Reflected in JS".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        200,
-        "Reflection found".to_string(),
-    );
+    let result2 = Result::builder(FindingType::Reflected)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com/api")
+        .param("data")
+        .payload("alert(2)")
+        .evidence("Reflected in JS")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(200)
+        .message_str("Reflection found")
+        .build();
 
     let results = vec![result1, result2];
     let markdown = Result::results_to_markdown(&results, false, false);
@@ -294,19 +285,18 @@ fn test_results_to_markdown() {
 
 #[test]
 fn test_results_to_markdown_with_request_response() {
-    let mut result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "test".to_string(),
-        "<x>".to_string(),
-        "test evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let mut result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("test")
+        .payload("<x>")
+        .evidence("test evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     result.request = Some("GET /?test=%3Cx%3E HTTP/1.1\nHost: example.com".to_string());
     result.response =
@@ -336,19 +326,18 @@ fn test_results_to_markdown_empty() {
 
 #[test]
 fn test_results_to_sarif_basic() {
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "Found script tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("Found script tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
     let results = vec![result];
     let sarif = Result::results_to_sarif(&results, false, false);
@@ -389,19 +378,18 @@ fn test_results_to_sarif_basic() {
 #[test]
 fn test_results_to_sarif_fingerprint_stable_across_payload_variants() {
     let mk = |payload: &str, data: &str| {
-        Result::new(
-            FindingType::Reflected,
-            "inHTML".to_string(),
-            "GET".to_string(),
-            data.to_string(),
-            "q".to_string(),
-            payload.to_string(),
-            "".to_string(),
-            "CWE-79".to_string(),
-            "Info".to_string(),
-            606,
-            "X".to_string(),
-        )
+        Result::builder(FindingType::Reflected)
+            .inject_type("inHTML")
+            .method("GET")
+            .data(data.to_string())
+            .param("q")
+            .payload(payload.to_string())
+            .evidence("")
+            .cwe("CWE-79")
+            .severity("Info")
+            .message_id(606)
+            .message_str("X")
+            .build()
     };
     let a = mk("<svg/onload=alert(1)>", "https://h/s?q=%3Csvg%3E");
     let b = mk("<img src=x onerror=alert(1)>", "https://h/s?q=%3Cimg%3E");
@@ -422,19 +410,18 @@ fn test_results_to_sarif_fingerprint_stable_across_payload_variants() {
 #[test]
 fn test_results_to_sarif_fingerprint_distinct_for_different_targets() {
     let mk = |data: &str, param: &str| {
-        Result::new(
-            FindingType::Verified,
-            "inHTML".to_string(),
-            "GET".to_string(),
-            data.to_string(),
-            param.to_string(),
-            "p".to_string(),
-            "".to_string(),
-            "CWE-79".to_string(),
-            "High".to_string(),
-            606,
-            "X".to_string(),
-        )
+        Result::builder(FindingType::Verified)
+            .inject_type("inHTML")
+            .method("GET")
+            .data(data.to_string())
+            .param(param.to_string())
+            .payload("p")
+            .evidence("")
+            .cwe("CWE-79")
+            .severity("High")
+            .message_id(606)
+            .message_str("X")
+            .build()
     };
     let a = Result::results_to_sarif(&[mk("https://h/a?q=x", "q")], false, false);
     let b = Result::results_to_sarif(&[mk("https://h/b?q=x", "q")], false, false);
@@ -450,19 +437,18 @@ fn test_results_to_sarif_fingerprint_distinct_for_different_targets() {
 
 #[test]
 fn test_results_to_sarif_with_request_response() {
-    let mut result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "test".to_string(),
-        "<x>".to_string(),
-        "test evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let mut result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("test")
+        .payload("<x>")
+        .evidence("test evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     result.request = Some("GET /?test=%3Cx%3E HTTP/1.1\nHost: example.com".to_string());
     result.response =
@@ -480,47 +466,44 @@ fn test_results_to_sarif_with_request_response() {
 
 #[test]
 fn test_results_to_sarif_severity_levels() {
-    let high = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "p1".to_string(),
-        "payload".to_string(),
-        "".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        1,
-        "High severity".to_string(),
-    );
+    let high = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("p1")
+        .payload("payload")
+        .evidence("")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(1)
+        .message_str("High severity")
+        .build();
 
-    let medium = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "p2".to_string(),
-        "payload".to_string(),
-        "".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        2,
-        "Medium severity".to_string(),
-    );
+    let medium = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("p2")
+        .payload("payload")
+        .evidence("")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(2)
+        .message_str("Medium severity")
+        .build();
 
-    let low = Result::new(
-        FindingType::Reflected,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "p3".to_string(),
-        "payload".to_string(),
-        "".to_string(),
-        "CWE-79".to_string(),
-        "Low".to_string(),
-        3,
-        "Low severity".to_string(),
-    );
+    let low = Result::builder(FindingType::Reflected)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("p3")
+        .payload("payload")
+        .evidence("")
+        .cwe("CWE-79")
+        .severity("Low")
+        .message_id(3)
+        .message_str("Low severity")
+        .build();
 
     // Test each severity level mapping
     let sarif_high = Result::results_to_sarif(&[high], false, false);
@@ -545,19 +528,18 @@ fn test_results_to_sarif_empty() {
 
 #[test]
 fn test_results_to_toml() {
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "Found script tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("Found script tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
     let results = vec![result];
     let toml_output = Result::results_to_toml(&results, false, false);
@@ -573,19 +555,18 @@ fn test_results_to_toml() {
 
 #[test]
 fn test_results_to_sarif_valid_json() {
-    let result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "payload".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "message".to_string(),
-    );
+    let result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("payload")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("message")
+        .build();
 
     let results = vec![result];
     let sarif = Result::results_to_sarif(&results, false, false);
@@ -608,19 +589,18 @@ fn test_results_to_sarif_valid_json() {
 
 #[test]
 fn test_to_json_value_respects_include_flags() {
-    let mut result = Result::new(
-        FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "payload".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        1,
-        "message".to_string(),
-    );
+    let mut result = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("payload")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(1)
+        .message_str("message")
+        .build();
     result.request = Some("GET / HTTP/1.1".to_string());
     result.response = Some("HTTP/1.1 200 OK".to_string());
 
@@ -641,19 +621,18 @@ fn test_to_json_value_respects_include_flags() {
 
 #[test]
 fn test_results_to_json_compact_and_jsonl() {
-    let mut result = Result::new(
-        FindingType::Reflected,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com/api".to_string(),
-        "data".to_string(),
-        "alert(1)".to_string(),
-        "reflected".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        2,
-        "reflection".to_string(),
-    );
+    let mut result = Result::builder(FindingType::Reflected)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com/api")
+        .param("data")
+        .payload("alert(1)")
+        .evidence("reflected")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(2)
+        .message_str("reflection")
+        .build();
     result.request = Some("POST /api HTTP/1.1".to_string());
 
     let results = vec![result];

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -81,19 +81,7 @@ fn integration_scan_args(skip_xss: bool) -> crate::cmd::scan::ScanArgs {
 }
 
 fn make_result(ft: FindingType) -> crate::scanning::result::Result {
-    crate::scanning::result::Result::new(
-        ft,
-        String::new(),
-        String::new(),
-        String::new(),
-        String::new(),
-        String::new(),
-        String::new(),
-        String::new(),
-        String::new(),
-        0,
-        String::new(),
-    )
+    crate::scanning::result::Result::builder(ft).build()
 }
 
 #[test]
@@ -241,19 +229,16 @@ fn make_typed_param_result_for(
     inject: &str,
     data: &str,
 ) -> crate::scanning::result::Result {
-    crate::scanning::result::Result::new(
-        ft,
-        inject.to_string(),
-        "GET".to_string(),
-        data.to_string(),
-        param.to_string(),
-        "PAY".to_string(),
-        String::new(),
-        "CWE-79".to_string(),
-        "Info".to_string(),
-        606,
-        String::new(),
-    )
+    crate::scanning::result::Result::builder(ft)
+        .inject_type(inject)
+        .method("GET")
+        .data(data)
+        .param(param)
+        .payload("PAY")
+        .cwe("CWE-79")
+        .severity("Info")
+        .message_id(606)
+        .build()
 }
 
 #[test]

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -13,7 +13,7 @@ fn build_blind_payloads(callback_url: &str, custom_template_path: Option<&str>) 
     if let Some(path) = custom_template_path {
         match crate::utils::fs::read_bounded(
             std::path::Path::new(path),
-            256 << 20, // 256 MiB budget
+            crate::utils::fs::MAX_FILE_READ_BYTES,
             "custom blind XSS template",
         ) {
             Ok(content) => {

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -392,7 +392,7 @@ pub fn load_custom_payloads(path: &str) -> Result<Vec<String>, Box<dyn std::erro
     // *something* in every failure mode so operators can debug.
     let content = crate::utils::fs::read_bounded(
         std::path::Path::new(path),
-        256 << 20, // 256 MiB budget
+        crate::utils::fs::MAX_FILE_READ_BYTES,
         "custom payload list",
     )
     .map_err(|e| {

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -10,6 +10,14 @@
 use std::io::Read;
 use std::path::Path;
 
+/// Default hard cap for bounded file/stdin reads: 256 MiB. Generous enough
+/// for legitimate target lists, wordlists, and custom-payload files, while
+/// cutting `/dev/zero`, runaway pipes, and gigabyte misclassified blobs to a
+/// fast, clear error instead of OOM-ing the process. Shared by the
+/// target-list, mining-wordlist, and custom-payload read paths so the limit
+/// has a single source of truth. See [`read_bounded`] / [`read_stdin_bounded`].
+pub const MAX_FILE_READ_BYTES: u64 = 256 << 20;
+
 /// Read a UTF-8 file with a hard byte cap. Refuses non-regular files
 /// (a symlink that resolves to a regular file is fine, since
 /// `metadata()` follows symlinks). Returns `Err` when the cap is hit

--- a/tests/integration/markdown_output_test.rs
+++ b/tests/integration/markdown_output_test.rs
@@ -3,19 +3,18 @@ use dalfox::scanning::result::Result as ScanResult;
 
 #[test]
 fn test_markdown_output_single_result() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "XSS script tag found".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS vulnerability detected".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("XSS script tag found")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS vulnerability detected")
+        .build();
 
     let results = vec![result];
     let markdown = ScanResult::results_to_markdown(&results, false, false);
@@ -42,33 +41,31 @@ fn test_markdown_output_single_result() {
 
 #[test]
 fn test_markdown_output_multiple_results() {
-    let result1 = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test1".to_string(),
-        "q".to_string(),
-        "<img src=x onerror=alert(1)>".to_string(),
-        "XSS in image tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result1 = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test1")
+        .param("q")
+        .payload("<img src=x onerror=alert(1)>")
+        .evidence("XSS in image tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
-    let result2 = ScanResult::new(
-        dalfox::scanning::result::FindingType::Reflected,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com/api".to_string(),
-        "callback".to_string(),
-        "alert(2)".to_string(),
-        "Reflection in JavaScript".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        200,
-        "Reflection found".to_string(),
-    );
+    let result2 = ScanResult::builder(dalfox::scanning::result::FindingType::Reflected)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com/api")
+        .param("callback")
+        .payload("alert(2)")
+        .evidence("Reflection in JavaScript")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(200)
+        .message_str("Reflection found")
+        .build();
 
     let results = vec![result1, result2];
     let markdown = ScanResult::results_to_markdown(&results, false, false);
@@ -88,19 +85,18 @@ fn test_markdown_output_multiple_results() {
 
 #[test]
 fn test_markdown_output_with_request_response() {
-    let mut result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?test=xss".to_string(),
-        "test".to_string(),
-        "<x>".to_string(),
-        "test evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let mut result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?test=xss")
+        .param("test")
+        .payload("<x>")
+        .evidence("test evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     result.request =
         Some("GET /?test=%3Cx%3E HTTP/1.1\nHost: example.com\nUser-Agent: Dalfox".to_string());
@@ -124,19 +120,18 @@ fn test_markdown_output_with_request_response() {
 
 #[test]
 fn test_markdown_output_without_request_response() {
-    let mut result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "test".to_string(),
-        "<x>".to_string(),
-        "evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let mut result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("test")
+        .payload("<x>")
+        .evidence("evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     result.request = Some("GET / HTTP/1.1".to_string());
     result.response = Some("HTTP/1.1 200 OK".to_string());
@@ -153,19 +148,18 @@ fn test_markdown_output_without_request_response() {
 
 #[test]
 fn test_markdown_output_special_characters() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "param|with|pipes".to_string(),
-        "payload|with|pipes".to_string(),
-        "evidence|test".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("param|with|pipes")
+        .payload("payload|with|pipes")
+        .evidence("evidence|test")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     let results = vec![result];
     let markdown = ScanResult::results_to_markdown(&results, false, false);

--- a/tests/integration/sarif_output_test.rs
+++ b/tests/integration/sarif_output_test.rs
@@ -3,19 +3,18 @@ use dalfox::scanning::result::Result as ScanResult;
 
 #[test]
 fn test_sarif_output_basic_structure() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test".to_string(),
-        "q".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "XSS script tag found".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS vulnerability detected".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test")
+        .param("q")
+        .payload("<script>alert(1)</script>")
+        .evidence("XSS script tag found")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS vulnerability detected")
+        .build();
 
     let results = vec![result];
     let sarif = ScanResult::results_to_sarif(&results, false, false);
@@ -72,33 +71,31 @@ fn test_sarif_output_basic_structure() {
 
 #[test]
 fn test_sarif_output_multiple_results() {
-    let result1 = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?q=test1".to_string(),
-        "q".to_string(),
-        "<img src=x onerror=alert(1)>".to_string(),
-        "XSS in image tag".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result1 = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?q=test1")
+        .param("q")
+        .payload("<img src=x onerror=alert(1)>")
+        .evidence("XSS in image tag")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
-    let result2 = ScanResult::new(
-        dalfox::scanning::result::FindingType::Reflected,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com/api".to_string(),
-        "callback".to_string(),
-        "alert(2)".to_string(),
-        "Reflection in JavaScript".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        200,
-        "Reflection found".to_string(),
-    );
+    let result2 = ScanResult::builder(dalfox::scanning::result::FindingType::Reflected)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com/api")
+        .param("callback")
+        .payload("alert(2)")
+        .evidence("Reflection in JavaScript")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(200)
+        .message_str("Reflection found")
+        .build();
 
     let results = vec![result1, result2];
     let sarif = ScanResult::results_to_sarif(&results, false, false);
@@ -130,19 +127,18 @@ fn test_sarif_output_multiple_results() {
 
 #[test]
 fn test_sarif_output_with_request_response() {
-    let mut result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com?test=xss".to_string(),
-        "test".to_string(),
-        "<x>".to_string(),
-        "test evidence".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS".to_string(),
-    );
+    let mut result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com?test=xss")
+        .param("test")
+        .payload("<x>")
+        .evidence("test evidence")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS")
+        .build();
 
     result.request =
         Some("GET /?test=%3Cx%3E HTTP/1.1\nHost: example.com\nUser-Agent: Dalfox".to_string());
@@ -187,19 +183,18 @@ fn test_sarif_output_with_request_response() {
 
 #[test]
 fn test_sarif_output_locations() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com/path?param=value".to_string(),
-        "param".to_string(),
-        "<script>alert(1)</script>".to_string(),
-        "Evidence text".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS found".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com/path?param=value")
+        .param("param")
+        .payload("<script>alert(1)</script>")
+        .evidence("Evidence text")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS found")
+        .build();
 
     let results = vec![result];
     let sarif = ScanResult::results_to_sarif(&results, false, false);
@@ -229,19 +224,18 @@ fn test_sarif_output_locations() {
 
 #[test]
 fn test_sarif_output_properties() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inJS".to_string(),
-        "POST".to_string(),
-        "https://example.com".to_string(),
-        "data".to_string(),
-        "alert(1)".to_string(),
-        "Test evidence".to_string(),
-        "CWE-79".to_string(),
-        "Medium".to_string(),
-        200,
-        "Test message".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inJS")
+        .method("POST")
+        .data("https://example.com")
+        .param("data")
+        .payload("alert(1)")
+        .evidence("Test evidence")
+        .cwe("CWE-79")
+        .severity("Medium")
+        .message_id(200)
+        .message_str("Test message")
+        .build();
 
     let results = vec![result];
     let sarif = ScanResult::results_to_sarif(&results, false, false);
@@ -288,19 +282,18 @@ fn test_sarif_severity_mappings() {
     ];
 
     for (severity, expected_level) in test_cases {
-        let result = ScanResult::new(
-            dalfox::scanning::result::FindingType::Verified,
-            "inHTML".to_string(),
-            "GET".to_string(),
-            "https://example.com".to_string(),
-            "param".to_string(),
-            "payload".to_string(),
-            "".to_string(),
-            "CWE-79".to_string(),
-            severity.to_string(),
-            1,
-            format!("{} severity test", severity),
-        );
+        let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+            .inject_type("inHTML")
+            .method("GET")
+            .data("https://example.com")
+            .param("param")
+            .payload("payload")
+            .evidence("")
+            .cwe("CWE-79")
+            .severity(severity.to_string())
+            .message_id(1)
+            .message_str(format!("{} severity test", severity))
+            .build();
 
         let results = vec![result];
         let sarif = ScanResult::results_to_sarif(&results, false, false);

--- a/tests/integration/sarif_validation_test.rs
+++ b/tests/integration/sarif_validation_test.rs
@@ -5,19 +5,18 @@ use serde_json::Value;
 #[test]
 fn test_sarif_schema_compliance() {
     // Create a comprehensive result with all possible fields
-    let mut result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com/test?param=value".to_string(),
-        "param".to_string(),
-        "<script>alert('XSS')</script>".to_string(),
-        "Script tag found in HTML response".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "Cross-site scripting vulnerability detected".to_string(),
-    );
+    let mut result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com/test?param=value")
+        .param("param")
+        .payload("<script>alert('XSS')</script>")
+        .evidence("Script tag found in HTML response")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("Cross-site scripting vulnerability detected")
+        .build();
 
     result.request = Some("GET /test?param=value HTTP/1.1\nHost: example.com".to_string());
     result.response = Some("HTTP/1.1 200 OK\nContent-Type: text/html\n\n<html></html>".to_string());
@@ -187,19 +186,18 @@ fn test_sarif_severity_to_level_mapping() {
     ];
 
     for (severity, expected_level) in test_cases {
-        let result = ScanResult::new(
-            dalfox::scanning::result::FindingType::Verified,
-            "inHTML".to_string(),
-            "GET".to_string(),
-            "https://example.com".to_string(),
-            "param".to_string(),
-            "payload".to_string(),
-            "".to_string(),
-            "CWE-79".to_string(),
-            severity.to_string(),
-            1,
-            "test".to_string(),
-        );
+        let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+            .inject_type("inHTML")
+            .method("GET")
+            .data("https://example.com")
+            .param("param")
+            .payload("payload")
+            .evidence("")
+            .cwe("CWE-79")
+            .severity(severity.to_string())
+            .message_id(1)
+            .message_str("test")
+            .build();
 
         let sarif = ScanResult::results_to_sarif(&[result], false, false);
         let json: Value = serde_json::from_str(&sarif).unwrap();
@@ -215,19 +213,18 @@ fn test_sarif_severity_to_level_mapping() {
 
 #[test]
 fn test_sarif_message_with_evidence() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "payload".to_string(),
-        "Found unescaped output".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        606,
-        "XSS detected".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("payload")
+        .evidence("Found unescaped output")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(606)
+        .message_str("XSS detected")
+        .build();
 
     let sarif = ScanResult::results_to_sarif(&[result], false, false);
     let json: Value = serde_json::from_str(&sarif).unwrap();
@@ -249,19 +246,18 @@ fn test_sarif_message_with_evidence() {
 
 #[test]
 fn test_sarif_partial_fingerprints() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "payload".to_string(),
-        "".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        12345,
-        "test".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("payload")
+        .evidence("")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(12345)
+        .message_str("test")
+        .build();
 
     let sarif = ScanResult::results_to_sarif(&[result], false, false);
     let json: Value = serde_json::from_str(&sarif).unwrap();
@@ -288,19 +284,18 @@ fn test_sarif_partial_fingerprints() {
 
 #[test]
 fn test_sarif_rule_metadata() {
-    let result = ScanResult::new(
-        dalfox::scanning::result::FindingType::Verified,
-        "inHTML".to_string(),
-        "GET".to_string(),
-        "https://example.com".to_string(),
-        "q".to_string(),
-        "payload".to_string(),
-        "".to_string(),
-        "CWE-79".to_string(),
-        "High".to_string(),
-        1,
-        "test".to_string(),
-    );
+    let result = ScanResult::builder(dalfox::scanning::result::FindingType::Verified)
+        .inject_type("inHTML")
+        .method("GET")
+        .data("https://example.com")
+        .param("q")
+        .payload("payload")
+        .evidence("")
+        .cwe("CWE-79")
+        .severity("High")
+        .message_id(1)
+        .message_str("test")
+        .build();
 
     let sarif = ScanResult::results_to_sarif(&[result], false, false);
     let json: Value = serde_json::from_str(&sarif).unwrap();


### PR DESCRIPTION
Resolves #1016.

Cleanup pass over the scanning engine. **No behavior change.**

### Magic numbers → documented constants
| Value | Constant | Location |
|---|---|---|
| `"90197752"` | `NUMERIC_PROBE_MARKER` | `scanning::check_reflection`, shared with `parameter_analysis::discovery` so the letter-stripping probe stays in sync |
| `3` / `4` / `2000` / `30_000` | `WAF_BACKOFF_THRESHOLD` / `_MAX_ESCALATION` / `_BASE_MS` / `_CAP_MS` | `scanning::check_reflection` |
| `256 << 20` (was duplicated 4×) | `utils::fs::MAX_FILE_READ_BYTES` | target-list, mining-wordlist, blind-XSS-template, custom-payload read paths |

### Deduplication
- Consolidated `check_reflection_with_response` + `check_reflection_with_response_client` into a single `check_reflection_with_response(client: Option<&Client>, …)`. `check_reflection` (bool) is now a thin wrapper over it.
- Replaced the 11-argument `Result::new` (and its `#[allow(clippy::too_many_arguments)]`) with a fluent `Result::builder()` / `ResultBuilder` (setters take `impl Into<String>`); migrated all call sites.

### Out of scope (per issue triage)
- Reflection/DOM worker-loop and `apply_payload_transforms` extractions were handled by the `run_scanning` decomposition in #1010 (closed).
- Progress-bar tick is already named (`shimmer::FRAME_MS`).
- WAF mutation cap is already `MAX_WAF_MUTATION_VARIANTS_PER_PAYLOAD`.

### Acceptance criteria
- ✅ No behavior change — consolidations are behavior-preserving, constants are equal values
- ✅ Tests pass — 1275 lib + 189 integration
- ✅ clippy clean — `cargo clippy --all-targets -- -D warnings`
- ✅ `cargo fmt --check` clean