### PR TITLE
test(target_parser): deflake client-cache tests via per-test timeout scoping

### DIFF
--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -24,18 +24,6 @@ fn client_cache() -> &'static Mutex<HashMap<ClientCacheKey, Client>> {
     CACHE.get_or_init(|| Mutex::new(HashMap::new()))
 }
 
-#[cfg(test)]
-fn client_cache_len_for_tests() -> usize {
-    client_cache().lock().map(|g| g.len()).unwrap_or(0)
-}
-
-#[cfg(test)]
-fn reset_client_cache_for_tests() {
-    if let Ok(mut guard) = client_cache().lock() {
-        guard.clear();
-    }
-}
-
 #[derive(Debug, Clone)]
 pub struct Target {
     pub url: Url,
@@ -326,48 +314,54 @@ pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::E
 mod tests {
     use super::*;
 
-    // The client cache is process-global; these tests mutate it via
-    // `reset_client_cache_for_tests()` / `build_client()`. Resetting
-    // before/after is not enough on its own: when the two cache tests run
-    // concurrently, one test's reset can clear the cache mid-assertion in the
-    // other (observed as a `len 0 -> 1` flake). Serialize them with a shared
-    // lock so each runs its build/reset sequence in isolation.
-    static CACHE_TEST_LOCK: std::sync::Mutex<()> = std::sync::Mutex::new(());
+    // The client cache is process-global and shared with every other test in
+    // this binary that builds a Client (e.g. the WAF tests). Asserting on the
+    // cache's *total* length is therefore racy: a concurrent test can insert
+    // an entry between two measurements, which previously surfaced as a
+    // `same key must reuse: left 1, right 2` flake. Each test below instead
+    // scopes its assertions to a timeout value no other test uses, so foreign
+    // inserts (which carry different timeouts) can't perturb the count. This
+    // makes the cache tests safe to run concurrently with no shared lock.
 
-    /// Cache returns the same Client on the second call with an equal key,
-    /// and a fresh entry for a different key. Tests run serially via
-    /// `--test-threads=1` is not assumed; we reset before/after to avoid
-    /// cross-test pollution.
+    /// Count cached Clients whose key carries `timeout`. Scoping by a
+    /// per-test-unique timeout isolates the measurement from any other test
+    /// that builds a Client into the same process-global cache.
+    fn cache_entries_with_timeout(timeout: u64) -> usize {
+        client_cache()
+            .lock()
+            .map(|g| g.keys().filter(|(t, _, _)| *t == timeout).count())
+            .unwrap_or(0)
+    }
+
+    /// Building twice with the same key reuses the cached Client instead of
+    /// creating a second entry.
     #[test]
     fn test_client_cache_reuses_for_same_key() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        reset_client_cache_for_tests();
         let mut t = parse_target("http://example.com").unwrap();
-        t.timeout = 7;
+        t.timeout = 60_001; // unique to this test
         t.follow_redirects = false;
         t.proxy = None;
         let _ = t.build_client().unwrap();
-        let len_after_first = client_cache_len_for_tests();
+        let after_first = cache_entries_with_timeout(t.timeout);
         let _ = t.build_client().unwrap();
-        let len_after_second = client_cache_len_for_tests();
-        assert_eq!(len_after_first, len_after_second, "same key must reuse");
-        assert!(len_after_first >= 1);
-        reset_client_cache_for_tests();
+        let after_second = cache_entries_with_timeout(t.timeout);
+        assert_eq!(after_first, after_second, "same key must reuse");
+        assert_eq!(after_first, 1, "exactly one entry for the shared key");
     }
 
+    /// Two targets differing only in an input that affects Client
+    /// construction (here, timeout) occupy two distinct cache entries.
     #[test]
     fn test_client_cache_separates_distinct_keys() {
-        let _guard = CACHE_TEST_LOCK.lock().unwrap_or_else(|e| e.into_inner());
-        reset_client_cache_for_tests();
         let mut a = parse_target("http://example.com").unwrap();
-        a.timeout = 7;
+        a.timeout = 60_002; // unique to this test
         let mut b = parse_target("http://example.com").unwrap();
-        b.timeout = 13; // different key
+        b.timeout = 60_003; // distinct key, also unique to this test
         let _ = a.build_client().unwrap();
         let _ = b.build_client().unwrap();
         let _ = a.build_client().unwrap();
-        assert_eq!(client_cache_len_for_tests(), 2);
-        reset_client_cache_for_tests();
+        assert_eq!(cache_entries_with_timeout(a.timeout), 1);
+        assert_eq!(cache_entries_with_timeout(b.timeout), 1);
     }
 
     #[test]

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -322,6 +322,13 @@ mod tests {
     // scopes its assertions to a timeout value no other test uses, so foreign
     // inserts (which carry different timeouts) can't perturb the count. This
     // makes the cache tests safe to run concurrently with no shared lock.
+    //
+    // Timeouts reserved for these tests' cache keys. The isolation guarantee
+    // rests on no other test building a Client with one of these values, so
+    // keep them unique to this module and do not reuse them elsewhere.
+    const REUSE_TIMEOUT: u64 = 60_001;
+    const DISTINCT_TIMEOUT_A: u64 = 60_002;
+    const DISTINCT_TIMEOUT_B: u64 = 60_003;
 
     /// Count cached Clients whose key carries `timeout`. Scoping by a
     /// per-test-unique timeout isolates the measurement from any other test
@@ -338,7 +345,7 @@ mod tests {
     #[test]
     fn test_client_cache_reuses_for_same_key() {
         let mut t = parse_target("http://example.com").unwrap();
-        t.timeout = 60_001; // unique to this test
+        t.timeout = REUSE_TIMEOUT;
         t.follow_redirects = false;
         t.proxy = None;
         let _ = t.build_client().unwrap();
@@ -354,9 +361,9 @@ mod tests {
     #[test]
     fn test_client_cache_separates_distinct_keys() {
         let mut a = parse_target("http://example.com").unwrap();
-        a.timeout = 60_002; // unique to this test
+        a.timeout = DISTINCT_TIMEOUT_A;
         let mut b = parse_target("http://example.com").unwrap();
-        b.timeout = 60_003; // distinct key, also unique to this test
+        b.timeout = DISTINCT_TIMEOUT_B; // distinct key
         let _ = a.build_client().unwrap();
         let _ = b.build_client().unwrap();
         let _ = a.build_client().unwrap();


### PR DESCRIPTION
## Summary

Fixes the intermittent failure of `target_parser::tests::test_client_cache_reuses_for_same_key` seen on main CI ([run 26862343825](https://github.com/hahwul/dalfox/actions/runs/26862343825/job/79218589184)):

```
assertion `left == right` failed: same key must reuse
  left: 1
 right: 2
```

## Root cause

The reqwest client cache (`build_client()`) is **process-global** and shared with every test in the lib binary that builds a Client. The test built the same target twice and asserted the cache's **total `.len()`** was unchanged. But other tests — e.g. `src/waf/tests.rs` calling `build_client_or_default()` — run concurrently and insert their own keys into the same global cache. When a foreign insert lands between the two length reads, `len` goes 1 → 2 and the assertion flakes.

The existing `CACHE_TEST_LOCK` only serialized the two cache tests against **each other**; it never covered foreign client builders, so the flake survived it.

## Fix

Stop asserting on the global cache length. Each test now uses a `timeout` value no other test uses (`60_001` / `60_002` / `60_003`) and counts only the entries carrying that timeout (`cache_entries_with_timeout`). Foreign inserts carry different timeouts, so they can't perturb the count — no lock or reset required. Removes the now-unnecessary `CACHE_TEST_LOCK`, `reset_client_cache_for_tests`, and `client_cache_len_for_tests`.

Test-only change; production `build_client` logic is untouched.

## Verification

- `cargo test --lib` — 1304 passed, run 5× consecutively, all green.
- `cargo clippy --lib --all-features -- -D warnings` — clean (no dead-code warnings from the removed helpers).