### PR TITLE
fix(scanning): close xssmaze waf-facade detection gaps (deferred-callback DOM-XSS + WAF backoff)

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -3836,6 +3836,49 @@ impl<'a> DomXssVisitor<'a> {
         }
         // Walk the callee
         self.walk_expression(&call.callee);
+
+        // Descend into function/arrow callbacks passed as arguments so a
+        // source→sink flow that lives *inside* a deferred callback is still
+        // analyzed. The classic shape is a `setTimeout` / `setInterval` /
+        // `requestAnimationFrame` / `queueMicrotask` body — e.g.
+        // `setTimeout(function(){ el.innerHTML = location.search }, 0)`. The
+        // callback never runs at parse time, and the call's arguments are not
+        // walked anywhere else (the trailing `walk_expression(&call.callee)`
+        // only descends the callee), so without this the body is invisible.
+        // Cases that own their callback walking (`addEventListener`, `.then`
+        // chains, `Reflect.apply`, …) `return` early and never reach here.
+        self.walk_callback_argument_bodies(call);
+    }
+
+    /// Walk function/arrow callbacks passed as call arguments, each with an
+    /// isolated taint scope so a callback-local variable (`var q = …` inside
+    /// the callback) does not leak taint into the enclosing scope. Only
+    /// function-shaped arguments are descended; data arguments keep their
+    /// existing taint-evaluation-only treatment.
+    fn walk_callback_argument_bodies(&mut self, call: &CallExpression<'a>) {
+        for arg in &call.arguments {
+            let Some(expr) = arg.as_expression() else {
+                continue;
+            };
+            let statements = match expr {
+                Expression::FunctionExpression(func) => {
+                    let Some(body) = &func.body else {
+                        continue;
+                    };
+                    &body.statements
+                }
+                Expression::ArrowFunctionExpression(arrow) => &arrow.body.statements,
+                _ => continue,
+            };
+
+            let saved_tainted = self.tainted_vars.clone();
+            let saved_aliases = self.var_aliases.clone();
+            let saved_field_taints = self.field_taints.clone();
+            self.walk_statements(statements);
+            self.tainted_vars = saved_tainted;
+            self.var_aliases = saved_aliases;
+            self.field_taints = saved_field_taints;
+        }
     }
 }
 

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -593,6 +593,68 @@ setInterval(code, 1000);
 }
 
 #[test]
+fn test_settimeout_callback_body_flow_detected() {
+    // The source→sink flow lives *inside* a `setTimeout(function(){ … })`
+    // deferred callback — the xssmaze `waf-facade/level8` shape (a fake
+    // "Checking your browser" challenge whose verify step writes the query
+    // into innerHTML). The callback never runs at parse time, so its body must
+    // be walked explicitly; without callback descent this slipped through.
+    let code = r#"
+setTimeout(function () {
+  var q = new URLSearchParams(location.search).get('query') || '';
+  document.getElementById('out').innerHTML = 'Resource: ' + q;
+}, 600);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let result = analyzer.analyze(code).unwrap();
+    assert!(
+        result.iter().any(|v| v.sink.contains("innerHTML")),
+        "Should detect URLSearchParams→innerHTML flow inside a setTimeout callback; got {:?}",
+        result
+            .iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn test_settimeout_arrow_callback_body_flow_detected() {
+    // Same deferred-callback flow, arrow-function form.
+    let code = r#"
+setTimeout(() => {
+  document.getElementById('out').innerHTML = location.hash;
+}, 0);
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let result = analyzer.analyze(code).unwrap();
+    assert!(
+        result.iter().any(|v| v.sink.contains("innerHTML")),
+        "Should detect location.hash→innerHTML flow inside a setTimeout arrow callback"
+    );
+}
+
+#[test]
+fn test_callback_body_local_taint_does_not_leak() {
+    // A callback-local tainted var must not leak into the enclosing scope and
+    // mark an unrelated outer write as vulnerable. Only the in-callback sink
+    // (if any) should fire — here the callback is inert, so nothing should.
+    let code = r#"
+setTimeout(function () { var q = location.search; var safe = 'static'; }, 0);
+document.getElementById('out').innerHTML = q;
+"#;
+    let analyzer = AstDomAnalyzer::new();
+    let result = analyzer.analyze(code).unwrap();
+    assert!(
+        result.is_empty(),
+        "Callback-local taint must not leak to the outer scope; got {:?}",
+        result
+            .iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_function_constructor() {
     let code = r#"
 let input = location.hash;

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -50,15 +50,17 @@ const WAF_BACKOFF_CAP_MS: u64 = 30_000;
 /// Base adaptive cooldown (milliseconds, before any jitter) for a WAF block
 /// response, or `0` for "don't pause". The block *class* decides whether the
 /// cooldown applies at all, because the correct reaction differs:
-///   * **429 / 503** are genuine rate-limit / overload signals — the origin is
-///     telling us to slow down, so the escalating cooldown is always honored.
-///   * **403 / 406** are per-request *content* blocks: *this payload* was
-///     rejected. The right move is to try the next payload immediately, so the
-///     cooldown is only paid under explicit `--waf-evasion` (the user opting
-///     into cautious, stealthy pacing). Otherwise a facade that 403s most
-///     payloads (signature / anomaly-scoring WAFs) would burn the entire
-///     `--scan-timeout` in backoff and never reach a bypass that does slip
-///     through — the failure mode behind xssmaze `waf-facade` L3/L5.
+///
+/// * **429 / 503** are genuine rate-limit / overload signals — the origin is
+///   telling us to slow down, so the escalating cooldown is always honored.
+/// * **403 / 406** are per-request *content* blocks: *this payload* was
+///   rejected. The right move is to try the next payload immediately, so the
+///   cooldown is only paid under explicit `--waf-evasion` (the user opting
+///   into cautious, stealthy pacing). Otherwise a facade that 403s most
+///   payloads (signature / anomaly-scoring WAFs) would burn the entire
+///   `--scan-timeout` in backoff and never reach a bypass that does slip
+///   through — the failure mode behind xssmaze `waf-facade` L3/L5.
+///
 /// Returns `0` below `WAF_BACKOFF_THRESHOLD` consecutive blocks (transient).
 fn waf_block_cooldown_ms(status_code: u16, consecutive: u32, waf_evasion: bool) -> u64 {
     let is_rate_limit = matches!(status_code, 429 | 503);

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -47,6 +47,31 @@ const WAF_BACKOFF_BASE_MS: u64 = 2000;
 /// Absolute ceiling (milliseconds) on a single adaptive-backoff sleep.
 const WAF_BACKOFF_CAP_MS: u64 = 30_000;
 
+/// Base adaptive cooldown (milliseconds, before any jitter) for a WAF block
+/// response, or `0` for "don't pause". The block *class* decides whether the
+/// cooldown applies at all, because the correct reaction differs:
+///   * **429 / 503** are genuine rate-limit / overload signals — the origin is
+///     telling us to slow down, so the escalating cooldown is always honored.
+///   * **403 / 406** are per-request *content* blocks: *this payload* was
+///     rejected. The right move is to try the next payload immediately, so the
+///     cooldown is only paid under explicit `--waf-evasion` (the user opting
+///     into cautious, stealthy pacing). Otherwise a facade that 403s most
+///     payloads (signature / anomaly-scoring WAFs) would burn the entire
+///     `--scan-timeout` in backoff and never reach a bypass that does slip
+///     through — the failure mode behind xssmaze `waf-facade` L3/L5.
+/// Returns `0` below `WAF_BACKOFF_THRESHOLD` consecutive blocks (transient).
+fn waf_block_cooldown_ms(status_code: u16, consecutive: u32, waf_evasion: bool) -> u64 {
+    let is_rate_limit = matches!(status_code, 429 | 503);
+    let is_content_block = matches!(status_code, 403 | 406);
+    let apply_cooldown = is_rate_limit || (is_content_block && waf_evasion);
+    if !apply_cooldown || consecutive < WAF_BACKOFF_THRESHOLD {
+        return 0;
+    }
+    let escalation = (consecutive - WAF_BACKOFF_THRESHOLD).min(WAF_BACKOFF_MAX_ESCALATION);
+    let backoff_ms = WAF_BACKOFF_BASE_MS * (1u64 << escalation);
+    backoff_ms.min(WAF_BACKOFF_CAP_MS)
+}
+
 /// Check whether *all* occurrences of `payload` in `html` fall inside safe tags
 /// (textarea, noscript, style, xmp, plaintext, title).  If the payload appears
 /// at least once outside a safe tag, returns `false`.
@@ -1255,19 +1280,14 @@ async fn fetch_injection_response_with_client(
             // consecutive counter is per-scan when bound (MCP / REST runners)
             // so one scan's WAF blocks don't slow down unrelated concurrent
             // scans; CLI falls back to the process-wide counter.
-            let is_waf_block = status_code == 403
-                || status_code == 406
-                || status_code == 429
-                || status_code == 503;
+            let is_waf_block = matches!(status_code, 403 | 406 | 429 | 503);
             if is_waf_block {
                 let consecutive = crate::tick_waf_block();
-                // Apply adaptive cooldown when consecutive blocks exceed the
-                // threshold — the "cooldown pause" half of --waf-evasion.
-                if consecutive >= WAF_BACKOFF_THRESHOLD {
-                    let escalation =
-                        (consecutive - WAF_BACKOFF_THRESHOLD).min(WAF_BACKOFF_MAX_ESCALATION);
-                    let backoff_ms = WAF_BACKOFF_BASE_MS * (1u64 << escalation);
-                    let mut backoff_ms = backoff_ms.min(WAF_BACKOFF_CAP_MS);
+                // `waf_block_cooldown_ms` decides whether (and how long) to
+                // pause based on the block class — see its doc comment.
+                let mut backoff_ms =
+                    waf_block_cooldown_ms(status_code, consecutive, args.waf_evasion);
+                if backoff_ms > 0 {
                     // Under --waf-evasion, scatter the cooldown by up to +50% so
                     // the backoff itself isn't a fixed, fingerprintable interval.
                     if args.waf_evasion {

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1428,3 +1428,72 @@ async fn test_path_reflection_suppressed_on_non_html_content_type() {
         "path-injection reflection on application/javascript should be suppressed"
     );
 }
+
+// ---- adaptive WAF cooldown policy (waf_block_cooldown_ms) ----
+
+#[test]
+fn content_block_does_not_cooldown_in_default_mode() {
+    // 403 / 406 are per-request content blocks: in default mode (no
+    // --waf-evasion) the scanner must keep churning payloads, never sleep —
+    // otherwise a facade that 403s most payloads burns the whole scan-timeout.
+    for status in [403u16, 406] {
+        for consecutive in [WAF_BACKOFF_THRESHOLD, WAF_BACKOFF_THRESHOLD + 10, 999] {
+            assert_eq!(
+                waf_block_cooldown_ms(status, consecutive, false),
+                0,
+                "status {status} should not cool down in default mode (n={consecutive})"
+            );
+        }
+    }
+}
+
+#[test]
+fn content_block_cools_down_under_waf_evasion() {
+    // With --waf-evasion the user opts into cautious pacing, so content blocks
+    // get the escalating cooldown once past the threshold.
+    assert_eq!(
+        waf_block_cooldown_ms(403, WAF_BACKOFF_THRESHOLD - 1, true),
+        0,
+        "below threshold = no cooldown even under evasion"
+    );
+    assert_eq!(
+        waf_block_cooldown_ms(403, WAF_BACKOFF_THRESHOLD, true),
+        WAF_BACKOFF_BASE_MS,
+        "first over-threshold block = base delay"
+    );
+    assert!(
+        waf_block_cooldown_ms(403, WAF_BACKOFF_THRESHOLD + 1, true) > WAF_BACKOFF_BASE_MS,
+        "cooldown escalates with consecutive blocks"
+    );
+}
+
+#[test]
+fn rate_limit_always_cools_down() {
+    // 429 / 503 are genuine "slow down" signals — honored regardless of mode.
+    for status in [429u16, 503] {
+        assert_eq!(
+            waf_block_cooldown_ms(status, WAF_BACKOFF_THRESHOLD, false),
+            WAF_BACKOFF_BASE_MS,
+            "status {status} must cool down even in default mode"
+        );
+        assert_eq!(
+            waf_block_cooldown_ms(status, WAF_BACKOFF_THRESHOLD - 1, false),
+            0,
+            "status {status} stays quiet below the transient threshold"
+        );
+    }
+}
+
+#[test]
+fn cooldown_is_capped_and_ignores_non_block_status() {
+    // Escalation plateaus at the absolute ceiling.
+    assert_eq!(
+        waf_block_cooldown_ms(429, 100, true),
+        WAF_BACKOFF_CAP_MS,
+        "a long block streak is capped at WAF_BACKOFF_CAP_MS"
+    );
+    // Non-block statuses never cool down.
+    for status in [200u16, 301, 404, 500] {
+        assert_eq!(waf_block_cooldown_ms(status, 999, true), 0);
+    }
+}


### PR DESCRIPTION
## Summary

Closes detection gaps surfaced by the new xssmaze `waf-facade/level1-8` endpoints (vulnerable pages disguised as commercial-WAF block pages). Detection went **4/8 → 7/8**, and the L3/L5 cases that *could* already be found dropped from ~120s to <1s.

Two independent, well-scoped fixes (one commit each):

### 1. `feat(scanning)`: analyze DOM-XSS flows inside deferred callbacks (L8)
`walk_call_expression` ended by walking only the callee, so function/arrow **arguments** (callbacks) were never traversed. A source→sink flow *inside* `setTimeout(function(){ el.innerHTML = location.search }, 0)` was invisible to the AST DOM analyzer — even though the identical flow written inline is detected.

- Added `walk_callback_argument_bodies` (invoked at the end of `walk_call_expression`) that descends into function/arrow-expression call arguments with an **isolated taint scope** (`tainted_vars` / `var_aliases` / `field_taints` saved & restored), so callback-local vars can't leak taint outward.
- Paths that already own their callback walking (`addEventListener`, `.then` chains, `Reflect.apply`) `return` early and are unaffected.
- L8 (fake "checking your browser" challenge whose verify step writes the query into `innerHTML` from a `setTimeout`) is now an AST DOM-XSS (type `A`) finding.

### 2. `fix(scanning)`: don't let WAF content-block backoff starve the scan-timeout (L3/L5)
The adaptive WAF cooldown fired on every 403/406/429/503 and its `sleep` ran regardless of `--waf-evasion` (only the jitter was gated). Against a signature/anomaly-scoring WAF that 403s most payloads, the escalating cooldown (threshold 3, base 2s, doubling, cap 30s) stretched a ~34-request scan to ~120s and blew past `--scan-timeout` — so a working bypass that *does* slip through (`<details open ontoggle=alert(1)>`) was never reached.

- New pure helper `waf_block_cooldown_ms(status, consecutive, waf_evasion)` separates the block classes by intent:
  - **429 / 503** (genuine rate-limit / overload) → always honor the escalating cooldown.
  - **403 / 406** (per-request content block) → retrying the next payload immediately is correct, so only pay the cooldown under explicit `--waf-evasion`.
- Default scans now churn their payload set without self-throttling on content blocks; rate-limit signals and evasion mode keep the full backoff. The decision is now unit-tested.

## Results (benchmark flags: `--skip-mining --timeout 7 --scan-timeout 40`)

| Level | WAF facade / bypass class | Before | After |
|------|---------------------------|--------|-------|
| L1 | Cloudflare — block page reflects raw | ✅ V | ✅ V |
| L2 | AWS WAF — first-100-byte inspection cap | ❌ | ❌ *(see below)* |
| L3 | ModSecurity/CRS — anomaly scoring | ❌ (120s) | ✅ V (0s) |
| L4 | Akamai — User-Agent header sink | ✅ V | ✅ V |
| L5 | F5 ASM — case-sensitive denylist | ❌ (120s) | ✅ V (0s) |
| L6 | Incapsula — JS-string context | ✅ V | ✅ V |
| L7 | ShieldWall — cosmetic client WAF | ✅ V | ✅ V |
| L8 | Cloudflare JS challenge — DOM innerHTML | ❌ | ✅ A |

## Out of scope (follow-up): L2 inspection-window evasion
The AWS-WAF facade inspects only `query[0,100]`; the bypass is ~100 benign bytes then the vector. A padding *mutation* alone won't help — padded payloads still contain `<`/`>`, and dalfox's short special-char probe trips the 403, so `adaptive prune` marks `<`/`>` invalid and drops all angle-bracket payloads. A real fix must make the prune/discovery path **inspection-window-aware** (e.g. when the benign marker reflects raw but specials read as blocked via a block *status*, retry the special-char probe with a benign prefix before concluding the char is filtered). That touches the most sensitive scanner path, so it warrants its own design + tests.

## Tests
- New: 3 AST callback tests + 4 backoff-policy tests (all passing).
- No regressions: `scanning::` 690, `waf::` 77, `check_reflection` 101, `ast_dom_analysis` 228 — all green; no clippy warnings on changed code.