### PR TITLE
feat(scanning): detect outdated / known-vulnerable JS libraries (#1074)

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -454,33 +454,11 @@ pub(crate) async fn run_preflight_and_analysis(
                 // response, once per target. Borrows the body so the AST block
                 // below can still consume it.
                 if let Some(body) = preflight_response_body.as_deref() {
-                    let lib_findings: Vec<crate::scanning::result::Result> =
-                        crate::scanning::vuln_libs::detect_vulnerable_libraries(body)
-                            .into_iter()
-                            .map(|v| {
-                                crate::scanning::result::Result::builder(
-                                    crate::scanning::result::FindingType::Informational,
-                                )
-                                .inject_type("OutdatedComponent")
-                                .method(target.method.clone())
-                                .data(target.url.to_string())
-                                .cwe("CWE-1104")
-                                .severity(v.severity)
-                                .message_id(1104)
-                                .message_str(format!(
-                                    "Outdated JavaScript library: {} {}",
-                                    v.library, v.version
-                                ))
-                                .evidence(format!(
-                                    "{} {} is known-vulnerable ({}); upgrade to >= {}",
-                                    v.library,
-                                    v.version,
-                                    v.advisories.join(", "),
-                                    v.fixed_in
-                                ))
-                                .build()
-                            })
-                            .collect();
+                    let lib_findings = crate::scanning::vuln_libs::library_findings(
+                        crate::scanning::vuln_libs::detect_vulnerable_libraries(body),
+                        target.url.as_str(),
+                        &target.method,
+                    );
                     if !lib_findings.is_empty() {
                         let added = lib_findings.len();
                         let mut guard = results_clone.lock().await;

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -449,6 +449,46 @@ pub(crate) async fn run_preflight_and_analysis(
                     let _ = done_rx.await;
                 }
 
+                // Outdated / known-vulnerable JS library detection (issue #1074).
+                // Emits informational (CWE-1104) findings from the initial
+                // response, once per target. Borrows the body so the AST block
+                // below can still consume it.
+                if let Some(body) = preflight_response_body.as_deref() {
+                    let lib_findings: Vec<crate::scanning::result::Result> =
+                        crate::scanning::vuln_libs::detect_vulnerable_libraries(body)
+                            .into_iter()
+                            .map(|v| {
+                                crate::scanning::result::Result::builder(
+                                    crate::scanning::result::FindingType::Informational,
+                                )
+                                .inject_type("OutdatedComponent")
+                                .method(target.method.clone())
+                                .data(target.url.to_string())
+                                .cwe("CWE-1104")
+                                .severity(v.severity)
+                                .message_id(1104)
+                                .message_str(format!(
+                                    "Outdated JavaScript library: {} {}",
+                                    v.library, v.version
+                                ))
+                                .evidence(format!(
+                                    "{} {} is known-vulnerable ({}); upgrade to >= {}",
+                                    v.library,
+                                    v.version,
+                                    v.advisories.join(", "),
+                                    v.fixed_in
+                                ))
+                                .build()
+                            })
+                            .collect();
+                    if !lib_findings.is_empty() {
+                        let added = lib_findings.len();
+                        let mut guard = results_clone.lock().await;
+                        guard.extend(lib_findings);
+                        findings_count_clone.fetch_add(added, Ordering::Relaxed);
+                    }
+                }
+
                 // Run AST-based DOM XSS analysis on the initial response
                 // (enabled by default). The helper is shared with the
                 // server (`dalfox server`) and MCP (`scan_with_dalfox`)

--- a/src/cmd/scan/poc.rs
+++ b/src/cmd/scan/poc.rs
@@ -253,12 +253,44 @@ fn render_httpie_poc(result: &crate::scanning::result::Result, attack_url: &str)
 /// isn't emitted twice with different shapes (the old streamer printed
 /// just the POC line, then end-of-scan re-emitted POC + tree, leaving
 /// users with a duplicated POC URL).
+/// Render an informational finding (no payload/parameter): a single tagged
+/// summary line plus an evidence sub-line. Cyan in `plain`, uncolored otherwise.
+fn render_informational_block(result: &crate::scanning::result::Result, poc_type: &str) -> String {
+    let tag = if result.inject_type.is_empty() {
+        "Informational".to_string()
+    } else {
+        result.inject_type.clone()
+    };
+    let line = format!("[INF][{}] {} | {}", tag, result.data, result.message_str);
+    let mut output = String::new();
+    if poc_type == "plain" {
+        output.push_str(&format!("\x1b[36m{}\x1b[0m\n", line.trim_end()));
+    } else {
+        output.push_str(line.trim_end());
+        output.push('\n');
+    }
+    if !result.evidence.is_empty() {
+        output.push_str(&format!(
+            "  \x1b[90m└──\x1b[0m \x1b[38;5;247m{}\x1b[0m\n",
+            result.evidence
+        ));
+    }
+    output
+}
+
 pub(crate) fn render_finding_block(
     result: &crate::scanning::result::Result,
     poc_type: &str,
     include_request: bool,
     include_response: bool,
 ) -> String {
+    // Informational findings (e.g. outdated/vulnerable libraries) have no
+    // payload/parameter, so the payload-oriented POC block below doesn't apply —
+    // render a compact, self-contained line instead.
+    if result.result_type == FindingType::Informational {
+        return render_informational_block(result, poc_type);
+    }
+
     let mut output = String::new();
 
     let poc_line = generate_poc(result, poc_type);
@@ -271,6 +303,8 @@ pub(crate) fn render_finding_block(
             FindingType::Verified => format!("\x1b[31m{}\x1b[0m", trimmed),
             FindingType::Reflected => format!("\x1b[33m{}\x1b[0m", trimmed),
             FindingType::AstDetected => format!("\x1b[35m{}\x1b[0m", trimmed),
+            // Unreachable (early-returned above) but required for exhaustiveness.
+            FindingType::Informational => trimmed.to_string(),
         }
     } else {
         trimmed.to_string()

--- a/src/cmd/scan/poc.rs
+++ b/src/cmd/scan/poc.rs
@@ -397,3 +397,6 @@ pub(crate) fn render_finding_block(
 
     output
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/cmd/scan/poc/tests.rs
+++ b/src/cmd/scan/poc/tests.rs
@@ -1,0 +1,48 @@
+use super::*;
+use crate::scanning::result::{FindingType, Result};
+
+fn informational(inject_type: &str) -> Result {
+    Result::builder(FindingType::Informational)
+        .inject_type(inject_type)
+        .data("https://example.com")
+        .message_str("Outdated JavaScript library: jQuery 1.7.2")
+        .evidence("jQuery 1.7.2 is known-vulnerable (CVE-2020-11023); upgrade to >= 3.5.0")
+        .cwe("CWE-1104")
+        .build()
+}
+
+#[test]
+fn informational_block_plain_is_compact_and_colored() {
+    let r = informational("OutdatedComponent");
+    let out = render_finding_block(&r, "plain", false, false);
+    // Tagged, payload-free summary line + evidence sub-line.
+    assert!(out.contains("[INF][OutdatedComponent]"), "{out}");
+    assert!(out.contains("https://example.com"));
+    assert!(out.contains("jQuery 1.7.2"));
+    assert!(out.contains("CVE-2020-11023"));
+    // plain output is colorized (cyan).
+    assert!(out.contains("\x1b[36m"));
+    // No payload-oriented "[POC]" / "Payload:" tree for informational findings.
+    assert!(!out.contains("[POC]"));
+    assert!(!out.contains("Payload:"));
+}
+
+#[test]
+fn informational_block_non_plain_summary_not_cyan() {
+    let r = informational("OutdatedComponent");
+    let out = render_finding_block(&r, "curl", false, false);
+    assert!(out.contains("[INF][OutdatedComponent]"));
+    // The summary line must not be cyan-wrapped for non-plain output (the tree
+    // sub-lines follow the existing always-colored convention).
+    assert!(
+        !out.contains("\x1b[36m"),
+        "non-plain summary must not be cyan-colored: {out:?}"
+    );
+}
+
+#[test]
+fn informational_block_defaults_tag_when_inject_type_empty() {
+    let r = informational("");
+    let out = render_finding_block(&r, "plain", false, false);
+    assert!(out.contains("[INF][Informational]"), "{out}");
+}

--- a/src/cmd/scan/postprocess.rs
+++ b/src/cmd/scan/postprocess.rs
@@ -27,6 +27,9 @@ fn result_priority(result: &Result) -> u8 {
         FindingType::Verified => 3,
         FindingType::AstDetected => 2,
         FindingType::Reflected => 1,
+        // Informational findings never enter the AST-dedup path (message_id != 0);
+        // this arm exists only for match exhaustiveness.
+        FindingType::Informational => 0,
     };
     let severity_score = match result.severity.as_str() {
         "High" => 3,

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -30,6 +30,7 @@ pub mod result;
 pub mod selectors;
 pub mod tech_detect;
 pub mod url_inject;
+pub mod vuln_libs;
 pub mod xss_blind;
 pub mod xss_common;
 

--- a/src/scanning/result.rs
+++ b/src/scanning/result.rs
@@ -19,6 +19,11 @@ pub enum FindingType {
     /// was not confirmed.
     #[serde(rename = "R")]
     Reflected,
+    /// Informational — a non-exploitable observation, e.g. an outdated or
+    /// known-vulnerable JavaScript library (CWE-1104). Not an XSS finding;
+    /// excluded from XSS-only dedup/collapse logic.
+    #[serde(rename = "I")]
+    Informational,
 }
 
 impl FindingType {
@@ -28,6 +33,7 @@ impl FindingType {
             FindingType::Verified => "V",
             FindingType::AstDetected => "A",
             FindingType::Reflected => "R",
+            FindingType::Informational => "I",
         }
     }
 
@@ -37,6 +43,7 @@ impl FindingType {
             FindingType::Verified => "Verified",
             FindingType::AstDetected => "AST-Detected",
             FindingType::Reflected => "Reflected",
+            FindingType::Informational => "Informational",
         }
     }
 
@@ -49,6 +56,9 @@ impl FindingType {
             }
             FindingType::Reflected => {
                 "Reflected XSS - payload appears in HTTP response but DOM execution not confirmed"
+            }
+            FindingType::Informational => {
+                "Informational - outdated or known-vulnerable component, not an exploitable XSS"
             }
         }
     }

--- a/src/scanning/result/tests.rs
+++ b/src/scanning/result/tests.rs
@@ -2,6 +2,26 @@ use super::*;
 use serde_json;
 
 #[test]
+fn informational_finding_type_labels_and_serde() {
+    assert_eq!(FindingType::Informational.short(), "I");
+    assert_eq!(FindingType::Informational.description(), "Informational");
+    assert!(
+        FindingType::Informational
+            .long_description()
+            .contains("Informational")
+    );
+    // Serializes to the compact "I" tag and round-trips.
+    let r = Result::builder(FindingType::Informational)
+        .inject_type("OutdatedComponent")
+        .cwe("CWE-1104")
+        .build();
+    let json = serde_json::to_string(&r).unwrap();
+    assert!(json.contains("\"type\":\"I\""), "json: {json}");
+    let back: Result = serde_json::from_str(&json).unwrap();
+    assert_eq!(back.result_type, FindingType::Informational);
+}
+
+#[test]
 fn test_result_creation() {
     let result = Result::builder(FindingType::Verified)
         .inject_type("inHTML")

--- a/src/scanning/vuln_libs.rs
+++ b/src/scanning/vuln_libs.rs
@@ -1,0 +1,316 @@
+//! Detection of outdated / known-vulnerable JavaScript libraries (issue #1074).
+//!
+//! retire.js-style, but deliberately small: extract a `(library, version)` pair
+//! from a response — script `src` URLs/filenames and inline version banners —
+//! and match it against a bundled, curated dataset of known-vulnerable version
+//! ranges. Each match becomes an **informational** finding (CWE-1104, "Use of a
+//! component with known vulnerabilities"); it is NOT a claim of an exploitable
+//! XSS on this target, just a flagged stale dependency that enriches a report.
+//!
+//! Scope notes:
+//! - The dataset is a curated subset (the libraries most commonly fingerprinted
+//!   on the web, each with well-known advisories), embedded so offline scans
+//!   still work. It is intentionally not the full retire.js corpus.
+//! - Version comparison is dotted-numeric (`1.7.2` < `3.5.0`); pre-release
+//!   suffixes are truncated to their numeric prefix. Good enough for the
+//!   coarse "older than the fixed release" test these ranges express.
+
+use regex::Regex;
+use std::collections::HashSet;
+use std::sync::LazyLock;
+
+/// A detected outdated/vulnerable library instance.
+#[derive(Debug, Clone, PartialEq)]
+pub struct VulnLib {
+    pub library: String,
+    pub version: String,
+    /// Advisory identifiers (CVE / GHSA) for the matched ranges.
+    pub advisories: Vec<String>,
+    /// Highest severity across matched ranges (`"Low"` | `"Medium"` | `"High"`).
+    pub severity: &'static str,
+    /// The earliest release that fixes every matched range (informational hint).
+    pub fixed_in: String,
+}
+
+/// One known-vulnerable version range for a library.
+struct VulnRange {
+    /// Inclusive lower bound; `None` means "from 0".
+    introduced: Option<&'static str>,
+    /// Exclusive upper bound — versions `< fixed` are in range.
+    fixed: &'static str,
+    advisories: &'static [&'static str],
+    severity: &'static str,
+}
+
+/// A library the detector knows how to fingerprint and judge.
+struct LibSpec {
+    name: &'static str,
+    /// Regexes that capture the version (group 1) from a script URL/filename,
+    /// e.g. `jquery-1.7.2.min.js` or `/ajax/libs/jquery/1.11.0/`.
+    url_patterns: &'static [&'static str],
+    /// Regexes that capture the version (group 1) from inline script content,
+    /// e.g. a `jQuery JavaScript Library v1.7.2` banner.
+    inline_patterns: &'static [&'static str],
+    ranges: &'static [VulnRange],
+}
+
+const SEV_LOW: &str = "Low";
+const SEV_MEDIUM: &str = "Medium";
+const SEV_HIGH: &str = "High";
+
+/// Curated dataset. Each library lists how to read its version and the ranges
+/// with known advisories. Kept small and high-signal; extend as needed.
+static LIB_SPECS: &[LibSpec] = &[
+    LibSpec {
+        name: "jQuery",
+        url_patterns: &[
+            r"(?i)jquery[._-](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js",
+            r"(?i)/jquery/(\d+\.\d+(?:\.\d+)?)/",
+        ],
+        inline_patterns: &[r"(?i)jQuery(?: JavaScript Library)? v(\d+\.\d+(?:\.\d+)?)"],
+        ranges: &[
+            VulnRange {
+                introduced: None,
+                fixed: "1.9.0",
+                advisories: &["CVE-2012-6708"],
+                severity: SEV_MEDIUM,
+            },
+            VulnRange {
+                introduced: None,
+                fixed: "3.0.0",
+                advisories: &["CVE-2015-9251"],
+                severity: SEV_MEDIUM,
+            },
+            VulnRange {
+                introduced: None,
+                fixed: "3.4.0",
+                advisories: &["CVE-2019-11358"],
+                severity: SEV_MEDIUM,
+            },
+            VulnRange {
+                introduced: None,
+                fixed: "3.5.0",
+                advisories: &["CVE-2020-11022", "CVE-2020-11023"],
+                severity: SEV_MEDIUM,
+            },
+        ],
+    },
+    LibSpec {
+        name: "jQuery UI",
+        url_patterns: &[r"(?i)jquery[-.]ui[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[r"(?i)jQuery UI(?: -)? v(\d+\.\d+(?:\.\d+)?)"],
+        ranges: &[VulnRange {
+            introduced: None,
+            fixed: "1.13.0",
+            advisories: &[
+                "CVE-2021-41182",
+                "CVE-2021-41183",
+                "CVE-2021-41184",
+                "CVE-2022-31160",
+            ],
+            severity: SEV_MEDIUM,
+        }],
+    },
+    LibSpec {
+        name: "AngularJS",
+        url_patterns: &[r"(?i)angular[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[r#"(?i)angular.*?\bversion\b.*?["'](\d+\.\d+\.\d+)["']"#],
+        ranges: &[VulnRange {
+            // AngularJS 1.x reached end-of-life with multiple sandbox/XSS issues.
+            introduced: None,
+            fixed: "1.8.3",
+            advisories: &["CVE-2020-7676", "CVE-2019-10768", "CVE-2022-25869"],
+            severity: SEV_MEDIUM,
+        }],
+    },
+    LibSpec {
+        name: "Bootstrap",
+        url_patterns: &[r"(?i)bootstrap[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[r"(?i)Bootstrap(?: v)?\s*v?(\d+\.\d+(?:\.\d+)?)"],
+        ranges: &[
+            VulnRange {
+                introduced: None,
+                fixed: "3.4.1",
+                advisories: &["CVE-2019-8331", "CVE-2018-14041", "CVE-2018-14042"],
+                severity: SEV_MEDIUM,
+            },
+            VulnRange {
+                introduced: Some("4.0.0"),
+                fixed: "4.3.1",
+                advisories: &["CVE-2019-8331"],
+                severity: SEV_MEDIUM,
+            },
+        ],
+    },
+    LibSpec {
+        name: "Lodash",
+        url_patterns: &[r"(?i)lodash[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[
+            r"(?i)lodash(?: modern build)? <(\d+\.\d+\.\d+)>|@license lodash (\d+\.\d+\.\d+)",
+        ],
+        ranges: &[VulnRange {
+            introduced: None,
+            fixed: "4.17.21",
+            advisories: &["CVE-2019-10744", "CVE-2020-8203", "CVE-2021-23337"],
+            severity: SEV_HIGH,
+        }],
+    },
+    LibSpec {
+        name: "Handlebars",
+        url_patterns: &[r"(?i)handlebars[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[r"(?i)Handlebars(?:\.js)?(?: v| version )(\d+\.\d+(?:\.\d+)?)"],
+        ranges: &[VulnRange {
+            introduced: None,
+            fixed: "4.7.7",
+            advisories: &["CVE-2019-19919", "CVE-2021-23369", "CVE-2021-23383"],
+            severity: SEV_HIGH,
+        }],
+    },
+    LibSpec {
+        name: "Moment.js",
+        url_patterns: &[r"(?i)moment[-.](\d+\.\d+(?:\.\d+)?)(?:\.min)?\.js"],
+        inline_patterns: &[r"(?i)//! moment\.js\s*\n//! version : (\d+\.\d+(?:\.\d+)?)"],
+        ranges: &[VulnRange {
+            introduced: None,
+            fixed: "2.29.4",
+            advisories: &["CVE-2022-31129", "CVE-2022-24785"],
+            severity: SEV_MEDIUM,
+        }],
+    },
+];
+
+/// Compiled form of a [`LibSpec`] (regexes built once).
+struct CompiledLib {
+    name: &'static str,
+    url_res: Vec<Regex>,
+    inline_res: Vec<Regex>,
+    ranges: &'static [VulnRange],
+}
+
+static COMPILED: LazyLock<Vec<CompiledLib>> = LazyLock::new(|| {
+    LIB_SPECS
+        .iter()
+        .map(|spec| CompiledLib {
+            name: spec.name,
+            url_res: spec
+                .url_patterns
+                .iter()
+                .filter_map(|p| Regex::new(p).ok())
+                .collect(),
+            inline_res: spec
+                .inline_patterns
+                .iter()
+                .filter_map(|p| Regex::new(p).ok())
+                .collect(),
+            ranges: spec.ranges,
+        })
+        .collect()
+});
+
+/// Parse a dotted version into numeric components, truncating any non-numeric
+/// suffix on each component (`"1.7.2-rc1"` → `[1, 7, 2]`).
+fn parse_version(v: &str) -> Vec<u64> {
+    v.split('.')
+        .map(|p| {
+            let digits: String = p.chars().take_while(|c| c.is_ascii_digit()).collect();
+            digits.parse().unwrap_or(0)
+        })
+        .collect()
+}
+
+/// `a < b` under dotted-numeric ordering (missing components treated as 0).
+fn version_lt(a: &str, b: &str) -> bool {
+    let (av, bv) = (parse_version(a), parse_version(b));
+    for i in 0..av.len().max(bv.len()) {
+        let x = av.get(i).copied().unwrap_or(0);
+        let y = bv.get(i).copied().unwrap_or(0);
+        if x != y {
+            return x < y;
+        }
+    }
+    false
+}
+
+/// `a >= b`.
+fn version_ge(a: &str, b: &str) -> bool {
+    !version_lt(a, b)
+}
+
+fn severity_rank(s: &str) -> u8 {
+    match s {
+        SEV_HIGH => 3,
+        SEV_MEDIUM => 2,
+        SEV_LOW => 1,
+        _ => 0,
+    }
+}
+
+/// Judge a single `(library, version)`: returns the aggregated advisories,
+/// worst severity, and earliest fixing release across all ranges the version
+/// falls into, or `None` if the version is not known-vulnerable.
+fn judge(lib: &CompiledLib, version: &str) -> Option<VulnLib> {
+    let mut advisories: Vec<String> = Vec::new();
+    let mut severity = SEV_LOW;
+    let mut fixed_in: Option<&'static str> = None;
+    for range in lib.ranges {
+        let in_range = range.introduced.is_none_or(|lo| version_ge(version, lo))
+            && version_lt(version, range.fixed);
+        if in_range {
+            for a in range.advisories {
+                if !advisories.iter().any(|x| x == a) {
+                    advisories.push((*a).to_string());
+                }
+            }
+            if severity_rank(range.severity) > severity_rank(severity) {
+                severity = range.severity;
+            }
+            // The most relevant "fixed in" is the highest fixed version among
+            // matched ranges (upgrading there clears them all).
+            fixed_in = Some(match fixed_in {
+                Some(f) if version_lt(range.fixed, f) => f,
+                _ => range.fixed,
+            });
+        }
+    }
+    if advisories.is_empty() {
+        return None;
+    }
+    Some(VulnLib {
+        library: lib.name.to_string(),
+        version: version.to_string(),
+        advisories,
+        severity,
+        fixed_in: fixed_in.unwrap_or("").to_string(),
+    })
+}
+
+/// Scan a response body for outdated/known-vulnerable JS libraries. Returns one
+/// [`VulnLib`] per distinct `(library, version)` found and judged vulnerable.
+pub fn detect_vulnerable_libraries(body: &str) -> Vec<VulnLib> {
+    let mut out: Vec<VulnLib> = Vec::new();
+    let mut seen: HashSet<(String, String)> = HashSet::new();
+
+    for lib in COMPILED.iter() {
+        let mut versions: Vec<String> = Vec::new();
+        for re in lib.url_res.iter().chain(lib.inline_res.iter()) {
+            for cap in re.captures_iter(body) {
+                // First non-empty capture group is the version (inline patterns
+                // may use alternation with two groups).
+                if let Some(v) = (1..cap.len()).find_map(|i| cap.get(i)).map(|m| m.as_str()) {
+                    versions.push(v.to_string());
+                }
+            }
+        }
+        for version in versions {
+            if let Some(found) = judge(lib, &version)
+                && seen.insert((lib.name.to_string(), version.clone()))
+            {
+                out.push(found);
+            }
+        }
+    }
+    out
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/scanning/vuln_libs.rs
+++ b/src/scanning/vuln_libs.rs
@@ -312,5 +312,42 @@ pub fn detect_vulnerable_libraries(body: &str) -> Vec<VulnLib> {
     out
 }
 
+/// Turn detected vulnerable libraries into informational [`crate::scanning::result::Result`]
+/// findings for `target_url` (CWE-1104, `OutdatedComponent`). Each finding is
+/// payload-/parameter-free and carries the advisories + suggested upgrade in its
+/// evidence. `message_id` is a non-zero sentinel so these never enter the
+/// `message_id == 0` AST-dedup path.
+pub fn library_findings(
+    vulns: Vec<VulnLib>,
+    target_url: &str,
+    method: &str,
+) -> Vec<crate::scanning::result::Result> {
+    use crate::scanning::result::{FindingType, Result};
+    vulns
+        .into_iter()
+        .map(|v| {
+            Result::builder(FindingType::Informational)
+                .inject_type("OutdatedComponent")
+                .method(method)
+                .data(target_url)
+                .cwe("CWE-1104")
+                .severity(v.severity)
+                .message_id(1104)
+                .message_str(format!(
+                    "Outdated JavaScript library: {} {}",
+                    v.library, v.version
+                ))
+                .evidence(format!(
+                    "{} {} is known-vulnerable ({}); upgrade to >= {}",
+                    v.library,
+                    v.version,
+                    v.advisories.join(", "),
+                    v.fixed_in
+                ))
+                .build()
+        })
+        .collect()
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/scanning/vuln_libs/tests.rs
+++ b/src/scanning/vuln_libs/tests.rs
@@ -1,0 +1,158 @@
+use super::*;
+
+#[test]
+fn version_ordering() {
+    assert!(version_lt("1.7.2", "3.5.0"));
+    assert!(version_lt("3.4.1", "3.5.0"));
+    assert!(!version_lt("3.5.0", "3.5.0"));
+    assert!(!version_lt("3.6.0", "3.5.0"));
+    // Missing components treated as 0.
+    assert!(version_lt("1.9", "1.9.1"));
+    assert!(!version_lt("2", "1.9.9"));
+    // Pre-release suffix truncated to numeric prefix.
+    assert!(version_lt("1.7.2-rc1", "1.8.0"));
+    assert!(version_ge("4.0.0", "4.0.0"));
+}
+
+fn libs(body: &str) -> Vec<VulnLib> {
+    detect_vulnerable_libraries(body)
+}
+
+#[test]
+fn detects_old_jquery_from_script_src() {
+    let body = r#"<html><head>
+        <script src="/assets/js/jquery-1.7.2.min.js"></script>
+        </head><body>x</body></html>"#;
+    let found = libs(body);
+    let jq = found
+        .iter()
+        .find(|v| v.library == "jQuery")
+        .expect("jQuery should be detected");
+    assert_eq!(jq.version, "1.7.2");
+    // 1.7.2 is below every jQuery fixed range, so all advisories aggregate.
+    assert!(jq.advisories.iter().any(|a| a == "CVE-2020-11023"));
+    assert!(jq.advisories.iter().any(|a| a == "CVE-2012-6708"));
+    assert_eq!(jq.fixed_in, "3.5.0");
+}
+
+#[test]
+fn detects_jquery_from_cdn_path() {
+    let body = r#"<script src="https://ajax.googleapis.com/ajax/libs/jquery/1.11.0/jquery.min.js"></script>"#;
+    let found = libs(body);
+    assert!(
+        found
+            .iter()
+            .any(|v| v.library == "jQuery" && v.version == "1.11.0"),
+        "expected jQuery 1.11.0 from CDN path, got {:?}",
+        found
+    );
+}
+
+#[test]
+fn detects_jquery_from_inline_banner() {
+    let body = "<script>/*! jQuery JavaScript Library v1.8.3\n ... */ \n var a=1;</script>";
+    let found = libs(body);
+    assert!(
+        found
+            .iter()
+            .any(|v| v.library == "jQuery" && v.version == "1.8.3"),
+        "expected jQuery 1.8.3 from inline banner, got {:?}",
+        found
+    );
+}
+
+#[test]
+fn current_jquery_is_not_flagged() {
+    let body = r#"<script src="/js/jquery-3.7.1.min.js"></script>"#;
+    let found = libs(body);
+    assert!(
+        !found.iter().any(|v| v.library == "jQuery"),
+        "current jQuery must not be flagged, got {:?}",
+        found
+    );
+}
+
+#[test]
+fn boundary_version_at_fix_is_safe() {
+    // Exactly the fixed release is not vulnerable (range is `< fixed`).
+    let body = r#"<script src="/js/jquery-3.5.0.min.js"></script>"#;
+    let found = libs(body);
+    assert!(found.iter().all(|v| v.library != "jQuery"));
+}
+
+#[test]
+fn partially_old_jquery_aggregates_only_matching_ranges() {
+    // 3.4.1: below 3.5.0 only → just the htmlPrefilter advisories.
+    let body = r#"<script src="/js/jquery-3.4.1.min.js"></script>"#;
+    let jq = libs(body)
+        .into_iter()
+        .find(|v| v.library == "jQuery")
+        .expect("3.4.1 is vulnerable to CVE-2020-11022/11023");
+    assert!(jq.advisories.iter().any(|a| a == "CVE-2020-11022"));
+    assert!(
+        !jq.advisories.iter().any(|a| a == "CVE-2012-6708"),
+        "must not attribute pre-1.9 advisory to 3.4.1"
+    );
+}
+
+#[test]
+fn detects_lodash_high_severity() {
+    let body = r#"<script src="/vendor/lodash-4.17.10.min.js"></script>"#;
+    let lo = libs(body)
+        .into_iter()
+        .find(|v| v.library == "Lodash")
+        .expect("old Lodash should be flagged");
+    assert_eq!(lo.severity, "High");
+    assert!(lo.advisories.iter().any(|a| a == "CVE-2021-23337"));
+}
+
+#[test]
+fn detects_angularjs_and_bootstrap() {
+    let body = r#"
+        <script src="/js/angular-1.5.8.min.js"></script>
+        <script src="/js/bootstrap-3.3.7.min.js"></script>
+    "#;
+    let found = libs(body);
+    assert!(
+        found
+            .iter()
+            .any(|v| v.library == "AngularJS" && v.version == "1.5.8")
+    );
+    assert!(
+        found
+            .iter()
+            .any(|v| v.library == "Bootstrap" && v.version == "3.3.7")
+    );
+}
+
+#[test]
+fn bootstrap_4_introduced_bound_respected() {
+    // Bootstrap 4.2.0 is in the [4.0.0, 4.3.1) range → flagged.
+    assert!(
+        libs(r#"<script src="/bootstrap-4.2.0.min.js">"#)
+            .iter()
+            .any(|v| v.library == "Bootstrap")
+    );
+    // Bootstrap 4.5.0 is past 4.3.1 and not in the <3.4.1 range → safe.
+    assert!(
+        libs(r#"<script src="/bootstrap-4.5.0.min.js">"#)
+            .iter()
+            .all(|v| v.library != "Bootstrap")
+    );
+}
+
+#[test]
+fn no_libraries_in_plain_page() {
+    let found = libs("<html><body><h1>hello</h1></body></html>");
+    assert!(found.is_empty(), "got {:?}", found);
+}
+
+#[test]
+fn dedups_repeated_same_version() {
+    let body = r#"
+        <script src="/a/jquery-1.7.2.min.js"></script>
+        <script src="/b/jquery-1.7.2.min.js"></script>
+    "#;
+    let count = libs(body).iter().filter(|v| v.library == "jQuery").count();
+    assert_eq!(count, 1, "same (lib, version) must be reported once");
+}

--- a/src/scanning/vuln_libs/tests.rs
+++ b/src/scanning/vuln_libs/tests.rs
@@ -156,3 +156,117 @@ fn dedups_repeated_same_version() {
     let count = libs(body).iter().filter(|v| v.library == "jQuery").count();
     assert_eq!(count, 1, "same (lib, version) must be reported once");
 }
+
+#[test]
+fn library_findings_builds_informational_results() {
+    use crate::scanning::result::FindingType;
+    let vulns = detect_vulnerable_libraries(r#"<script src="/jquery-1.7.2.min.js"></script>"#);
+    assert!(!vulns.is_empty());
+    let findings = library_findings(vulns, "https://t.example/page", "GET");
+    let f = findings.first().expect("one finding");
+    assert_eq!(f.result_type, FindingType::Informational);
+    assert_eq!(f.inject_type, "OutdatedComponent");
+    assert_eq!(f.cwe, "CWE-1104");
+    assert_eq!(f.method, "GET");
+    assert_eq!(f.data, "https://t.example/page");
+    assert_eq!(f.severity, "Medium");
+    assert_ne!(
+        f.message_id, 0,
+        "must avoid the message_id==0 AST-dedup path"
+    );
+    assert!(f.message_str.contains("jQuery 1.7.2"));
+    assert!(f.evidence.contains("CVE-") && f.evidence.contains("upgrade to >= 3.5.0"));
+    // Payload/param-free (so POC synthesis is bypassed).
+    assert!(f.payload.is_empty() && f.param.is_empty());
+}
+
+#[test]
+fn library_findings_empty_for_no_vulns() {
+    assert!(library_findings(vec![], "https://t.example", "GET").is_empty());
+}
+
+#[test]
+fn detects_jquery_ui_from_src() {
+    let body = r#"<script src="/js/jquery-ui-1.11.4.min.js"></script>"#;
+    let ui = libs(body)
+        .into_iter()
+        .find(|v| v.library == "jQuery UI")
+        .expect("old jQuery UI should be flagged");
+    assert_eq!(ui.version, "1.11.4");
+    assert!(ui.advisories.iter().any(|a| a == "CVE-2022-31160"));
+}
+
+#[test]
+fn detects_handlebars_from_src_and_inline() {
+    let from_src = libs(r#"<script src="/vendor/handlebars-4.0.5.min.js"></script>"#);
+    assert!(
+        from_src
+            .iter()
+            .any(|v| v.library == "Handlebars" && v.version == "4.0.5" && v.severity == "High"),
+        "got {from_src:?}"
+    );
+    let from_inline = libs("<script>/* Handlebars.js v4.0.5 */</script>");
+    assert!(
+        from_inline
+            .iter()
+            .any(|v| v.library == "Handlebars" && v.version == "4.0.5"),
+        "inline Handlebars banner should be detected, got {from_inline:?}"
+    );
+}
+
+#[test]
+fn detects_moment_from_src_and_inline() {
+    let from_src = libs(r#"<script src="/js/moment-2.20.1.min.js"></script>"#);
+    assert!(
+        from_src
+            .iter()
+            .any(|v| v.library == "Moment.js" && v.version == "2.20.1"),
+        "got {from_src:?}"
+    );
+    let from_inline = libs("//! moment.js\n//! version : 2.20.1\n//! authors");
+    assert!(
+        from_inline
+            .iter()
+            .any(|v| v.library == "Moment.js" && v.version == "2.20.1"),
+        "inline Moment banner should be detected, got {from_inline:?}"
+    );
+}
+
+#[test]
+fn detects_angularjs_from_inline_version() {
+    let body = r#"<script>angular.module('a'); angular.version = {full: "1.5.8"};</script>"#;
+    assert!(
+        libs(body)
+            .iter()
+            .any(|v| v.library == "AngularJS" && v.version == "1.5.8"),
+        "inline AngularJS version should be detected"
+    );
+}
+
+#[test]
+fn detects_bootstrap_from_inline_banner() {
+    let body = "<script>/*! Bootstrap v3.3.7 (https://getbootstrap.com) */</script>";
+    assert!(
+        libs(body)
+            .iter()
+            .any(|v| v.library == "Bootstrap" && v.version == "3.3.7"),
+        "inline Bootstrap banner should be detected"
+    );
+}
+
+#[test]
+fn current_libraries_across_dataset_are_safe() {
+    // A modern stack must produce zero findings (guards against over-broad ranges).
+    let body = r#"
+        <script src="/jquery-ui-1.13.2.min.js"></script>
+        <script src="/handlebars-4.7.8.min.js"></script>
+        <script src="/moment-2.29.4.min.js"></script>
+        <script src="/lodash-4.17.21.min.js"></script>
+        <script src="/bootstrap-5.3.0.min.js"></script>
+    "#;
+    assert!(
+        libs(body).is_empty(),
+        "modern stack flagged: {:?}",
+        libs(body)
+    );
+}

--- a/tests/functional/mock_cases/realworld/vuln_libs.toml
+++ b/tests/functional/mock_cases/realworld/vuln_libs.toml
@@ -1,0 +1,27 @@
+# Outdated / known-vulnerable JS library detection benchmark (issue #1074).
+#
+# The page serves a library <script> tag in the initial response; the scanner's
+# preflight body is scanned for known-vulnerable versions, emitting an
+# informational (CWE-1104) finding. The reflected `{input}` lands in a
+# <textarea> (a safe, non-executing context) so these cases isolate the library
+# finding from any XSS finding.
+#
+# IDs use the 9100+ block to stay clear of the existing realworld corpus.
+
+[[case]]
+id = 9101
+name = "vuln_lib_jquery_1_7_2"
+description = "Serves jQuery 1.7.2 (known-vulnerable) -> informational finding expected"
+handler_type = "realworld"
+reflection = "<script src=\"/static/js/jquery-1.7.2.min.js\"></script><textarea>{input}</textarea>"
+expected_detection = true
+category = "vuln_lib"
+
+[[case]]
+id = 9102
+name = "current_lib_jquery_3_7_1"
+description = "Serves current jQuery 3.7.1 -> no library finding"
+handler_type = "realworld"
+reflection = "<script src=\"/static/js/jquery-3.7.1.min.js\"></script><textarea>{input}</textarea>"
+expected_detection = false
+category = "vuln_lib"

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -2593,3 +2593,156 @@ async fn test_synthesis_filter_effectiveness_v2() {
         GAP_CASE_ID
     );
 }
+
+/// Run a library-detection-only scan against a realworld case id. Uses
+/// `deep_scan=false` (so the preflight body — where vuln-lib detection lives,
+/// alongside tech detection and initial AST — actually runs; `run_scan_test`
+/// forces `deep_scan=true`, which skips that preflight path) and
+/// `skip_xss_scanning`/`skip_ast_analysis` to isolate the informational
+/// library finding. Returns the findings array.
+async fn run_libscan(addr: SocketAddr, case_id: u32) -> Vec<serde_json::Value> {
+    let target = format!(
+        "http://{}:{}/realworld/query/{}?query=seed",
+        addr.ip(),
+        addr.port(),
+        case_id
+    );
+    let out_path = std::env::temp_dir().join(format!(
+        "dalfox_libscan_{}_{}_{}.json",
+        case_id,
+        addr.ip(),
+        addr.port()
+    ));
+    let out_path_str = out_path.to_string_lossy().to_string();
+
+    let args = ScanArgs {
+        input_type: "url".to_string(),
+        format: "json".to_string(),
+        targets: vec![target],
+        param: vec![],
+        data: None,
+        headers: vec![],
+        cookies: vec![],
+        method: "GET".to_string(),
+        user_agent: None,
+        cookie_from_raw: None,
+        include_url: vec![],
+        exclude_url: vec![],
+        ignore_param: vec![],
+        out_of_scope: vec![],
+        out_of_scope_file: None,
+        mining_dict_word: None,
+        skip_mining: true,
+        skip_mining_dict: true,
+        skip_mining_dom: true,
+        only_discovery: false,
+        skip_discovery: false,
+        skip_reflection_header: true,
+        skip_reflection_cookie: true,
+        skip_reflection_path: true,
+        timeout: 5,
+        scan_timeout: 0,
+        delay: 0,
+        proxy: None,
+        follow_redirects: false,
+        ignore_return: vec![],
+        output: Some(out_path_str.clone()),
+        include_request: false,
+        include_response: false,
+        include_all: false,
+        no_color: true,
+        silence: true,
+        dry_run: false,
+        stream_findings: false,
+        poc_type: "plain".to_string(),
+        limit: None,
+        limit_result_type: "all".to_string(),
+        only_poc: vec![],
+        workers: 4,
+        max_concurrent_targets: 4,
+        max_targets_per_host: 100,
+        encoders: vec![],
+        custom_blind_xss_payload: None,
+        blind_callback_url: None,
+        custom_payload: None,
+        only_custom_payload: false,
+        inject_marker: None,
+        custom_alert_value: "1".to_string(),
+        custom_alert_type: "none".to_string(),
+        // Library detection runs in the analysis/preflight phase; skipping the
+        // XSS and AST passes keeps the run fast and isolates the lib finding.
+        skip_xss_scanning: true,
+        deep_scan: false,
+        sxss: false,
+        sxss_url: None,
+        sxss_method: "GET".to_string(),
+        sxss_retries: 3,
+        skip_ast_analysis: true,
+        hpp: false,
+        waf_bypass: "off".to_string(),
+        skip_waf_probe: true,
+        force_waf: None,
+        waf_evasion: false,
+        waf_min_confidence: 0.0,
+        remote_payloads: vec![],
+        remote_wordlists: vec![],
+        max_payloads_per_param: 0,
+    };
+
+    scan::run_scan(&args).await;
+
+    let content = std::fs::read_to_string(&out_path).expect("scan should write JSON output file");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("output should be valid JSON");
+    v["findings"]
+        .as_array()
+        .expect("json should have a 'findings' array")
+        .clone()
+}
+
+/// End-to-end test for outdated/known-vulnerable JS library detection
+/// (issue #1074). A page serving a known-vulnerable jQuery must yield an
+/// informational `OutdatedComponent` finding; a page serving a current version
+/// must not.
+#[tokio::test]
+#[ignore = "functional: issue #1074 outdated/vulnerable JS library detection"]
+async fn test_vuln_library_detection_v2() {
+    dalfox::ensure_crypto_provider();
+    let (addr, _state) = start_mock_server_v2().await;
+    tokio::time::sleep(Duration::from_millis(100)).await;
+
+    let is_outdated_lib = |f: &serde_json::Value| {
+        f.get("type").and_then(|t| t.as_str()) == Some("I")
+            && f.get("inject_type").and_then(|t| t.as_str()) == Some("OutdatedComponent")
+    };
+
+    // Vulnerable jQuery 1.7.2 -> informational finding naming the version + a CVE.
+    let vuln = run_libscan(addr, 9101).await;
+    let lib_finding = vuln.iter().find(|f| is_outdated_lib(f)).unwrap_or_else(|| {
+        panic!("expected an OutdatedComponent finding for jQuery 1.7.2, got {vuln:?}")
+    });
+    let evidence = lib_finding
+        .get("evidence")
+        .and_then(|e| e.as_str())
+        .unwrap_or("");
+    assert!(
+        evidence.contains("jQuery") && evidence.contains("1.7.2"),
+        "evidence should name jQuery 1.7.2: {evidence:?}"
+    );
+    assert!(
+        evidence.contains("CVE-"),
+        "evidence should cite an advisory: {evidence:?}"
+    );
+    assert_eq!(
+        lib_finding.get("cwe").and_then(|c| c.as_str()),
+        Some("CWE-1104")
+    );
+    println!("[#9101] outdated-lib finding: {evidence}");
+
+    // Current jQuery 3.7.1 -> NO library finding.
+    let safe = run_libscan(addr, 9102).await;
+    assert!(
+        !safe.iter().any(is_outdated_lib),
+        "current jQuery must not yield an OutdatedComponent finding, got {safe:?}"
+    );
+    println!("[#9102] current jQuery: no outdated-lib finding (correct)");
+}


### PR DESCRIPTION
Closes #1074.

## What
Detects outdated / known-vulnerable JavaScript libraries served by a target and reports them as **informational** findings (CWE-1104) — a retire.js-style enrichment that sits alongside XSS results, not a claim of an exploitable XSS.

## How
- **`src/scanning/vuln_libs.rs`** — `detect_vulnerable_libraries(body)`. Extracts `(library, version)` from:
  - script `src` filenames (`jquery-1.7.2.min.js`),
  - CDN paths (`/ajax/libs/jquery/1.11.0/`),
  - inline version banners (`/*! jQuery JavaScript Library v1.8.3 */`).
  Matches against a bundled, curated dataset of known-vulnerable ranges (jQuery, jQuery UI, AngularJS, Bootstrap, Lodash, Handlebars, Moment.js) with real CVEs, using dotted-numeric version comparison and `introduced`/`fixed` bounds. Deduped per `(library, version)`.
- **`FindingType::Informational`** (`"I"`) — a new finding kind, excluded from the XSS dedup/collapse paths. Rendered as a compact, payload-free line in `plain` output (`[INF][OutdatedComponent] <url> | <msg>` + evidence) and carried through `json`/`jsonl`/`sarif`/`markdown`.
- Wired into the analysis/preflight path, **right next to tech detection and the initial AST pass** (all three run on the preflight body), emitting one informational finding per detected vulnerable library, once per target.

## Tests
- **12 unit tests** (`vuln_libs::tests`): extraction from src/CDN/inline; range matching including the `introduced`/`fixed` bounds and boundary-at-fix safety (`3.5.0` is *not* flagged); advisory aggregation (`1.7.2` → all four jQuery ranges; `3.4.1` → only the htmlPrefilter CVEs); severity; dedup; current versions not flagged.
- **Functional end-to-end** (`test_vuln_library_detection_v2`, `#[ignore]`): a page serving jQuery `1.7.2` yields an `OutdatedComponent` finding citing its CVEs and `upgrade to >= 3.5.0`; jQuery `3.7.1` yields none.
- 1316 lib unit tests pass; `fmt` clean; `clippy --lib --tests` 0 warnings; request-sensitive integration tests unaffected.

## Notes / scope
- Like tech detection and the initial AST analysis, this runs on the **preflight body** (the default scan mode). `--deep-scan` skips that preflight path, so the functional test drives a `deep_scan=false` scan to exercise it.
- The dataset is a curated, embedded subset (offline-capable), intentionally not the full retire.js corpus; it is straightforward to extend.
- The preflight body is capped (~8 KB), which covers libraries referenced in `<head>`/early markup (the common case).
