### PR TITLE
docs(site): add Integrations nav, hwaro footer credit, solid sidebar border

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -330,15 +330,8 @@ body::before {
     width: var(--sidebar-w);
     height: calc(100vh - var(--header-h));
     background: var(--bg-sidebar);
-    border-right: 1px solid transparent;
-    /* Vertical ink rule that softens toward the bottom. */
-    border-image: linear-gradient(
-            180deg,
-            var(--ink-line-strong),
-            var(--ink-line) 55%,
-            transparent
-        )
-        1;
+    /* Explicit full-height divider rule against the content column. */
+    border-right: 1px solid var(--border-light);
     overflow-y: auto;
     padding: 1.5rem 0 2rem;
     z-index: 150;

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -1,5 +1,4 @@
       <footer class="docs-footer">
-        <span>Last edited {{ page.date | default(value="") }}</span>
         <span><a href="https://github.com/hahwul/dalfox/edit/main/docs/content/{{ page.relative_path | default(value='') }}" target="_blank" rel="noopener">Edit this page on GitHub</a></span>
       </footer>
     </main>
@@ -17,9 +16,11 @@
   <footer class="site-footer">
     <div class="footer-inner">
       <div class="footer-branding">
-        <span>&copy; 2026 <a href="https://github.com/hahwul">hahwul</a></span>
+        <span>&copy; 2026 <a href="https://github.com/hahwul">HAHWUL</a></span>
         <span class="divider" style="color:var(--border-light)">·</span>
         <span>Released under the MIT License</span>
+        <span class="divider" style="color:var(--border-light)">·</span>
+        <span>Built with <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">hwaro</a></span>
       </div>
       <div class="footer-links">
         <a href="https://github.com/hahwul/dalfox" target="_blank" rel="noopener">GitHub</a>

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -52,6 +52,7 @@
         <nav class="header-nav">
           <a href="{{ base_url }}/getting-started/">Getting Started</a>
           <a href="{{ base_url }}/guide/">Guide</a>
+          <a href="{{ base_url }}/integrations/">Integrations</a>
           <a href="{{ base_url }}/reference/">Reference</a>
         </nav>
       </div>


### PR DESCRIPTION
## Summary
Polish the docs site chrome (header / footer / sidebar).

- **Header nav**: add the **Integrations** link. The `content/integrations/` section (caido, mcp, server, skills) already existed with `weight = 3` but was missing from the top nav — placed between Guide and Reference to match the weight order.
- **Footer**: add a "Built with [hwaro](https://hwaro.hahwul.com)" credit next to the MIT License line (same `·` divider pattern), uppercase the copyright name to **HAHWUL**, and remove the per-page "Last edited" line.
- **Sidebar**: replace the fading `border-image` gradient (which faded to transparent at the bottom) with an explicit full-height `border-right` using the theme's `--border-light` token.

## Test plan
- [x] Reviewed rendered diff locally (`HWARO_DEV=1 hwaro serve -i docs`)
- Template/CSS-only changes; no build logic touched.