### PR TITLE
fix(scanning): clear DOM taint on unconditional clean/sanitized reassignment

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -121,6 +121,13 @@ struct DomXssVisitor<'a> {
     /// set is pushed/popped as the promise-chain driver enters and leaves
     /// each callback so the binding never leaks past its callback.
     response_object_vars: HashSet<String>,
+    /// Nesting depth of conditional/loop/switch/try branch bodies currently
+    /// being walked. The analysis is flow-insensitive, so taint is a *union*
+    /// over paths: it is always added, but only *cleared* on an unconditional
+    /// reassignment (`branch_depth == 0`). Clearing inside a branch would
+    /// wrongly drop taint set on a sibling path — e.g.
+    /// `if (c) out = taint; else out = 'x'; sink(out)`.
+    branch_depth: u32,
 }
 
 // Module-level DOM source/sink/sanitizer constants
@@ -513,6 +520,7 @@ impl<'a> DomXssVisitor<'a> {
             script_element_vars: HashSet::new(),
             script_element_ids: HashSet::new(),
             response_object_vars: HashSet::new(),
+            branch_depth: 0,
         }
     }
 
@@ -1930,16 +1938,22 @@ impl<'a> DomXssVisitor<'a> {
             }
             Statement::IfStatement(if_stmt) => {
                 self.walk_expression(&if_stmt.test);
+                // Branch bodies are conditional: suppress detaint inside them.
+                self.branch_depth += 1;
                 self.walk_statement(&if_stmt.consequent);
                 if let Some(alt) = &if_stmt.alternate {
                     self.walk_statement(alt);
                 }
+                self.branch_depth -= 1;
             }
             Statement::WhileStatement(while_stmt) => {
                 self.walk_expression(&while_stmt.test);
+                self.branch_depth += 1;
                 self.walk_statement(&while_stmt.body);
+                self.branch_depth -= 1;
             }
             Statement::ForStatement(for_stmt) => {
+                // `init` runs unconditionally; `update`/`body` are conditional.
                 if let Some(ForStatementInit::VariableDeclaration(var_decl)) = &for_stmt.init {
                     for decl in &var_decl.declarations {
                         self.walk_variable_declarator(decl);
@@ -1948,10 +1962,12 @@ impl<'a> DomXssVisitor<'a> {
                 if let Some(test) = &for_stmt.test {
                     self.walk_expression(test);
                 }
+                self.branch_depth += 1;
                 if let Some(update) = &for_stmt.update {
                     self.walk_expression(update);
                 }
                 self.walk_statement(&for_stmt.body);
+                self.branch_depth -= 1;
             }
             Statement::FunctionDeclaration(func_decl) => {
                 // Parameterized functions are primarily handled through summaries/call sites.
@@ -1997,14 +2013,19 @@ impl<'a> DomXssVisitor<'a> {
             }
             Statement::SwitchStatement(switch_stmt) => {
                 self.walk_expression(&switch_stmt.discriminant);
+                self.branch_depth += 1;
                 for case in &switch_stmt.cases {
                     if let Some(test) = &case.test {
                         self.walk_expression(test);
                     }
                     self.walk_statements(&case.consequent);
                 }
+                self.branch_depth -= 1;
             }
             Statement::TryStatement(try_stmt) => {
+                // `catch`/`finally` are conditional; the `try` block may also
+                // abort partway, so treat the whole construct as a branch.
+                self.branch_depth += 1;
                 self.walk_statements(&try_stmt.block.body);
                 if let Some(handler) = &try_stmt.handler {
                     self.walk_statements(&handler.body.body);
@@ -2012,6 +2033,7 @@ impl<'a> DomXssVisitor<'a> {
                 if let Some(finalizer) = &try_stmt.finalizer {
                     self.walk_statements(&finalizer.body);
                 }
+                self.branch_depth -= 1;
             }
             _ => {}
         }
@@ -3131,6 +3153,25 @@ impl<'a> DomXssVisitor<'a> {
                     if let Some(source) = right_source.clone() {
                         self.var_aliases.insert(target_name.to_string(), source);
                     }
+                } else if self.branch_depth == 0 {
+                    // Reassigning a previously-tainted variable to a clean or
+                    // sanitized value clears its taint — e.g.
+                    // `x = location.hash; x = DOMPurify.sanitize(x)` or
+                    // `x = "static"`. Without this the flow-insensitive walker
+                    // keeps the stale taint and reports a false positive at any
+                    // later sink that reads `x`. This mirrors the
+                    // `instance_classes` / `bound_function_aliases` clears just
+                    // above. Because the walker runs top-to-bottom, a sink that
+                    // consumed the tainted value *before* this reassignment was
+                    // already reported, so confirmed flows are not lost.
+                    //
+                    // Only clear at `branch_depth == 0` (unconditional
+                    // reassignment). Taint is a union over paths, so a clean
+                    // assignment inside one conditional branch must not drop
+                    // taint set on a sibling branch
+                    // (`if (c) out = taint; else out = 'x'; sink(out)`).
+                    self.tainted_vars.remove(target_name);
+                    self.var_aliases.remove(target_name);
                 }
 
                 if self.is_assignment_sink_property(target_name) && right_tainted {

--- a/tests/functional/mock_cases/dom_xss/sanitized_flows.toml
+++ b/tests/functional/mock_cases/dom_xss/sanitized_flows.toml
@@ -770,3 +770,68 @@ Reflect.apply(el.insertAdjacentHTML, el, ['beforeend', DOMPurify.sanitize(locati
 </html>
 """
 expected_detection = false
+
+# --- Reassignment-detaint cases: taint must clear when an already-tainted
+# variable is reassigned to a clean / sanitized value before reaching the sink.
+# These are genuinely safe (the value at the sink is a constant or a sanitized
+# result). A flow-insensitive engine that only ever ADDS taint and never clears
+# it on reassignment reports them as false positives. ---
+
+[[case]]
+id = 1441
+name = "reassign_tainted_to_literal_safe"
+description = "Tainted var reassigned to a string literal before the sink is safe"
+handler_type = "dom_xss"
+reflection = """
+<html>
+<body>
+<div id="out"></div>
+<script>
+var x = location.hash.substring(1);
+x = "static safe content";
+document.getElementById('out').innerHTML = x;
+</script>
+</body>
+</html>
+"""
+expected_detection = false
+
+[[case]]
+id = 1442
+name = "reassign_tainted_to_sanitized_safe"
+description = "Tainted var reassigned to its DOMPurify-sanitized form before the sink is safe"
+handler_type = "dom_xss"
+reflection = """
+<html>
+<body>
+<div id="out"></div>
+<script src="https://cdn.jsdelivr.net/npm/dompurify@2.4.0/dist/purify.min.js"></script>
+<script>
+var x = location.search.substring(1);
+x = DOMPurify.sanitize(x);
+document.getElementById('out').innerHTML = x;
+</script>
+</body>
+</html>
+"""
+expected_detection = false
+
+[[case]]
+id = 1443
+name = "reassign_tainted_to_clean_var_safe"
+description = "Tainted var overwritten by a clean variable before the sink is safe"
+handler_type = "dom_xss"
+reflection = """
+<html>
+<body>
+<div id="out"></div>
+<script>
+var src = location.hash.substring(1);
+var safe = "constant value";
+src = safe;
+document.getElementById('out').innerHTML = src;
+</script>
+</body>
+</html>
+"""
+expected_detection = false


### PR DESCRIPTION
## Problem

The flow-insensitive AST DOM-XSS taint engine only ever **added** taint to a
variable and never cleared it when the variable was reassigned to a clean or
sanitized value. So genuinely-safe code reported a false positive at the sink:

```js
var x = location.hash;
x = DOMPurify.sanitize(x);          // or: x = "static"
document.getElementById('out').innerHTML = x;   // <- false positive
```

## Fix

Clear taint on reassignment to a non-tainted RHS — but **only at
`branch_depth == 0`** (an unconditional reassignment). Taint is a *union over
paths*, so clearing inside a conditional / loop / switch / try branch would
wrongly drop taint set on a sibling path, e.g.:

```js
if (c) { out = location.hash; } else { out = 'safe'; }
sink(out);   // must still be detected
```

A new `branch_depth` counter is incremented around each branch body in
`walk_statement`; taint *insertion* stays unconditional, only *removal* is gated.

## Impact (measured)

| guard | before | after |
|---|---|---|
| DOM `sanitized_flows` false-positive rate | 7.0% (3/43) | **0.0% (0/43)** |
| DOM `complex_flows` detection (FN guard) | 68/68 | **68/68** (no regression) |
| comprehensive DOM positives | 110/110 | **110/110** |
| library unit tests | — | **1345/1345 pass** |

Adds 3 `sanitized_flows` regression cases (reassign-to-literal / -sanitized /
-clean-var) that fail before the fix and pass after, locking in the behavior.