### PR TITLE
chore: add just fix recipe for cargo fmt and clippy

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,7 @@ just dev      # cargo run
 just test     # unit + integration tests
 ```
 
-Before opening a PR, please run `cargo fmt`, `cargo clippy`, and `just test`.
+Before opening a PR, please run `just fix` (runs `cargo fmt` + `cargo clippy --fix`) and `just test`.
 
 ## Reporting Issues
 

--- a/justfile
+++ b/justfile
@@ -1,6 +1,7 @@
 alias b := build
 alias d := dev
 alias ds := docs-serve
+alias f := fix
 alias t := test
 alias vc := version-check
 alias vu := version-update
@@ -35,10 +36,11 @@ docs-serve:
 docs-dependencies:
     brew install hahwul/hwaro/hwaro
 
-#[group('development')]
-#fix:
-#    cargo fmt
-#    cargo clippy --fix --allow-dirty
+# Format code and apply clippy suggestions.
+[group('build')]
+fix:
+    cargo fmt
+    cargo clippy --fix --allow-dirty
 
 # Report dalfox version across Cargo.toml, Cargo.lock, flake.nix, snap.
 [group('release')]


### PR DESCRIPTION
* Uncommented and activated the fix recipe in justfile, placed in build group with doc comment
* Added alias f := fix for convenience
* Updated CONTRIBUTING.md to reference just fix instead of raw cargo commands

Issue #1070 