### PR TITLE
docs(aur): explain why LTO is disabled in PKGBUILD

### DIFF
--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -8,6 +8,8 @@ url="https://github.com/hahwul/dalfox"
 license=('MIT')
 depends=('gcc-libs')
 makedepends=('cargo')
+# Disable LTO: makepkg's -flto leaks into ring's `cc` build, producing objects
+# that fail to link with lld (undefined `ring_core_*` symbols). See #1061.
 options=(!lto)
 source=("$pkgname-$pkgver.tar.gz::https://github.com/hahwul/dalfox/archive/refs/tags/v$pkgver.tar.gz")
 sha256sums=('SKIP')


### PR DESCRIPTION
Adds a short comment above `options=(!lto)` in `aur/PKGBUILD` documenting why LTO is disabled, so the line isn't mistaken for a removable tweak later.

### Why
makepkg enables LTO by default and injects `-flto` into `CFLAGS`. `ring`'s build script compiles its C/asm through the `cc` crate, which inherits that flag and emits LTO-only objects with no machine code. The final `lld` link can't resolve them → `undefined symbol: ring_core_*` (#1061). Disabling makepkg LTO for this package makes `ring` build normal objects again.

### Verification
Reproduced and verified in an x86_64 Arch container (rust 1.95, `ld.lld`):
- LTO on  → `undefined symbol: ring_core_*`, build fails
- `options=(!lto)` → clean build; installing the published `dalfox 3.0.2-2` via `makepkg -si` succeeds and the binary runs

Comment-only change; no functional effect.