### PR TITLE
fix(server, mcp): align validation, reachability, progress & blind-XSS across async interfaces

### DIFF
--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -120,6 +120,16 @@ Response (done):
 }
 ```
 
+`progress.estimated_completion_pct` and `params_tested` advance live as each
+discovered parameter finishes (they no longer sit at 0 until the scan ends), so
+they are usable for pacing polls — honor `suggested_poll_interval_ms`.
+
+If the target can't be reached (DNS failure, connection refused, TLS error,
+timeout) the scan ends as `status: "error"` with `error_message` containing
+`CONNECTION_FAILED`, rather than `done` with an empty `results` — the same
+distinction `preflight_dalfox` reports via `reachable: false`. The `target`
+must start with `http://` or `https://`.
+
 ### `list_scans_dalfox`
 
 List every tracked scan. Optional filter:

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -205,6 +205,14 @@ queued → running → done
 
 Terminal states (`done`, `error`, `cancelled`) are sticky.
 
+A target that can't be connected to (DNS failure, connection refused, TLS
+error, timeout) ends as `error` with an `error_message` of
+`target unreachable: connection failed (CONNECTION_FAILED)` — not `done` with
+zero findings, so you can tell "scanned, nothing found" apart from "never
+reached the host." Use `POST /preflight` first if you want to check
+reachability without launching a scan. The `url` must start with `http://` or
+`https://`; any other scheme is rejected with `400` (same as `/preflight`).
+
 ## Running under systemd
 
 ```ini
@@ -233,3 +241,14 @@ sudo systemctl enable --now dalfox
 - **Always set `--api-key`** on a remote bind.
 - **Keep the API key out of logs.** Dalfox does not log it, but reverse proxies might.
 - **Put it behind TLS** (nginx, Caddy, Traefik) if you expose it over a network.
+- **`callback_url` and the scan target are server-side requests.** Dalfox is a
+  URL scanner: it dials whatever target you submit, and on completion it POSTs
+  the result JSON to `callback_url`. Only `http(s)` schemes are dialed, but the
+  *host* is not filtered — loopback, link-local (e.g. cloud metadata at
+  `169.254.169.254`), and private addresses are all reachable. On an
+  unauthenticated bind this is a server-side request forgery + exfiltration
+  primitive for anyone who can submit a scan, so set `--api-key` and restrict
+  egress when exposing the API to untrusted callers.
+- **`--jsonp` makes `GET` endpoints readable cross-origin** via `<script>`,
+  which is not subject to the CORS allow-list. Enable it only when you intend
+  that, and pair it with `--api-key`.

--- a/skills/dalfox/references/mcp.md
+++ b/skills/dalfox/references/mcp.md
@@ -94,7 +94,15 @@ Use this before expensive scans when the user is concerned about request volume.
 ## Error Handling in MCP
 
 - Out-of-range numbers → `invalid_params` with exact message.
+- Non-`http(s)` target → `invalid_params` (rejected before queueing).
 - Unreachable target in preflight → `reachable: false` + `error_code`.
+- Unreachable target in `scan_with_dalfox` → terminal `status: "error"` with
+  `error_message` containing `CONNECTION_FAILED` (not `done` with empty
+  results), so "unreachable" is distinguishable from "no findings".
+- `blind_callback_url` triggers blind-XSS probes on the scan path (parity with
+  the CLI and REST server).
+- `progress.params_tested` / `estimated_completion_pct` advance live as each
+  parameter finishes; use them with `suggested_poll_interval_ms` for pacing.
 - Use the shared error codes from `cmd::error_codes` (see `results.md`).
 
 ## Recommended Agent Loop (MCP)

--- a/skills/dalfox/references/server-and-payload.md
+++ b/skills/dalfox/references/server-and-payload.md
@@ -31,6 +31,10 @@ Runs an async HTTP API (axum) that exposes the same scanning engine.
 
 Jobs are in-memory only. Same `queued / running / done / error / cancelled` lifecycle as MCP.
 
+`POST`/`GET /scan` require an `http(s)` `url` (other schemes → `400`, like `/preflight`). An unreachable target ends as `error` (message contains `CONNECTION_FAILED`), not `done` with zero findings. `GET /scan` numeric query params (`worker`/`delay`/`timeout`) that are present but unparseable → `400` rather than silently using the default. `progress.params_tested` advances live during the scan.
+
+**Webhook/SSRF**: `callback_url` (and the scan target itself) are dialed server-side with no host filtering — loopback/link-local/private hosts are reachable. Set `--api-key` and restrict egress on untrusted binds. `--jsonp` exposes GET endpoints cross-origin (bypasses the CORS allow-list); enable deliberately.
+
 **Authentication**: when `--api-key` is set, every mutating endpoint requires the key. Read endpoints can be open or also protected depending on deployment choice.
 
 **JSONP**: only works for GET endpoints and requires the callback parameter. The server is strict about the callback name to avoid XSS in the JSONP wrapper itself.

--- a/src/cmd/scan/scan_loop.rs
+++ b/src/cmd/scan/scan_loop.rs
@@ -223,6 +223,9 @@ pub(crate) async fn run_scan_loop(
                             findings_count_target,
                             Some(cancel_flag_inner.clone()),
                             finding_tx_target,
+                            // CLI renders its own indicatif progress bar; no
+                            // external params_tested counter to feed.
+                            None,
                         );
                         // Honor --scan-timeout as a hard wall-clock cap per
                         // target. When a slow endpoint streams a partial body

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -168,6 +168,19 @@ impl<T> Drop for AbortOnDrop<T> {
 ///
 /// Used by preflight reachability probes so the result reflects what a real
 /// scan would see, not what a default reqwest client sees.
+/// True when `url` (after trimming) carries an `http`/`https` scheme. The
+/// scheme is matched case-insensitively because URI schemes are
+/// case-insensitive (RFC 3986 §3.1) and `parse_target` already lowercases the
+/// scheme — so `HTTP://x` is a valid target the scanner would otherwise dial.
+/// Shared by the REST server (`/scan`, `/preflight`) and the MCP scan/preflight
+/// tools so the accepted-target contract is identical everywhere. Allocation-
+/// and panic-free (byte-prefix compare, never slices on a char boundary).
+pub fn has_http_scheme(url: &str) -> bool {
+    let b = url.trim().as_bytes();
+    let starts_with = |p: &[u8]| b.len() >= p.len() && b[..p.len()].eq_ignore_ascii_case(p);
+    starts_with(b"http://") || starts_with(b"https://")
+}
+
 /// The `error_message` recorded when a scan target can't be connected to.
 /// Shared by the REST server and MCP so the client-facing string — which
 /// callers grep to tell "unreachable" apart from "scanned, no findings" —

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -168,6 +168,18 @@ impl<T> Drop for AbortOnDrop<T> {
 ///
 /// Used by preflight reachability probes so the result reflects what a real
 /// scan would see, not what a default reqwest client sees.
+/// The `error_message` recorded when a scan target can't be connected to.
+/// Shared by the REST server and MCP so the client-facing string — which
+/// callers grep to tell "unreachable" apart from "scanned, no findings" —
+/// has a single source of truth. Carries the `CONNECTION_FAILED` code that
+/// `/preflight` already returns in its `error_code` field.
+pub fn unreachable_error_message() -> String {
+    format!(
+        "target unreachable: connection failed ({})",
+        crate::cmd::error_codes::CONNECTION_FAILED
+    )
+}
+
 pub async fn send_reachability_probe(target: &Target) -> bool {
     let client = target.build_client_or_default();
     let mut req = client.request(target.parse_method(), target.url.clone());

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -1,6 +1,32 @@
 use super::*;
 
 #[test]
+fn test_has_http_scheme() {
+    // Accepts http/https, case-insensitively, after trimming.
+    for ok in [
+        "http://example.com",
+        "https://example.com/p?q=1",
+        "HTTP://EXAMPLE.COM",
+        "HtTpS://x",
+        "  http://x  ",
+    ] {
+        assert!(has_http_scheme(ok), "should accept {:?}", ok);
+    }
+    // Rejects other schemes, bare hosts, and empties.
+    for bad in [
+        "ftp://x",
+        "file:///etc/passwd",
+        "javascript:alert(1)",
+        "example.com",
+        "",
+        "   ",
+        "httpx://x",
+    ] {
+        assert!(!has_http_scheme(bad), "should reject {:?}", bad);
+    }
+}
+
+#[test]
 fn test_parse_job_status_round_trip() {
     for status in [
         JobStatus::Queued,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -42,8 +42,8 @@ use crate::{
     cmd::scan::ScanArgs,
     job::{
         AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-        MAX_WORKERS, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
-        send_reachability_probe, unreachable_error_message,
+        MAX_WORKERS, has_http_scheme, now_ms, parse_job_status,
+        purge_expired_jobs as purge_jobs_map, send_reachability_probe, unreachable_error_message,
     },
     parameter_analysis::analyze_parameters,
     scanning::result::{Result as ScanResult, SanitizedResult},
@@ -752,7 +752,7 @@ Final results (via get_results_dalfox) include finding type \
                 None,
             ));
         }
-        if !(target.starts_with("http://") || target.starts_with("https://")) {
+        if !has_http_scheme(&target) {
             return Err(ErrorData::invalid_params(
                 "target must start with http:// or https:// (example: \"https://example.com/page?q=test\")",
                 None,
@@ -1179,7 +1179,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                 None,
             ));
         }
-        if !(target_url.starts_with("http://") || target_url.starts_with("https://")) {
+        if !has_http_scheme(&target_url) {
             return Err(ErrorData::invalid_params(
                 "target must start with http:// or https:// (example: \"https://example.com/page?q=test\")",
                 None,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -43,7 +43,7 @@ use crate::{
     job::{
         AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
         MAX_WORKERS, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
-        send_reachability_probe,
+        send_reachability_probe, unreachable_error_message,
     },
     parameter_analysis::analyze_parameters,
     scanning::result::{Result as ScanResult, SanitizedResult},
@@ -211,10 +211,6 @@ impl DalfoxMcp {
         }
     }
 
-    fn make_scan_id(s: &str) -> String {
-        crate::utils::make_scan_id(s)
-    }
-
     fn log(level: &str, msg: &str) {
         let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
         eprintln!("[{}] [{}] {}", ts, level, msg);
@@ -307,6 +303,18 @@ impl DalfoxMcp {
             }
         };
 
+        // Reachability gate, mirroring preflight_dalfox and the REST server:
+        // a parseable-but-unreachable target otherwise finishes `done` with 0
+        // findings, which a client can't distinguish from "scanned, no XSS".
+        // Any HTTP response (incl. 4xx/5xx) counts as reachable; only a
+        // connection-level failure trips this.
+        if !send_reachability_probe(&target).await {
+            let msg = unreachable_error_message();
+            Self::log("ERR", &msg);
+            mark_job_error_sync(&self.jobs, &scan_id, msg);
+            return;
+        }
+
         // Per-job WAF consecutive-block counter so one scan's WAF backoff
         // doesn't throttle an unrelated scan. The request counter is the
         // public `progress.requests_sent` field itself — scoping it directly
@@ -342,6 +350,22 @@ impl DalfoxMcp {
             .scope(progress.requests_sent.clone(), async {
                 crate::WAF_CONSECUTIVE_BLOCKS_JOB
                     .scope(job_waf_consecutive.clone(), async {
+                        // Dispatch blind-XSS probes when a callback URL was
+                        // supplied. MCP exposes `blind_callback_url` in its
+                        // scan schema and wires it into ScanArgs, but the
+                        // execution path never invoked blind_scanning — so the
+                        // documented option was a silent no-op, diverging from
+                        // both the CLI and the REST server (which call this
+                        // here). run_scanning does not cover blind scanning.
+                        if let Some(callback_url) = &scan_args.blind_callback_url {
+                            crate::scanning::blind_scanning(
+                                &target,
+                                callback_url,
+                                scan_args.custom_blind_xss_payload.as_deref(),
+                            )
+                            .await;
+                        }
+
                         // Initial AST DOM-XSS pass on the GET response so MCP
                         // scans match CLI for targets where the vulnerability
                         // lives entirely in JS (location.hash → innerHTML
@@ -387,6 +411,11 @@ impl DalfoxMcp {
                             findings_count.clone(),
                             Some(cancel_flag.clone()),
                             None,
+                            // Feed the live per-parameter completion counter
+                            // so get_results_dalfox reports `params_tested`
+                            // (and estimated_completion_pct) advancing during
+                            // the scan instead of staying at 0 until done.
+                            Some(progress.params_tested.clone()),
                         )
                         .await;
                     })
@@ -758,12 +787,20 @@ Final results (via get_results_dalfox) include finding type \
             ));
         }
 
-        let scan_id = Self::make_scan_id(&target);
-
-        {
+        // Reserve a unique scan_id and insert the queued job under a single
+        // lock. `make_scan_id` mixes in a nanosecond nonce, so collisions are
+        // already vanishingly rare — but two same-target submissions landing
+        // in the same nanosecond would otherwise have the second `insert`
+        // silently clobber the first job (the original scan keeps running but
+        // its entry is replaced, so its poller starts seeing a different
+        // scan's results). Regenerating on collision makes the guarantee
+        // explicit and cheap.
+        let scan_id = {
             let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
-            jobs.insert(scan_id.clone(), Job::new_queued(target.clone()));
-        }
+            let id = crate::utils::make_unique_scan_id(&target, |id| jobs.contains_key(id));
+            jobs.insert(id.clone(), Job::new_queued(target.clone()));
+            id
+        };
 
         Self::log(
             "JOB",

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -257,6 +257,69 @@ async fn test_run_job_sets_error_on_unreachable_target() {
 }
 
 #[tokio::test]
+async fn test_run_job_dispatches_blind_xss_when_callback_set() {
+    // Regression: MCP previously accepted `blind_callback_url` but never
+    // invoked blind_scanning (silent no-op). blind_scanning emits one extra
+    // probe per query/body/header/cookie param, all counted in
+    // `progress.requests_sent`, so a scan with a callback URL must issue
+    // strictly more requests than the same scan without one.
+    use axum::{Router, response::Html, routing::get};
+    use std::net::{Ipv4Addr, SocketAddr};
+    use std::sync::atomic::Ordering::Relaxed;
+
+    async fn ok() -> Html<&'static str> {
+        Html("<html><body>ok</body></html>")
+    }
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind blind target listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let app = Router::new().route("/", get(ok)).route("/{*rest}", get(ok));
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    let url = format!("http://{}/?a=1&b=2&c=3", addr);
+
+    async fn run_count(mcp: &DalfoxMcp, id: &str, url: &str, blind: Option<String>) -> u64 {
+        {
+            let mut jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+            jobs.insert(id.to_string(), test_job(JobStatus::Queued, None));
+        }
+        let progress = {
+            let jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+            jobs.get(id).expect("job").progress.clone()
+        };
+        let mut args = default_scan_args(url);
+        args.targets = vec![url.to_string()];
+        args.skip_mining = true;
+        args.skip_mining_dict = true;
+        args.skip_mining_dom = true;
+        args.skip_ast_analysis = true;
+        args.encoders = vec!["none".to_string()];
+        args.blind_callback_url = blind;
+        mcp.run_job(id.to_string(), Arc::new(args)).await;
+        progress.requests_sent.load(Relaxed)
+    }
+
+    let mcp = DalfoxMcp::new();
+    let without = run_count(&mcp, "blind-off", &url, None).await;
+    let with = run_count(
+        &mcp,
+        "blind-on",
+        &url,
+        Some("http://callback.example/hook".to_string()),
+    )
+    .await;
+    assert!(
+        with > without,
+        "blind_callback_url must trigger extra blind-XSS probes: with={} without={}",
+        with,
+        without
+    );
+}
+
+#[tokio::test]
 async fn test_scan_with_dalfox_queues_and_can_be_queried() {
     let mcp = DalfoxMcp::new();
     let params = ScanWithDalfoxParams {

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -137,7 +137,7 @@ fn parse_result_json(result: &CallToolResult) -> serde_json::Value {
 
 #[test]
 fn test_make_scan_id_shape() {
-    let a = DalfoxMcp::make_scan_id("https://example.com");
+    let a = crate::utils::make_scan_id("https://example.com");
     assert_eq!(a.len(), 64);
     assert!(a.chars().all(|c| c.is_ascii_hexdigit()));
 }
@@ -223,6 +223,36 @@ async fn test_run_job_sets_error_on_parse_failure() {
     assert!(
         job.error_message.as_ref().unwrap().contains("parse_target"),
         "error_message should describe the failure"
+    );
+}
+
+#[tokio::test]
+async fn test_run_job_sets_error_on_unreachable_target() {
+    // A parseable but unreachable target must end as Error with a
+    // connection-failed message, mirroring preflight_dalfox — not finish
+    // `done` with 0 findings, which a client can't tell apart from
+    // "scanned, no XSS".
+    let mcp = DalfoxMcp::new();
+    let scan_id = "job-unreachable".to_string();
+    {
+        let mut jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+        jobs.insert(scan_id.clone(), test_job(JobStatus::Queued, None));
+    }
+
+    let mut args = default_scan_args("http://127.0.0.1:1/");
+    args.targets = vec!["http://127.0.0.1:1/".to_string()];
+    args.timeout = 2;
+    mcp.run_job(scan_id.clone(), Arc::new(args)).await;
+
+    let jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+    let job = jobs.get(&scan_id).expect("job exists");
+    assert_eq!(job.status, JobStatus::Error);
+    assert!(
+        job.error_message
+            .as_deref()
+            .is_some_and(|m| m.contains("unreachable") && m.contains("CONNECTION_FAILED")),
+        "expected connection-failed error message, got {:?}",
+        job.error_message
     );
 }
 

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -43,7 +43,7 @@ use crate::target_parser::Target;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
 use std::collections::HashSet;
 use std::sync::Arc;
-use std::sync::atomic::{AtomicUsize, Ordering};
+use std::sync::atomic::{AtomicU32, AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::{Mutex, RwLock, Semaphore};
 
@@ -1150,6 +1150,9 @@ struct ScanWorkerCtx {
     cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
     finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
     semaphore: Arc<Semaphore>,
+    /// Live per-parameter completion counter (see `run_scanning`'s
+    /// `params_done`). Bumped once per finished parameter worker.
+    params_done: Option<Arc<AtomicU32>>,
 }
 
 impl ScanWorkerCtx {
@@ -1749,6 +1752,12 @@ pub async fn run_scanning(
     findings_count: Arc<AtomicUsize>,
     cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
     finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
+    // Live "parameters finished" counter for async front-ends (REST server,
+    // MCP). Each per-parameter worker bumps it on completion so pollers see
+    // `params_tested` climb during the scan instead of staying pinned at 0
+    // until the very end. `None` for the CLI, which renders its own
+    // indicatif progress bar from `total_tasks` instead.
+    params_done: Option<Arc<AtomicU32>>,
 ) {
     // Short-circuit scanning when skip_xss_scanning is enabled (e.g., in unit tests)
     if args.skip_xss_scanning {
@@ -1792,6 +1801,7 @@ pub async fn run_scanning(
         cancel: cancel.clone(),
         finding_tx: finding_tx.clone(),
         semaphore: semaphore.clone(),
+        params_done: params_done.clone(),
     };
 
     // === Stage 5 & 6: spawn one worker per parameter (Reflection + DOM) ===
@@ -1814,7 +1824,13 @@ pub async fn run_scanning(
         };
         if already_found && !args.deep_scan {
             // Skip further testing for this param if reflection or DOM XSS
-            // already found and not deep scanning
+            // already found and not deep scanning. This param *was* exercised
+            // (the finding came from its probe/AST pass), so count it toward
+            // the live progress counter — otherwise `params_tested` would
+            // permanently under-report it on a cancelled scan.
+            if let Some(done) = &ctx.params_done {
+                done.fetch_add(1, Ordering::Relaxed);
+            }
             continue;
         }
         // Early stop if global limit reached
@@ -1833,6 +1849,13 @@ pub async fn run_scanning(
         let handle = tokio::spawn(async move {
             ctx.scan_param(param_clone, reflection_payloads, dom_payloads)
                 .await;
+            // Bump the live completion counter after this parameter is fully
+            // processed (covers every `scan_param` exit path, including the
+            // non-reflective early return), so async front-ends observe
+            // `params_tested` advancing as each worker finishes.
+            if let Some(done) = &ctx.params_done {
+                done.fetch_add(1, Ordering::Relaxed);
+            }
         });
         handles.push(handle);
     }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -941,6 +941,7 @@ async fn test_xss_scanning_get_query() {
         Arc::new(AtomicUsize::new(0)),
         None,
         None,
+        None,
     )
     .await;
 
@@ -1037,6 +1038,7 @@ async fn test_xss_scanning_post_body() {
         None,
         None,
         Arc::new(AtomicUsize::new(0)),
+        None,
         None,
         None,
     )
@@ -1153,6 +1155,7 @@ async fn test_run_scanning_with_reflection_params() {
         Arc::new(AtomicUsize::new(0)),
         None,
         None,
+        None,
     )
     .await;
 }
@@ -1227,6 +1230,7 @@ async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
         Arc::new(AtomicUsize::new(0)),
         None,
         None,
+        None,
     )
     .await;
 
@@ -1258,6 +1262,73 @@ async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
             || m.contains("JS-context AST")),
         "V finding must carry a DomEvidenceKind label from classify_dom_evidence; got {:?}",
         labels
+    );
+}
+
+#[tokio::test]
+async fn test_run_scanning_increments_params_done_counter() {
+    // Each per-parameter worker must bump the live `params_done` counter once
+    // on completion — including the non-reflective early-return path — so the
+    // REST server and MCP can report `params_tested` climbing during a scan
+    // instead of pinning it at 0 until the very end. The target reflects
+    // nothing, so every worker takes the "no reflection, skip payloads" path;
+    // the counter must still reach the param count.
+    use axum::{Router, response::Html, routing::get};
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::time::{Duration, sleep};
+    async fn ok_handler() -> Html<String> {
+        Html("<html><body>no reflection here</body></html>".to_string())
+    }
+    let app = Router::new().route("/", get(ok_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let url = format!("http://{}/?a=1&b=2&c=3", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.reflection_params.clear();
+    for name in ["a", "b", "c"] {
+        target.reflection_params.push(Param {
+            name: name.to_string(),
+            value: "1".to_string(),
+            location: Location::Query,
+            injection_context: Some(InjectionContext::Html(None)),
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: None,
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: None,
+            framework_sink: None,
+            escaped_specials: None,
+            js_breakout: None,
+        });
+    }
+
+    let params_done = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    run_scanning(
+        &target,
+        Arc::new(integration_scan_args(false)),
+        Arc::new(Mutex::new(Vec::new())),
+        None,
+        None,
+        Arc::new(AtomicUsize::new(0)),
+        None,
+        None,
+        Some(params_done.clone()),
+    )
+    .await;
+
+    assert_eq!(
+        params_done.load(std::sync::atomic::Ordering::Relaxed),
+        3,
+        "every parameter worker must increment params_done exactly once"
     );
 }
 
@@ -1347,6 +1418,7 @@ async fn test_run_scanning_empty_params() {
         None,
         None,
         Arc::new(AtomicUsize::new(0)),
+        None,
         None,
         None,
     )

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -39,10 +39,23 @@ pub(crate) async fn start_scan_handler(
         }
     };
 
-    if req.url.trim().is_empty() {
+    let trimmed_url = req.url.trim();
+    if trimmed_url.is_empty() {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url is required".to_string(),
+            data: None,
+        };
+        return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
+    }
+    // Require an http(s) scheme, matching /preflight and the MCP scan tool.
+    // Without this, a garbage target (e.g. "ftp://x" or a bare host) was
+    // queued and "scanned", silently finishing as `done` with 0 findings —
+    // indistinguishable from a real target that simply had no XSS.
+    if !(trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://")) {
+        let resp = ApiResponse::<serde_json::Value> {
+            code: 400,
+            msg: "url must start with http:// or https://".to_string(),
             data: None,
         };
         return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
@@ -61,9 +74,12 @@ pub(crate) async fn start_scan_handler(
     let include_response = opts.include_response.unwrap_or(false);
     let callback_url = opts.callback_url.clone();
 
-    let id = make_scan_id(&req.url);
-    {
+    // Reserve a unique scan_id and insert the queued job under one lock so a
+    // same-target resubmission in the same nanosecond can't clobber an
+    // in-flight job (see make_scan_id's nonce). Regenerate on collision.
+    let id = {
         let mut jobs = state.jobs.lock().await;
+        let id = crate::utils::make_unique_scan_id(&req.url, |id| jobs.contains_key(id));
         jobs.insert(
             id.clone(),
             Job {
@@ -79,7 +95,8 @@ pub(crate) async fn start_scan_handler(
                 finished_at_ms: None,
             },
         );
-    }
+        id
+    };
     log(&state, "JOB", &format!("queued id={} url={}", id, req.url));
 
     spawn_scan_task(
@@ -243,6 +260,15 @@ pub(crate) async fn get_scan_handler(
         };
         return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
     }
+    // Require an http(s) scheme, matching POST /scan, /preflight, and MCP.
+    if !(url.trim().starts_with("http://") || url.trim().starts_with("https://")) {
+        let resp = ApiResponse::<serde_json::Value> {
+            code: 400,
+            msg: "url must start with http:// or https://".to_string(),
+            data: None,
+        };
+        return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
+    }
 
     // Build ScanOptions from query parameters
     let headers_param = params.get("header").cloned().unwrap_or_default();
@@ -266,9 +292,23 @@ pub(crate) async fn get_scan_handler(
             .collect()
     };
     let cookie = params.get("cookie").cloned();
-    let worker = params.get("worker").and_then(|s| s.parse::<usize>().ok());
-    let delay = params.get("delay").and_then(|s| s.parse::<u64>().ok());
-    let timeout = params.get("timeout").and_then(|s| s.parse::<u64>().ok());
+    // A present-but-unparseable numeric query param is a 400, not a silent
+    // fallback to the default (which is what `.parse().ok()` used to do).
+    let (worker, delay, timeout): (Option<usize>, Option<u64>, Option<u64>) = match (
+        parse_num_query::<usize>(&params, "worker"),
+        parse_num_query::<u64>(&params, "delay"),
+        parse_num_query::<u64>(&params, "timeout"),
+    ) {
+        (Ok(w), Ok(d), Ok(t)) => (w, d, t),
+        (Err(msg), ..) | (_, Err(msg), _) | (.., Err(msg)) => {
+            let resp = ApiResponse::<serde_json::Value> {
+                code: 400,
+                msg,
+                data: None,
+            };
+            return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
+        }
+    };
     let blind = params.get("blind").cloned();
     let method = params
         .get("method")
@@ -341,9 +381,10 @@ pub(crate) async fn get_scan_handler(
     }
 
     let callback_url = opts.callback_url.clone();
-    let id = make_scan_id(&url);
-    {
+    // Reserve a unique scan_id under one lock (see POST /scan).
+    let id = {
         let mut jobs = state.jobs.lock().await;
+        let id = crate::utils::make_unique_scan_id(&url, |id| jobs.contains_key(id));
         jobs.insert(
             id.clone(),
             Job {
@@ -359,7 +400,8 @@ pub(crate) async fn get_scan_handler(
                 finished_at_ms: None,
             },
         );
-    }
+        id
+    };
     log(&state, "JOB", &format!("queued id={} url={}", id, url));
 
     let id_for_resp = id.clone();

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -39,8 +39,10 @@ pub(crate) async fn start_scan_handler(
         }
     };
 
-    let trimmed_url = req.url.trim();
-    if trimmed_url.is_empty() {
+    // Trim once and use the trimmed value throughout (validation, scan_id,
+    // stored target, dispatch) so whitespace variants stay consistent.
+    let url = req.url.trim().to_string();
+    if url.is_empty() {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url is required".to_string(),
@@ -52,7 +54,7 @@ pub(crate) async fn start_scan_handler(
     // Without this, a garbage target (e.g. "ftp://x" or a bare host) was
     // queued and "scanned", silently finishing as `done` with 0 findings —
     // indistinguishable from a real target that simply had no XSS.
-    if !(trimmed_url.starts_with("http://") || trimmed_url.starts_with("https://")) {
+    if !has_http_scheme(&url) {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url must start with http:// or https://".to_string(),
@@ -79,7 +81,7 @@ pub(crate) async fn start_scan_handler(
     // in-flight job (see make_scan_id's nonce). Regenerate on collision.
     let id = {
         let mut jobs = state.jobs.lock().await;
-        let id = crate::utils::make_unique_scan_id(&req.url, |id| jobs.contains_key(id));
+        let id = crate::utils::make_unique_scan_id(&url, |id| jobs.contains_key(id));
         jobs.insert(
             id.clone(),
             Job {
@@ -89,7 +91,7 @@ pub(crate) async fn start_scan_handler(
                 progress: JobProgress::default(),
                 cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
                 error_message: None,
-                target_url: req.url.clone(),
+                target_url: url.clone(),
                 queued_at_ms: now_ms(),
                 started_at_ms: None,
                 finished_at_ms: None,
@@ -97,12 +99,12 @@ pub(crate) async fn start_scan_handler(
         );
         id
     };
-    log(&state, "JOB", &format!("queued id={} url={}", id, req.url));
+    log(&state, "JOB", &format!("queued id={} url={}", id, url));
 
     spawn_scan_task(
         state.clone(),
         id.clone(),
-        req.url.clone(),
+        url.clone(),
         opts,
         include_request,
         include_response,
@@ -111,7 +113,7 @@ pub(crate) async fn start_scan_handler(
     let resp = ApiResponse::<serde_json::Value> {
         code: 200,
         msg: "ok".to_string(),
-        data: Some(serde_json::json!({ "scan_id": id, "target": req.url })),
+        data: Some(serde_json::json!({ "scan_id": id, "target": url })),
     };
     make_api_response(&state, &headers, &params, StatusCode::OK, &resp)
 }
@@ -251,8 +253,16 @@ pub(crate) async fn get_scan_handler(
 
     purge_expired_jobs(&state).await;
 
-    let url = params.get("url").cloned().unwrap_or_default();
-    if url.trim().is_empty() {
+    // Trim once and use the trimmed value throughout, so whitespace variants
+    // of the same URL validate, hash to the same scan_id, and store the same
+    // target consistently.
+    let url = params
+        .get("url")
+        .cloned()
+        .unwrap_or_default()
+        .trim()
+        .to_string();
+    if url.is_empty() {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url is required".to_string(),
@@ -261,7 +271,7 @@ pub(crate) async fn get_scan_handler(
         return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
     }
     // Require an http(s) scheme, matching POST /scan, /preflight, and MCP.
-    if !(url.trim().starts_with("http://") || url.trim().starts_with("https://")) {
+    if !has_http_scheme(&url) {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url must start with http:// or https://".to_string(),
@@ -720,9 +730,7 @@ pub(crate) async fn preflight_handler(
     };
 
     let target_url = req.url.trim().to_string();
-    if target_url.is_empty()
-        || !(target_url.starts_with("http://") || target_url.starts_with("https://"))
-    {
+    if target_url.is_empty() || !has_http_scheme(&target_url) {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
             msg: "url must start with http:// or https://".to_string(),

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -378,6 +378,17 @@ pub(crate) async fn run_scan_job(
         }
     };
 
+    // Reachability gate. A parseable-but-unreachable target (connection
+    // refused, DNS failure, TLS error, timeout) otherwise runs the full
+    // pipeline and finishes `done` with 0 findings — indistinguishable from
+    // "scanned, found no XSS". /preflight already probes reachability and
+    // returns reachable:false; mirror that here so /scan clients can tell the
+    // two apart. Any HTTP response (including 4xx/5xx) counts as reachable.
+    if !send_reachability_probe(&target).await {
+        mark_job_error(&state, &job_id, &url, unreachable_error_message()).await;
+        return;
+    }
+
     // Per-job WAF consecutive-block counter so one scan's WAF backoff doesn't
     // throttle an unrelated scan.
     //
@@ -471,6 +482,10 @@ pub(crate) async fn run_scan_job(
                         findings_count.clone(),
                         Some(cancel_flag.clone()),
                         None,
+                        // Feed the live per-parameter completion counter so
+                        // GET /scan/{id} reports `params_tested` climbing
+                        // during the scan instead of staying at 0 until done.
+                        Some(progress.params_tested.clone()),
                     )
                     .await;
                 })
@@ -554,9 +569,19 @@ pub(crate) async fn run_scan_job(
 }
 
 /// POST the scan-completion payload to the configured webhook, if any.
-/// Only `http`/`https` URLs are dialed (mitigates SSRF via odd schemes such
-/// as `file://`). The status string is the same one we put in the response
-/// payload (`"done"` or `"cancelled"`) so downstream consumers can branch
+///
+/// Only `http`/`https` URLs are dialed, which blocks non-network schemes such
+/// as `file://`. NOTE: this is *not* a host-based SSRF guard — the callback
+/// host is whatever the scan submitter supplied, so loopback, link-local
+/// (e.g. cloud metadata at 169.254.169.254), and RFC1918 addresses are all
+/// reachable, and the full result JSON is POSTed there. This is inherent to
+/// the server being a URL scanner (the scan target itself is unrestricted in
+/// the same way), so host filtering is intentionally left to deployment: run
+/// `dalfox server` with `--api-key` and appropriate network egress controls
+/// when exposing it to untrusted submitters.
+///
+/// The status string is the same one we put in the response payload
+/// (`"done"` / `"cancelled"` / `"error"`) so downstream consumers can branch
 /// on it without re-deriving terminal state.
 pub(crate) async fn send_terminal_webhook(
     state: &AppState,

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use serde::{Deserialize, Serialize};
 pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
     AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-    MAX_WORKERS, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
+    MAX_WORKERS, has_http_scheme, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
     send_reachability_probe, unreachable_error_message,
 };
 pub(crate) use crate::parameter_analysis::analyze_parameters;

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -37,7 +37,7 @@ pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
     AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
     MAX_WORKERS, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
-    send_reachability_probe,
+    send_reachability_probe, unreachable_error_message,
 };
 pub(crate) use crate::parameter_analysis::analyze_parameters;
 pub(crate) use crate::scanning::result::{Result as ScanResult, SanitizedResult};

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -111,6 +111,37 @@ async fn start_slow_target_server() -> SocketAddr {
     addr
 }
 
+/// Echoes every query-param value back into the HTML body so
+/// `analyze_parameters` classifies each as a reflection param — giving a
+/// scan with `params_total > 0` to exercise the live `params_tested` counter.
+async fn target_reflect_handler(Query(q): Query<Map<String, String>>) -> impl IntoResponse {
+    let mut body = String::from("<html><body>");
+    for (k, v) in &q {
+        body.push_str(&format!("<div>{k}={v}</div>"));
+    }
+    body.push_str("</body></html>");
+    (
+        StatusCode::OK,
+        [("content-type", "text/html; charset=utf-8")],
+        body,
+    )
+}
+
+async fn start_reflecting_target_server() -> SocketAddr {
+    let app = Router::new()
+        .route("/", any(target_reflect_handler))
+        .route("/{*rest}", any(target_reflect_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind reflecting target listener");
+    let addr = listener.local_addr().expect("reflecting target local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    addr
+}
+
 #[test]
 fn test_check_api_key_variants() {
     let state_no_key = make_state(None, None, false, false, "callback");
@@ -907,6 +938,54 @@ async fn test_run_scan_job_populates_live_request_counter() {
     assert_eq!(
         params_tested, params_total,
         "params_tested should equal params_total after completion"
+    );
+}
+
+#[tokio::test]
+async fn test_run_scan_job_wires_live_params_tested_counter() {
+    // End-to-end at the server layer: run_scan_job must thread the live
+    // `params_done` counter into run_scanning so `progress.params_tested`
+    // reflects the discovered parameters. Against a reflecting target with
+    // three query params, the scan should discover >= 2 and end with
+    // params_tested == params_total (the live increments + the natural-
+    // completion store agree). The per-worker live mechanism itself is
+    // covered by scanning::tests::test_run_scanning_increments_params_done_counter.
+    let addr = start_reflecting_target_server().await;
+    let state = make_state(None, None, false, false, "cb");
+    let id = "params-tested-wiring".to_string();
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), test_job(JobStatus::Queued, None, ""));
+    }
+    let opts = ScanOptions {
+        skip_mining: Some(true),
+        worker: Some(4),
+        encoders: Some(vec!["none".to_string()]),
+        ..ScanOptions::default()
+    };
+    let progress = {
+        let jobs = state.jobs.lock().await;
+        jobs.get(&id).expect("job").progress.clone()
+    };
+    let url = format!("http://{}/?a=1&b=2&c=3", addr);
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        run_scan_job(state.clone(), id.clone(), url, opts, false, false),
+    )
+    .await;
+    assert!(run.is_ok(), "scan should finish in time");
+
+    use std::sync::atomic::Ordering::Relaxed;
+    let total = progress.params_total.load(Relaxed);
+    let tested = progress.params_tested.load(Relaxed);
+    assert!(
+        total >= 2,
+        "reflecting target with 3 query params should discover >= 2, got {}",
+        total
+    );
+    assert_eq!(
+        tested, total,
+        "server must feed the live params_done counter so params_tested reaches params_total"
     );
 }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -131,7 +131,7 @@ fn test_check_api_key_variants() {
 
 #[test]
 fn test_make_and_short_scan_id_shape() {
-    let id = make_scan_id("https://example.com");
+    let id = crate::utils::make_scan_id("https://example.com");
     assert_eq!(id.len(), 64);
     assert!(id.chars().all(|c| c.is_ascii_hexdigit()));
     assert_eq!(crate::utils::short_scan_id(&id).len(), 7);
@@ -562,7 +562,7 @@ async fn test_start_scan_handler_success_creates_queued_job() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "not-a-valid-target".to_string(),
+            url: "http://127.0.0.1:1/".to_string(),
             options: Some(ScanOptions {
                 include_request: Some(true),
                 include_response: Some(true),
@@ -607,7 +607,7 @@ async fn test_start_scan_handler_success_jsonp_response() {
         HeaderMap::new(),
         Query(q),
         Ok(Json(ScanRequest {
-            url: "still-not-valid-target".to_string(),
+            url: "http://127.0.0.1:1/".to_string(),
             options: None,
         })),
     )
@@ -673,7 +673,7 @@ async fn test_get_scan_handler_success_parses_query_options_and_jsonp() {
     let state = make_state(None, None, false, true, "cb");
     let mut params = Map::new();
     params.insert("cb".to_string(), "getCb".to_string());
-    params.insert("url".to_string(), "bad-target-for-fast-fail".to_string());
+    params.insert("url".to_string(), "http://127.0.0.1:1/".to_string());
     params.insert("header".to_string(), "X-A:1,Invalid,X-B:2".to_string());
     params.insert("encoders".to_string(), "url,html,base64".to_string());
     params.insert("worker".to_string(), "3".to_string());
@@ -1187,7 +1187,7 @@ async fn test_get_result_handler_jsonp_done_branch() {
 async fn test_get_scan_handler_success_plain_json_defaults() {
     let state = make_state(None, None, false, false, "cb");
     let mut params = Map::new();
-    params.insert("url".to_string(), "still-invalid-for-fast-fail".to_string());
+    params.insert("url".to_string(), "http://127.0.0.1:1/".to_string());
 
     let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
         .await
@@ -1495,6 +1495,130 @@ async fn test_get_scan_handler_rejects_out_of_range_delay() {
         .await
         .into_response();
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[tokio::test]
+async fn test_start_scan_handler_rejects_non_http_url() {
+    // POST /scan must reject a non-http(s) target with a 400, matching
+    // /preflight and the MCP scan tool — instead of queueing it and
+    // silently finishing `done` with 0 findings.
+    let state = make_state(None, None, false, false, "cb");
+    for bad in [
+        "ftp://x",
+        "file:///etc/passwd",
+        "example.com",
+        "javascript:alert(1)",
+    ] {
+        let resp = start_scan_handler(
+            State(state.clone()),
+            HeaderMap::new(),
+            Query(Map::new()),
+            Ok(Json(ScanRequest {
+                url: bad.to_string(),
+                options: None,
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "POST /scan should reject non-http(s) url {:?}",
+            bad
+        );
+        let body = response_body_string(resp).await;
+        assert!(
+            body.contains("must start with http"),
+            "expected scheme error for {:?}, got {}",
+            bad,
+            body
+        );
+    }
+    // No jobs should have been queued for any of the rejected targets.
+    assert!(state.jobs.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_scan_handler_rejects_non_http_url() {
+    // GET /scan must enforce the same http(s) scheme check as POST /scan.
+    let state = make_state(None, None, false, false, "cb");
+    let mut params = Map::new();
+    params.insert("url".to_string(), "ftp://x".to_string());
+    let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    let body = response_body_string(resp).await;
+    assert!(body.contains("must start with http"));
+    assert!(state.jobs.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn test_get_scan_handler_rejects_unparseable_numeric_query() {
+    // A present-but-unparseable numeric query param is a 400, not a silent
+    // fallback to the default. (`?timeout=0` is already rejected by range
+    // validation; this covers the non-numeric / negative class.)
+    for (key, val) in [("timeout", "abc"), ("worker", "-5"), ("delay", "1.5")] {
+        let state = make_state(None, None, false, false, "cb");
+        let mut params = Map::new();
+        params.insert("url".to_string(), "http://example.com".to_string());
+        params.insert(key.to_string(), val.to_string());
+        let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+            .await
+            .into_response();
+        assert_eq!(
+            resp.status(),
+            StatusCode::BAD_REQUEST,
+            "GET /scan should reject {}={}",
+            key,
+            val
+        );
+        let body = response_body_string(resp).await;
+        assert!(
+            body.contains(key),
+            "error should name the offending field {}, got {}",
+            key,
+            body
+        );
+        assert!(state.jobs.lock().await.is_empty());
+    }
+}
+
+#[tokio::test]
+async fn test_run_scan_job_unreachable_target_sets_error() {
+    // A parseable but unreachable target (connection refused) must end as
+    // Error with a connection-failed message — not `done` with 0 findings,
+    // which a client cannot distinguish from "scanned, no XSS". Mirrors
+    // /preflight's reachable:false / CONNECTION_FAILED behavior.
+    let state = make_state(None, None, false, false, "cb");
+    let id = "unreachable-scan".to_string();
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), test_job(JobStatus::Queued, None, ""));
+    }
+    run_scan_job(
+        state.clone(),
+        id.clone(),
+        "http://127.0.0.1:1/".to_string(),
+        ScanOptions {
+            timeout: Some(2),
+            ..ScanOptions::default()
+        },
+        false,
+        false,
+    )
+    .await;
+
+    let jobs = state.jobs.lock().await;
+    let job = jobs.get(&id).expect("job should exist");
+    assert_eq!(job.status, JobStatus::Error);
+    assert!(
+        job.error_message
+            .as_deref()
+            .is_some_and(|m| m.contains("unreachable") && m.contains("CONNECTION_FAILED")),
+        "expected connection-failed error message, got {:?}",
+        job.error_message
+    );
 }
 
 #[tokio::test]

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -40,8 +40,28 @@ pub(crate) async fn purge_expired_jobs(state: &AppState) {
     purge_jobs_map(&mut jobs, JOB_RETENTION_SECS);
 }
 
-pub(crate) fn make_scan_id(s: &str) -> String {
-    crate::utils::make_scan_id(s)
+/// Parse an optional numeric query parameter, distinguishing "absent" (→
+/// `Ok(None)`, use the default) from "present but unparseable" (→ `Err`).
+/// GET /scan used to swallow `?timeout=abc` / `?worker=-5` via
+/// `.and_then(|s| s.parse().ok())`, silently dropping the caller's override
+/// and running with the default — while `?timeout=0` was correctly rejected.
+/// This makes the bad-input handling consistent: a malformed value is a 400,
+/// not a silent fallback.
+pub(crate) fn parse_num_query<T>(
+    params: &HashMap<String, String>,
+    key: &str,
+) -> Result<Option<T>, String>
+where
+    T: std::str::FromStr,
+{
+    match params.get(key) {
+        Some(raw) => raw
+            .trim()
+            .parse::<T>()
+            .map(Some)
+            .map_err(|_| format!("{} must be a non-negative integer (got '{}')", key, raw)),
+        None => Ok(None),
+    }
 }
 
 /// Split the server's HTTP-style `Cookie` header value (`a=b; c=d`) into

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -15,7 +15,7 @@ pub mod term;
 // Re-export banner helpers at `crate::utils::*`
 pub use banner::print_banner_once;
 // Re-export scan_id helpers at `crate::utils::*`
-pub use scan_id::{make_scan_id, short_scan_id};
+pub use scan_id::{make_scan_id, make_unique_scan_id, short_scan_id};
 // Re-export http helpers at `crate::utils::*`
 pub use http::{
     apply_header_overrides, apply_headers_ua_cookies, build_preflight_request, build_request,

--- a/src/utils/scan_id.rs
+++ b/src/utils/scan_id.rs
@@ -24,6 +24,25 @@ pub fn make_scan_id(seed: &str) -> String {
     make_scan_id_with_nonce(seed, now)
 }
 
+/// Generate a scan id that is unique with respect to an existing-id predicate.
+///
+/// `make_scan_id` already mixes in a nanosecond nonce, so a clash is
+/// vanishingly rare — but two same-seed submissions landing in the same
+/// nanosecond would otherwise collide. This regenerates (varying the seed with
+/// an attempt suffix, which also re-draws the nonce) until `exists` returns
+/// false. Callers hold whatever lock guards their id store and pass a closure
+/// that checks membership, so the check-and-reserve stays atomic at the call
+/// site. Shared by the REST server's `/scan` handlers and the MCP scan tool.
+pub fn make_unique_scan_id(seed: &str, exists: impl Fn(&str) -> bool) -> String {
+    let mut id = make_scan_id(seed);
+    let mut attempt: u32 = 0;
+    while exists(&id) {
+        attempt += 1;
+        id = make_scan_id(&format!("{}#{}", seed, attempt));
+    }
+    id
+}
+
 /// Deterministic variant for generating a scan id using a provided nonce.
 /// Useful for tests or when the caller wants to control uniqueness explicitly.
 ///

--- a/src/utils/scan_id/tests.rs
+++ b/src/utils/scan_id/tests.rs
@@ -18,6 +18,46 @@ fn test_make_scan_id_uniqueness_with_different_nonces() {
 }
 
 #[test]
+fn test_make_unique_scan_id_regenerates_on_collision() {
+    use std::cell::RefCell;
+    // Report the first candidate as already-taken, the second as free. The
+    // predicate must be consulted twice, the two candidates must differ
+    // (the suffixed reseed re-draws the nonce), and the returned id is the
+    // second (free) one. `make_scan_id` is non-deterministic, so we capture
+    // the candidates the helper actually produced rather than precomputing.
+    let seen = RefCell::new(Vec::<String>::new());
+    let id = make_unique_scan_id("seed", |candidate| {
+        seen.borrow_mut().push(candidate.to_string());
+        seen.borrow().len() == 1
+    });
+    let seen = seen.into_inner();
+    assert_eq!(
+        seen.len(),
+        2,
+        "should regenerate once after the first collides"
+    );
+    assert_ne!(
+        seen[0], seen[1],
+        "regenerated id must differ from the colliding one"
+    );
+    assert_eq!(id, seen[1]);
+    assert_eq!(id.len(), 64);
+}
+
+#[test]
+fn test_make_unique_scan_id_no_collision_returns_first() {
+    // When nothing collides, the predicate is consulted once and the first id
+    // is returned unchanged.
+    let calls = std::cell::Cell::new(0u32);
+    let id = make_unique_scan_id("seed", |_| {
+        calls.set(calls.get() + 1);
+        false
+    });
+    assert_eq!(calls.get(), 1);
+    assert_eq!(id.len(), 64);
+}
+
+#[test]
 fn test_short_scan_id() {
     assert_eq!(short_scan_id("abcdef1234"), "abcdef1");
     assert_eq!(short_scan_id("abc"), "abc");


### PR DESCRIPTION
## Summary

Hands-on review of `dalfox server` (REST) and `dalfox mcp` (stdio/JSON-RPC), cross-checked with an adversarial review pass, surfaced several behaviors that diverged between the two async front-ends and the CLI — or that silently misled clients. This PR fixes them and adds the missing tests. Every change was verified end-to-end against a running binary.

## What changed

| Area | Before | After |
|------|--------|-------|
| **URL scheme** | `POST`/`GET /scan` queued non-`http(s)` targets (`ftp://x`, bare host) and finished `done` with 0 findings | Rejected with `400 url must start with http:// or https://`, matching `/preflight` and MCP |
| **GET `/scan` numerics** | `?timeout=abc` / `?worker=-5` silently fell back to defaults (while `?timeout=0` was rejected) | Present-but-unparseable value → `400` naming the field (`parse_num_query`) |
| **Reachability** | An unreachable but parseable target finished `done` with 0 findings — indistinguishable from "no XSS" | Ends as `error` with `CONNECTION_FAILED` on both server and MCP (mirrors `/preflight`) |
| **MCP blind-XSS** | `blind_callback_url` was accepted, documented, wired into `ScanArgs`… but **never dispatched** (silent no-op) | `run_job` now calls `blind_scanning`, matching CLI/REST |
| **Live progress** | `params_tested` / `estimated_completion_pct` sat at `0` for the whole scan, then jumped to `100` | A `params_done` counter threaded through `run_scanning` makes them climb live (also fixes cancelled-scan under-reporting) |
| **scan_id collisions** | Same-target resubmission in the same nanosecond could clobber an in-flight job | `make_unique_scan_id` regenerates on collision under the jobs lock (MCP + both server handlers) |

Plus: corrected the misleading webhook "SSRF guard" comment (scheme-only; host is unrestricted by design — the scanner dials arbitrary URLs) and documented the `--jsonp` cross-origin exposure; refreshed the server/MCP integration docs and agent-skill references.

## Verification

- `cargo test --lib` → **1367 passing / 0 failing**; `cargo clippy --lib --tests` → clean; `cargo fmt`.
- New tests (**+8**): non-http reject (POST + GET), GET unparseable-numeric reject, reachability → error (server + MCP), live `params_done` counter, `make_unique_scan_id` collision/no-collision.
- Manual e2e against running `dalfox server` + `dalfox mcp`: scheme/numeric `400`s, unreachable → `error (CONNECTION_FAILED)`, `params_tested` observed climbing `0→6`, blind requests `3→6` with `blind_callback_url` set.

## Notes / intentional (now documented) surfaces

- `callback_url` and the scan target are unfiltered server-side requests (loopback/link-local/RFC1918 reachable) — inherent to a URL scanner; gate with `--api-key` + egress controls.
- `--jsonp` exposes GET endpoints cross-origin past the CORS allow-list (legacy opt-in).

## Deferred (tracked separately)

`run_scanning`'s 9-positional-arg signature → options struct; an overall `scan_timeout` for server/MCP; reconciling `params_total` with Fragment-skipped params; preflight estimate accuracy.
