### PR TITLE
fix(server,mcp): per-job scope leak + rate-limit/concurrency caps + parsing fixes

### DIFF
--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -55,6 +55,7 @@ Submit a scan. Returns immediately.
   "encoders": ["url", "html"],
   "timeout": 10,
   "workers": 50,
+  "rate_limit": 0,
   "blind_callback_url": "https://callback.example",
   "deep_scan": false,
   "skip_ast_analysis": false,
@@ -65,6 +66,10 @@ Submit a scan. Returns immediately.
 `detect_outdated_libs` is opt-in (default `false`): set it `true` to also emit
 informational `[I]` findings for outdated / known-vulnerable JS libraries
 (CWE-1104, 0 extra requests). Left off, the scan reports only XSS.
+
+`rate_limit` caps the scan's outbound requests/second (`0` = unlimited, the
+default), now enforced across all worker tasks — use it to be gentle on a
+fragile target or to stay under a WAF threshold.
 
 Response:
 

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -167,6 +167,7 @@ Returns version, `auth_required`, and the list of supported endpoints. Good for 
     "worker": 50,
     "delay": 0,
     "timeout": 10,
+    "rate_limit": 0,
     "blind": "https://callback.interact.sh",
     "method": "POST",
     "data": "user=test",
@@ -194,6 +195,20 @@ Fields mirror the CLI flags. See the [CLI reference](../../reference/cli/) for m
 `detect_outdated_libs` is opt-in (default `false`): set it `true` to also report
 outdated / known-vulnerable JS libraries as informational `[I]` findings
 (CWE-1104, 0 extra requests). The same key works as a `GET /scan` query parameter.
+
+`rate_limit` caps the scan's outbound requests/second (`0` = unlimited, the
+default), enforced across all worker tasks. The server-wide `--rate-limit` flag
+is an upper bound: a request may ask for a lower rate but cannot exceed or
+disable it.
+
+### Server flags worth setting
+
+- `--rate-limit <rps>` — cap every scan's outbound request rate (protects targets).
+- `--max-concurrent-scans <n>` — reject new submissions with `503` once `n`
+  scans are queued/running (default `100`, `0` = unlimited). Bounds memory and
+  the blocking pool against a flood of submissions.
+- `--max-body-bytes <n>` — explicit request-body cap for `POST /scan` and
+  `/preflight` (default `1048576` = 1 MiB); oversized bodies get `413`.
 
 ## Job lifecycle
 

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -633,7 +633,7 @@ impl ScanArgs {
             rate_limit: 0,
             retries: 0,
             retry_delay: 1000,
-            waf_min_confidence: 0.0,
+            waf_min_confidence: DEFAULT_WAF_MIN_CONFIDENCE,
             remote_payloads: vec![],
             remote_wordlists: vec![],
         }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -51,6 +51,69 @@ pub const MAX_DELAY_MS: u64 = 9999;
 /// Maximum worker count accepted via scan options (inclusive).
 pub const MAX_WORKERS: usize = 500;
 
+/// Cap on the number of distinct parameters a single async (server/MCP) scan
+/// will test. `analyze_parameters` can discover/mine a very large parameter set
+/// on a hostile or sprawling target, and scanning fans out O(params × payloads)
+/// worker tasks — so an uncapped count amplifies CPU / memory / outbound load
+/// from one submission. Beyond this the candidate set is truncated with a log.
+pub const MAX_DISCOVERED_PARAMS: usize = 512;
+
+/// Default ceiling on concurrently active (queued + running) scans for the MCP
+/// runtime, which — unlike the REST server's `--max-concurrent-scans` — has no
+/// config surface. Submissions past this are rejected so an agent loop can't
+/// grow the job map / blocking pool without bound.
+pub const MAX_ACTIVE_SCANS_MCP: usize = 100;
+
+/// Resolve the effective per-scan request-rate limit (requests/second) from a
+/// per-request value and an optional server-side cap.
+///
+/// - `0` means "no limit" (unlimited), matching the CLI's `--rate-limit 0`.
+/// - When the server sets a cap (`Some(c)` with `c > 0`) it is an *upper bound*
+///   on outbound RPS: a request may ask for a lower rate but cannot raise it
+///   past the cap or disable it (a requested `0` is clamped down to the cap).
+///   This lets an operator bound the load every submitted scan can put on a
+///   target, regardless of what an (authenticated) client requests.
+pub fn effective_rate_limit(requested: Option<u32>, server_cap: Option<u32>) -> u32 {
+    match (requested, server_cap.filter(|c| *c > 0)) {
+        (Some(r), Some(cap)) => {
+            if r == 0 {
+                cap
+            } else {
+                r.min(cap)
+            }
+        }
+        (Some(r), None) => r,
+        (None, Some(cap)) => cap,
+        (None, None) => 0,
+    }
+}
+
+/// Truncate a target's discovered parameter set to [`MAX_DISCOVERED_PARAMS`],
+/// returning how many were dropped (0 if already under the cap). Shared by the
+/// REST server, MCP, and both preflight paths so every async front-end bounds
+/// the per-scan fan-out identically. Callers should log when the return is > 0.
+pub fn cap_reflection_params(target: &mut Target) -> usize {
+    let n = target.reflection_params.len();
+    if n > MAX_DISCOVERED_PARAMS {
+        target.reflection_params.truncate(MAX_DISCOVERED_PARAMS);
+        n - MAX_DISCOVERED_PARAMS
+    } else {
+        0
+    }
+}
+
+/// Split an HTTP-style `Cookie` header value (`a=b; c=d`) into `(name, value)`
+/// pairs, trimming whitespace around each pair and around the `=`. Shared by the
+/// REST server and the MCP scan/preflight paths so a multi-cookie value parses
+/// identically everywhere (a single `split_once('=')` would fold `; c=d` into
+/// the first value and leave `=`-adjacent whitespace in).
+pub fn split_cookie_pairs(raw: &str) -> Vec<(String, String)> {
+    raw.split(';')
+        .filter_map(|p| p.trim().split_once('='))
+        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .collect()
+}
+
 /// Current unix time in milliseconds (UTC).
 pub fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -130,6 +130,39 @@ fn job_status_deserializes_from_lowercase_string() {
 }
 
 #[test]
+fn effective_rate_limit_resolves_request_and_cap() {
+    // No request, no cap → unlimited.
+    assert_eq!(effective_rate_limit(None, None), 0);
+    // No request, cap set → the cap applies to everyone.
+    assert_eq!(effective_rate_limit(None, Some(20)), 20);
+    // Cap explicitly 0 → still unlimited.
+    assert_eq!(effective_rate_limit(None, Some(0)), 0);
+    // Request only → used as-is (including an explicit unlimited).
+    assert_eq!(effective_rate_limit(Some(50), None), 50);
+    assert_eq!(effective_rate_limit(Some(0), None), 0);
+    // Request below the cap → request wins (a client may ask for less).
+    assert_eq!(effective_rate_limit(Some(5), Some(20)), 5);
+    // Request above the cap → clamped down to the cap.
+    assert_eq!(effective_rate_limit(Some(100), Some(20)), 20);
+    // Request tries to go unlimited while a cap is set → clamped to the cap.
+    assert_eq!(effective_rate_limit(Some(0), Some(20)), 20);
+}
+
+#[test]
+fn split_cookie_pairs_splits_and_trims_multi_cookie_value() {
+    // The bug F4 fixes: a bare split_once('=') would fold "; lang=en" into the
+    // first value and keep the surrounding whitespace.
+    let pairs = split_cookie_pairs("session = abc ; lang=en");
+    assert_eq!(
+        pairs,
+        vec![
+            ("session".to_string(), "abc".to_string()),
+            ("lang".to_string(), "en".to_string()),
+        ]
+    );
+}
+
+#[test]
 fn job_status_rejects_unknown_variant() {
     assert!(serde_json::from_str::<JobStatus>("\"finished\"").is_err());
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -150,6 +150,76 @@ where
     }
 }
 
+/// Snapshot of the per-job task-local scopes (request counter, WAF-backoff
+/// counter, rate limiter) captured from the currently-executing task.
+///
+/// The REST server and MCP runner bind these task-locals on the *parent* scan
+/// future so concurrent scans stay isolated. But `run_scanning` fans work out
+/// to per-parameter workers via `tokio::spawn`, and tokio task-locals are NOT
+/// inherited across `spawn`. Without re-binding, those workers — which send the
+/// bulk of a scan's requests — silently fall back to the process-wide globals:
+/// the per-job `requests_sent` under-counts the whole injection phase, and one
+/// scan's WAF backoff bleeds into unrelated concurrent scans. Capture the
+/// scopes in the parent task, then re-enter them inside each spawned worker via
+/// [`with_job_scopes`].
+///
+/// All three are `None` on the CLI path (it binds no per-job scope and uses the
+/// process-wide globals by design), so capture + re-enter is a no-op there.
+#[derive(Clone, Default)]
+pub struct JobScopes {
+    requests: Option<std::sync::Arc<AtomicU64>>,
+    waf: Option<std::sync::Arc<std::sync::atomic::AtomicU32>>,
+    limiter: Option<std::sync::Arc<utils::rate_limit::RateLimiter>>,
+}
+
+impl JobScopes {
+    /// Capture whatever per-job task-locals are currently bound in the calling
+    /// task. Returns all-`None` when called outside any per-job scope (the CLI).
+    pub fn capture() -> Self {
+        Self {
+            requests: REQUEST_COUNT_JOB.try_with(std::sync::Arc::clone).ok(),
+            waf: WAF_CONSECUTIVE_BLOCKS_JOB
+                .try_with(std::sync::Arc::clone)
+                .ok(),
+            limiter: RATE_LIMITER_JOB.try_with(std::sync::Arc::clone).ok(),
+        }
+    }
+
+    /// True when no per-job scope was captured (the CLI path).
+    pub fn is_empty(&self) -> bool {
+        self.requests.is_none() && self.waf.is_none() && self.limiter.is_none()
+    }
+}
+
+/// Run `fut` with the captured per-job task-local scopes re-bound, so work
+/// spawned via `tokio::spawn` writes through to the per-job counters/limiter
+/// instead of the process-wide globals. A plain `fut.await` (no boxing) when no
+/// scope was captured — the CLI path — so it adds nothing there.
+pub async fn with_job_scopes<F>(scopes: JobScopes, fut: F) -> F::Output
+where
+    F: std::future::Future + Send + 'static,
+    F::Output: 'static,
+{
+    if scopes.is_empty() {
+        return fut.await;
+    }
+    // Each present scope re-binds via `.scope()`, which yields a distinct future
+    // type, so build the (0–3 deep) chain with boxed futures. `Box<dyn Future +
+    // Send>` carries an implicit `+ 'static`, keeping the result spawn-safe.
+    let mut f: std::pin::Pin<Box<dyn std::future::Future<Output = F::Output> + Send>> =
+        Box::pin(fut);
+    if let Some(limiter) = scopes.limiter {
+        f = Box::pin(RATE_LIMITER_JOB.scope(limiter, f));
+    }
+    if let Some(waf) = scopes.waf {
+        f = Box::pin(WAF_CONSECUTIVE_BLOCKS_JOB.scope(waf, f));
+    }
+    if let Some(requests) = scopes.requests {
+        f = Box::pin(REQUEST_COUNT_JOB.scope(requests, f));
+    }
+    f.await
+}
+
 /// Acquire one permit from the active request rate limiter before sending a
 /// request. Prefers the per-job task-local limiter (bound by MCP / REST
 /// runners) and falls back to the process-wide one installed from the CLI.
@@ -216,5 +286,88 @@ pub fn reset_waf_consecutive() {
     {
         Ok(_) => {}
         Err(_) => WAF_CONSECUTIVE_BLOCKS.store(0, std::sync::atomic::Ordering::Relaxed),
+    }
+}
+
+#[cfg(test)]
+mod job_scope_tests {
+    //! Regression tests for [`JobScopes`] / [`with_job_scopes`]: the per-job
+    //! task-local scopes (`requests_sent`, WAF backoff) that `run_scanning`'s
+    //! `tokio::spawn`'d workers must re-enter. Assertions are on per-job
+    //! counters (fresh `Arc`s), never the process-wide globals, so they don't
+    //! flake under parallel test runs that also bump those globals.
+    use super::*;
+    use std::sync::Arc;
+    use std::sync::atomic::{AtomicU32, AtomicU64, Ordering};
+
+    #[tokio::test]
+    async fn with_job_scopes_rebinds_request_counter_across_spawn() {
+        let job_counter = Arc::new(AtomicU64::new(0));
+        REQUEST_COUNT_JOB
+            .scope(job_counter.clone(), async {
+                let scopes = JobScopes::capture();
+                tokio::spawn(with_job_scopes(scopes, async {
+                    tick_request_count();
+                    tick_request_count();
+                }))
+                .await
+                .unwrap();
+            })
+            .await;
+        assert_eq!(
+            job_counter.load(Ordering::Relaxed),
+            2,
+            "with_job_scopes must route spawned-worker ticks to the per-job counter"
+        );
+    }
+
+    #[tokio::test]
+    async fn bare_spawn_loses_per_job_request_scope() {
+        // Negative control: this is the F1 bug. A bare tokio::spawn does NOT
+        // inherit the task-local, so the per-job counter is never touched —
+        // which is exactly why workers need with_job_scopes.
+        let job_counter = Arc::new(AtomicU64::new(0));
+        REQUEST_COUNT_JOB
+            .scope(job_counter.clone(), async {
+                tokio::spawn(async {
+                    tick_request_count();
+                })
+                .await
+                .unwrap();
+            })
+            .await;
+        assert_eq!(
+            job_counter.load(Ordering::Relaxed),
+            0,
+            "tokio::spawn does not inherit task-locals; the per-job counter is missed without with_job_scopes"
+        );
+    }
+
+    #[tokio::test]
+    async fn with_job_scopes_rebinds_waf_counter_across_spawn() {
+        let job_waf = Arc::new(AtomicU32::new(0));
+        let observed = WAF_CONSECUTIVE_BLOCKS_JOB
+            .scope(job_waf.clone(), async {
+                let scopes = JobScopes::capture();
+                tokio::spawn(with_job_scopes(scopes, async { tick_waf_block() }))
+                    .await
+                    .unwrap()
+            })
+            .await;
+        assert_eq!(
+            observed, 1,
+            "tick_waf_block must see the per-job counter inside the re-scoped worker"
+        );
+        assert_eq!(job_waf.load(Ordering::Relaxed), 1);
+    }
+
+    #[tokio::test]
+    async fn capture_is_empty_and_passes_through_outside_any_job_scope() {
+        // The CLI path: no per-job scope bound, so capture() is empty and
+        // with_job_scopes is a transparent pass-through (no boxing).
+        let scopes = JobScopes::capture();
+        assert!(scopes.is_empty(), "no per-job scope bound should be empty");
+        let out = with_job_scopes(scopes, async { 7u8 }).await;
+        assert_eq!(out, 7);
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -362,6 +362,32 @@ mod job_scope_tests {
     }
 
     #[tokio::test]
+    async fn with_job_scopes_rebinds_rate_limiter_across_spawn() {
+        // The limiter arm: a per-job rate limiter bound via with_job_rate_limiter
+        // must be visible inside the re-scoped worker (so rate_limit_acquire
+        // throttles against the job budget), while a bare spawn loses it.
+        // Deterministic — checks scope presence, not throttling timing.
+        let (with, without) = with_job_rate_limiter(5, async {
+            let scopes = JobScopes::capture();
+            let with = tokio::spawn(with_job_scopes(scopes, async {
+                RATE_LIMITER_JOB.try_with(|_| ()).is_ok()
+            }))
+            .await
+            .unwrap();
+            let without = tokio::spawn(async { RATE_LIMITER_JOB.try_with(|_| ()).is_ok() })
+                .await
+                .unwrap();
+            (with, without)
+        })
+        .await;
+        assert!(with, "re-scoped worker must see the per-job rate limiter");
+        assert!(
+            !without,
+            "bare spawn must not inherit the rate-limiter scope"
+        );
+    }
+
+    #[tokio::test]
     async fn capture_is_empty_and_passes_through_outside_any_job_scope() {
         // The CLI path: no per-job scope bound, so capture() is empty and
         // with_job_scopes is a transparent pass-through (no boxing).

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -41,9 +41,10 @@ use rmcp::{
 use crate::{
     cmd::scan::ScanArgs,
     job::{
-        AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-        MAX_WORKERS, has_http_scheme, now_ms, parse_job_status,
-        purge_expired_jobs as purge_jobs_map, send_reachability_probe, unreachable_error_message,
+        AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_ACTIVE_SCANS_MCP, MAX_DELAY_MS,
+        MAX_DISCOVERED_PARAMS, MAX_TIMEOUT_SECS, MAX_WORKERS, cap_reflection_params,
+        has_http_scheme, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
+        send_reachability_probe, split_cookie_pairs, unreachable_error_message,
     },
     parameter_analysis::analyze_parameters,
     scanning::result::{Result as ScanResult, SanitizedResult},
@@ -275,17 +276,19 @@ impl DalfoxMcp {
                 t.ignore_return = scan_args.ignore_return.clone();
                 t.workers = scan_args.workers;
                 t.user_agent = scan_args.user_agent.clone();
+                // Parse via the shared helpers so MCP matches the REST server:
+                // empty header names are rejected, and each cookie entry is
+                // `;`-split + trimmed (a bare split_once would keep whitespace
+                // and fold `a=b; c=d` into one value).
                 t.headers = scan_args
                     .headers
                     .iter()
-                    .filter_map(|h| h.split_once(':'))
-                    .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+                    .filter_map(|h| crate::utils::http::parse_header_line(h))
                     .collect();
                 t.cookies = scan_args
                     .cookies
                     .iter()
-                    .filter_map(|c| c.split_once('='))
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .flat_map(|c| split_cookie_pairs(c))
                     .collect();
                 t.data = scan_args.data.clone();
                 t
@@ -346,6 +349,9 @@ impl DalfoxMcp {
             }
         }));
 
+        // Captured from inside the scoped/async blocks below so the worker-panic
+        // count survives past the scan; assigned by the run_scanning call.
+        let mut scan_report = crate::scanning::ScanRunReport::default();
         crate::with_job_rate_limiter(
             scan_args.rate_limit,
             crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
@@ -397,13 +403,27 @@ impl DalfoxMcp {
                         // Parameter discovery / mining
                         analyze_parameters(&mut target, scan_args.as_ref(), None).await;
 
+                        // Bound the per-scan fan-out: a sprawling/hostile target
+                        // can expose thousands of params, and scanning spawns
+                        // O(params × payloads) workers. Truncate past the cap.
+                        let dropped = cap_reflection_params(&mut target);
+                        if dropped > 0 {
+                            Self::log(
+                                "WRN",
+                                &format!(
+                                    "scan_id={} discovered params capped to {} (dropped {})",
+                                    scan_id, MAX_DISCOVERED_PARAMS, dropped
+                                ),
+                            );
+                        }
+
                         // Record discovered param count
                         progress.params_total.store(
                             target.reflection_params.len() as u32,
                             std::sync::atomic::Ordering::Relaxed,
                         );
 
-                        crate::scanning::run_scanning(
+                        scan_report = crate::scanning::run_scanning(
                             &target,
                             scan_args.clone(),
                             results_arc.clone(),
@@ -458,14 +478,29 @@ impl DalfoxMcp {
                 .collect::<Vec<_>>()
         };
 
+        // A worker-task panic means a parameter's findings are incomplete;
+        // surface it as `error` (partial results still attached) so a poller
+        // can't mistake a crashed scan for a clean finish. Cancellation wins.
+        let panicked = !was_cancelled && scan_report.worker_panics > 0;
         {
             let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
             if let Some(j) = jobs.get_mut(&scan_id) {
                 // Store partial or complete results
                 j.results = Some(Arc::new(sanitized));
-                // Only update status if not already cancelled (cancel sets status immediately)
+                // Only update status if not already cancelled (cancel sets it
+                // immediately). Map a worker panic to Error, otherwise Done.
                 if j.status != JobStatus::Cancelled {
-                    j.status = JobStatus::Done;
+                    j.status = if panicked {
+                        JobStatus::Error
+                    } else {
+                        JobStatus::Done
+                    };
+                }
+                if panicked && j.error_message.is_none() {
+                    j.error_message = Some(format!(
+                        "{} scan worker task(s) panicked; results are partial",
+                        scan_report.worker_panics
+                    ));
                 }
                 // finished_at_ms may already be set by cancel_scan_dalfox; preserve it
                 // so we record the moment the user asked to stop, not when the task noticed.
@@ -477,6 +512,8 @@ impl DalfoxMcp {
 
         let status_label = if was_cancelled {
             "cancelled"
+        } else if panicked {
+            "error"
         } else {
             "finished"
         };
@@ -593,6 +630,12 @@ pub struct ScanWithDalfoxParams {
     #[serde(default = "default_workers")]
     #[schemars(range(min = 1, max = 500))]
     pub workers: usize,
+
+    /// Cap the scan's outbound request rate (requests/second). 0 = unlimited
+    /// (the default). Use this to be gentle on a fragile target or to stay
+    /// under a WAF's threshold. Now enforced across all worker tasks.
+    #[serde(default)]
+    pub rate_limit: u32,
 }
 
 fn default_method() -> String {
@@ -745,6 +788,7 @@ Final results (via get_results_dalfox) include finding type \
             detect_outdated_libs,
             blind_callback_url,
             workers,
+            rate_limit,
         } = params;
 
         let target = target.trim().to_string();
@@ -797,8 +841,22 @@ Final results (via get_results_dalfox) include finding type \
         // its entry is replaced, so its poller starts seeing a different
         // scan's results). Regenerating on collision makes the guarantee
         // explicit and cheap.
+        // Enforce a concurrency cap and reserve the scan_id under one lock.
+        // MCP has no config surface, so the bound is a constant; submissions
+        // past it are rejected so an agent loop can't grow the job map /
+        // blocking pool without bound.
         let scan_id = {
             let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let active = jobs.values().filter(|j| !j.is_terminal()).count();
+            if active >= MAX_ACTIVE_SCANS_MCP {
+                return Err(ErrorData::invalid_params(
+                    format!(
+                        "at capacity: {} scans already active (max {}); wait for some to finish or cancel/delete them",
+                        active, MAX_ACTIVE_SCANS_MCP
+                    ),
+                    None,
+                ));
+            }
             let id = crate::utils::make_unique_scan_id(&target, |id| jobs.contains_key(id));
             jobs.insert(id.clone(), Job::new_queued(target.clone()));
             id
@@ -873,7 +931,9 @@ Final results (via get_results_dalfox) include finding type \
             limit: None,
             limit_result_type: "all".to_string(),
             only_poc: vec![],
-            no_color: false,
+            // Match the REST server: scan output is silenced and serialized as
+            // JSON, so strip ANSI from any diagnostic the pipeline emits.
+            no_color: true,
             workers,
             max_concurrent_targets: 50,
             max_targets_per_host: 100,
@@ -898,10 +958,14 @@ Final results (via get_results_dalfox) include finding type \
             skip_waf_probe: false,
             force_waf: None,
             waf_evasion: false,
-            rate_limit: 0,
+            // Per-call request-rate cap, now honored across all worker tasks
+            // (see crate::with_job_scopes). 0 = unlimited.
+            rate_limit,
             retries: 0,
             retry_delay: 1000,
-            waf_min_confidence: 0.0,
+            // Match the server/CLI default so MCP doesn't surface low-confidence
+            // WAF fingerprints the other front-ends filter out (was 0.0).
+            waf_min_confidence: crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE,
             remote_payloads: vec![],
             remote_wordlists: vec![],
         });
@@ -1034,10 +1098,12 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
                 if let Some(ref err_msg) = snap.error_message {
                     out["error_message"] = serde_json::json!(err_msg);
                 }
-                // Include progress info when scan is running, done, or cancelled
+                // Include progress for running/terminal jobs — Error too, so an
+                // early infra failure still exposes any params/requests counted
+                // before it failed instead of an opaque error_message alone.
                 if matches!(
                     snap.status,
-                    JobStatus::Running | JobStatus::Done | JobStatus::Cancelled
+                    JobStatus::Running | JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
                 ) {
                     let params_total = snap
                         .progress
@@ -1057,36 +1123,40 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
                         .load(std::sync::atomic::Ordering::Relaxed);
 
                     // Estimate completion percentage from params tested vs total
-                    let estimated_completion_pct: u32 =
-                        if matches!(snap.status, JobStatus::Done | JobStatus::Cancelled) {
-                            if snap.status == JobStatus::Done {
-                                100
-                            } else if params_total > 0 {
-                                ((params_tested as f64 / params_total as f64) * 100.0) as u32
-                            } else {
-                                0
-                            }
+                    let estimated_completion_pct: u32 = if matches!(
+                        snap.status,
+                        JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
+                    ) {
+                        if snap.status == JobStatus::Done {
+                            100
                         } else if params_total > 0 {
-                            ((params_tested as f64 / params_total as f64) * 100.0).min(99.0) as u32
+                            ((params_tested as f64 / params_total as f64) * 100.0) as u32
                         } else {
                             0
-                        };
+                        }
+                    } else if params_total > 0 {
+                        ((params_tested as f64 / params_total as f64) * 100.0).min(99.0) as u32
+                    } else {
+                        0
+                    };
 
                     // Suggest poll interval based on progress:
                     // - queued/early: poll every 2s
                     // - mid-scan: poll every 3s
                     // - near completion (>80%): poll every 1s
                     // - done/cancelled: no more polling needed
-                    let suggested_poll_interval_ms: u64 =
-                        if matches!(snap.status, JobStatus::Done | JobStatus::Cancelled) {
-                            0
-                        } else if estimated_completion_pct > 80 {
-                            1000
-                        } else if estimated_completion_pct > 10 {
-                            3000
-                        } else {
-                            2000
-                        };
+                    let suggested_poll_interval_ms: u64 = if matches!(
+                        snap.status,
+                        JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
+                    ) {
+                        0
+                    } else if estimated_completion_pct > 80 {
+                        1000
+                    } else if estimated_completion_pct > 10 {
+                        3000
+                    } else {
+                        2000
+                    };
 
                     out["progress"] = serde_json::json!({
                         "params_total": params_total,
@@ -1214,17 +1284,17 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                 t.proxy = params.proxy.clone();
                 t.follow_redirects = params.follow_redirects;
                 t.user_agent = params.user_agent.clone();
+                // Shared parsers: reject empty header names and `;`-split +
+                // trim each cookie, matching the scan path and the REST server.
                 t.headers = params
                     .headers
                     .iter()
-                    .filter_map(|h| h.split_once(":"))
-                    .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+                    .filter_map(|h| crate::utils::http::parse_header_line(h))
                     .collect();
                 t.cookies = params
                     .cookies
                     .iter()
-                    .filter_map(|c| c.split_once('='))
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .flat_map(|c| split_cookie_pairs(c))
                     .collect();
                 t.data = params.data.clone();
                 t
@@ -1237,10 +1307,13 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             }
         };
 
-        // Build minimal ScanArgs for parameter analysis only
+        // Build minimal ScanArgs for parameter analysis only.
+        // `param: vec![]` so preflight reports the FULL discovered set (impact
+        // estimate), matching the REST server's /preflight — passing the
+        // client's `param` filter here would under-report discovery.
         let scan_args = ScanArgs::for_preflight(crate::cmd::scan::PreflightOptions {
             target: target_url.clone(),
-            param: params.param.clone(),
+            param: vec![],
             method: params.method.clone(),
             data: params.data.clone(),
             headers: params.headers.clone(),
@@ -1283,6 +1356,9 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                     }
 
                     analyze_parameters(&mut target, &scan_args, None).await;
+                    // Apply the same per-scan parameter cap a real scan would,
+                    // so the estimate reflects what scanning actually fans out to.
+                    cap_reflection_params(&mut target);
 
                     // Estimate request count (encoder expansion factor)
                     let enc_factor = if scan_args.encoders.iter().any(|e| e == "none") {

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -695,7 +695,10 @@ pub struct PreflightDalfoxParams {
     /// Target URL to analyze. Must start with http:// or https://.
     pub target: String,
 
-    /// Specific parameters to test. Supports location hints via "name:location" syntax.
+    /// Accepted for symmetry with scan_with_dalfox but NOT used by preflight:
+    /// preflight always reports the full auto-discovered parameter set (the
+    /// impact estimate), matching the REST `/preflight` endpoint. Pass the
+    /// filter to scan_with_dalfox when you actually run the scan.
     #[serde(default)]
     pub param: Vec<String>,
 

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -47,6 +47,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
         detect_outdated_libs: false,
         blind_callback_url: None,
         workers: 1,
+        rate_limit: 0,
     }
 }
 
@@ -977,6 +978,22 @@ async fn test_scan_with_dalfox_accepts_workers_at_max() {
     mcp.scan_with_dalfox(Parameters(params))
         .await
         .expect("workers == MAX_WORKERS must be accepted");
+}
+
+#[tokio::test]
+async fn test_scan_with_dalfox_accepts_rate_limit() {
+    // F2: a per-call rate_limit is accepted and the scan queues normally.
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        rate_limit: 5,
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+    let resp = mcp
+        .scan_with_dalfox(Parameters(params))
+        .await
+        .expect("scan with rate_limit must queue");
+    let payload = parse_result_json(&resp);
+    assert_eq!(payload["status"], "queued");
 }
 
 #[tokio::test]

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1746,6 +1746,18 @@ impl ScanWorkerCtx {
     }
 }
 
+/// Outcome of a `run_scanning` call. Currently carries only the number of
+/// per-parameter worker tasks that panicked. The CLI ignores it (it returns it
+/// as a statement value); the REST server and MCP runners inspect
+/// `worker_panics` so a scan that lost workers to a panic can be surfaced as a
+/// partial/failed result instead of being silently reported `done` — a worker
+/// panic means the param's findings are incomplete, indistinguishable from
+/// "scanned, found nothing" otherwise.
+#[derive(Debug, Default, Clone, Copy)]
+pub struct ScanRunReport {
+    pub worker_panics: usize,
+}
+
 #[allow(clippy::too_many_arguments)]
 pub async fn run_scanning(
     target: &Target,
@@ -1762,10 +1774,10 @@ pub async fn run_scanning(
     // until the very end. `None` for the CLI, which renders its own
     // indicatif progress bar from `total_tasks` instead.
     params_done: Option<Arc<AtomicU32>>,
-) {
+) -> ScanRunReport {
     // Short-circuit scanning when skip_xss_scanning is enabled (e.g., in unit tests)
     if args.skip_xss_scanning {
-        return;
+        return ScanRunReport::default();
     }
     let arc_target = Arc::new(target.clone());
     let shared_client = Arc::new(arc_target.build_client_or_default());
@@ -1810,6 +1822,14 @@ pub async fn run_scanning(
 
     // === Stage 5 & 6: spawn one worker per parameter (Reflection + DOM) ===
     let mut handles = vec![];
+    // Capture the per-job task-local scopes (request counter, WAF backoff, rate
+    // limiter) bound by the REST/MCP runners. `tokio::spawn` does NOT inherit
+    // task-locals, so each worker re-enters them via `with_job_scopes`;
+    // otherwise the injection-phase requests (the bulk of the scan) would bump
+    // only the process-wide globals — under-counting per-job `requests_sent`
+    // and leaking one scan's WAF backoff into unrelated concurrent scans. No-op
+    // on the CLI, which binds no per-job scope.
+    let job_scopes = crate::JobScopes::capture();
     for (param_clone, reflection_payloads, dom_payloads) in param_jobs {
         // Check cancellation before spawning next param task
         if ctx.cancelled() {
@@ -1846,11 +1866,14 @@ pub async fn run_scanning(
                     format!("Completed scanning {}", target.url),
                 );
             }
-            return;
+            return ScanRunReport::default();
         }
 
         let ctx = ctx.clone();
-        let handle = tokio::spawn(async move {
+        // Re-enter the per-job scopes inside the spawned worker so the requests
+        // it sends are tallied and rate-limited against THIS job, not the
+        // process-wide globals (see `JobScopes`). Cheap no-op on the CLI.
+        let handle = tokio::spawn(crate::with_job_scopes(job_scopes.clone(), async move {
             ctx.scan_param(param_clone, reflection_payloads, dom_payloads)
                 .await;
             // Bump the live completion counter after this parameter is fully
@@ -1860,12 +1883,20 @@ pub async fn run_scanning(
             if let Some(done) = &ctx.params_done {
                 done.fetch_add(1, Ordering::Relaxed);
             }
-        });
+        }));
         handles.push(handle);
     }
 
+    let mut worker_panics = 0usize;
     for handle in handles {
         if let Err(e) = handle.await {
+            // A JoinError from a worker is almost always a panic inside
+            // scan_param (a scanning-pipeline bug). Count it so the caller can
+            // mark the scan as partial/failed instead of reporting a clean
+            // `done`; the param's findings are incomplete either way.
+            if e.is_panic() {
+                worker_panics += 1;
+            }
             eprintln!("[!] scanning task failed: {e}");
         }
     }
@@ -1884,6 +1915,8 @@ pub async fn run_scanning(
             format!("Completed scanning {}", target.url),
         );
     }
+
+    ScanRunReport { worker_panics }
 }
 
 /// Drop Reflected findings on the *current target* that are already covered

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -305,13 +305,9 @@ pub(crate) async fn get_scan_handler(
     let cookie = params.get("cookie").cloned();
     // A present-but-unparseable numeric query param is a 400, not a silent
     // fallback to the default (which is what `.parse().ok()` used to do).
-    let (worker, delay, timeout, rate_limit, scan_timeout): (
-        Option<usize>,
-        Option<u64>,
-        Option<u64>,
-        Option<u32>,
-        Option<u64>,
-    ) = match (
+    // Types infer from the `parse_num_query` turbofishes — worker:usize,
+    // delay/timeout/scan_timeout:u64, rate_limit:u32, each wrapped in Option.
+    let (worker, delay, timeout, rate_limit, scan_timeout) = match (
         parse_num_query::<usize>(&params, "worker"),
         parse_num_query::<u64>(&params, "delay"),
         parse_num_query::<u64>(&params, "timeout"),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -78,26 +78,20 @@ pub(crate) async fn start_scan_handler(
 
     // Reserve a unique scan_id and insert the queued job under one lock so a
     // same-target resubmission in the same nanosecond can't clobber an
-    // in-flight job (see make_scan_id's nonce). Regenerate on collision.
-    let id = {
-        let mut jobs = state.jobs.lock().await;
-        let id = crate::utils::make_unique_scan_id(&url, |id| jobs.contains_key(id));
-        jobs.insert(
-            id.clone(),
-            Job {
-                status: JobStatus::Queued,
-                results: None,
-                callback_url: callback_url.clone(),
-                progress: JobProgress::default(),
-                cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                error_message: None,
-                target_url: url.clone(),
-                queued_at_ms: now_ms(),
-                started_at_ms: None,
-                finished_at_ms: None,
-            },
-        );
-        id
+    // in-flight job (see make_scan_id's nonce), and so the concurrency cap is
+    // checked race-free against the live job count. 503 when at capacity.
+    let id = match try_admit_and_queue(&state, &url, callback_url).await {
+        Some(id) => id,
+        None => {
+            let resp = at_capacity_response(&state);
+            return make_api_response(
+                &state,
+                &headers,
+                &params,
+                StatusCode::SERVICE_UNAVAILABLE,
+                &resp,
+            );
+        }
     };
     log(&state, "JOB", &format!("queued id={} url={}", id, url));
 
@@ -143,9 +137,12 @@ pub(crate) async fn get_result_handler(
 
     match job {
         Some(j) => {
+            // Include Error so an early infra failure (parse/reachability/panic)
+            // still exposes params_total / requests_sent gathered before it
+            // failed, instead of an opaque error_message with no progress.
             let progress_data = if matches!(
                 j.status,
-                JobStatus::Running | JobStatus::Done | JobStatus::Cancelled
+                JobStatus::Running | JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
             ) {
                 let params_total = j
                     .progress
@@ -155,30 +152,34 @@ pub(crate) async fn get_result_handler(
                     .progress
                     .params_tested
                     .load(std::sync::atomic::Ordering::Relaxed);
-                let estimated_completion_pct =
-                    if matches!(j.status, JobStatus::Done | JobStatus::Cancelled) {
-                        if j.status == JobStatus::Done {
-                            100
-                        } else if params_total > 0 {
-                            ((params_tested as f64 / params_total as f64) * 100.0) as u32
-                        } else {
-                            0
-                        }
+                let estimated_completion_pct = if matches!(
+                    j.status,
+                    JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
+                ) {
+                    if j.status == JobStatus::Done {
+                        100
                     } else if params_total > 0 {
-                        ((params_tested as f64 / params_total as f64) * 100.0).min(99.0) as u32
+                        ((params_tested as f64 / params_total as f64) * 100.0) as u32
                     } else {
                         0
-                    };
-                let suggested_poll_interval_ms: u64 =
-                    if matches!(j.status, JobStatus::Done | JobStatus::Cancelled) {
-                        0
-                    } else if estimated_completion_pct > 80 {
-                        1000
-                    } else if estimated_completion_pct > 10 {
-                        3000
-                    } else {
-                        2000
-                    };
+                    }
+                } else if params_total > 0 {
+                    ((params_tested as f64 / params_total as f64) * 100.0).min(99.0) as u32
+                } else {
+                    0
+                };
+                let suggested_poll_interval_ms: u64 = if matches!(
+                    j.status,
+                    JobStatus::Done | JobStatus::Cancelled | JobStatus::Error
+                ) {
+                    0
+                } else if estimated_completion_pct > 80 {
+                    1000
+                } else if estimated_completion_pct > 10 {
+                    3000
+                } else {
+                    2000
+                };
                 Some(ProgressPayload {
                     params_total,
                     params_tested,
@@ -304,13 +305,19 @@ pub(crate) async fn get_scan_handler(
     let cookie = params.get("cookie").cloned();
     // A present-but-unparseable numeric query param is a 400, not a silent
     // fallback to the default (which is what `.parse().ok()` used to do).
-    let (worker, delay, timeout): (Option<usize>, Option<u64>, Option<u64>) = match (
+    let (worker, delay, timeout, rate_limit): (
+        Option<usize>,
+        Option<u64>,
+        Option<u64>,
+        Option<u32>,
+    ) = match (
         parse_num_query::<usize>(&params, "worker"),
         parse_num_query::<u64>(&params, "delay"),
         parse_num_query::<u64>(&params, "timeout"),
+        parse_num_query::<u32>(&params, "rate_limit"),
     ) {
-        (Ok(w), Ok(d), Ok(t)) => (w, d, t),
-        (Err(msg), ..) | (_, Err(msg), _) | (.., Err(msg)) => {
+        (Ok(w), Ok(d), Ok(t), Ok(rl)) => (w, d, t, rl),
+        (Err(msg), ..) | (_, Err(msg), ..) | (_, _, Err(msg), _) | (.., Err(msg)) => {
             let resp = ApiResponse::<serde_json::Value> {
                 code: 400,
                 msg,
@@ -326,8 +333,9 @@ pub(crate) async fn get_scan_handler(
         .unwrap_or_else(|| "GET".to_string());
     let data_opt = params.get("data").cloned();
     let user_agent = params.get("user_agent").cloned();
-    let include_request = params.get("include_request").is_some_and(|s| s == "true");
-    let include_response = params.get("include_response").is_some_and(|s| s == "true");
+    // Lenient boolean parse (1/true/yes/on) shared with DELETE; see parse_bool_query.
+    let include_request = parse_bool_query(&params, "include_request");
+    let include_response = parse_bool_query(&params, "include_response");
 
     let param_list: Option<Vec<String>> = params.get("param").map(|s| {
         s.split(',')
@@ -336,14 +344,12 @@ pub(crate) async fn get_scan_handler(
             .collect()
     });
     let proxy = params.get("proxy").cloned();
-    let follow_redirects = params.get("follow_redirects").is_some_and(|s| s == "true");
-    let skip_mining = params.get("skip_mining").is_some_and(|s| s == "true");
-    let skip_discovery = params.get("skip_discovery").is_some_and(|s| s == "true");
-    let deep_scan = params.get("deep_scan").is_some_and(|s| s == "true");
-    let skip_ast_analysis = params.get("skip_ast_analysis").is_some_and(|s| s == "true");
-    let detect_outdated_libs = params
-        .get("detect_outdated_libs")
-        .is_some_and(|s| s == "true");
+    let follow_redirects = parse_bool_query(&params, "follow_redirects");
+    let skip_mining = parse_bool_query(&params, "skip_mining");
+    let skip_discovery = parse_bool_query(&params, "skip_discovery");
+    let deep_scan = parse_bool_query(&params, "deep_scan");
+    let skip_ast_analysis = parse_bool_query(&params, "skip_ast_analysis");
+    let detect_outdated_libs = parse_bool_query(&params, "detect_outdated_libs");
 
     let opts = ScanOptions {
         cookie,
@@ -379,6 +385,7 @@ pub(crate) async fn get_scan_handler(
         deep_scan: Some(deep_scan),
         skip_ast_analysis: Some(skip_ast_analysis),
         detect_outdated_libs: Some(detect_outdated_libs),
+        rate_limit,
     };
 
     if let Err(msg) = validate_scan_options(&opts) {
@@ -391,26 +398,20 @@ pub(crate) async fn get_scan_handler(
     }
 
     let callback_url = opts.callback_url.clone();
-    // Reserve a unique scan_id under one lock (see POST /scan).
-    let id = {
-        let mut jobs = state.jobs.lock().await;
-        let id = crate::utils::make_unique_scan_id(&url, |id| jobs.contains_key(id));
-        jobs.insert(
-            id.clone(),
-            Job {
-                status: JobStatus::Queued,
-                results: None,
-                callback_url,
-                progress: JobProgress::default(),
-                cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-                error_message: None,
-                target_url: url.clone(),
-                queued_at_ms: now_ms(),
-                started_at_ms: None,
-                finished_at_ms: None,
-            },
-        );
-        id
+    // Reserve a unique scan_id and enforce the concurrency cap under one lock
+    // (see POST /scan). 503 when at capacity.
+    let id = match try_admit_and_queue(&state, &url, callback_url).await {
+        Some(id) => id,
+        None => {
+            let resp = at_capacity_response(&state);
+            return make_api_response(
+                &state,
+                &headers,
+                &params,
+                StatusCode::SERVICE_UNAVAILABLE,
+                &resp,
+            );
+        }
     };
     log(&state, "JOB", &format!("queued id={} url={}", id, url));
 
@@ -495,9 +496,7 @@ pub(crate) async fn cancel_scan_handler(
     // When ?purge=1, delete the job from memory instead of (or in addition to)
     // cancelling it. Only allowed when the job is already terminal — callers
     // must first cancel a running scan and wait for it to settle.
-    let purge_requested = params
-        .get("purge")
-        .is_some_and(|v| v == "1" || v.eq_ignore_ascii_case("true"));
+    let purge_requested = parse_bool_query(&params, "purge");
 
     let mut jobs = state.jobs.lock().await;
     match jobs.get_mut(&id) {
@@ -625,14 +624,23 @@ pub(crate) async fn list_scans_handler(
     };
 
     // Optional pagination. offset defaults to 0, limit == 0 means return all.
-    let offset: usize = params
-        .get("offset")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
-    let limit: usize = params
-        .get("limit")
-        .and_then(|s| s.parse().ok())
-        .unwrap_or(0);
+    // A present-but-unparseable value is a 400, not a silent fallback — matching
+    // GET /scan's strict numeric handling (parse_num_query) rather than the old
+    // `.parse().ok()` that turned `?limit=abc` into "return everything".
+    let (offset, limit): (usize, usize) = match (
+        parse_num_query::<usize>(&params, "offset"),
+        parse_num_query::<usize>(&params, "limit"),
+    ) {
+        (Ok(o), Ok(l)) => (o.unwrap_or(0), l.unwrap_or(0)),
+        (Err(msg), _) | (_, Err(msg)) => {
+            let resp = ApiResponse::<serde_json::Value> {
+                code: 400,
+                msg,
+                data: None,
+            };
+            return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
+        }
+    };
 
     let jobs = state.jobs.lock().await;
 
@@ -803,6 +811,9 @@ pub(crate) async fn preflight_handler(
                 });
 
                 analyze_parameters(&mut target, &scan_args, None).await;
+                // Apply the same per-scan parameter cap a real scan would, so
+                // the estimate reflects what scanning actually fans out to.
+                cap_reflection_params(&mut target);
 
                 let enc_factor = {
                     let encs = &scan_args.encoders;

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -317,7 +317,10 @@ pub(crate) async fn run_scan_job(
         skip_waf_probe: false,
         force_waf: None,
         waf_evasion: false,
-        rate_limit: 0,
+        // Per-scan outbound request rate (RPS), capped by the server-wide
+        // `--rate-limit`. Honored in `run_scanning`'s workers now that they
+        // re-enter the per-job rate-limiter scope (see crate::with_job_scopes).
+        rate_limit: effective_rate_limit(opts.rate_limit, state.rate_limit),
         retries: 0,
         retry_delay: 1000,
         waf_min_confidence: crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE,
@@ -432,6 +435,9 @@ pub(crate) async fn run_scan_job(
         }
     }));
 
+    // Captured from inside the scoped/async blocks below so worker-panic count
+    // survives past the scan; assigned by the run_scanning call.
+    let mut scan_report = crate::scanning::ScanRunReport::default();
     crate::with_job_rate_limiter(
         args.rate_limit,
         crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
@@ -478,12 +484,27 @@ pub(crate) async fn run_scan_job(
                     silent_args.silence = true;
                     analyze_parameters(&mut target, &silent_args, None).await;
 
+                    // Bound the per-scan fan-out: a sprawling/hostile target can
+                    // expose thousands of params, and scanning spawns O(params ×
+                    // payloads) workers. Truncate with a warning past the cap.
+                    let dropped = cap_reflection_params(&mut target);
+                    if dropped > 0 {
+                        log(
+                            &state,
+                            "WRN",
+                            &format!(
+                                "id={} discovered params capped to {} (dropped {})",
+                                job_id, MAX_DISCOVERED_PARAMS, dropped
+                            ),
+                        );
+                    }
+
                     progress.params_total.store(
                         target.reflection_params.len() as u32,
                         std::sync::atomic::Ordering::Relaxed,
                     );
 
-                    crate::scanning::run_scanning(
+                    scan_report = crate::scanning::run_scanning(
                         &target,
                         Arc::new(args.clone()),
                         results.clone(),
@@ -533,6 +554,11 @@ pub(crate) async fn run_scan_job(
             .collect::<Vec<_>>()
     };
 
+    // A worker-task panic means at least one parameter's findings are
+    // incomplete. Surface that as `error` (with the partial results still
+    // attached) so a poller can't mistake a crashed scan for a clean `done`.
+    // Cancellation takes precedence (it's already a partial-by-design state).
+    let panicked = !was_cancelled && scan_report.worker_panics > 0;
     let final_results_arc = Arc::new(final_results);
     let callback_url = {
         let mut jobs = state.jobs.lock().await;
@@ -542,9 +568,17 @@ pub(crate) async fn run_scan_job(
             if job.status != JobStatus::Cancelled {
                 job.status = if was_cancelled {
                     JobStatus::Cancelled
+                } else if panicked {
+                    JobStatus::Error
                 } else {
                     JobStatus::Done
                 };
+            }
+            if panicked && job.error_message.is_none() {
+                job.error_message = Some(format!(
+                    "{} scan worker task(s) panicked; results are partial",
+                    scan_report.worker_panics
+                ));
             }
             // Preserve an earlier finished_at_ms set by cancel_scan_handler
             // (which records when the user asked to stop, not when the task noticed).
@@ -556,7 +590,13 @@ pub(crate) async fn run_scan_job(
             None
         }
     };
-    let status_label = if was_cancelled { "cancelled" } else { "done" };
+    let status_label = if was_cancelled {
+        "cancelled"
+    } else if panicked {
+        "error"
+    } else {
+        "done"
+    };
     log(
         &state,
         "JOB",
@@ -645,13 +685,14 @@ pub(crate) fn hydrate_preflight_target(
     t.user_agent = opts.user_agent.clone();
     t.proxy = opts.proxy.clone();
     t.follow_redirects = opts.follow_redirects.unwrap_or(false);
+    // Parse via the shared helper so preflight rejects empty header names the
+    // same way the scan path does (a bare `:value` is dropped, not forwarded).
     t.headers = opts
         .header
         .as_ref()
         .map(|h| {
             h.iter()
-                .filter_map(|s| s.split_once(":"))
-                .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+                .filter_map(|s| crate::utils::http::parse_header_line(s))
                 .collect()
         })
         .unwrap_or_default();

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,9 +35,11 @@ pub(crate) use serde::{Deserialize, Serialize};
 
 pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
-    AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_TIMEOUT_SECS,
-    MAX_WORKERS, has_http_scheme, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
-    send_reachability_probe, unreachable_error_message,
+    AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS,
+    MAX_DISCOVERED_PARAMS, MAX_TIMEOUT_SECS, MAX_WORKERS, cap_reflection_params,
+    effective_rate_limit, has_http_scheme, now_ms, parse_job_status,
+    purge_expired_jobs as purge_jobs_map, send_reachability_probe, split_cookie_pairs,
+    unreachable_error_message,
 };
 pub(crate) use crate::parameter_analysis::analyze_parameters;
 pub(crate) use crate::scanning::result::{Result as ScanResult, SanitizedResult};
@@ -137,6 +139,8 @@ pub async fn run_server(args: ServerArgs) {
         allow_headers,
         jsonp_enabled: args.jsonp,
         callback_param_name: args.callback_param_name.clone(),
+        rate_limit: args.rate_limit,
+        max_concurrent_scans: args.max_concurrent_scans,
     };
 
     let app = Router::new()
@@ -154,6 +158,10 @@ pub async fn run_server(args: ServerArgs) {
         .route("/scan/{id}", options(options_result_handler))
         .route("/health", get(health_handler))
         .route("/health", options(options_scan_handler))
+        // Explicit request-body cap for every route. Replaces axum's implicit
+        // 2 MiB default so the bound is documented and operator-tunable; a
+        // body over the limit is rejected with 413 before handler code runs.
+        .layer(axum::extract::DefaultBodyLimit::max(args.max_body_bytes))
         .with_state(state.clone());
 
     log(

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2340,6 +2340,42 @@ async fn test_list_scans_rejects_unparseable_limit() {
     assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
 }
 
+#[tokio::test]
+async fn test_get_result_exposes_progress_for_error_jobs() {
+    // F10: an Error job still surfaces its progress block (params discovered
+    // before the failure) plus error_message, with a terminal poll interval of
+    // 0 — not an opaque error with no progress.
+    let state = make_state(None, None, false, false, "cb");
+    {
+        let mut jobs = state.jobs.lock().await;
+        let mut job = test_job(JobStatus::Error, None, "http://x/");
+        job.error_message = Some("boom".to_string());
+        job.progress
+            .params_total
+            .store(4, std::sync::atomic::Ordering::Relaxed);
+        job.progress
+            .params_tested
+            .store(1, std::sync::atomic::Ordering::Relaxed);
+        jobs.insert("errored".to_string(), job);
+    }
+    let resp = get_result_handler(
+        State(state.clone()),
+        HeaderMap::new(),
+        Path("errored".to_string()),
+        Query(Map::new()),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body_string(resp).await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json");
+    assert_eq!(parsed["data"]["status"], "error");
+    assert_eq!(parsed["data"]["error_message"], "boom");
+    assert_eq!(parsed["data"]["progress"]["params_total"], 4);
+    assert_eq!(parsed["data"]["progress"]["params_tested"], 1);
+    assert_eq!(parsed["data"]["progress"]["suggested_poll_interval_ms"], 0);
+}
+
 #[test]
 fn test_parse_bool_query_accepts_common_truthy_forms() {
     // F13: 1/true/yes/on (any case, trimmed) are truthy; everything else false.

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -28,6 +28,9 @@ fn make_state(
         allow_headers: "Content-Type,X-API-KEY,Authorization".to_string(),
         jsonp_enabled: jsonp,
         callback_param_name: cb_name.to_string(),
+        rate_limit: None,
+        // 0 = unlimited so existing tests aren't rejected by the concurrency cap.
+        max_concurrent_scans: 0,
     }
 }
 
@@ -1028,6 +1031,7 @@ async fn test_run_scan_job_success_marks_done() {
         skip_ast_analysis: None,
         // Exercise the ON path: opts -> job_runner -> ScanArgs -> analysis gate.
         detect_outdated_libs: Some(true),
+        rate_limit: None,
     };
 
     let run = tokio::time::timeout(
@@ -1298,6 +1302,9 @@ async fn test_run_server_returns_on_invalid_bind_address() {
         host: "not a valid host".to_string(),
         api_key: None,
         log_file: None,
+        rate_limit: None,
+        max_concurrent_scans: 100,
+        max_body_bytes: 1_048_576,
         allowed_origins: None,
         jsonp: false,
         callback_param_name: "callback".to_string(),
@@ -1319,6 +1326,9 @@ async fn test_run_server_returns_on_bind_failure_after_state_build() {
         host: Ipv4Addr::LOCALHOST.to_string(),
         api_key: Some("server-key".to_string()),
         log_file: None,
+        rate_limit: None,
+        max_concurrent_scans: 100,
+        max_body_bytes: 1_048_576,
         allowed_origins: Some(
             "*,regex:^https://.*\\.example\\.com$,https://*.corp.local".to_string(),
         ),
@@ -2270,4 +2280,78 @@ async fn test_cancel_scan_handler_purge_deletes_terminal_job() {
 
     let jobs = state.jobs.lock().await;
     assert!(!jobs.contains_key("done-purge"));
+}
+
+#[tokio::test]
+async fn test_start_scan_handler_503_when_at_capacity() {
+    // F3: with max_concurrent_scans=1 and one active (Running) job, a new
+    // submission is rejected with 503 and no job is queued.
+    let mut state = make_state(None, None, false, false, "callback");
+    state.max_concurrent_scans = 1;
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(
+            "active-1".to_string(),
+            test_job(JobStatus::Running, None, "http://busy/"),
+        );
+    }
+    let resp = start_scan_handler(
+        State(state.clone()),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            url: "http://example.com".to_string(),
+            options: None,
+        })),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::SERVICE_UNAVAILABLE);
+    let body = response_body_string(resp).await;
+    assert!(body.contains("at capacity"), "got {body}");
+    // No new job queued — still just the one we seeded.
+    assert_eq!(state.jobs.lock().await.len(), 1);
+}
+
+#[test]
+fn test_sanitize_log_message_escapes_crlf() {
+    // F11: clean strings are passed through unchanged (borrowed)...
+    assert_eq!(sanitize_log_message("clean line").as_ref(), "clean line");
+    // ...but CR/LF that could forge a log line are escaped, tab preserved.
+    let forged = sanitize_log_message("http://x/\n[2026] [ERR] forged\r");
+    assert!(
+        !forged.contains('\n') && !forged.contains('\r'),
+        "got {forged}"
+    );
+    assert!(forged.contains("\\n") && forged.contains("\\r"));
+    assert!(sanitize_log_message("a\tb").contains('\t'));
+}
+
+#[tokio::test]
+async fn test_list_scans_rejects_unparseable_limit() {
+    // F12: a present-but-unparseable pagination value is a 400, matching GET
+    // /scan rather than the old silent "return everything" fallback.
+    let state = make_state(None, None, false, false, "cb");
+    let mut params = Map::new();
+    params.insert("limit".to_string(), "abc".to_string());
+    let resp = list_scans_handler(State(state), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+}
+
+#[test]
+fn test_parse_bool_query_accepts_common_truthy_forms() {
+    // F13: 1/true/yes/on (any case, trimmed) are truthy; everything else false.
+    for v in ["1", "true", "TRUE", "yes", "on", "  True  "] {
+        let mut p = Map::new();
+        p.insert("flag".to_string(), v.to_string());
+        assert!(parse_bool_query(&p, "flag"), "should accept {v:?}");
+    }
+    for v in ["0", "false", "no", "off", "", "2"] {
+        let mut p = Map::new();
+        p.insert("flag".to_string(), v.to_string());
+        assert!(!parse_bool_query(&p, "flag"), "should reject {v:?}");
+    }
+    assert!(!parse_bool_query(&Map::new(), "absent"));
 }

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -24,6 +24,27 @@ pub struct ServerArgs {
     #[arg(long = "log-file")]
     pub log_file: Option<String>,
 
+    /// Server-wide cap on each scan's outbound request rate (requests/second;
+    /// 0 or unset = unlimited). Applied to every submitted scan: a request's
+    /// own `rate_limit` may be lower but cannot exceed or disable this cap.
+    #[clap(help_heading = "SERVER")]
+    #[arg(long = "rate-limit")]
+    pub rate_limit: Option<u32>,
+
+    /// Maximum number of concurrently active (queued + running) scans. Once the
+    /// cap is hit, new submissions get HTTP 503 until a slot frees. 0 disables
+    /// the cap (unbounded). Bounds memory + the blocking-pool against a flood
+    /// of submissions.
+    #[clap(help_heading = "SERVER")]
+    #[arg(long = "max-concurrent-scans", default_value_t = 100)]
+    pub max_concurrent_scans: usize,
+
+    /// Maximum accepted request-body size (bytes) for POST /scan and /preflight.
+    /// Replaces axum's implicit 2 MiB default with an explicit, documented bound.
+    #[clap(help_heading = "SERVER")]
+    #[arg(long = "max-body-bytes", default_value_t = 1_048_576)]
+    pub max_body_bytes: usize,
+
     /// Comma-separated list of allowed origins for CORS. Supports:
     /// - "*" (match all)
     /// - exact origins (http://localhost:3000)
@@ -75,6 +96,11 @@ pub(crate) struct AppState {
     // JSONP
     pub(crate) jsonp_enabled: bool,
     pub(crate) callback_param_name: String,
+    // Server-wide per-scan request-rate cap (RPS). None/Some(0) leaves scans
+    // unbounded unless a request supplies its own rate_limit.
+    pub(crate) rate_limit: Option<u32>,
+    // Max concurrent (queued + running) scans; 0 = unlimited.
+    pub(crate) max_concurrent_scans: usize,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -126,6 +152,9 @@ pub(crate) struct ScanOptions {
     pub(crate) skip_ast_analysis: Option<bool>,
     /// Also report outdated / known-vulnerable JS libraries (informational, CWE-1104).
     pub(crate) detect_outdated_libs: Option<bool>,
+    /// Per-scan outbound request rate (requests/second; 0 = unlimited). Capped
+    /// by the server's `--rate-limit` when set.
+    pub(crate) rate_limit: Option<u32>,
 }
 
 #[derive(Debug, Clone, Serialize)]

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -64,19 +64,97 @@ where
     }
 }
 
-/// Split the server's HTTP-style `Cookie` header value (`a=b; c=d`) into
-/// `(name, value)` pairs. Earlier code did a single `split_once('=')` on the
-/// whole input, which silently folded `; c=d` into the value of the first
-/// pair — `preflight_handler` already used the `;`-split form, so the two
-/// endpoints disagreed on what a multi-cookie header meant.
-pub(crate) fn split_cookie_pairs(raw: &str) -> Vec<(String, String)> {
-    raw.split(';')
-        .filter_map(|p| p.trim().split_once('='))
-        .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
-        .collect()
+/// Lenient boolean query-parameter parse shared by GET /scan and DELETE
+/// /scan/{id}. `?flag=1` / `true` / `yes` / `on` (any case, trimmed) read as
+/// true; absent or anything else reads as false. Previously GET /scan accepted
+/// only the exact string `"true"` while DELETE's `?purge` accepted `"1"` and
+/// `"true"`, so the same `?include_request=1` silently did nothing.
+pub(crate) fn parse_bool_query(params: &HashMap<String, String>, key: &str) -> bool {
+    params.get(key).is_some_and(|v| {
+        let v = v.trim();
+        v == "1"
+            || v.eq_ignore_ascii_case("true")
+            || v.eq_ignore_ascii_case("yes")
+            || v.eq_ignore_ascii_case("on")
+    })
+}
+
+/// Admit a new scan and insert a queued `Job` for `url` under a single
+/// jobs-lock, or return `None` when the server is already at its
+/// `max_concurrent_scans` capacity (`0` = unlimited). Counting active
+/// (non-terminal) jobs and inserting under the *same* lock keeps the check
+/// race-free. Returns the reserved scan_id on success. Shared by POST and GET
+/// /scan so both paths enforce the cap and build the queued job identically.
+pub(crate) async fn try_admit_and_queue(
+    state: &AppState,
+    url: &str,
+    callback_url: Option<String>,
+) -> Option<String> {
+    let mut jobs = state.jobs.lock().await;
+    if state.max_concurrent_scans > 0
+        && jobs.values().filter(|j| !j.is_terminal()).count() >= state.max_concurrent_scans
+    {
+        return None;
+    }
+    let id = crate::utils::make_unique_scan_id(url, |id| jobs.contains_key(id));
+    jobs.insert(
+        id.clone(),
+        Job {
+            status: JobStatus::Queued,
+            results: None,
+            callback_url,
+            progress: JobProgress::default(),
+            cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
+            error_message: None,
+            target_url: url.to_string(),
+            queued_at_ms: now_ms(),
+            started_at_ms: None,
+            finished_at_ms: None,
+        },
+    );
+    Some(id)
+}
+
+/// Build the standard 503 "at capacity" response body for a rejected admission.
+pub(crate) fn at_capacity_response(state: &AppState) -> ApiResponse<serde_json::Value> {
+    ApiResponse::<serde_json::Value> {
+        code: 503,
+        msg: format!(
+            "server at capacity: {} concurrent scans already in flight (raise or disable with --max-concurrent-scans)",
+            state.max_concurrent_scans
+        ),
+        data: None,
+    }
+}
+
+/// Defang ASCII control characters in a (possibly user-controlled) log message
+/// so a submitter can't forge extra log lines. Log calls embed the target URL
+/// and error strings, which carry attacker-supplied bytes; `has_http_scheme`
+/// only checks the prefix, so an embedded `\n`/`\r` would otherwise inject a
+/// whole fabricated `[ts] [LVL] ...` line into the file and onto stdout.
+/// CR/LF become `\n`/`\r`; other C0 controls become `\xNN`; tab is kept. Returns
+/// a borrowed string on the common (clean) path so non-injecting logs allocate
+/// nothing.
+pub(crate) fn sanitize_log_message(msg: &str) -> std::borrow::Cow<'_, str> {
+    if !msg.bytes().any(|b| b < 0x20 && b != b'\t') {
+        return std::borrow::Cow::Borrowed(msg);
+    }
+    let mut out = String::with_capacity(msg.len() + 8);
+    for c in msg.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push('\t'),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    std::borrow::Cow::Owned(out)
 }
 
 pub(crate) fn log(state: &AppState, level: &str, message: &str) {
+    let message = sanitize_log_message(message);
+    let message = message.as_ref();
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
     let (color, lvl) = match level {
         "INF" => ("\x1b[36m", "INF"),


### PR DESCRIPTION
## Summary

A multi-agent audit of the MCP + REST-server subsystem (follow-up to the `scan_timeout` work) surfaced **15 adversarially-verified findings**. This PR fixes them. The headline (**F1**) is the same class as `scan_timeout`: wiring that *looks* correct but is silently a no-op.

## Headline: F1 — per-job task-local scopes lost across `tokio::spawn`

`run_scanning` fans out one worker per parameter via `tokio::spawn`, and **tokio task-locals are not inherited across `spawn`**. The per-job scopes the server/MCP bind on the parent future (`REQUEST_COUNT_JOB` / `WAF_CONSECUTIVE_BLOCKS_JOB` / `RATE_LIMITER_JOB`) were invisible to the workers — which send ~95% of a scan's requests — so they fell back to the process-wide globals:

- `progress.requests_sent` under-counted the entire injection phase (live pollers saw a near-static counter until completion);
- one scan's consecutive-WAF-block backoff bled into unrelated concurrent scans;
- the per-job rate limiter was bypassed for the injection loop.

Fix: `JobScopes::capture()` + `with_job_scopes()` (`lib.rs`) capture the bound task-locals in the parent and re-enter them inside each spawned worker. **No-op on the CLI** (binds no per-job scope). Covered by a positive test + a negative-control proving a bare `spawn` misses the counter.

## Resource controls

- **F2** — expose per-scan `rate_limit` (REST `ScanOptions`/GET-query + MCP param), capped by a new server-wide `--rate-limit` (`effective_rate_limit` resolves precedence). Actually enforced now that F1 lands.
- **F3** — `--max-concurrent-scans` (default 100, `0`=unlimited) → `503` at capacity on POST/GET `/scan`; constant cap for MCP.
- **F14** — cap discovered params at `MAX_DISCOVERED_PARAMS` (512) before fan-out (scan + preflight).
- **F15** — explicit `--max-body-bytes` (default 1 MiB) `DefaultBodyLimit`, replacing axum's implicit default.

## server↔MCP divergence & correctness

| | |
|---|---|
| **F4/F5** | MCP cookie/header parsing routed through shared `split_cookie_pairs` / `parse_header_line` (multi-cookie split + empty-name rejection) |
| **F6** | MCP/preflight `waf_min_confidence` `0.0` → `DEFAULT_WAF_MIN_CONFIDENCE` |
| **F7** | MCP preflight uses `param: vec![]` so it reports the full discovered set |
| **F8** | MCP `no_color: true` (match server) |
| **F9** | a worker-panicked scan is marked `error` with partial results (both fronts); `run_scanning` returns `ScanRunReport` |
| **F10** | progress block exposed on `Error` jobs |
| **F11** | sanitize CR/LF in server logs (log-injection via target URL/error) |
| **F12** | strict `/scans` pagination (`400` on unparseable offset/limit) |
| **F13** | lenient, shared boolean query parsing (`1`/`true`/`yes`/`on`) |

## Notes

- Branched off `main`, **independent of** the `scan_timeout` PR (#1103); they touch some of the same files, so expect a trivial merge conflict whichever lands second.
- `--max-concurrent-scans` defaults to 100 (was unbounded). Only affects someone running >100 concurrent scans; set `0` to restore unbounded.
- New tests: `effective_rate_limit`, `split_cookie_pairs`, `with_job_scopes` re-bind (+ negative control), 503-at-capacity, log sanitize, `/scans` 400, `parse_bool_query`, MCP `rate_limit`.

Full lib suite green (1431 passed), `clippy` clean, `fmt` applied.