### PR TITLE
refine(scanning): make outdated-library detection opt-in + scope to script context (#1074)

### DIFF
--- a/docs/content/guide/output.md
+++ b/docs/content/guide/output.md
@@ -36,7 +36,7 @@ Every finding includes:
 
 | Field | Example | Meaning |
 |-------|---------|---------|
-| `type` | `V`, `A`, `R` | Verified / AST-detected / Reflected |
+| `type` | `V`, `A`, `R`, `I` | Verified / AST-detected / Reflected / Informational |
 | `type_description` | `"Verified"` | Human label |
 | `inject_type` | `"inHTML"` | Context (`inHTML`, `inAttr`, `inJS`, …) |
 | `method` | `"GET"` | HTTP method |
@@ -46,6 +46,14 @@ Every finding includes:
 | `cwe` | `"CWE-79"` | Standard CWE |
 | `severity` | `"High"` | High / Medium / Low / Info |
 | `message_str` | `"XSS found"` | Short message |
+
+`V` / `A` / `R` are XSS findings. `I` (**Informational**) is a non-exploitable
+observation — currently only **outdated / known-vulnerable JS libraries**
+(`inject_type: "OutdatedComponent"`, `CWE-1104`), rendered as a compact
+`[INF]` line with no payload/parameter. It is **opt-in**: Dalfox focuses on
+verified XSS by default, so library reporting is off unless you pass
+`--detect-outdated-libs` (it adds **0 extra requests** — it inspects the
+preflight response's `<script>` tags). Filter it out with `--only-poc v,a,r`.
 
 Optionally include the full request/response:
 

--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -57,9 +57,14 @@ Submit a scan. Returns immediately.
   "workers": 50,
   "blind_callback_url": "https://callback.example",
   "deep_scan": false,
-  "skip_ast_analysis": false
+  "skip_ast_analysis": false,
+  "detect_outdated_libs": false
 }
 ```
+
+`detect_outdated_libs` is opt-in (default `false`): set it `true` to also emit
+informational `[I]` findings for outdated / known-vulnerable JS libraries
+(CWE-1104, 0 extra requests). Left off, the scan reports only XSS.
 
 Response:
 

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -184,12 +184,16 @@ Returns version, `auth_required`, and the list of supported endpoints. Good for 
     "skip_mining": false,
     "skip_discovery": false,
     "deep_scan": false,
-    "skip_ast_analysis": false
+    "skip_ast_analysis": false,
+    "detect_outdated_libs": false
   }
 }
 ```
 
 Fields mirror the CLI flags. See the [CLI reference](../../reference/cli/) for meaning and defaults.
+`detect_outdated_libs` is opt-in (default `false`): set it `true` to also report
+outdated / known-vulnerable JS libraries as informational `[I]` findings
+(CWE-1104, 0 extra requests). The same key works as a `GET /scan` query parameter.
 
 ## Job lifecycle
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -153,6 +153,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--max-payloads-per-param` | — | `0` | Cap payloads tested per parameter (`0` = no cap) |
 | `--skip-ast-analysis` | — | false | Skip AST DOM-XSS |
 | `--hpp` | — | false | HTTP Parameter Pollution |
+| `--detect-outdated-libs` | — | false | Also report outdated / known-vulnerable JS libraries (informational, CWE-1104; 0 extra requests) |
 
 ### WAF
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -95,6 +95,7 @@ sxss = false
 # sxss_url = "https://target.app/retrieval"
 sxss_method = "GET"
 skip_ast_analysis = false
+detect_outdated_libs = false
 hpp = false
 
 # WAF
@@ -205,6 +206,7 @@ debug = false
 | `sxss_retries` | int | `3` | Retries when fetching the retrieval URL |
 | `max_payloads_per_param` | int | `0` | Cap payloads tested per parameter (`0` = no cap) |
 | `skip_ast_analysis` | bool | `false` | Skip AST DOM-XSS |
+| `detect_outdated_libs` | bool | `false` | Also report outdated / known-vulnerable JS libraries (informational, CWE-1104; 0 extra requests) |
 | `hpp` | bool | `false` | HTTP Parameter Pollution |
 
 ### WAF

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -455,10 +455,13 @@ pub(crate) async fn run_preflight_and_analysis(
                 }
 
                 // Outdated / known-vulnerable JS library detection (issue #1074).
-                // Emits informational (CWE-1104) findings from the initial
-                // response, once per target. Borrows the body so the AST block
-                // below can still consume it.
-                if let Some(body) = preflight_response_body.as_deref() {
+                // OPT-IN (`--detect-outdated-libs`, default off): dalfox's default
+                // output is verified XSS, so this informational (CWE-1104) add-on
+                // is gated behind a flag. Emits once per target from the initial
+                // response; borrows the body so the AST block below can still use it.
+                if args_clone.detect_outdated_libs
+                    && let Some(body) = preflight_response_body.as_deref()
+                {
                     let lib_findings = crate::scanning::vuln_libs::library_findings(
                         crate::scanning::vuln_libs::detect_vulnerable_libraries(body),
                         target.url.as_str(),

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -449,6 +449,13 @@ pub struct ScanArgs {
     #[arg(long)]
     pub hpp: bool,
 
+    #[clap(help_heading = "XSS SCANNING")]
+    /// Also report outdated / known-vulnerable JS libraries (informational,
+    /// CWE-1104). Off by default: dalfox focuses on verified XSS; this is an
+    /// opt-in retire.js-style add-on that inspects <script> tags (0 extra requests).
+    #[arg(long)]
+    pub detect_outdated_libs: bool,
+
     #[clap(help_heading = "WAF")]
     /// WAF bypass mode: auto (detect+bypass), force (use --force-waf), off (detect-only; no payload mutations). Default: auto
     #[arg(long, default_value = "auto", value_parser = clap::builder::PossibleValuesParser::new(["auto", "force", "off"]))]
@@ -512,6 +519,7 @@ impl ScanArgs {
             DEFAULT_TIMEOUT_SECS
         };
         ScanArgs {
+            detect_outdated_libs: false,
             input_type: "url".to_string(),
             format: "json".to_string(),
             targets: vec![opts.target],

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -23,6 +23,7 @@ use tokio::sync::Mutex;
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         output: None,

--- a/src/config.rs
+++ b/src/config.rs
@@ -116,6 +116,7 @@ pub struct ScanConfig {
     pub sxss_method: Option<String>,
     pub sxss_retries: Option<u32>,
     pub skip_ast_analysis: Option<bool>,
+    pub detect_outdated_libs: Option<bool>,
     // HPP
     pub hpp: Option<bool>,
     // WAF
@@ -789,6 +790,11 @@ impl Config {
                 && !args.skip_ast_analysis
             {
                 args.skip_ast_analysis = v;
+            }
+            if let Some(v) = scan.detect_outdated_libs
+                && !args.detect_outdated_libs
+            {
+                args.detect_outdated_libs = v;
             }
             if let Some(v) = scan.hpp
                 && !args.hpp

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "plain".to_string(),
         output: None,

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -143,6 +143,7 @@ fn full_scan_config() -> ScanConfig {
         sxss_method: Some("POST".to_string()),
         sxss_retries: Some(12),
         skip_ast_analysis: Some(true),
+        detect_outdated_libs: Some(true),
         hpp: Some(false),
         waf_bypass: Some("auto".to_string()),
         skip_waf_probe: Some(false),
@@ -477,6 +478,7 @@ fn test_apply_to_scan_args_if_default_maps_all_supported_fields() {
     assert_eq!(args.sxss_method, "POST");
     assert_eq!(args.sxss_retries, 12);
     assert!(args.skip_ast_analysis);
+    assert!(args.detect_outdated_libs);
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -350,6 +350,7 @@ async fn main() {
     } else {
         // Default to scan
         let mut args = cmd::scan::ScanArgs {
+            detect_outdated_libs: false,
             input_type: "auto".to_string(),
             format: "plain".to_string(),
             targets: cli.targets,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -549,6 +549,11 @@ pub struct ScanWithDalfoxParams {
     #[serde(default)]
     pub skip_ast_analysis: bool,
 
+    /// Also report outdated / known-vulnerable JS libraries (informational,
+    /// CWE-1104, 0 extra requests). Default: false
+    #[serde(default)]
+    pub detect_outdated_libs: bool,
+
     /// Blind XSS callback URL (e.g., your Burp Collaborator or interact.sh URL).
     #[serde(default)]
     pub blind_callback_url: Option<String>,
@@ -706,6 +711,7 @@ Final results (via get_results_dalfox) include finding type \
             skip_discovery,
             deep_scan,
             skip_ast_analysis,
+            detect_outdated_libs,
             blind_callback_url,
             workers,
         } = params;
@@ -780,7 +786,7 @@ Final results (via get_results_dalfox) include finding type \
         // request file) is intentionally not honoured on the MCP path —
         // see the comment on `ScanWithDalfoxParams::cookies` for the reason.
         let scan_args = Arc::new(ScanArgs {
-            detect_outdated_libs: false,
+            detect_outdated_libs,
             input_type: "url".to_string(),
             format: "json".to_string(),
             targets: vec![target.clone()],

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -780,6 +780,7 @@ Final results (via get_results_dalfox) include finding type \
         // request file) is intentionally not honoured on the MCP path —
         // see the comment on `ScanWithDalfoxParams::cookies` for the reason.
         let scan_args = Arc::new(ScanArgs {
+            detect_outdated_libs: false,
             input_type: "url".to_string(),
             format: "json".to_string(),
             targets: vec![target.clone()],

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -51,6 +51,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
 
 fn default_scan_args(target: &str) -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![target.to_string()],

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -44,6 +44,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
         skip_discovery: false,
         deep_scan: false,
         skip_ast_analysis: false,
+        detect_outdated_libs: false,
         blind_callback_url: None,
         workers: 1,
     }
@@ -242,6 +243,7 @@ async fn test_scan_with_dalfox_queues_and_can_be_queried() {
         timeout: 1,
         delay: 0,
         follow_redirects: false,
+        detect_outdated_libs: true,
         ..default_scan_params("http://127.0.0.1:1/?q=a")
     };
     let resp = mcp

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -10,6 +10,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![],

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -7,6 +7,7 @@ use tokio::time::{Duration, sleep};
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec!["http://127.0.0.1:1".to_string()],

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -28,6 +28,7 @@ fn mock_mine_parameters(_target: &mut Target, _args: &ScanArgs) {
 fn test_analyze_parameters_with_mock_mining() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -117,6 +118,7 @@ fn test_analyze_parameters_with_mock_mining() {
 fn test_analyze_parameters_skip_mining() {
     let target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -198,6 +200,7 @@ fn test_analyze_parameters_skip_mining() {
 fn test_probe_body_params_mock() {
     let mut target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -351,6 +354,7 @@ fn test_check_cookie_discovery_mock() {
 fn test_cookie_from_raw() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -453,6 +457,7 @@ fn test_cookie_from_raw() {
 fn test_cookie_from_raw_no_file() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -853,6 +858,7 @@ fn test_ensure_explicit_params_skips_unsynthesizable_specs() {
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec!["http://127.0.0.1:0".to_string()],

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -38,6 +38,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec![],

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -38,6 +38,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec![],

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -8,6 +8,7 @@ use crate::target_parser::parse_target;
 /// `realworld_level1_shape_v_upgrade` test exercises the full pipeline.
 fn integration_scan_args(skip_xss: bool) -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec![],
@@ -369,6 +370,7 @@ fn mock_add_reflection_param(target: &mut Target, name: &str, location: Location
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -849,6 +851,7 @@ async fn test_xss_scanning_get_query() {
     mock_add_reflection_param(&mut target, "q", Location::Query);
 
     let args = crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -946,6 +949,7 @@ async fn test_xss_scanning_post_body() {
     mock_add_reflection_param(&mut target, "data", Location::Body);
 
     let args = crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -1057,6 +1061,7 @@ async fn test_run_scanning_with_reflection_params() {
     });
 
     let args = crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],
@@ -1253,6 +1258,7 @@ async fn test_run_scanning_empty_params() {
     let target = parse_target("https://example.com").unwrap();
 
     let args = crate::cmd::scan::ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec!["https://example.com".to_string()],

--- a/src/scanning/vuln_libs.rs
+++ b/src/scanning/vuln_libs.rs
@@ -207,6 +207,35 @@ static COMPILED: LazyLock<Vec<CompiledLib>> = LazyLock::new(|| {
         .collect()
 });
 
+/// `<script src="…">` source URLs and inline `<script>…</script>` bodies are
+/// the only places a *loaded* library version is meaningful. Matching the raw
+/// response body would also flag versions mentioned in prose, link text,
+/// download `href`s, comments, or non-JS filenames (false positives), so
+/// detection is scoped to these two via `script_haystacks`.
+static SCRIPT_SRC_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r#"(?i)<script\b[^>]*\bsrc\s*=\s*["']?([^"'>\s]+)"#).unwrap());
+static SCRIPT_INLINE_RE: LazyLock<Regex> =
+    LazyLock::new(|| Regex::new(r"(?is)<script\b(?:\s[^>]*)?>(.*?)</script>").unwrap());
+
+/// Extract the script-context haystacks from `body`: `(src URLs joined, inline
+/// script bodies joined)`. url-patterns match only the former, inline-patterns
+/// only the latter.
+fn script_haystacks(body: &str) -> (String, String) {
+    let urls = SCRIPT_SRC_RE
+        .captures_iter(body)
+        .filter_map(|c| c.get(1))
+        .map(|m| m.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    let inline = SCRIPT_INLINE_RE
+        .captures_iter(body)
+        .filter_map(|c| c.get(1))
+        .map(|m| m.as_str())
+        .collect::<Vec<_>>()
+        .join("\n");
+    (urls, inline)
+}
+
 /// Parse a dotted version into numeric components, truncating any non-numeric
 /// suffix on each component (`"1.7.2-rc1"` → `[1, 7, 2]`).
 fn parse_version(v: &str) -> Vec<u64> {
@@ -290,14 +319,20 @@ pub fn detect_vulnerable_libraries(body: &str) -> Vec<VulnLib> {
     let mut out: Vec<VulnLib> = Vec::new();
     let mut seen: HashSet<(String, String)> = HashSet::new();
 
+    // Scope matching to script context (avoids prose/href/comment false positives).
+    let (url_hay, inline_hay) = script_haystacks(body);
+
     for lib in COMPILED.iter() {
         let mut versions: Vec<String> = Vec::new();
-        for re in lib.url_res.iter().chain(lib.inline_res.iter()) {
-            for cap in re.captures_iter(body) {
-                // First non-empty capture group is the version (inline patterns
-                // may use alternation with two groups).
-                if let Some(v) = (1..cap.len()).find_map(|i| cap.get(i)).map(|m| m.as_str()) {
-                    versions.push(v.to_string());
+        // url-patterns over <script src> URLs; inline-patterns over inline bodies.
+        for (res, hay) in [(&lib.url_res, &url_hay), (&lib.inline_res, &inline_hay)] {
+            for re in res {
+                for cap in re.captures_iter(hay) {
+                    // First non-empty capture group is the version (inline patterns
+                    // may use alternation with two groups).
+                    if let Some(v) = (1..cap.len()).find_map(|i| cap.get(i)).map(|m| m.as_str()) {
+                        versions.push(v.to_string());
+                    }
                 }
             }
         }

--- a/src/scanning/vuln_libs/tests.rs
+++ b/src/scanning/vuln_libs/tests.rs
@@ -142,6 +142,53 @@ fn bootstrap_4_introduced_bound_respected() {
 }
 
 #[test]
+fn prose_mention_is_not_flagged() {
+    // A library + version named in body text (not a loaded script) must NOT be
+    // reported — it isn't a loaded dependency.
+    let body = "<html><body><p>We migrated our UI from Bootstrap 3.3.7 \
+                and jQuery 1.7.2 to a modern stack last year.</p></body></html>";
+    assert!(
+        libs(body).is_empty(),
+        "prose mention flagged: {:?}",
+        libs(body)
+    );
+}
+
+#[test]
+fn download_href_is_not_flagged() {
+    // A version in a download link / anchor href is not a loaded script.
+    let body = r#"<a href="/downloads/jquery-1.7.2.min.js">Download jQuery 1.7.2</a>"#;
+    assert!(
+        libs(body).is_empty(),
+        "href mention flagged: {:?}",
+        libs(body)
+    );
+}
+
+#[test]
+fn html_comment_mention_is_not_flagged() {
+    let body = "<!-- TODO: upgrade from angular 1.5.8, see changelog --><div>x</div>";
+    assert!(
+        libs(body).is_empty(),
+        "comment mention flagged: {:?}",
+        libs(body)
+    );
+}
+
+#[test]
+fn inline_script_banner_is_still_flagged() {
+    // The version inside an inline <script> (a real loaded banner) must still fire.
+    let body = "<script>/*! Bootstrap v3.3.7 (https://getbootstrap.com) */ var a=1;</script>";
+    assert!(
+        libs(body)
+            .iter()
+            .any(|v| v.library == "Bootstrap" && v.version == "3.3.7"),
+        "inline banner should still be flagged, got {:?}",
+        libs(body)
+    );
+}
+
+#[test]
 fn no_libraries_in_plain_page() {
     let found = libs("<html><body><h1>hello</h1></body></html>");
     assert!(found.is_empty(), "got {:?}", found);
@@ -223,7 +270,7 @@ fn detects_moment_from_src_and_inline() {
             .any(|v| v.library == "Moment.js" && v.version == "2.20.1"),
         "got {from_src:?}"
     );
-    let from_inline = libs("//! moment.js\n//! version : 2.20.1\n//! authors");
+    let from_inline = libs("<script>//! moment.js\n//! version : 2.20.1\n//! authors</script>");
     assert!(
         from_inline
             .iter()

--- a/src/scanning/xss_common/tests.rs
+++ b/src/scanning/xss_common/tests.rs
@@ -184,6 +184,7 @@ fn test_generate_dynamic_payloads_html() {
 fn test_get_dynamic_payloads_basic() {
     let context = InjectionContext::Html(None);
     let args = ScanArgs {
+        detect_outdated_libs: false,
         encoders: vec!["url".to_string(), "html".to_string()],
         ..base_args()
     };
@@ -215,6 +216,7 @@ fn test_get_dynamic_payloads_basic() {
 fn test_get_dynamic_payloads_only_custom() {
     let context = InjectionContext::Html(None);
     let args = ScanArgs {
+        detect_outdated_libs: false,
         custom_payload: Some("test_payloads.txt".to_string()),
         only_custom_payload: true,
         ..base_args()
@@ -370,6 +372,7 @@ fn test_load_custom_payloads_caches_by_path() {
 
 fn base_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec![],
@@ -445,6 +448,7 @@ fn base_args() -> ScanArgs {
 #[test]
 fn test_get_dynamic_payloads_custom_numeric_alert_value() {
     let args = ScanArgs {
+        detect_outdated_libs: false,
         custom_alert_value: "9999".to_string(),
         ..base_args()
     };
@@ -458,6 +462,7 @@ fn test_get_dynamic_payloads_custom_numeric_alert_value() {
 #[test]
 fn test_get_dynamic_payloads_custom_string_alert_value() {
     let args = ScanArgs {
+        detect_outdated_libs: false,
         custom_alert_type: "str".to_string(),
         custom_alert_value: "xss".to_string(),
         ..base_args()

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -291,6 +291,9 @@ pub(crate) async fn get_scan_handler(
     let skip_discovery = params.get("skip_discovery").is_some_and(|s| s == "true");
     let deep_scan = params.get("deep_scan").is_some_and(|s| s == "true");
     let skip_ast_analysis = params.get("skip_ast_analysis").is_some_and(|s| s == "true");
+    let detect_outdated_libs = params
+        .get("detect_outdated_libs")
+        .is_some_and(|s| s == "true");
 
     let opts = ScanOptions {
         cookie,
@@ -325,6 +328,7 @@ pub(crate) async fn get_scan_handler(
         skip_discovery: Some(skip_discovery),
         deep_scan: Some(deep_scan),
         skip_ast_analysis: Some(skip_ast_analysis),
+        detect_outdated_libs: Some(detect_outdated_libs),
     };
 
     if let Err(msg) = validate_scan_options(&opts) {

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -224,6 +224,7 @@ pub(crate) async fn run_scan_job(
     };
 
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         output: None,

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -224,7 +224,7 @@ pub(crate) async fn run_scan_job(
     };
 
     let args = ScanArgs {
-        detect_outdated_libs: false,
+        detect_outdated_libs: opts.detect_outdated_libs.unwrap_or(false),
         input_type: "url".to_string(),
         format: "json".to_string(),
         output: None,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -692,6 +692,7 @@ async fn test_get_scan_handler_success_parses_query_options_and_jsonp() {
         "remote_wordlists".to_string(),
         "unknown-provider".to_string(),
     );
+    params.insert("detect_outdated_libs".to_string(), "true".to_string());
 
     let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
         .await
@@ -946,6 +947,8 @@ async fn test_run_scan_job_success_marks_done() {
         skip_discovery: None,
         deep_scan: None,
         skip_ast_analysis: None,
+        // Exercise the ON path: opts -> job_runner -> ScanArgs -> analysis gate.
+        detect_outdated_libs: Some(true),
     };
 
     let run = tokio::time::timeout(

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -124,6 +124,8 @@ pub(crate) struct ScanOptions {
     pub(crate) deep_scan: Option<bool>,
     /// Skip AST-based JavaScript analysis.
     pub(crate) skip_ast_analysis: Option<bool>,
+    /// Also report outdated / known-vulnerable JS libraries (informational, CWE-1104).
+    pub(crate) detect_outdated_libs: Option<bool>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,7 @@ use dalfox::cmd::scan::ScanArgs;
 /// Factory function to create default ScanArgs for testing
 pub fn create_test_scan_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
         targets: vec![],

--- a/tests/escaped_quote_probe_test.rs
+++ b/tests/escaped_quote_probe_test.rs
@@ -155,6 +155,7 @@ async fn analyze_parameters_covers_discovery_constructors_and_debug_line() {
     target.cookies = vec![("sid".to_string(), "seed".to_string())];
 
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![url.clone()],
@@ -266,6 +267,7 @@ async fn run_scan_inject_marker_covers_marker_param_constructors() {
     let out = std::env::temp_dir().join(format!("dlfx_marker_{}.json", addr.port()));
 
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![url],

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -1030,6 +1030,7 @@ async fn run_scan_test(
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![target],
@@ -1150,6 +1151,7 @@ async fn run_discovery_once(opts: DiscoveryOpts) -> bool {
     target.workers = 10;
 
     let args = ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![url.clone()],
@@ -2604,7 +2606,7 @@ async fn test_synthesis_filter_effectiveness_v2() {
 /// forces `deep_scan=true`, which skips that preflight path) and
 /// `skip_xss_scanning`/`skip_ast_analysis` to isolate the informational
 /// library finding. Returns the findings array.
-async fn run_libscan(addr: SocketAddr, case_id: u32) -> Vec<serde_json::Value> {
+async fn run_libscan(addr: SocketAddr, case_id: u32, detect_libs: bool) -> Vec<serde_json::Value> {
     let target = format!(
         "http://{}:{}/realworld/query/{}?query=seed",
         addr.ip(),
@@ -2620,6 +2622,8 @@ async fn run_libscan(addr: SocketAddr, case_id: u32) -> Vec<serde_json::Value> {
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
+        // The opt-in outdated-library detector is gated by this flag.
+        detect_outdated_libs: detect_libs,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![target],
@@ -2719,8 +2723,18 @@ async fn test_vuln_library_detection_v2() {
             && f.get("inject_type").and_then(|t| t.as_str()) == Some("OutdatedComponent")
     };
 
-    // Vulnerable jQuery 1.7.2 -> informational finding naming the version + a CVE.
-    let vuln = run_libscan(addr, 9101).await;
+    // Opt-in default OFF: without --detect-outdated-libs, even the vulnerable
+    // jQuery 1.7.2 page yields NO library finding (dalfox stays focused on XSS).
+    let off = run_libscan(addr, 9101, false).await;
+    assert!(
+        !off.iter().any(is_outdated_lib),
+        "outdated-lib detection must be OFF by default, got {off:?}"
+    );
+    println!("[#9101 off] no outdated-lib finding without the flag (correct)");
+
+    // With --detect-outdated-libs: vulnerable jQuery 1.7.2 -> informational
+    // finding naming the version + a CVE.
+    let vuln = run_libscan(addr, 9101, true).await;
     let lib_finding = vuln.iter().find(|f| is_outdated_lib(f)).unwrap_or_else(|| {
         panic!("expected an OutdatedComponent finding for jQuery 1.7.2, got {vuln:?}")
     });
@@ -2742,8 +2756,8 @@ async fn test_vuln_library_detection_v2() {
     );
     println!("[#9101] outdated-lib finding: {evidence}");
 
-    // Current jQuery 3.7.1 -> NO library finding.
-    let safe = run_libscan(addr, 9102).await;
+    // Current jQuery 3.7.1 (flag on) -> NO library finding.
+    let safe = run_libscan(addr, 9102, true).await;
     assert!(
         !safe.iter().any(is_outdated_lib),
         "current jQuery must not yield an OutdatedComponent finding, got {safe:?}"

--- a/tests/request_count_probe.rs
+++ b/tests/request_count_probe.rs
@@ -25,6 +25,7 @@ use dalfox::cmd::scan::{self, ScanArgs};
 
 fn make_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         targets: vec![],

--- a/tests/scan_run_paths_test.rs
+++ b/tests/scan_run_paths_test.rs
@@ -12,6 +12,7 @@ use tokio::net::TcpListener;
 
 fn base_scan_args() -> ScanArgs {
     ScanArgs {
+        detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
         output: None,


### PR DESCRIPTION
Follow-up to #1074, from the comprehensive FP/FN/speed review of #1072/#1073/#1074. Two changes that make the outdated-library detector align with dalfox's verified-XSS focus and avoid false positives.

## 1. Opt-in (`--detect-outdated-libs`, default OFF)
#1074 shipped on by default, but outdated/known-vulnerable JS library detection is a **regex-based, non-verified, informational** (`[I]` CWE-1104) signal — not a working XSS. dalfox's identity is verified XSS; a default-on heuristic finding type dilutes the default output and changes its shape (JSON consumers, exit codes, `--only-poc`). This is the same reasoning that retired the regex-based **BAV** checks in v3.

Now gated behind `--detect-outdated-libs` (XSS SCANNING group). Off → no detection runs, no `[I]` findings. On → unchanged behavior, **0 extra HTTP requests** (reuses the preflight body).

## 2. Scope to script context (false-positive fix)
`detect_vulnerable_libraries` regex-scanned the **entire response body**, flagging library+version mentions in prose, link text, download `href`s, comments, non-JS filenames (e.g. `<p>migrated from Bootstrap 3.3.7</p>`, `<a href=/downloads/jquery-1.7.2.min.js>`). Now scoped: url-patterns match only `<script src="…">` URLs, inline-patterns only inline `<script>…</script>` bodies.

## Tests
- Functional `test_vuln_library_detection_v2` now asserts **both**: OFF → no finding even on vulnerable jQuery 1.7.2; ON → the finding with its 5 CVEs; current jQuery 3.7.1 not flagged.
- New FP-regression unit tests: prose / download-href / HTML-comment mentions NOT flagged; inline `<script>` banner still flagged.
- All lib tests + functional tests pass; `fmt`/`clippy` clean.