### PR TITLE
docs(payload): list useful-tags selector in payload summary examples

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -47,6 +47,7 @@ fn print_summary() {
     println!("----------------");
     println!("Provide a selector to list payloads. Examples:");
     println!("  dalfox payload event-handlers");
+    println!("  dalfox payload useful-tags");
     println!("  dalfox payload payloadbox");
     println!("  dalfox payload portswigger");
     println!("  dalfox payload uri-scheme\n");


### PR DESCRIPTION
## What & why

`dalfox payload` (run with no selector) prints a summary whose "Examples"
list showed only 4 of the 5 valid selectors — `useful-tags` was missing,
even though it is a valid selector (handled in `run_payload` and present in
`KNOWN_SELECTORS`). This adds it to the examples list, in the canonical
selector order (right after `event-handlers`, matching `KNOWN_SELECTORS`
and the `--help` / `long_help` listings), so the summary now lists all 5
selectors.

## How to test

```
cargo run -- payload
```

The "Examples" block now lists all 5 selectors:

```
  dalfox payload event-handlers
  dalfox payload useful-tags
  dalfox payload payloadbox
  dalfox payload portswigger
  dalfox payload uri-scheme
```

## Notes

- Single-line, output-only change.
- Verified locally: `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`, and `cargo test` (188 passed / 0 failed) all green.

Closes #1071
