### PR TITLE
feat(server,mcp): add scan_timeout whole-scan budget for server and MCP

### DIFF
--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -54,6 +54,7 @@ Submit a scan. Returns immediately.
   "headers": ["Authorization: Bearer token"],
   "encoders": ["url", "html"],
   "timeout": 10,
+  "scan_timeout": 0,
   "workers": 50,
   "blind_callback_url": "https://callback.example",
   "deep_scan": false,
@@ -65,6 +66,12 @@ Submit a scan. Returns immediately.
 `detect_outdated_libs` is opt-in (default `false`): set it `true` to also emit
 informational `[I]` findings for outdated / known-vulnerable JS libraries
 (CWE-1104, 0 extra requests). Left off, the scan reports only XSS.
+
+`scan_timeout` is the whole-scan wall-clock budget in seconds (default `0` =
+unbounded), distinct from the per-request `timeout`. When it trips, the scan
+stops, keeps any partial findings, and settles as `cancelled` with an
+`error_message` mentioning `scan_timeout`. Set it to bound long or `deep_scan`
+runs so an agent's poll loop is guaranteed to terminate.
 
 Response:
 

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -167,6 +167,7 @@ Returns version, `auth_required`, and the list of supported endpoints. Good for 
     "worker": 50,
     "delay": 0,
     "timeout": 10,
+    "scan_timeout": 0,
     "blind": "https://callback.interact.sh",
     "method": "POST",
     "data": "user=test",
@@ -194,6 +195,15 @@ Fields mirror the CLI flags. See the [CLI reference](../../reference/cli/) for m
 `detect_outdated_libs` is opt-in (default `false`): set it `true` to also report
 outdated / known-vulnerable JS libraries as informational `[I]` findings
 (CWE-1104, 0 extra requests). The same key works as a `GET /scan` query parameter.
+
+`scan_timeout` is the whole-scan wall-clock budget in seconds (default `0` =
+unbounded), distinct from the per-request `timeout`. When the budget is reached
+the scan stops, keeps whatever partial findings it gathered, and settles as
+`cancelled` with an `error_message` that mentions `scan_timeout` (so you can tell
+a timeout apart from a client-issued cancel). Start the server with
+`--scan-timeout <secs>` to cap **every** submitted scan: a request may ask for a
+shorter budget but cannot exceed or disable the server cap — useful for bounding
+long or `deep_scan` jobs so one target can't pin a worker indefinitely.
 
 ## Job lifecycle
 
@@ -252,3 +262,8 @@ sudo systemctl enable --now dalfox
 - **`--jsonp` makes `GET` endpoints readable cross-origin** via `<script>`,
   which is not subject to the CORS allow-list. Enable it only when you intend
   that, and pair it with `--api-key`.
+- **Bound scan runtime with `--scan-timeout`.** The per-request `timeout` only
+  caps a single HTTP request; a scan with many parameters and payloads (or
+  `deep_scan`) can still run for a long time. Set `--scan-timeout <secs>` so
+  every submitted scan has a hard wall-clock budget and a single slow target
+  can't tie up a worker indefinitely.

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -50,6 +50,10 @@ pub const MAX_TIMEOUT_SECS: u64 = 299;
 pub const MAX_DELAY_MS: u64 = 9999;
 /// Maximum worker count accepted via scan options (inclusive).
 pub const MAX_WORKERS: usize = 500;
+/// Maximum whole-scan wall-clock budget accepted via scan options (inclusive,
+/// 24h). `0` always means "no budget" (unbounded). The ceiling only exists to
+/// reject obvious typos; a real long-running deep scan can still set hours.
+pub const MAX_SCAN_TIMEOUT_SECS: u64 = 86_400;
 
 /// Current unix time in milliseconds (UTC).
 pub fn now_ms() -> i64 {
@@ -191,6 +195,62 @@ pub fn unreachable_error_message() -> String {
         "target unreachable: connection failed ({})",
         crate::cmd::error_codes::CONNECTION_FAILED
     )
+}
+
+/// Resolve the effective whole-scan wall-clock budget (seconds) for a job from
+/// a per-request value and an optional server-side cap.
+///
+/// - `0` means "no budget" (unbounded), matching the CLI's `--scan-timeout 0`.
+/// - When the server sets a cap (`Some(c)` with `c > 0`) it is an *upper bound*:
+///   a request may ask for a shorter budget but cannot raise it past the cap or
+///   disable it (a requested `0` is clamped up to the cap). This lets an
+///   operator bound every submitted scan regardless of what an (authenticated)
+///   client requests, without breaking the unbounded default when no cap is set.
+///
+/// Shared by the REST server (per-request option + `--scan-timeout` cap) and the
+/// MCP scan tool (per-call value, no server cap) so the budget semantics match.
+pub fn effective_scan_timeout(requested: Option<u64>, server_cap: Option<u64>) -> u64 {
+    match (requested, server_cap.filter(|c| *c > 0)) {
+        (Some(r), Some(cap)) => {
+            if r == 0 {
+                cap
+            } else {
+                r.min(cap)
+            }
+        }
+        (Some(r), None) => r,
+        (None, Some(cap)) => cap,
+        (None, None) => 0,
+    }
+}
+
+/// Drive `fut` to completion, but abort it after `budget_secs` of wall-clock
+/// time when `budget_secs > 0`. On expiry the shared `cancel` flag is set — so
+/// any scan workers still in flight wind down at their next cancellation
+/// checkpoint, exactly as a user-initiated cancel would — and `true` is
+/// returned. `budget_secs == 0` disables the cap and always returns `false`.
+///
+/// Used by the REST server and MCP runners to bound a single scan's total
+/// runtime; the CLI enforces the same `--scan-timeout` budget in its scan loop.
+/// Wrapping (rather than only setting the cancel flag from a watchdog) is what
+/// bounds phases that don't poll the flag — discovery, mining, and the initial
+/// AST fetch — so a slow target can't keep a scan alive past its budget there.
+pub async fn run_within_scan_budget<F>(budget_secs: u64, cancel: &Arc<AtomicBool>, fut: F) -> bool
+where
+    F: std::future::Future<Output = ()>,
+{
+    if budget_secs == 0 {
+        fut.await;
+        return false;
+    }
+    let budget = std::time::Duration::from_secs(budget_secs);
+    match tokio::time::timeout(budget, fut).await {
+        Ok(()) => false,
+        Err(_elapsed) => {
+            cancel.store(true, std::sync::atomic::Ordering::Relaxed);
+            true
+        }
+    }
 }
 
 pub async fn send_reachability_probe(target: &Target) -> bool {

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -133,3 +133,66 @@ fn job_status_deserializes_from_lowercase_string() {
 fn job_status_rejects_unknown_variant() {
     assert!(serde_json::from_str::<JobStatus>("\"finished\"").is_err());
 }
+
+#[test]
+fn effective_scan_timeout_resolves_request_and_cap() {
+    // No request, no cap → unbounded.
+    assert_eq!(effective_scan_timeout(None, None), 0);
+    // No request, cap set → the cap applies to everyone.
+    assert_eq!(effective_scan_timeout(None, Some(30)), 30);
+    // No request, cap explicitly 0 → still unbounded (a 0 cap is "no cap").
+    assert_eq!(effective_scan_timeout(None, Some(0)), 0);
+    // Request only → used as-is, including an explicit disable.
+    assert_eq!(effective_scan_timeout(Some(45), None), 45);
+    assert_eq!(effective_scan_timeout(Some(0), None), 0);
+    // Request under the cap → request wins (a client may ask for less).
+    assert_eq!(effective_scan_timeout(Some(10), Some(30)), 10);
+    // Request over the cap → clamped down to the cap (can't exceed it).
+    assert_eq!(effective_scan_timeout(Some(120), Some(30)), 30);
+    // Request tries to disable while a cap is set → clamped up to the cap
+    // (a client cannot opt out of a server-enforced budget).
+    assert_eq!(effective_scan_timeout(Some(0), Some(30)), 30);
+    // Equal values → that value.
+    assert_eq!(effective_scan_timeout(Some(30), Some(30)), 30);
+}
+
+#[tokio::test]
+async fn run_within_scan_budget_trips_and_sets_cancel_on_expiry() {
+    let cancel = Arc::new(AtomicBool::new(false));
+    // Budget of 1s against a future that would take 3s → must abort at the
+    // budget (~1s), set the cancel flag, and report that it timed out.
+    let timed_out = run_within_scan_budget(1, &cancel, async {
+        tokio::time::sleep(std::time::Duration::from_secs(3)).await;
+    })
+    .await;
+    assert!(timed_out, "an over-budget scan must report timed_out");
+    assert!(
+        cancel.load(std::sync::atomic::Ordering::Relaxed),
+        "expiry must trip the shared cancel flag so workers wind down"
+    );
+}
+
+#[tokio::test]
+async fn run_within_scan_budget_passes_through_when_under_budget() {
+    let cancel = Arc::new(AtomicBool::new(false));
+    // Completes well inside the budget → no timeout, cancel flag untouched.
+    let timed_out = run_within_scan_budget(5, &cancel, async {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    })
+    .await;
+    assert!(!timed_out, "a scan that finishes in time must not time out");
+    assert!(!cancel.load(std::sync::atomic::Ordering::Relaxed));
+}
+
+#[tokio::test]
+async fn run_within_scan_budget_zero_disables_the_cap() {
+    let cancel = Arc::new(AtomicBool::new(false));
+    // budget_secs == 0 takes the no-cap branch: it just awaits the future and
+    // returns false without ever arming a timer or touching the cancel flag.
+    let timed_out = run_within_scan_budget(0, &cancel, async {
+        tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    })
+    .await;
+    assert!(!timed_out, "a 0 budget must never report a timeout");
+    assert!(!cancel.load(std::sync::atomic::Ordering::Relaxed));
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -41,9 +41,10 @@ use rmcp::{
 use crate::{
     cmd::scan::ScanArgs,
     job::{
-        AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-        MAX_WORKERS, has_http_scheme, now_ms, parse_job_status,
-        purge_expired_jobs as purge_jobs_map, send_reachability_probe, unreachable_error_message,
+        AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_DELAY_MS, MAX_SCAN_TIMEOUT_SECS,
+        MAX_TIMEOUT_SECS, MAX_WORKERS, has_http_scheme, now_ms, parse_job_status,
+        purge_expired_jobs as purge_jobs_map, run_within_scan_budget, send_reachability_probe,
+        unreachable_error_message,
     },
     parameter_analysis::analyze_parameters,
     scanning::result::{Result as ScanResult, SanitizedResult},
@@ -346,7 +347,7 @@ impl DalfoxMcp {
             }
         }));
 
-        crate::with_job_rate_limiter(
+        let scan_fut = crate::with_job_rate_limiter(
             scan_args.rate_limit,
             crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
                 crate::WAF_CONSECUTIVE_BLOCKS_JOB
@@ -422,8 +423,14 @@ impl DalfoxMcp {
                     })
                     .await;
             }),
-        )
-        .await;
+        );
+
+        // Enforce the whole-scan wall-clock budget. On expiry the cancel flag is
+        // tripped so in-flight workers wind down at their next checkpoint and
+        // the job settles as `cancelled` with partial results, mirroring a user
+        // cancel — plus an error_message below so a timeout stays distinguishable.
+        let timed_out =
+            run_within_scan_budget(scan_args.scan_timeout, &cancel_flag, scan_fut).await;
 
         drop(findings_updater);
 
@@ -463,9 +470,24 @@ impl DalfoxMcp {
             if let Some(j) = jobs.get_mut(&scan_id) {
                 // Store partial or complete results
                 j.results = Some(Arc::new(sanitized));
-                // Only update status if not already cancelled (cancel sets status immediately)
+                // Only update status if not already cancelled (cancel sets status
+                // immediately). A scan_timeout trips `cancel_flag` without setting
+                // the status, so map `was_cancelled` to Cancelled here — otherwise
+                // a timed-out scan would mislabel itself Done at 100%.
                 if j.status != JobStatus::Cancelled {
-                    j.status = JobStatus::Done;
+                    j.status = if was_cancelled {
+                        JobStatus::Cancelled
+                    } else {
+                        JobStatus::Done
+                    };
+                }
+                // Record *why* a budget-tripped scan stopped so a client can tell
+                // a timeout apart from a user cancel (both surface as `cancelled`).
+                if timed_out && j.error_message.is_none() {
+                    j.error_message = Some(format!(
+                        "scan exceeded scan_timeout ({}s); returning partial results",
+                        scan_args.scan_timeout
+                    ));
                 }
                 // finished_at_ms may already be set by cancel_scan_dalfox; preserve it
                 // so we record the moment the user asked to stop, not when the task noticed.
@@ -482,7 +504,13 @@ impl DalfoxMcp {
         };
         Self::log(
             "JOB",
-            &format!("scan {} scan_id={} url={}", status_label, scan_id, url),
+            &format!(
+                "scan {}{} scan_id={} url={}",
+                status_label,
+                if timed_out { " (scan_timeout)" } else { "" },
+                scan_id,
+                url
+            ),
         );
     }
 }
@@ -542,6 +570,14 @@ pub struct ScanWithDalfoxParams {
     #[serde(default = "default_timeout")]
     #[schemars(range(min = 1, max = 299))]
     pub timeout: u64,
+
+    /// Whole-scan wall-clock budget in seconds (0-86400). When the budget is
+    /// reached the scan stops, returns whatever partial results it gathered, and
+    /// settles as `cancelled` with an error_message noting the timeout. 0 = no
+    /// budget (unbounded). Use this to bound long/deep scans. Default: 0
+    #[serde(default)]
+    #[schemars(range(max = 86400))]
+    pub scan_timeout: u64,
 
     /// Delay between requests in milliseconds (0-9999). Default: 0
     #[serde(default)]
@@ -733,6 +769,7 @@ Final results (via get_results_dalfox) include finding type \
             user_agent,
             encoders,
             timeout,
+            scan_timeout,
             delay,
             follow_redirects,
             proxy,
@@ -784,6 +821,15 @@ Final results (via get_results_dalfox) include finding type \
                 format!(
                     "workers must be between 1 and {} (got {})",
                     MAX_WORKERS, workers
+                ),
+                None,
+            ));
+        }
+        if scan_timeout > MAX_SCAN_TIMEOUT_SECS {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "scan_timeout must be between 0 and {} seconds (got {})",
+                    MAX_SCAN_TIMEOUT_SECS, scan_timeout
                 ),
                 None,
             ));
@@ -857,7 +903,10 @@ Final results (via get_results_dalfox) include finding type \
             skip_reflection_cookie: false,
             skip_reflection_path: false,
             timeout,
-            scan_timeout: 0,
+            // Whole-scan wall-clock budget; 0 = unbounded. Enforced in
+            // `run_job` by wrapping the scan future (run_scanning doesn't honor
+            // this field — the CLI applies the same budget in its scan loop).
+            scan_timeout,
             delay,
             proxy,
             follow_redirects,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -35,6 +35,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
         user_agent: None,
         encoders: vec!["none".to_string()],
         timeout: 1,
+        scan_timeout: 0,
         delay: 0,
         follow_redirects: false,
         proxy: None,
@@ -977,6 +978,34 @@ async fn test_scan_with_dalfox_accepts_workers_at_max() {
     mcp.scan_with_dalfox(Parameters(params))
         .await
         .expect("workers == MAX_WORKERS must be accepted");
+}
+
+#[tokio::test]
+async fn test_scan_with_dalfox_rejects_scan_timeout_over_max() {
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        scan_timeout: MAX_SCAN_TIMEOUT_SECS + 1,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    let err = mcp
+        .scan_with_dalfox(Parameters(params))
+        .await
+        .expect_err("scan_timeout over the ceiling must be rejected");
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(err.message.contains("scan_timeout must be between"));
+}
+
+#[tokio::test]
+async fn test_scan_with_dalfox_accepts_scan_timeout_zero() {
+    // 0 means "no budget" and must be accepted (it's the default-equivalent).
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        scan_timeout: 0,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    mcp.scan_with_dalfox(Parameters(params))
+        .await
+        .expect("scan_timeout == 0 (unbounded) must be accepted");
 }
 
 #[tokio::test]

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -304,13 +304,19 @@ pub(crate) async fn get_scan_handler(
     let cookie = params.get("cookie").cloned();
     // A present-but-unparseable numeric query param is a 400, not a silent
     // fallback to the default (which is what `.parse().ok()` used to do).
-    let (worker, delay, timeout): (Option<usize>, Option<u64>, Option<u64>) = match (
+    let (worker, delay, timeout, scan_timeout): (
+        Option<usize>,
+        Option<u64>,
+        Option<u64>,
+        Option<u64>,
+    ) = match (
         parse_num_query::<usize>(&params, "worker"),
         parse_num_query::<u64>(&params, "delay"),
         parse_num_query::<u64>(&params, "timeout"),
+        parse_num_query::<u64>(&params, "scan_timeout"),
     ) {
-        (Ok(w), Ok(d), Ok(t)) => (w, d, t),
-        (Err(msg), ..) | (_, Err(msg), _) | (.., Err(msg)) => {
+        (Ok(w), Ok(d), Ok(t), Ok(st)) => (w, d, t, st),
+        (Err(msg), ..) | (_, Err(msg), ..) | (_, _, Err(msg), _) | (.., Err(msg)) => {
             let resp = ApiResponse::<serde_json::Value> {
                 code: 400,
                 msg,
@@ -379,6 +385,7 @@ pub(crate) async fn get_scan_handler(
         deep_scan: Some(deep_scan),
         skip_ast_analysis: Some(skip_ast_analysis),
         detect_outdated_libs: Some(detect_outdated_libs),
+        scan_timeout,
     };
 
     if let Err(msg) = validate_scan_options(&opts) {

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -281,7 +281,11 @@ pub(crate) async fn run_scan_job(
         timeout: opts
             .timeout
             .unwrap_or(crate::cmd::scan::DEFAULT_TIMEOUT_SECS),
-        scan_timeout: 0,
+        // Whole-scan wall-clock budget: the request's own value, capped by the
+        // server-wide `--scan-timeout` when set. Enforced below by wrapping the
+        // scan future, since `run_scanning` itself doesn't honor this field
+        // (the CLI applies the same budget in its scan loop, not in scanning).
+        scan_timeout: effective_scan_timeout(opts.scan_timeout, state.scan_timeout),
         delay: opts.delay.unwrap_or(0),
         proxy: opts.proxy.clone(),
         follow_redirects: opts.follow_redirects.unwrap_or(false),
@@ -432,7 +436,7 @@ pub(crate) async fn run_scan_job(
         }
     }));
 
-    crate::with_job_rate_limiter(
+    let scan_fut = crate::with_job_rate_limiter(
         args.rate_limit,
         crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
             crate::WAF_CONSECUTIVE_BLOCKS_JOB
@@ -501,8 +505,13 @@ pub(crate) async fn run_scan_job(
                 })
                 .await;
         }),
-    )
-    .await;
+    );
+
+    // Enforce the whole-scan wall-clock budget. On expiry the cancel flag is
+    // tripped so any in-flight workers wind down at their next checkpoint, and
+    // the job settles as `cancelled` with whatever partial results it gathered
+    // (plus an explanatory error_message) — the same shape as a user cancel.
+    let timed_out = run_within_scan_budget(args.scan_timeout, &cancel_flag, scan_fut).await;
 
     drop(findings_updater);
 
@@ -546,6 +555,15 @@ pub(crate) async fn run_scan_job(
                     JobStatus::Done
                 };
             }
+            // Record *why* a budget-tripped scan stopped so a client can tell a
+            // timeout apart from a user-initiated cancel (both surface as
+            // `cancelled`). Don't clobber an error_message a prior path set.
+            if timed_out && job.error_message.is_none() {
+                job.error_message = Some(format!(
+                    "scan exceeded scan_timeout ({}s); returning partial results",
+                    args.scan_timeout
+                ));
+            }
             // Preserve an earlier finished_at_ms set by cancel_scan_handler
             // (which records when the user asked to stop, not when the task noticed).
             if job.finished_at_ms.is_none() {
@@ -560,7 +578,13 @@ pub(crate) async fn run_scan_job(
     log(
         &state,
         "JOB",
-        &format!("{} id={} url={}", status_label, job_id, url),
+        &format!(
+            "{}{} id={} url={}",
+            status_label,
+            if timed_out { " (scan_timeout)" } else { "" },
+            job_id,
+            url
+        ),
     );
 
     // Reuse the target's HTTP configuration (proxy, TLS relaxation, redirect

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,8 +35,9 @@ pub(crate) use serde::{Deserialize, Serialize};
 
 pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
-    AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-    MAX_WORKERS, has_http_scheme, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
+    AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS,
+    MAX_SCAN_TIMEOUT_SECS, MAX_TIMEOUT_SECS, MAX_WORKERS, effective_scan_timeout, has_http_scheme,
+    now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map, run_within_scan_budget,
     send_reachability_probe, unreachable_error_message,
 };
 pub(crate) use crate::parameter_analysis::analyze_parameters;
@@ -137,6 +138,7 @@ pub async fn run_server(args: ServerArgs) {
         allow_headers,
         jsonp_enabled: args.jsonp,
         callback_param_name: args.callback_param_name.clone(),
+        scan_timeout: args.scan_timeout,
     };
 
     let app = Router::new()

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -28,6 +28,7 @@ fn make_state(
         allow_headers: "Content-Type,X-API-KEY,Authorization".to_string(),
         jsonp_enabled: jsonp,
         callback_param_name: cb_name.to_string(),
+        scan_timeout: None,
     }
 }
 
@@ -135,6 +136,48 @@ async fn start_reflecting_target_server() -> SocketAddr {
         .await
         .expect("bind reflecting target listener");
     let addr = listener.local_addr().expect("reflecting target local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    addr
+}
+
+/// Reflects each query value back into the HTML body — but with the
+/// XSS-significant characters (`< > " '`) stripped — after a fixed per-request
+/// delay. The alphanumeric reflection probe still appears, so `analyze_parameters`
+/// classifies the param as reflective and `run_scanning` sweeps the *whole*
+/// payload set; yet no payload can ever verify (the breakout chars are gone),
+/// so the scan never short-circuits on a finding. Combined with the delay this
+/// guarantees the scan runs long enough for a small `scan_timeout` to trip.
+async fn target_slow_reflect_handler(Query(q): Query<Map<String, String>>) -> impl IntoResponse {
+    tokio::time::sleep(std::time::Duration::from_millis(120)).await;
+    let mut body = String::from("<html><body>");
+    for (k, v) in &q {
+        let safe: String = v
+            .chars()
+            .filter(|c| !matches!(c, '<' | '>' | '"' | '\''))
+            .collect();
+        body.push_str(&format!("<div>{k}={safe}</div>"));
+    }
+    body.push_str("</body></html>");
+    (
+        StatusCode::OK,
+        [("content-type", "text/html; charset=utf-8")],
+        body,
+    )
+}
+
+async fn start_slow_reflecting_target_server() -> SocketAddr {
+    let app = Router::new()
+        .route("/", any(target_slow_reflect_handler))
+        .route("/{*rest}", any(target_slow_reflect_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind slow reflecting target listener");
+    let addr = listener
+        .local_addr()
+        .expect("slow reflecting target local addr");
     tokio::spawn(async move {
         let _ = axum::serve(listener, app).await;
     });
@@ -1028,6 +1071,7 @@ async fn test_run_scan_job_success_marks_done() {
         skip_ast_analysis: None,
         // Exercise the ON path: opts -> job_runner -> ScanArgs -> analysis gate.
         detect_outdated_libs: Some(true),
+        scan_timeout: None,
     };
 
     let run = tokio::time::timeout(
@@ -1048,6 +1092,71 @@ async fn test_run_scan_job_success_marks_done() {
     let job = jobs.get(&id).expect("job should remain");
     assert_eq!(job.status, JobStatus::Done);
     assert!(job.results.is_some());
+}
+
+#[tokio::test]
+async fn test_run_scan_job_scan_timeout_marks_cancelled_with_partial_results() {
+    // End-to-end: a per-request `scan_timeout` must bound the whole scan. The
+    // target reflects (neutralized) values after a 120ms delay, and with a
+    // single worker the payload sweep serializes well past the 1s budget — so
+    // the budget trips mid-scan. The job must settle as `cancelled` (not Done
+    // at a bogus 100%), expose whatever partial results it has, and record an
+    // error_message that distinguishes a timeout from a user-initiated cancel.
+    let addr = start_slow_reflecting_target_server().await;
+    let state = make_state(None, None, false, false, "callback");
+    let id = "scan-timeout-job".to_string();
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), test_job(JobStatus::Queued, None, ""));
+    }
+
+    let opts = ScanOptions {
+        encoders: Some(vec!["none".to_string()]),
+        worker: Some(1),
+        // Skip mining so the (slow) traffic is the reflective-param payload
+        // sweep rather than dictionary guessing — keeps the test focused.
+        skip_mining: Some(true),
+        scan_timeout: Some(1),
+        ..ScanOptions::default()
+    };
+
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        run_scan_job(
+            state.clone(),
+            id.clone(),
+            format!("http://{}/?q=test", addr),
+            opts,
+            false,
+            false,
+        ),
+    )
+    .await;
+    assert!(
+        run.is_ok(),
+        "run_scan_job should return once the budget trips"
+    );
+
+    let jobs = state.jobs.lock().await;
+    let job = jobs.get(&id).expect("job should remain");
+    assert_eq!(
+        job.status,
+        JobStatus::Cancelled,
+        "a budget-tripped scan must settle as cancelled, not done"
+    );
+    let msg = job
+        .error_message
+        .as_deref()
+        .expect("a timeout must record an error_message");
+    assert!(
+        msg.contains("scan_timeout"),
+        "error_message should mention scan_timeout, got: {msg}"
+    );
+    assert!(
+        job.results.is_some(),
+        "partial results vector should be attached even on timeout"
+    );
+    assert!(job.finished_at_ms.is_some());
 }
 
 #[tokio::test]
@@ -1298,6 +1407,7 @@ async fn test_run_server_returns_on_invalid_bind_address() {
         host: "not a valid host".to_string(),
         api_key: None,
         log_file: None,
+        scan_timeout: None,
         allowed_origins: None,
         jsonp: false,
         callback_param_name: "callback".to_string(),
@@ -1319,6 +1429,7 @@ async fn test_run_server_returns_on_bind_failure_after_state_build() {
         host: Ipv4Addr::LOCALHOST.to_string(),
         api_key: Some("server-key".to_string()),
         log_file: None,
+        scan_timeout: None,
         allowed_origins: Some(
             "*,regex:^https://.*\\.example\\.com$,https://*.corp.local".to_string(),
         ),
@@ -1540,6 +1651,18 @@ fn test_validate_scan_options_rejects_out_of_range() {
         ..ScanOptions::default()
     };
     assert!(validate_scan_options(&bad_worker_hi).is_err());
+
+    // scan_timeout: 0 is allowed (disabled); anything over the ceiling is not.
+    let ok_disabled = ScanOptions {
+        scan_timeout: Some(0),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&ok_disabled).is_ok());
+    let bad_scan_timeout = ScanOptions {
+        scan_timeout: Some(MAX_SCAN_TIMEOUT_SECS + 1),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&bad_scan_timeout).is_err());
 }
 
 #[tokio::test]
@@ -1637,7 +1760,12 @@ async fn test_get_scan_handler_rejects_unparseable_numeric_query() {
     // A present-but-unparseable numeric query param is a 400, not a silent
     // fallback to the default. (`?timeout=0` is already rejected by range
     // validation; this covers the non-numeric / negative class.)
-    for (key, val) in [("timeout", "abc"), ("worker", "-5"), ("delay", "1.5")] {
+    for (key, val) in [
+        ("timeout", "abc"),
+        ("worker", "-5"),
+        ("delay", "1.5"),
+        ("scan_timeout", "soon"),
+    ] {
         let state = make_state(None, None, false, false, "cb");
         let mut params = Map::new();
         params.insert("url".to_string(), "http://example.com".to_string());

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -24,6 +24,14 @@ pub struct ServerArgs {
     #[arg(long = "log-file")]
     pub log_file: Option<String>,
 
+    /// Server-wide cap on each scan's total wall-clock runtime, in seconds
+    /// (0 or unset = unbounded). Applied to every submitted scan: a request's
+    /// own scan_timeout may be shorter but cannot exceed or disable this cap.
+    /// Bounds long/deep scans so a single target can't pin a worker indefinitely.
+    #[clap(help_heading = "SERVER")]
+    #[arg(long = "scan-timeout")]
+    pub scan_timeout: Option<u64>,
+
     /// Comma-separated list of allowed origins for CORS. Supports:
     /// - "*" (match all)
     /// - exact origins (http://localhost:3000)
@@ -75,6 +83,9 @@ pub(crate) struct AppState {
     // JSONP
     pub(crate) jsonp_enabled: bool,
     pub(crate) callback_param_name: String,
+    // Server-wide cap on per-scan wall-clock runtime (seconds). `None`/`Some(0)`
+    // leaves scans unbounded unless a request supplies its own scan_timeout.
+    pub(crate) scan_timeout: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +137,10 @@ pub(crate) struct ScanOptions {
     pub(crate) skip_ast_analysis: Option<bool>,
     /// Also report outdated / known-vulnerable JS libraries (informational, CWE-1104).
     pub(crate) detect_outdated_libs: Option<bool>,
+    /// Whole-scan wall-clock budget in seconds (0 = unbounded). When the server
+    /// was started with `--scan-timeout`, that value caps this one — a request
+    /// may ask for a shorter budget but cannot exceed or disable the cap.
+    pub(crate) scan_timeout: Option<u64>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -30,6 +30,14 @@ pub(crate) fn validate_scan_options(opts: &ScanOptions) -> Result<(), String> {
             MAX_WORKERS, w
         ));
     }
+    if let Some(st) = opts.scan_timeout
+        && st > MAX_SCAN_TIMEOUT_SECS
+    {
+        return Err(format!(
+            "scan_timeout must be between 0 and {} seconds (got {})",
+            MAX_SCAN_TIMEOUT_SECS, st
+        ));
+    }
     Ok(())
 }
 


### PR DESCRIPTION
## Summary

The REST server and MCP runtimes hardcoded `scan_timeout: 0`, so a single scan ran **unbounded** — only the per-request `timeout` (max 299s) was tunable. A scan with many parameters/payloads (or `deep_scan`) could pin a worker indefinitely, a DoS surface the CLI already guards with `--scan-timeout`. This adds the same whole-scan wall-clock budget to both front-ends.

## What changed

**Shared helpers (`src/job/mod.rs`)**
- `effective_scan_timeout(requested, server_cap)` — resolves the per-request value against an optional server-wide cap. The cap is an **upper bound**: a request may ask for a shorter budget but cannot exceed or disable it.
- `run_within_scan_budget(budget_secs, &cancel, fut)` — wraps the scan future in `tokio::time::timeout` **and** sets the cancel flag on expiry (CLI precedent). Wrapping bounds the discovery/mining/AST phases that don't poll the cancel flag, and setting the flag winds down detached `run_scanning` workers.
- `MAX_SCAN_TIMEOUT_SECS` (86400) ceiling; `0` always means unbounded.

**REST server**
- `ScanOptions.scan_timeout` (per-request, also a `GET /scan` query param)
- `ServerArgs --scan-timeout` (server-wide cap applied to every submitted scan)
- validated in `validate_scan_options`

**MCP**
- `ScanWithDalfoxParams.scan_timeout` (with schema range) + validation
- Fixes the MCP terminal block, which unconditionally marked a flag-cancelled scan `done` instead of mapping `was_cancelled` → `cancelled`.

## Terminal state

On expiry the job settles as `cancelled` with whatever partial results it gathered, plus an `error_message` (`scan exceeded scan_timeout (Ns)...`) so a timeout stays distinguishable from a user-issued cancel. No new `JobStatus` variant — reuses `cancelled` so partial results/progress/webhook contracts are unchanged.

## Tests

- `job::tests`: precedence table, budget expiry/passthrough/disabled
- `server::tests`: end-to-end timeout (slow reflecting target → `cancelled` + partial + message), `scan_timeout` validation, GET query rejection
- `mcp::tests`: rejects `> max`, accepts `0`

Full lib suite green (1427 passed), `clippy` clean, `fmt` applied. Docs updated in `server.md` / `mcp.md`.

## Behavior

Default (`0`/unset) is unchanged — scans stay unbounded unless a budget is configured, so this is non-breaking.