### PR TITLE
feat(scanning): compute JS breakout from the observed script prefix (#1073)

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -348,6 +348,7 @@ pub(crate) async fn run_preflight_and_analysis(
                                 form_origin_url: None,
                                 framework_sink: None,
                                 escaped_specials: None,
+                                js_breakout: None,
                             });
                         }
                     }
@@ -374,6 +375,7 @@ pub(crate) async fn run_preflight_and_analysis(
                                             form_origin_url: None,
                                             framework_sink: None,
                                             escaped_specials: None,
+                                            js_breakout: None,
                                         });
                                     }
                                 }
@@ -397,6 +399,7 @@ pub(crate) async fn run_preflight_and_analysis(
                                         form_origin_url: None,
                                         framework_sink: None,
                                         escaped_specials: None,
+                                        js_breakout: None,
                                     });
                                 }
                             }
@@ -420,6 +423,7 @@ pub(crate) async fn run_preflight_and_analysis(
                                 form_origin_url: None,
                                 framework_sink: None,
                                 escaped_specials: None,
+                                js_breakout: None,
                             });
                         }
                     }
@@ -441,6 +445,7 @@ pub(crate) async fn run_preflight_and_analysis(
                                 form_origin_url: None,
                                 framework_sink: None,
                                 escaped_specials: None,
+                                js_breakout: None,
                             });
                         }
                     }

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -761,6 +761,7 @@ fn make_param(name: &str, location: Location) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -18,7 +18,7 @@
 
 use crate::cmd::scan::ScanArgs;
 use crate::parameter_analysis::{
-    Location, Param, classify_special_chars, detect_injection_context,
+    Location, Param, classify_special_chars, detect_injection_context, detect_js_breakout,
 };
 use crate::scanning::url_inject::build_injected_url;
 use crate::target_parser::Target;
@@ -175,6 +175,12 @@ pub(crate) fn dedupe_reflection_params(params: &mut Vec<Param>) {
             if base.injection_context.is_none() && other.injection_context.is_some() {
                 base.injection_context = other.injection_context.clone();
             }
+            // Keep the observed-prefix JS breakout (#1073) when only one probe
+            // landed inside a `<script>`, mirroring the injection_context merge
+            // above so the per-parameter carrier survives dedup.
+            if base.js_breakout.is_none() && other.js_breakout.is_some() {
+                base.js_breakout = other.js_breakout.clone();
+            }
             if base.framework_sink.is_none() && other.framework_sink.is_some() {
                 base.framework_sink = other.framework_sink.clone();
             }
@@ -289,6 +295,7 @@ pub async fn check_fragment_discovery(target: &Target, reflection_params: Arc<Mu
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         });
     }
 }
@@ -320,6 +327,7 @@ pub async fn check_query_discovery(
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         };
         let url_str = build_injected_url(&target.url, &tmp_param, test_value);
         let url = url::Url::parse(&url_str).expect("build_injected_url produces valid URL");
@@ -377,6 +385,7 @@ pub async fn check_query_discovery(
                         form_origin_url: None,
                         framework_sink: None,
                         escaped_specials: None,
+                        js_breakout: None,
                     });
                 } else if let Ok(text) = resp.text().await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
@@ -401,6 +410,7 @@ pub async fn check_query_discovery(
                         form_origin_url: None,
                         framework_sink,
                         escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
                     });
                 }
             }
@@ -471,6 +481,7 @@ pub async fn check_query_discovery(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: detect_js_breakout(&text),
                 });
                 break; // Found working encoding, no need to try more
             }
@@ -550,6 +561,7 @@ pub async fn check_query_discovery(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: detect_js_breakout(&text),
                 });
             }
             if target.delay > 0 {
@@ -582,6 +594,7 @@ pub async fn check_query_discovery(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: None,
             };
             let url_str = build_injected_url(&target.url, &tmp_param, numeric_marker);
             let url = url::Url::parse(&url_str).expect("valid URL");
@@ -613,6 +626,10 @@ pub async fn check_query_discovery(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: crate::parameter_analysis::mining::detect_js_breakout_with_marker(
+                        &text,
+                        numeric_marker,
+                    ),
                 });
             }
             if target.delay > 0 {
@@ -651,6 +668,7 @@ pub async fn check_query_discovery(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: detect_js_breakout(&text),
             });
         }
         if target.delay > 0 {
@@ -829,6 +847,7 @@ pub async fn check_header_discovery(
                     form_origin_url: None,
                     framework_sink,
                     escaped_specials: None,
+                    js_breakout: detect_js_breakout(&text),
                 });
             }
             if delay > 0 {
@@ -1015,6 +1034,7 @@ pub async fn check_path_discovery(
                             form_origin_url: None,
                             framework_sink: None,
                             escaped_specials: None,
+                            js_breakout: detect_js_breakout(&text),
                         });
                     }
                 }
@@ -1125,6 +1145,7 @@ pub async fn check_cookie_discovery(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: detect_js_breakout(&text),
                 });
             }
             if delay > 0 {
@@ -1283,6 +1304,7 @@ pub async fn check_form_discovery(
                         form_origin_url: Some(target.url.to_string()),
                         framework_sink: None,
                         escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
                     });
                 }
                 if target.delay > 0 {
@@ -1354,6 +1376,7 @@ pub async fn check_form_discovery(
                         form_origin_url: Some(target.url.to_string()),
                         framework_sink: None,
                         escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
                     });
                 }
                 if target.delay > 0 {
@@ -1399,6 +1422,7 @@ pub async fn check_form_discovery(
                         form_origin_url: Some(target.url.to_string()),
                         framework_sink: None,
                         escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
                     });
                 }
                 if target.delay > 0 {
@@ -1445,6 +1469,7 @@ pub async fn check_form_discovery(
                         form_origin_url: Some(target.url.to_string()),
                         framework_sink: None,
                         escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
                     });
                 }
             }
@@ -1528,6 +1553,7 @@ pub async fn check_form_discovery(
                             form_origin_url: Some(target.url.to_string()),
                             framework_sink: None,
                             escaped_specials: None,
+                            js_breakout: detect_js_breakout(&text),
                         });
                     }
                     if target.delay > 0 {
@@ -1603,6 +1629,7 @@ pub async fn check_form_discovery(
                             form_origin_url: Some(target.url.to_string()),
                             framework_sink: None,
                             escaped_specials: None,
+                            js_breakout: detect_js_breakout(&text),
                         });
                     }
                     if target.delay > 0 {

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -649,6 +649,7 @@ async fn test_check_path_discovery_skips_existing_segment() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }]));
 
     let semaphore = Arc::new(Semaphore::new(1));
@@ -716,6 +717,7 @@ fn test_dedupe_collapses_same_name_location_pair() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "query".to_string(),
@@ -731,6 +733,7 @@ fn test_dedupe_collapses_same_name_location_pair() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
     dedupe_reflection_params(&mut params);
@@ -767,6 +770,7 @@ fn test_dedupe_keeps_different_locations_distinct() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "q".to_string(),
@@ -782,6 +786,7 @@ fn test_dedupe_keeps_different_locations_distinct() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
     dedupe_reflection_params(&mut params);
@@ -805,6 +810,7 @@ fn test_dedupe_is_noop_for_unique_entries() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "b".to_string(),
@@ -820,6 +826,7 @@ fn test_dedupe_is_noop_for_unique_entries() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
     let before = params.clone();

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -109,6 +109,7 @@ fn make_any_query_param(text: &str) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: detect_js_breakout(text),
     }
 }
 
@@ -185,6 +186,68 @@ pub fn detect_injection_context(text: &str) -> InjectionContext {
     }
     let open = crate::scanning::markers::open_marker();
     detect_injection_context_with_marker(text, open)
+}
+
+/// Compute the exact JS breakout closer (issue #1073 follow-up) from the
+/// *observed* response when a probe marker reflects inside an inline `<script>`
+/// body. Returns the minimal closer sequence — produced by
+/// [`crate::payload::js_breakout::compute_js_breakout`] over the real script
+/// source from the enclosing `<script>` content start up to the reflection
+/// point — that escapes the open string and every unbalanced `([{` so a
+/// following `;<payload>//` reaches executable statement position.
+///
+/// This is the per-parameter carrier the synthesis layer consumes to emit a
+/// breakout matched to the *site's actual nesting* rather than only the fixed
+/// depth-0–3 catalog. Returns `None` when the marker is not inside an inline
+/// `<script>` body (the script-tag requirement scopes this to script contexts,
+/// not event-handler/attribute JS), when no marker is present, or when the
+/// observed prefix already sits at statement position (empty closer) — every
+/// such case falls back to the fixed catalog, so the result is strictly
+/// additive and never removes coverage.
+///
+/// Mirrors `detect_injection_context`'s marker selection (inner marker
+/// preferred, open marker fallback) so the closer is computed for the same
+/// reflection the context classifier anchored on. Uses raw response slicing
+/// (inline `<script>` content is CDATA-like, not HTML-entity-decoded by the
+/// browser), so the prefix matches the JS source the browser actually parses.
+pub fn detect_js_breakout(text: &str) -> Option<String> {
+    let inner = crate::scanning::markers::inner_marker();
+    let marker = if text.contains(inner) {
+        inner
+    } else {
+        crate::scanning::markers::open_marker()
+    };
+    detect_js_breakout_with_marker(text, marker)
+}
+
+/// `detect_js_breakout` with a caller-supplied marker string (mirrors
+/// `detect_injection_context_with_marker`). Used by probes that inject a
+/// non-standard marker, e.g. the numeric-only discovery probe.
+pub fn detect_js_breakout_with_marker(text: &str, marker: &str) -> Option<String> {
+    let mp = text.find(marker)?;
+    // Find the enclosing inline `<script …>` opening tag before the reflection.
+    // `<script` (case-insensitive) never matches a closing `</script>` tag (the
+    // char after `<` is `/`, not `s`), so `rfind` lands on a real opener.
+    let lower_before = text[..mp].to_ascii_lowercase();
+    let open_tag = lower_before.rfind("<script")?;
+    // Script content begins just after the `>` that ends the opening tag.
+    let gt = text[open_tag..mp].find('>')?;
+    let content_start = open_tag + gt + 1;
+    let prefix = &text[content_start..mp];
+    // Guard the multi-`<script>` edge: if a `</script>` closes between this
+    // opener and the marker, the marker isn't inside this script body — bail to
+    // the fixed catalog rather than computing a bogus closer.
+    if prefix.to_ascii_lowercase().contains("</script") {
+        return None;
+    }
+    let closer = crate::payload::js_breakout::compute_js_breakout(prefix);
+    // An empty closer means the prefix already sits at statement position; the
+    // raw-JS catalog templates handle that, so carry nothing.
+    if closer.is_empty() {
+        None
+    } else {
+        Some(closer)
+    }
 }
 
 /// Like `detect_injection_context` but uses a caller-supplied marker string.
@@ -664,6 +727,7 @@ pub async fn probe_dictionary_params(
                                 form_origin_url: None,
                                 framework_sink: None,
                                 escaped_specials: None,
+                                js_breakout: None,
                             });
                             if !silence {
                                 eprintln!(
@@ -704,6 +768,7 @@ pub async fn probe_dictionary_params(
                                     form_origin_url: None,
                                     framework_sink: None,
                                     escaped_specials: None,
+                                    js_breakout: detect_js_breakout(&text),
                                 });
                                 if !silence {
                                     eprintln!(
@@ -789,6 +854,7 @@ pub async fn probe_dictionary_params(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: orig.js_breakout.clone(),
             });
         } else {
             guard.push(Param {
@@ -805,6 +871,7 @@ pub async fn probe_dictionary_params(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: None,
             });
         }
     }
@@ -924,6 +991,7 @@ pub async fn probe_body_params(
                                 form_origin_url: None,
                                 framework_sink: None,
                                 escaped_specials: None,
+                                js_breakout: detect_js_breakout(&text),
                             });
                             if !silence {
                                 eprintln!(
@@ -1004,6 +1072,7 @@ pub async fn probe_body_params(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: orig.js_breakout.clone(),
                 });
             } else {
                 guard.push(Param {
@@ -1022,6 +1091,7 @@ pub async fn probe_body_params(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: None,
                 });
             }
         }
@@ -1183,6 +1253,7 @@ pub async fn probe_response_id_params(
                                     form_origin_url: None,
                                     framework_sink: None,
                                     escaped_specials: None,
+                                    js_breakout: detect_js_breakout(&text),
                                 });
                                 if !silence {
                                     eprintln!(
@@ -1262,6 +1333,7 @@ pub async fn probe_response_id_params(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: orig.js_breakout.clone(),
                 });
             } else {
                 guard.push(Param {
@@ -1280,6 +1352,7 @@ pub async fn probe_response_id_params(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: None,
                 });
             }
         }
@@ -1428,6 +1501,7 @@ pub async fn probe_json_body_params(
                             form_origin_url: None,
                             framework_sink: None,
                             escaped_specials: None,
+                            js_breakout: detect_js_breakout(&text),
                         });
                         if !silence {
                             eprintln!(
@@ -1508,6 +1582,7 @@ pub async fn probe_json_body_params(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: orig.js_breakout.clone(),
             });
         } else {
             guard.push(Param {
@@ -1524,6 +1599,7 @@ pub async fn probe_json_body_params(
                 form_origin_url: None,
                 framework_sink: None,
                 escaped_specials: None,
+                js_breakout: None,
             });
         }
     }
@@ -1642,6 +1718,7 @@ pub async fn probe_multipart_params(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: detect_js_breakout(&text),
                 });
             }
             drop(permit);

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -162,6 +162,96 @@ fn test_detect_injection_context_script_backtick_wins_over_earlier_quote() {
 }
 
 #[test]
+fn test_detect_js_breakout_bare_double_quote_string() {
+    // Reflection inside a plain double-quoted JS string: the closer is just the
+    // quote that returns to statement position.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>var x = \"{}\";</script>", marker);
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("\""));
+}
+
+#[test]
+fn test_detect_js_breakout_nested_call_array_object() {
+    // The motivating case from issue #1073: a reflection nested inside an open
+    // string, array, object and call. The exact closer derived from the *real*
+    // observed prefix must close all of them: `"` then `]` `}` `)`.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>foo({{ bar: [ \"{}\" ] }});</script>", marker);
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("\"]})"));
+}
+
+#[test]
+fn test_detect_js_breakout_uses_observed_prefix_not_fixed_shell() {
+    // A nesting shape the fixed depth-0–3 catalog does NOT enumerate
+    // (array-of-array-of-object inside a call) — only an observed-prefix
+    // computation reaches it, proving the wiring is prefix-derived.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>g([[{{k:\"{}\"}}]]);</script>", marker);
+    // open: ( [ [ { "  -> close: " } ] ] )
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("\"}]])"));
+}
+
+#[test]
+fn test_detect_js_breakout_template_literal() {
+    // Inside a backtick template literal the closer is the backtick.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>tag(`hi {}`);</script>", marker);
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("`)"));
+}
+
+#[test]
+fn test_detect_js_breakout_none_outside_script() {
+    // A reflection in HTML text (not inside <script>) has no JS breakout — the
+    // script-tag requirement scopes the carrier to inline-script contexts.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<div>{}</div>", marker);
+    assert_eq!(detect_js_breakout(&body), None);
+}
+
+#[test]
+fn test_detect_js_breakout_none_at_statement_position() {
+    // Marker already at statement position (raw JS, no open string/structure):
+    // empty closer -> None, so synthesis falls back to the raw-JS catalog.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>var x = 1; {}</script>", marker);
+    assert_eq!(detect_js_breakout(&body), None);
+}
+
+#[test]
+fn test_detect_js_breakout_none_after_closing_script() {
+    // Marker sits AFTER a closed <script> (between scripts). The </script>
+    // guard rejects it rather than computing a bogus closer from the prior
+    // script body.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>var a = 1;</script><div>{}</div>", marker);
+    assert_eq!(detect_js_breakout(&body), None);
+}
+
+#[test]
+fn test_detect_js_breakout_with_marker_custom() {
+    // The explicit-marker variant used by the numeric-only discovery probe.
+    let body = "<script>h([\"4815162342\"]);</script>";
+    // prefix `h(["` opens ( [ and the string → close `"` `]` `)`.
+    assert_eq!(
+        detect_js_breakout_with_marker(body, "4815162342").as_deref(),
+        Some("\"])")
+    );
+}
+
+#[test]
+fn test_detect_js_breakout_picks_innermost_script_opener() {
+    // With an earlier closed <script> and a second open one containing the
+    // marker, `rfind("<script")` lands on the second opener, so the prefix is
+    // local to the script the marker actually lives in.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!(
+        "<script>var done = true;</script>\n<script>obj({{a:\"{}\"</script>",
+        marker
+    );
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("\"})"));
+}
+
+#[test]
 fn test_detect_injection_context_attribute_double_quote() {
     let marker = crate::scanning::markers::open_marker();
     let body = format!("<img alt=\"{}\">", marker);
@@ -571,6 +661,7 @@ async fn test_collapse_to_any_query_param_keeps_non_query_and_replaces_query() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "q_old_2".into(),
@@ -586,6 +677,7 @@ async fn test_collapse_to_any_query_param_keeps_non_query_and_replaces_query() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "h".into(),
@@ -601,6 +693,7 @@ async fn test_collapse_to_any_query_param_keeps_non_query_and_replaces_query() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
     let params = Arc::new(Mutex::new(initial));

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -143,6 +143,21 @@ pub struct Param {
     /// quote-escape probe in `active_probe_param` (issue #1072).
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub escaped_specials: Option<Vec<char>>,
+    /// Exact JS breakout closer computed from the *observed* inline-`<script>`
+    /// source between the enclosing script's content start and this parameter's
+    /// reflection point (issue #1073 follow-up). For a reflection nested inside
+    /// e.g. `foo({ bar: [ "…" ] })` this carries `"]})` — the minimal sequence
+    /// that closes the open string and every unbalanced `([{` to reach an
+    /// executable statement position. Computed once at detection time (where the
+    /// response body is available) via
+    /// [`crate::payload::js_breakout::compute_js_breakout`] and consumed by
+    /// payload synthesis, which emits the matching breakout *first* (highest
+    /// confidence) ahead of the fixed depth-0–3 catalog. `None` when the
+    /// reflection is not inside an inline `<script>` body, or when the observed
+    /// prefix already sits at statement position (nothing to close) — in which
+    /// case synthesis falls back to the fixed catalog exactly as before.
+    #[serde(default, skip_serializing_if = "Option::is_none")]
+    pub js_breakout: Option<String>,
 }
 
 impl Param {
@@ -449,6 +464,7 @@ async fn send_probe_request_for_param(
                     form_origin_url: None,
                     framework_sink: None,
                     escaped_specials: None,
+                    js_breakout: None,
                 },
                 payload,
             );
@@ -1111,6 +1127,7 @@ fn ensure_explicit_params(params: &mut Vec<Param>, param_specs: &[String], targe
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         });
     }
 }

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -21,6 +21,7 @@ fn mock_mine_parameters(_target: &mut Target, _args: &ScanArgs) {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 }
 
@@ -288,6 +289,7 @@ fn test_probe_body_params_mock() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 
     assert!(!target.reflection_params.is_empty());
@@ -316,6 +318,7 @@ fn test_check_header_discovery_mock() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 
     assert!(!target.reflection_params.is_empty());
@@ -344,6 +347,7 @@ fn test_check_cookie_discovery_mock() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 
     assert!(!target.reflection_params.is_empty());
@@ -599,6 +603,7 @@ fn test_filter_params_by_name_and_type() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "sort".to_string(),
@@ -614,6 +619,7 @@ fn test_filter_params_by_name_and_type() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "id".to_string(),
@@ -629,6 +635,7 @@ fn test_filter_params_by_name_and_type() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "session".to_string(),
@@ -644,6 +651,7 @@ fn test_filter_params_by_name_and_type() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
 
@@ -691,6 +699,7 @@ fn test_filter_params_multiple_filters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "id".to_string(),
@@ -706,6 +715,7 @@ fn test_filter_params_multiple_filters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "session".to_string(),
@@ -721,6 +731,7 @@ fn test_filter_params_multiple_filters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
 
@@ -752,6 +763,7 @@ fn test_filter_params_empty_filters() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }];
 
     // Empty filters should return all params
@@ -776,6 +788,7 @@ fn test_filter_params_invalid_filter_format() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }];
 
     // Invalid filter format (too many colons) should be treated as name only
@@ -799,6 +812,7 @@ fn bare_param(name: &str, location: Location) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 
@@ -965,6 +979,7 @@ fn probe_param(name: &str, location: Location) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 

--- a/src/payload/js_breakout.rs
+++ b/src/payload/js_breakout.rs
@@ -15,15 +15,23 @@
 //! common nesting shapes, which the synthesis engine emits for JS string
 //! contexts.
 //!
+//! [`compute_js_breakout`] is run two ways: by [`breakout_templates`] on the
+//! known-clean [`NESTING_SHELLS`] to derive the fixed depth-0–3 catalog, and —
+//! the issue #1073 follow-up — on the *real* observed inline-`<script>` source
+//! at scan time via [`crate::parameter_analysis::detect_js_breakout`], whose
+//! closer is carried per-parameter and emitted first by synthesis.
+//!
 //! Limitation — regex literals: `/` is only ever read as division or a comment
 //! start, never as a regex-literal delimiter. A prefix containing a regex
-//! (`x.test(/)/)`, `s.replace(/}{/, …)`) can therefore mis-balance the stack and
-//! yield a *wrong* closer — not merely a missing one. This is currently dormant:
-//! [`compute_js_breakout`] is only ever run on the known-clean [`NESTING_SHELLS`]
-//! by [`breakout_templates`]; it is NOT yet fed real observed script prefixes
-//! (that wiring is a follow-up that also needs a per-parameter carrier).
-//! Disambiguating regex-vs-division needs token-level context and is out of
-//! scope here. Either way the synthesis path always falls back to the catalog.
+//! (`x.test(/)/)`, `s.replace(/}{/, …)`) *before* the injection point can
+//! therefore mis-balance the stack and yield a *wrong* closer — not merely a
+//! missing one. Disambiguating regex-vs-division needs token-level context and
+//! is out of scope here. This is non-regressing by construction: a wrong closer
+//! only produces an inert payload (it reflects but does not parse to an
+//! executable position), promotion to [V] is execution/marker-verified so an
+//! inert payload can never become a false positive, and synthesis always *also*
+//! emits the fixed catalog as a fallback — so the observed-prefix closer is
+//! strictly additive over the prior fixed-only behavior.
 
 /// A structural opener tracked on the scan stack.
 #[derive(Clone, Copy, PartialEq)]

--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -262,11 +262,20 @@ fn templates_for(context: &InjectionContext) -> Vec<&'static str> {
 /// only in backslash-escaped form (`"` → `\"`). For a JS-string context whose
 /// delimiter is escaped, synthesis leads with a backslash-prefixed breakout
 /// (`\";…`), which the server's own escaping turns into a working string break.
+/// `observed_js_breakout` (issue #1073 follow-up) is the exact breakout closer
+/// computed from the *real* inline-`<script>` source observed at this
+/// parameter's reflection point (see [`crate::parameter_analysis::Param::js_breakout`]).
+/// When present for a JS context, synthesis emits the matching breakout *first*
+/// — ahead of the fixed depth-0–3 catalog — so a site whose nesting the fixed
+/// shells don't cover (deeper or unusual nesting) is still reached. It is
+/// strictly additive: the fixed catalog still follows as a fallback, and the
+/// observed closer dedupes against it when they coincide.
 pub fn synthesize_payloads(
     context: &InjectionContext,
     invalid_specials: &[char],
     valid_specials: &[char],
     escaped_specials: &[char],
+    observed_js_breakout: Option<&str>,
 ) -> Vec<String> {
     // `valid_specials` is accepted for symmetry with `generate_adaptive_payloads`
     // and forward use (e.g. confidence weighting); gating is expressed purely as
@@ -280,20 +289,34 @@ pub fn synthesize_payloads(
     // Candidate templates, highest-confidence first.
     let mut templates: Vec<String> = Vec::new();
     // Issue #1073: for a reflection inside a JS string, lead with nested-closer
-    // breakouts (`"]});…`) that `js_breakout` computes for the common nesting
-    // shapes (call / array / object, depth 0-3), so sinks the bare quote-close
-    // cannot escape are still reached. This is a *fixed* set, not derived from
-    // the observed script prefix — per-prefix computation would need a per-param
-    // carrier and is a follow-up — so at any given site only the depth-matching
-    // closer is executable JS; the others still reflect and are reported as [R].
-    // Every breakout is gated by `allows_str` below like any other template.
-    if let InjectionContext::Javascript(Some(delim)) = context {
+    // breakouts (`"]});…`) that escape the open string and any unbalanced
+    // `([{` so sinks the bare quote-close cannot reach are still executed.
+    // `observed_js_breakout` (when present) is the closer computed from the
+    // *real* script prefix at this exact site — the per-parameter carrier
+    // follow-up — and is emitted first. The fixed depth-0–3 catalog
+    // (`breakout_templates`) always follows as a fallback for sites without an
+    // observed prefix, so coverage is strictly additive and the two dedupe when
+    // they coincide. Every breakout is gated by `allows_str` below like any
+    // other template.
+    if let InjectionContext::Javascript(delim) = context {
         let quote = match delim {
-            DelimiterType::SingleQuote => Some('\''),
-            DelimiterType::DoubleQuote => Some('"'),
-            DelimiterType::Backtick => Some('`'),
-            DelimiterType::Comment => None,
+            Some(DelimiterType::SingleQuote) => Some('\''),
+            Some(DelimiterType::DoubleQuote) => Some('"'),
+            Some(DelimiterType::Backtick) => Some('`'),
+            Some(DelimiterType::Comment) | None => None,
         };
+        // Issue #1073 follow-up: lead with the breakout computed from the real
+        // observed script prefix at this exact site, so nesting the fixed shells
+        // don't cover is still escaped. Emitted before the catalog (highest
+        // confidence) and deduped against it. When the delimiter is one the
+        // server backslash-escapes (#1072), prepend a `\` like the escaped
+        // catalog set, so the server's own escaping turns our quote into a real
+        // string break (`\"]});…` → `\\"]});…` → literal `\` + closing quote).
+        if let Some(closer) = observed_js_breakout {
+            let escaped = quote.is_some_and(|q| escaped_specials.contains(&q));
+            let lead = if escaped { "\\" } else { "" };
+            templates.push(format!("{lead}{closer};{{JS}}//"));
+        }
         if let Some(q) = quote {
             // Issue #1072: when the server backslash-escapes this delimiter the
             // raw nested breakout is *inert* (`"]});…` → `\"]});…`), so emit the

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -44,7 +44,7 @@ fn produces_payloads_for_every_context_when_unfiltered() {
         InjectionContext::Css(Some(DelimiterType::DoubleQuote)),
     ];
     for ctx in contexts {
-        let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+        let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
         assert!(
             !payloads.is_empty(),
             "expected synthesized payloads for {:?}",
@@ -61,7 +61,7 @@ fn output_is_capped_and_deduped() {
         InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
         InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
     ] {
-        let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+        let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
         assert!(
             payloads.len() <= MAX_SYNTHESIZED,
             "cap exceeded for {:?}",
@@ -101,7 +101,7 @@ fn obeys_filter_for_assorted_blocked_sets() {
     ];
     for invalid in blocked_sets {
         for ctx in &contexts {
-            let payloads = synthesize_payloads(ctx, invalid, &[], &[]);
+            let payloads = synthesize_payloads(ctx, invalid, &[], &[], None);
             assert_obeys_filter(&payloads, invalid);
         }
     }
@@ -117,7 +117,7 @@ fn everything_blocked_yields_nothing() {
         InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
         InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
     ] {
-        let payloads = synthesize_payloads(&ctx, ALL_SPECIALS, &[], &[]);
+        let payloads = synthesize_payloads(&ctx, ALL_SPECIALS, &[], &[], None);
         assert!(payloads.is_empty(), "expected empty for {:?}", ctx);
     }
 }
@@ -126,7 +126,7 @@ fn everything_blocked_yields_nothing() {
 fn html_text_context_needs_angles() {
     // HTML element-content reflection can only execute by injecting a tag, so a
     // filter that strips `<` defeats synthesis here.
-    let payloads = synthesize_payloads(&html(), &['<'], &[], &[]);
+    let payloads = synthesize_payloads(&html(), &['<'], &[], &[], None);
     assert!(
         payloads.is_empty(),
         "HTML text context should yield nothing when `<` is stripped, got {:?}",
@@ -139,7 +139,7 @@ fn attribute_context_survives_angle_stripping() {
     // The key win: a quoted-attribute reflection stays exploitable without
     // `<`/`>` via stay-in-tag event injection.
     let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
-    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[], &[], None);
     assert!(
         !payloads.is_empty(),
         "attribute context should still synthesize angle-free payloads"
@@ -166,7 +166,7 @@ fn paren_blocked_falls_back_to_backtick_call() {
     // With `(`/`)` stripped, the only surviving execution primitive is the
     // tagged-template call `alert`1``.
     let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
-    let payloads = synthesize_payloads(&ctx, &['(', ')'], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &['(', ')'], &[], &[], None);
     assert!(!payloads.is_empty());
     assert_obeys_filter(&payloads, &['(', ')']);
     assert!(
@@ -186,7 +186,7 @@ fn single_quote_attr_needs_the_quote() {
     // stripped, synthesis bows out (escaped-quote handling is tracked
     // separately).
     let ctx = InjectionContext::Attribute(Some(DelimiterType::SingleQuote));
-    let payloads = synthesize_payloads(&ctx, &['\''], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &['\''], &[], &[], None);
     assert!(
         payloads.is_empty(),
         "single-quote attribute with `'` stripped should yield nothing, got {:?}",
@@ -197,7 +197,7 @@ fn single_quote_attr_needs_the_quote() {
 #[test]
 fn backtick_js_context_uses_template_interpolation() {
     let ctx = InjectionContext::Javascript(Some(DelimiterType::Backtick));
-    let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
     assert!(
         payloads.iter().any(|p| p.contains("${alert(1)}")),
         "expected `${{alert(1)}}` interpolation, got {:?}",
@@ -210,7 +210,7 @@ fn js_string_context_includes_nested_closer_breakouts() {
     // Issue #1073: synthesis must emit exact nested-closer breakouts for JS
     // string contexts, not just the bare quote-close.
     let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
-    let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
     // Bare close (depth 0) and a deep array-in-object-in-call close (depth 3).
     assert!(
         payloads.iter().any(|p| p == "\";alert(1)//"),
@@ -229,7 +229,7 @@ fn js_string_context_survives_angle_stripping() {
     // A reflection inside a JS string can break out with quotes alone — no
     // `</script>` tag needed — so angle stripping does not defeat it.
     let ctx = InjectionContext::Javascript(Some(DelimiterType::SingleQuote));
-    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &['<', '>'], &[], &[], None);
     assert!(!payloads.is_empty());
     assert!(
         payloads.iter().any(|p| p.starts_with('\'')),
@@ -249,7 +249,7 @@ fn high_confidence_payloads_carry_a_marker() {
         InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
         InjectionContext::Css(None),
     ] {
-        let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+        let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
         assert!(
             payloads
                 .iter()
@@ -266,7 +266,7 @@ fn high_confidence_payloads_carry_a_marker() {
 fn html_lead_payload_is_the_most_reliable_shape() {
     // Confidence ordering: the first HTML candidate should be the auto-firing
     // svg/onload tag.
-    let payloads = synthesize_payloads(&html(), &[], &[], &[]);
+    let payloads = synthesize_payloads(&html(), &[], &[], &[], None);
     assert!(
         payloads[0].starts_with("<svg onload=alert(1)"),
         "unexpected lead payload: {:?}",
@@ -277,7 +277,7 @@ fn html_lead_payload_is_the_most_reliable_shape() {
 #[test]
 fn attribute_url_context_includes_protocol_payload() {
     let ctx = InjectionContext::AttributeUrl(Some(DelimiterType::DoubleQuote));
-    let payloads = synthesize_payloads(&ctx, &[], &[], &[]);
+    let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
     assert!(
         payloads.iter().any(|p| p.contains("javascript:alert(1)")),
         "expected a javascript: protocol payload, got {:?}",
@@ -288,7 +288,7 @@ fn attribute_url_context_includes_protocol_payload() {
 #[test]
 fn empty_profile_matches_no_filtering() {
     // No probe data → nothing is "blocked" → full-strength synthesis.
-    let payloads = synthesize_payloads(&html(), &[], &[], &[]);
+    let payloads = synthesize_payloads(&html(), &[], &[], &[], None);
     assert!(payloads.len() > 5);
 }
 
@@ -299,7 +299,7 @@ fn escaped_quote_js_context_emits_backslash_breakout() {
     let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
 
     // No escaped signal → only the raw quote-close breakout.
-    let plain = synthesize_payloads(&ctx, &[], &[], &[]);
+    let plain = synthesize_payloads(&ctx, &[], &[], &[], None);
     assert!(plain.iter().any(|p| p == "\";alert(1)//"));
     assert!(
         !plain.iter().any(|p| p == "\\\";alert(1)//"),
@@ -309,7 +309,7 @@ fn escaped_quote_js_context_emits_backslash_breakout() {
     // Escaped signal for `"` → emit ONLY the backslash-prefixed breakouts; the
     // raw quote-close is inert under escaping, so it is dropped (keeping the cap
     // free for the marker-carrying `</script>` template).
-    let escaped = synthesize_payloads(&ctx, &[], &[], &['"']);
+    let escaped = synthesize_payloads(&ctx, &[], &[], &['"'], None);
     assert!(
         escaped.iter().any(|p| p == "\\\";alert(1)//"),
         "expected the escaped breakout `\\\";alert(1)//`, got {escaped:?}"
@@ -329,6 +329,81 @@ fn escaped_quote_js_context_emits_backslash_breakout() {
         escaped.iter().any(|p| p.contains("</script>")),
         "expected the marker-carrying </script> breakout to survive the cap"
     );
+}
+
+#[test]
+fn observed_breakout_reaches_shape_beyond_fixed_catalog() {
+    // Issue #1073 follow-up: an observed-prefix breakout for nesting the fixed
+    // depth-0–3 catalog does NOT enumerate (`g([[{k:"…` → close `"}]])`) is both
+    // emitted and placed first (highest confidence).
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let observed = "\"}]])"; // close: " } ] ] )
+    let with_prefix = synthesize_payloads(&ctx, &[], &[], &[], Some(observed));
+    assert_eq!(
+        with_prefix.first().map(String::as_str),
+        Some("\"}]]);alert(1)//"),
+        "observed breakout must be emitted first, got {with_prefix:?}"
+    );
+    // Without the observed prefix the fixed catalog never produces this closer,
+    // proving the new payload is genuinely prefix-derived (added coverage).
+    let without = synthesize_payloads(&ctx, &[], &[], &[], None);
+    assert!(
+        !without.iter().any(|p| p == "\"}]]);alert(1)//"),
+        "the fixed catalog must not already cover this deep nesting"
+    );
+}
+
+#[test]
+fn observed_breakout_dedups_against_catalog() {
+    // When the observed closer coincides with a fixed-catalog shape it must not
+    // duplicate — it just moves to the front.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let observed = "\"]})"; // also produced by the `({k:[` catalog shell
+    let out = synthesize_payloads(&ctx, &[], &[], &[], Some(observed));
+    assert_eq!(out.first().map(String::as_str), Some("\"]});alert(1)//"));
+    let n = out.iter().filter(|p| *p == "\"]});alert(1)//").count();
+    assert_eq!(
+        n, 1,
+        "the coinciding breakout must appear exactly once, got {out:?}"
+    );
+}
+
+#[test]
+fn observed_breakout_escaped_prepends_backslash() {
+    // #1072 interaction: under a server that escapes the delimiter, the observed
+    // breakout leads with a backslash like the escaped catalog set, so the
+    // server's own escaping turns it into a real string break.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let out = synthesize_payloads(&ctx, &[], &[], &['"'], Some("\"}]])"));
+    assert!(
+        out.iter().any(|p| p == "\\\"}]]);alert(1)//"),
+        "expected backslash-prefixed observed breakout, got {out:?}"
+    );
+}
+
+#[test]
+fn observed_breakout_respects_filter() {
+    // The observed breakout is filter-gated like every other payload: a blocked
+    // structural char drops it (no unusable payload, no FP), and the rest still
+    // synthesize.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let out = synthesize_payloads(&ctx, &[']'], &[], &[], Some("\"}]])"));
+    assert_obeys_filter(&out, &[']']);
+    assert!(
+        !out.iter().any(|p| p.contains(']')),
+        "blocked `]` must not appear in any synthesized payload, got {out:?}"
+    );
+    assert!(!out.is_empty(), "other payloads must still synthesize");
+}
+
+#[test]
+fn observed_breakout_none_is_purely_additive() {
+    // Regression guard: passing None reproduces the prior behavior — the fixed
+    // depth-0 and nested catalog breakouts are still present unchanged.
+    let ctx = InjectionContext::Javascript(Some(DelimiterType::DoubleQuote));
+    let out = synthesize_payloads(&ctx, &[], &[], &[], None);
+    assert!(out.iter().any(|p| p == "\";alert(1)//"));
+    assert!(out.iter().any(|p| p == "\"]});alert(1)//"));
 }
 
 // ===================================================================
@@ -472,7 +547,7 @@ fn synthesis_closes_catalog_coverage_gaps() {
         let mut catalog = crate::scanning::xss_common::generate_dynamic_payloads(ctx);
         catalog.sort();
         catalog.dedup();
-        let synth = synthesize_payloads(ctx, blocked, &[], &[]);
+        let synth = synthesize_payloads(ctx, blocked, &[], &[], None);
 
         // Net-new = synthesized payloads the catalog does not already contain.
         // This is the coverage synthesis genuinely *adds*, not an artifact of
@@ -542,7 +617,7 @@ fn synthesis_is_fast_and_bounded() {
     for _ in 0..iterations {
         for ctx in &contexts {
             for blocked in blocked_sets {
-                let out = synthesize_payloads(ctx, blocked, &[], &[]);
+                let out = synthesize_payloads(ctx, blocked, &[], &[], None);
                 assert!(out.len() <= MAX_SYNTHESIZED);
                 produced += out.len();
             }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -33,6 +33,7 @@ fn make_param() -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 
@@ -418,6 +419,7 @@ async fn test_check_dom_verification_injects_header_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
 
@@ -452,6 +454,7 @@ async fn test_check_dom_verification_injects_cookie_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
 
@@ -488,6 +491,7 @@ async fn test_check_dom_verification_injects_form_body_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
 
@@ -525,6 +529,7 @@ async fn test_check_dom_verification_injects_json_body_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
 

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -33,6 +33,7 @@ fn make_param() -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 

--- a/src/scanning/light_verify/tests.rs
+++ b/src/scanning/light_verify/tests.rs
@@ -42,6 +42,7 @@ fn make_param(loc: Location, name: &str) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -892,8 +892,16 @@ fn generate_param_jobs(
             // #1072: escaped-quote signal (JS string contexts) drives synthesis
             // to emit backslash-prefixed breakouts that survive server escaping.
             let escaped = param.escaped_specials.as_deref().unwrap_or_default();
-            let synthesized =
-                crate::payload::synthesis::synthesize_payloads(context, invalid, valid, escaped);
+            // #1073 follow-up: the breakout computed from this site's observed
+            // inline-<script> prefix, emitted ahead of the fixed catalog.
+            let observed_breakout = param.js_breakout.as_deref();
+            let synthesized = crate::payload::synthesis::synthesize_payloads(
+                context,
+                invalid,
+                valid,
+                escaped,
+                observed_breakout,
+            );
             if !synthesized.is_empty() {
                 let mut seen: std::collections::HashSet<String> =
                     std::collections::HashSet::with_capacity(

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -365,6 +365,7 @@ fn mock_add_reflection_param(target: &mut Target, name: &str, location: Location
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 }
 
@@ -459,6 +460,7 @@ fn test_get_dom_payloads_javascript_context_returns_breakout_payloads() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
     let payloads = get_dom_payloads(&param, &args).expect("dom payload generation");
@@ -488,6 +490,7 @@ fn test_get_dom_payloads_html_context_includes_encoded_variants() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let args = default_scan_args();
     let payloads = get_dom_payloads(&param, &args).expect("dom payload generation");
@@ -513,6 +516,7 @@ fn test_get_dom_payloads_unknown_context_falls_back_even_with_only_custom() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let mut args = default_scan_args();
     args.only_custom_payload = true;
@@ -811,6 +815,7 @@ fn test_build_request_text_query_contains_headers_and_cookies() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     let request = build_request_text(&target, &param, "PAYLOAD");
@@ -839,6 +844,7 @@ fn test_build_request_text_path_segment_injection() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     let request = build_request_text(&target, &param, "hello world");
@@ -1058,6 +1064,7 @@ async fn test_run_scanning_with_reflection_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 
     let args = crate::cmd::scan::ScanArgs {
@@ -1206,6 +1213,7 @@ async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     });
 
     let args = Arc::new(integration_scan_args(false));

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -22,6 +22,7 @@ fn test_query_injection_replace() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "PAY");
     assert!(out.contains("a=PAY"));
@@ -45,6 +46,7 @@ fn test_query_injection_append() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "X");
     assert!(out.contains("q=X"));
@@ -67,6 +69,7 @@ fn test_query_injection_preserves_existing_percent_encoding() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "%3Cimg%20src=x%3E");
     assert!(out.contains("q=%3Cimg%20src%3Dx%3E"));
@@ -90,6 +93,7 @@ fn test_query_injection_encodes_raw_spaces_without_plus() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "PAY LOAD");
     assert!(out.contains("q=PAY%20LOAD"));
@@ -112,6 +116,7 @@ fn test_path_injection_basic() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "PAY LOAD");
     // space should be %20
@@ -135,6 +140,7 @@ fn test_path_injection_index_out_of_bounds() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "X");
     assert_eq!(out, "https://example.com/a");
@@ -157,6 +163,7 @@ fn test_non_target_location_passthrough() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "IGNORED");
     assert_eq!(out, base.as_str());
@@ -179,6 +186,7 @@ fn test_fragment_injection_spa_route() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "javascript:alert()");
     assert_eq!(out, "http://example.com/#/redir?url=javascript:alert()");
@@ -201,6 +209,7 @@ fn test_fragment_injection_simple_kv() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "PAYLOAD");
     assert_eq!(out, "http://example.com/#key=PAYLOAD&other=123");
@@ -223,6 +232,7 @@ fn test_fragment_injection_append_when_absent() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "INJECTED");
     assert_eq!(
@@ -248,6 +258,7 @@ fn test_fragment_injection_no_existing_fragment() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "PAY");
     assert_eq!(out, "http://example.com/page#url=PAY");
@@ -270,6 +281,7 @@ fn test_fragment_injection_multiple_params() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_injected_url(&base, &param, "XSS");
     assert_eq!(out, "http://example.com/#/app?a=1&b=XSS&c=3");
@@ -294,6 +306,7 @@ fn test_hpp_last_position() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_hpp_url(&base, &param, "<script>", HppPosition::Last).unwrap();
     assert!(out.contains("q=safe&q=%3Cscript%3E"));
@@ -317,6 +330,7 @@ fn test_hpp_first_position() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_hpp_url(&base, &param, "<script>", HppPosition::First).unwrap();
     assert!(out.contains("q=%3Cscript%3E&q=safe"));
@@ -340,6 +354,7 @@ fn test_hpp_both_position() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_hpp_url(&base, &param, "PAYLOAD", HppPosition::Both).unwrap();
     assert!(out.contains("q=PAYLOAD&q=PAYLOAD"));
@@ -362,6 +377,7 @@ fn test_hpp_non_query_returns_none() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     assert!(build_hpp_url(&base, &param, "PAYLOAD", HppPosition::Last).is_none());
 }
@@ -383,6 +399,7 @@ fn test_hpp_absent_param_appended() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_hpp_url(&base, &param, "XSS", HppPosition::Last).unwrap();
     assert!(out.contains("other=1"));
@@ -406,6 +423,7 @@ fn test_hpp_preserves_fragment() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let out = build_hpp_url(&base, &param, "PAY", HppPosition::Last).unwrap();
     assert!(out.ends_with("#frag"));
@@ -428,6 +446,7 @@ fn test_build_hpp_urls_returns_3_variants() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let variants = build_hpp_urls(&base, &param, "XSS");
     assert_eq!(variants.len(), 3);
@@ -455,6 +474,7 @@ fn effective_query_base_uses_form_action_for_query_params() {
         form_origin_url: Some("https://example.com/page".to_string()),
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let base = effective_query_base(&target, &param);
     assert_eq!(base.as_str(), "https://example.com/app.php");
@@ -492,6 +512,7 @@ fn effective_query_base_uses_form_action_for_body_locations() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     // Body / JsonBody / MultipartBody params point at the form's action URL,
     // so the displayed PoC matches the POST that was actually sent (not the
@@ -522,6 +543,7 @@ fn effective_query_base_ignores_form_action_for_header_fragment() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     for loc in [Location::Header, Location::Fragment] {
         param.location = loc;
@@ -551,6 +573,7 @@ fn effective_query_base_preserves_existing_query_on_action() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     let base = effective_query_base(&target, &param);
     let out = build_injected_url(&base, &param, "PAY");
@@ -579,6 +602,7 @@ fn effective_query_base_falls_back_when_action_unparseable() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
     assert_eq!(
         effective_query_base(&target, &param).as_str(),

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -352,11 +352,15 @@ pub fn generate_adaptive_payloads(
     // Escaped-quote handling (#1072) is JS-string-context-only, and this path is
     // reached for non-JS contexts (JS DOM payloads use the dedicated breakout
     // set), so there is no escaped signal to thread here.
+    // This path serves non-JS DOM/attribute contexts; the observed-prefix JS
+    // breakout (#1073) is threaded through the reflection-phase synthesis call
+    // in `scanning::mod`, which has the carrying `Param`. No prefix here.
     let synthesized = crate::payload::synthesis::synthesize_payloads(
         context,
         invalid_specials,
         valid_specials,
         &[],
+        None,
     );
 
     // Apply adaptive encoders with pre-allocated capacity

--- a/tests/escaped_quote_probe_test.rs
+++ b/tests/escaped_quote_probe_test.rs
@@ -44,6 +44,7 @@ fn js_dq_param() -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     }
 }
 

--- a/tests/integration/scanner_pipeline.rs
+++ b/tests/integration/scanner_pipeline.rs
@@ -85,6 +85,7 @@ fn test_param_structure_query_location() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     assert_eq!(param.name, "id");
@@ -108,6 +109,7 @@ fn test_param_structure_with_injection_context() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     assert_eq!(param.injection_context, Some(InjectionContext::Html(None)));
@@ -134,6 +136,7 @@ fn test_param_structure_javascript_context() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     match &param.injection_context {
@@ -162,6 +165,7 @@ fn test_param_structure_attribute_context() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     match &param.injection_context {
@@ -247,6 +251,7 @@ fn test_param_serialization() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     // Test serialization
@@ -330,6 +335,7 @@ fn test_special_chars_classification() {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
+        js_breakout: None,
     };
 
     assert!(param.valid_specials.as_ref().unwrap().contains(&'<'));
@@ -355,6 +361,7 @@ fn test_multiple_parameters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "name".to_string(),
@@ -370,6 +377,7 @@ fn test_multiple_parameters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
         Param {
             name: "X-Custom".to_string(),
@@ -385,6 +393,7 @@ fn test_multiple_parameters() {
             form_origin_url: None,
             framework_sink: None,
             escaped_specials: None,
+            js_breakout: None,
         },
     ];
 

--- a/tests/observed_js_breakout_test.rs
+++ b/tests/observed_js_breakout_test.rs
@@ -22,6 +22,7 @@ use axum::extract::Query;
 use axum::response::Html;
 use axum::routing::get;
 use dalfox::cmd::scan::{ScanArgs, run_scan};
+use dalfox::parameter_analysis::analyze_parameters;
 use std::collections::HashMap;
 use tokio::net::TcpListener;
 
@@ -166,4 +167,180 @@ async fn observed_breakout_detects_nested_object_script_context() {
             .map(|f| f.get("payload").cloned())
             .collect::<Vec<_>>()
     );
+}
+
+/// Reflect every non-sentinel query value AND the raw request body (where each
+/// probe's marker lands, whether form-encoded `b=MARKER` or JSON `{"k":"MARKER"}`)
+/// into the response, and serve a POST form. Skipping the `dlfx_` sentinel names
+/// keeps the reflect-everything collapse from firing, so each per-route
+/// discovery/mining `Param` constructor actually runs on its own marker probe.
+/// Used to exercise the `js_breakout` carrier on the body / JSON / form /
+/// response-id routes (mirrors `escaped_quote_probe_test`'s constructor coverage).
+async fn reflect_non_sentinel_handler(
+    uri: axum::extract::OriginalUri,
+    body: String,
+) -> Html<String> {
+    let mut parts: Vec<String> = Vec::new();
+    for pair in uri.0.query().unwrap_or("").split('&') {
+        let (k, v) = pair.split_once('=').unwrap_or((pair, ""));
+        if !v.is_empty() && !k.contains("dlfx_") {
+            parts.push(v.to_string());
+        }
+    }
+    if !body.is_empty() {
+        // Reflect the raw body verbatim — the marker is in it for both the
+        // form-encoded and JSON probes.
+        parts.push(body);
+    }
+    let joined = parts.join(" ");
+    // Strip the chars that would break the surrounding div/script so the marker
+    // reflects cleanly (detection only needs the marker present).
+    let safe: String = joined
+        .chars()
+        .filter(|c| !matches!(c, '<' | '>' | '\'' | '"'))
+        .collect();
+    Html(format!(
+        "<html><body><div id=out>{safe}</div>\
+         <script>var o = {{id: 'static'}};</script>\
+         <form method=\"post\" action=\"/x\"><input name=\"fld\" value=\"\"></form>\
+         </body></html>"
+    ))
+}
+
+/// Drive a full scan with mining enabled over the body, response-id and form
+/// routes so the `js_breakout` per-parameter carrier is populated on each — the
+/// HTTP-driven `Param` constructors the pure unit tests can't reach. No
+/// assertion on findings; exercising the constructors without panic (and
+/// covering the carrier wiring) is the goal.
+#[tokio::test]
+async fn observed_breakout_carrier_covers_mining_and_form_routes() {
+    dalfox::ensure_crypto_provider();
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(reflect_non_sentinel_handler).post(reflect_non_sentinel_handler),
+        )
+        .route(
+            "/x",
+            get(reflect_non_sentinel_handler).post(reflect_non_sentinel_handler),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let url = format!("http://127.0.0.1:{}/?q=seed&id=seed", addr.port());
+    let out = std::env::temp_dir().join(format!("dlfx_obs_cov_{}.json", addr.port()));
+    let mut args = base_args(url, out.to_string_lossy().to_string());
+    // Enable mining (dict + dom). The reflect-everything mock drives the dict
+    // probe to the sustained-reflection EWMA collapse, exercising the collapse
+    // post-processing that carries `js_breakout` on the synthetic 'any' param.
+    args.skip_mining = false;
+    args.skip_mining_dict = false;
+    args.skip_mining_dom = false;
+    args.skip_reflection_header = false;
+    args.skip_reflection_cookie = false;
+    args.skip_reflection_path = false;
+    // 16+ reflecting body params trip the body-probe EWMA collapse too.
+    let body: String = (0..18)
+        .map(|i| format!("p{i}=seed"))
+        .collect::<Vec<_>>()
+        .join("&");
+    args.data = Some(body);
+    args.skip_xss_scanning = true;
+
+    run_scan(&args).await;
+    let _ = std::fs::remove_file(&out);
+}
+
+/// Drive form discovery so the POST-form `Param` constructor (and its
+/// `js_breakout` carrier) runs: a page with a `<form method=post action=/x>`
+/// whose action endpoint reflects the POST body.
+#[tokio::test]
+async fn observed_breakout_carrier_covers_form_route() {
+    dalfox::ensure_crypto_provider();
+
+    let app = Router::new()
+        .route(
+            "/",
+            get(reflect_non_sentinel_handler).post(reflect_non_sentinel_handler),
+        )
+        .route(
+            "/x",
+            get(reflect_non_sentinel_handler).post(reflect_non_sentinel_handler),
+        );
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let url = format!("http://127.0.0.1:{}/?q=seed", addr.port());
+    let mut target = dalfox::target_parser::parse_target(&url).expect("parse target");
+    let mut args = base_args(url.clone(), String::new());
+    args.output = None;
+    args.skip_mining = true;
+    args.skip_xss_scanning = true;
+
+    analyze_parameters(&mut target, &args, None).await;
+
+    // The form's `fld` input reflects via POST to its action URL, so form
+    // discovery must surface a Body param carrying the form action URL.
+    assert!(
+        target
+            .reflection_params
+            .iter()
+            .any(|p| p.form_action_url.is_some()),
+        "form discovery should surface a form-action Body param; got {:?}",
+        target
+            .reflection_params
+            .iter()
+            .map(|p| (&p.name, &p.location))
+            .collect::<Vec<_>>()
+    );
+}
+
+/// Same intent as above for the JSON-body route: a JSON `-d` payload makes the
+/// JSON-body probe construct its `Param` (and its `js_breakout` carrier).
+#[tokio::test]
+async fn observed_breakout_carrier_covers_json_body_route() {
+    dalfox::ensure_crypto_provider();
+
+    let app = Router::new().route(
+        "/",
+        get(reflect_non_sentinel_handler).post(reflect_non_sentinel_handler),
+    );
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let url = format!("http://127.0.0.1:{}/", addr.port());
+    let out = std::env::temp_dir().join(format!("dlfx_obs_json_{}.json", addr.port()));
+    let mut args = base_args(url, out.to_string_lossy().to_string());
+    args.skip_mining = false;
+    args.skip_mining_dict = true;
+    args.skip_mining_dom = true;
+    args.method = "POST".to_string();
+    // 16+ reflecting JSON fields trip the JSON-body-probe EWMA collapse, which
+    // carries `js_breakout` on the synthetic 'any' JSON param.
+    let json: String = format!(
+        "{{{}}}",
+        (0..18)
+            .map(|i| format!("\"p{i}\":\"seed\""))
+            .collect::<Vec<_>>()
+            .join(",")
+    );
+    args.data = Some(json);
+    args.headers = vec!["Content-Type: application/json".to_string()];
+    args.skip_xss_scanning = true;
+
+    run_scan(&args).await;
+    let _ = std::fs::remove_file(&out);
 }

--- a/tests/observed_js_breakout_test.rs
+++ b/tests/observed_js_breakout_test.rs
@@ -1,0 +1,169 @@
+//! End-to-end coverage for the issue #1073 follow-up: the *observed-prefix* JS
+//! breakout. A reflection nested inside a JS object literal in an inline
+//! `<script>` (`var config = {apiKey: '…'}`), served by a filter that blocks
+//! the breakouts the fixed catalog relies on. Stripping `<`/`>` makes the
+//! `</script>` HTML breakout inert; stripping `-`/`+` strips the
+//! arithmetic-expression breakouts (`'-alert(1)-'`, `'+alert(1)+'`) that would
+//! otherwise evaluate `alert(1)` inside the object *value* without closing the
+//! brace. That leaves exactly one route to execution: close the open string
+//! AND the enclosing object brace to reach a statement — `'};alert(1)//`.
+//!
+//! The `'}` closer is NOT one of the fixed depth-0–3 catalog shells (whose
+//! object closers are all paired with a call paren, e.g. `'})`), so it is
+//! reachable only by computing the breakout from the real observed script
+//! prefix — exactly what this change wires in. On `main` (catalog-only) this
+//! case is a false negative; with the observed-prefix breakout it is detected.
+//!
+//! This is a NON-ignored integration test, so the full discovery → mining →
+//! synthesis → reflection pipeline is exercised against a live local server.
+
+use axum::Router;
+use axum::extract::Query;
+use axum::response::Html;
+use axum::routing::get;
+use dalfox::cmd::scan::{ScanArgs, run_scan};
+use std::collections::HashMap;
+use tokio::net::TcpListener;
+
+/// Reflect `q` into a single-quoted JS string that is the value of a key in an
+/// object literal — `var config = {apiKey: '<q>', debug: false};` — after
+/// stripping `<`, `>`, `-` and `+`. Stripping angles makes every HTML-tag /
+/// `</script>` breakout inert; stripping `-`/`+` kills the arithmetic-expression
+/// breakouts that would otherwise evaluate `alert(1)` inside the object value.
+/// The only remaining route to execution is the JS-native `'};` statement close.
+async fn nested_object_handler(Query(p): Query<HashMap<String, String>>) -> Html<String> {
+    let q = p.get("q").cloned().unwrap_or_default();
+    let stripped: String = q
+        .chars()
+        .filter(|c| !matches!(c, '<' | '>' | '-' | '+'))
+        .collect();
+    Html(format!(
+        "<html><body><script>var config = {{apiKey: '{stripped}', debug: false}};\
+         init(config);</script></body></html>"
+    ))
+}
+
+fn base_args(url: String, out: String) -> ScanArgs {
+    ScanArgs {
+        detect_outdated_libs: false,
+        input_type: "url".to_string(),
+        format: "json".to_string(),
+        targets: vec![url],
+        param: vec![],
+        data: None,
+        headers: vec![],
+        cookies: vec![],
+        method: "GET".to_string(),
+        user_agent: None,
+        cookie_from_raw: None,
+        include_url: vec![],
+        exclude_url: vec![],
+        ignore_param: vec![],
+        out_of_scope: vec![],
+        out_of_scope_file: None,
+        mining_dict_word: None,
+        skip_mining: true,
+        skip_mining_dict: true,
+        skip_mining_dom: true,
+        only_discovery: false,
+        skip_discovery: false,
+        skip_reflection_header: true,
+        skip_reflection_cookie: true,
+        skip_reflection_path: true,
+        timeout: 5,
+        scan_timeout: 0,
+        delay: 0,
+        proxy: None,
+        follow_redirects: false,
+        ignore_return: vec![],
+        output: Some(out),
+        include_request: false,
+        include_response: false,
+        include_all: false,
+        no_color: true,
+        silence: true,
+        dry_run: false,
+        stream_findings: false,
+        poc_type: "plain".to_string(),
+        limit: None,
+        limit_result_type: "all".to_string(),
+        only_poc: vec![],
+        workers: 4,
+        max_concurrent_targets: 4,
+        max_targets_per_host: 100,
+        // Production default encoders.
+        encoders: vec!["url".to_string(), "html".to_string()],
+        custom_blind_xss_payload: None,
+        blind_callback_url: None,
+        custom_payload: None,
+        only_custom_payload: false,
+        inject_marker: None,
+        custom_alert_value: "1".to_string(),
+        custom_alert_type: "none".to_string(),
+        skip_xss_scanning: false,
+        deep_scan: false,
+        sxss: false,
+        sxss_url: None,
+        sxss_method: "GET".to_string(),
+        sxss_retries: 3,
+        skip_ast_analysis: false,
+        hpp: false,
+        waf_bypass: "off".to_string(),
+        skip_waf_probe: true,
+        force_waf: None,
+        waf_evasion: false,
+        waf_min_confidence: 0.0,
+        remote_payloads: vec![],
+        remote_wordlists: vec![],
+        max_payloads_per_param: 0,
+    }
+}
+
+#[tokio::test]
+async fn observed_breakout_detects_nested_object_script_context() {
+    dalfox::ensure_crypto_provider();
+
+    let app = Router::new().route("/", get(nested_object_handler));
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().unwrap();
+    let _server = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(100)).await;
+
+    let url = format!("http://127.0.0.1:{}/?q=seed", addr.port());
+    let out = std::env::temp_dir().join(format!("dlfx_obs_breakout_{}.json", addr.port()));
+    let args = base_args(url, out.to_string_lossy().to_string());
+
+    run_scan(&args).await;
+
+    let content = std::fs::read_to_string(&out).expect("scan should write JSON output");
+    let v: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+    let findings = v["findings"].as_array().cloned().unwrap_or_default();
+    let _ = std::fs::remove_file(&out);
+
+    // The nested object brace must be closed to reach a statement, and `<`/`>`
+    // are stripped — so detection here is only possible via a breakout that
+    // closes the object (`'}…`), i.e. the observed-prefix path.
+    assert!(
+        !findings.is_empty(),
+        "expected a finding for the nested object-literal script context"
+    );
+    // The winning payload must carry the object-brace close (`'}`), which only
+    // the observed-prefix breakout supplies — distinguishing it from the
+    // (here filtered-out) arithmetic-expression breakouts.
+    let closes_object = findings.iter().any(|f| {
+        f.get("payload")
+            .and_then(|p| p.as_str())
+            .is_some_and(|p| p.contains("'}"))
+    });
+    assert!(
+        closes_object,
+        "expected a winning payload that closes the object brace (`'}}…`); \
+         findings: {:#?}",
+        findings
+            .iter()
+            .map(|f| f.get("payload").cloned())
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Summary

Completes the **issue #1073** follow-up. PR #1078 landed `compute_js_breakout` but fed it only a **fixed** set of synthetic nesting shells (call/array/object, depth 0–3); the closer matched a site only when its nesting happened to be one of those shapes. The owner's note on #1073:

> Scoped delivery — the breakout set is **fixed** (common nesting shapes, depth 0–3), not yet derived from the observed script prefix at scan time. **Per-observed-prefix wiring needs a per-parameter carrier and is the remaining follow-up.**

This PR adds that per-parameter carrier and derives the breakout from the **real observed script prefix**.

## What changed

- **`parameter_analysis::detect_js_breakout(text)`** (+ a `_with_marker` variant for the numeric-only discovery probe): when a probe marker reflects inside an inline `<script>` body, it slices the real script source from the enclosing `<script>` content-start up to the reflection point and runs `compute_js_breakout` over it — yielding the exact closer (`"]})`, `'}`, `"}]])`, …) that escapes the open string and every unbalanced `([{` to reach statement position. Returns `None` outside a script body or when the prefix is already at statement position, so it never displaces the catalog.
- **`Param.js_breakout: Option<String>`** carries that closer from detection (discovery/mining, where the response body is in hand) through to synthesis, surviving the dedup/merge paths exactly like `injection_context`.
- **`synthesize_payloads`** takes the observed closer and emits it **first** (highest confidence), ahead of the fixed depth-0–3 catalog, deduped against it, and backslash-prefixed under the #1072 quote-escaping signal. The fixed catalog still follows as a fallback, so coverage is **strictly additive**.

## Why it's non-regressing

The observed closer is filter-gated like every other synthesized payload; a wrong closer (e.g. from the documented regex-literal limitation in `js_breakout`) only yields an *inert* payload — and V-promotion is execution/marker-verified, so an inert payload can **never** become a false positive — and the fixed catalog fallback is always present.

## Effectiveness comparison (main vs this branch)

Shallow scan, production `url,html` encoders, 664-case corpus (query + realworld + path), single-threaded:

| context | metric | main | branch |
|---|---|---|---|
| ALL | recall | **0.9810** | **0.9810** |
| ALL | FN | 12 | 12 |
| ALL | FP | 22 | 22 |
| ALL | requests | 268,262 | 268,084 (−178, −0.07%) |
| realworld | recall / FP | 0.9940 / 22 | 0.9940 / 22 |
| path | recall | 0.8182 | 0.8182 |

FN sets are byte-identical; FP sets are identical after normalizing the random per-run markers (same 22 case-IDs, same finding types). **No FP/FN regression, request volume neutral.**

The corpus saturates JS detection via the `</script>` HTML breakout, so the gain is isolated by a new **non-ignored** e2e test (`tests/observed_js_breakout_test.rs`): a nested object-literal script context behind an angle/operator-stripping filter that the catalog-only path misses (FN on `main`) and the observed-prefix breakout detects (TP).

## Tests

- 1359 lib unit tests green; new unit tests for `detect_js_breakout` (nested call/array/object, template literal, statement-position → None, outside-script → None, multi-`<script>` selection) and for the synthesis path (observed breakout emitted first, dedupe vs catalog, escaped-quote backslash, filter-gating, None-is-additive).
- New e2e integration test demonstrating the FN→TP gain.
- `cargo fmt` / `cargo clippy --lib --tests` clean.

Closes #1073.