### PR TITLE
fix(scan): accept htmlpad, unicode, zwsp in --encoders allowlist

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -58,7 +58,9 @@ fn print_summary() {
     println!("- Use scanning to apply payloads: dalfox scan <target>");
     println!("- Add your own payloads with: --custom-payload <file>");
     println!("- Only test custom payloads with: --only-custom-payload");
-    println!("- Control encoder variants with: -e none,url,2url,3url,4url,html,base64");
+    println!(
+        "- Control encoder variants with: -e none,url,2url,3url,4url,html,htmlpad,base64,unicode,zwsp"
+    );
 }
 
 /// Fetch payloads from a remote provider and print one per line.

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -354,8 +354,8 @@ pub struct ScanArgs {
     pub max_targets_per_host: usize,
 
     #[clap(help_heading = "XSS SCANNING")]
-    /// Specify payload encoders to use (comma-separated). Options: none, url, 2url, 3url, 4url, html, base64. Default: url,html
-    #[arg(short = 'e', long, value_delimiter = ',', default_values = &["url", "html"], value_parser = clap::builder::PossibleValuesParser::new(["none", "url", "2url", "3url", "4url", "html", "base64"]))]
+    /// Specify payload encoders to use (comma-separated). Options: none, url, 2url, 3url, 4url, html, htmlpad, base64, unicode, zwsp. Default: url,html
+    #[arg(short = 'e', long, value_delimiter = ',', default_values = &["url", "html"], value_parser = clap::builder::PossibleValuesParser::new(["none", "url", "2url", "3url", "4url", "html", "htmlpad", "base64", "unicode", "zwsp"]))]
     pub encoders: Vec<String>,
 
     #[clap(help_heading = "XSS SCANNING")]
@@ -589,6 +589,28 @@ impl ScanArgs {
 mod arg_parser_tests {
     use super::*;
     use crate::cmd::scan::DEFAULT_TIMEOUT_SECS;
+
+    #[test]
+    fn encoders_arg_accepts_all_implemented_encoders() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            scan: ScanArgs,
+        }
+
+        // Regression for #1069: the clap allowlist must accept every encoder the
+        // engine implements, including htmlpad, unicode, and zwsp.
+        let cli = TestCli::try_parse_from([
+            "dalfox",
+            "https://example.com",
+            "-e",
+            "htmlpad,unicode,zwsp",
+        ])
+        .expect("encoders htmlpad,unicode,zwsp should be accepted");
+        assert_eq!(cli.scan.encoders, vec!["htmlpad", "unicode", "zwsp"]);
+    }
 
     #[test]
     fn force_waf_arg_normalizes_known_alias() {


### PR DESCRIPTION
## What & why
`-e` / `--encoders` accepted only 7 of the 10 encoders the engine implements.
`htmlpad`, `unicode`, and `zwsp` are fully implemented (`src/encoding/mod.rs`)
and documented in `docs/content/guide/payloads.md` and `waf-bypass.md`, but the
clap `PossibleValuesParser` allowlist omitted them — so e.g.
`dalfox scan <url> -e unicode,zwsp` errored out at the CLI.

This adds the three missing values and aligns the help text and the
`dalfox payload` tip with the encoder table in the docs.

## Changes
- `src/cmd/scan/args.rs`: add `htmlpad`, `unicode`, `zwsp` to the `--encoders`
  allowlist and update the help string to list all 10 options (doc-table order).
- `src/cmd/payload.rs`: update the encoder tip to list all 10 options.
- tests: add a regression test asserting `-e htmlpad,unicode,zwsp` parses.

## How to test
```
cargo run -- scan https://example.com -e htmlpad,unicode,zwsp   # no clap error
cargo run -- scan --help                                        # lists all 10
cargo test encoders_arg_accepts_all_implemented_encoders
```

## Notes
- Local checks on rustc 1.96.0 all pass: `cargo fmt --all -- --check`,
  `cargo clippy --all-targets --all-features -- -D warnings`, `cargo test`.
- No behavior change to encoding itself — only the CLI allowlist/help/tip were
  out of sync with the engine.

Fixes #1069
