### PR TITLE
Disable LTO in AUR PKGBUILD

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -8,6 +8,7 @@ url="https://github.com/hahwul/dalfox"
 license=('MIT')
 depends=('gcc-libs')
 makedepends=('cargo')
+options=(!lto)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/hahwul/dalfox/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')
 


### PR DESCRIPTION
for #1061 / In the case of LTO release during the test, it was built normally.