### PR TITLE
docs(site): recolor footer hahwul logo to match muted text

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1039,13 +1039,18 @@ nav.pagination a:hover {
     line-height: 0;
 }
 .hahwul-img {
+    display: inline-block;
     width: 80px;
-    height: auto;
-    filter: grayscale(100%) brightness(0.5);
-    transition: filter 0.3s ease;
+    height: 80px;
+    /* Recolor the logo to match the footer text by using its alpha as a mask
+       and filling with the muted text token (the raster itself is white). */
+    background-color: var(--text-muted);
+    -webkit-mask: url("../images/hahwul.webp") center / contain no-repeat;
+            mask: url("../images/hahwul.webp") center / contain no-repeat;
+    transition: background-color 0.3s ease;
 }
 .hahwul-img:hover {
-    filter: grayscale(0%) brightness(1.1);
+    background-color: var(--text-primary);
 }
 .footer-love {
     margin-top: 0.85rem;

--- a/docs/templates/landing.html
+++ b/docs/templates/landing.html
@@ -15,7 +15,7 @@
   <footer class="site-footer">
     <div class="footer-mark">
       <a href="https://www.hahwul.com" target="_blank" rel="noopener">
-        <img src="{{ base_url }}/images/hahwul.webp" class="hahwul-img" alt="hahwul">
+        <span class="hahwul-img" role="img" aria-label="hahwul"></span>
       </a>
       <p class="footer-love">Built with Love</p>
     </div>


### PR DESCRIPTION
## Summary
- Recolor the footer `hahwul` logo on the docs landing page to `var(--text-muted)` so it matches the adjacent "Built with Love" text.
- The logo (`hahwul.webp`) is a white silhouette whose shape lives in its alpha channel, so an `<img>` can't be recolored via `background-color` (it paints its own white pixels). Switched it to a masked element that uses the image's alpha as a CSS mask filled with the muted text token — staying in sync with the variable.

## Changes
- `docs/templates/landing.html`: `<img class="hahwul-img">` → accessible `<span class="hahwul-img" role="img" aria-label="hahwul">`.
- `docs/static/css/style.css`: replace the `filter: grayscale(...)` recolor with `mask` + `background-color: var(--text-muted)`; hover transitions to `var(--text-primary)`.

## Verification
- `hwaro build` succeeds (22 pages, no errors); built `public/` reflects the span + mask rules.
- Mask references a same-origin self-hosted asset (`img-src 'self'`), so no CSP impact.