### PR TITLE
feat(scanning): detect & bypass size-limited WAF inspection windows (xssmaze waf-facade L2)

### DIFF
--- a/docs/content/guide/waf-bypass.md
+++ b/docs/content/guide/waf-bypass.md
@@ -121,6 +121,12 @@ Different WAFs fall to different tricks. A small sample:
 
 You don't configure these directly; they're selected automatically per WAF. To inspect what's happening, run with `--debug`.
 
+## Inspection-window overflow
+
+Some WAFs (e.g. AWS WAF-style configs) only inspect the **first N bytes** of a parameter value. A vector at the start of the value trips a block, but the same vector reflects untouched once it's pushed past the inspected window.
+
+During active probing, when a parameter's special-character probe comes back fully blocked, Dalfox re-tries it behind a long benign filler prefix. If the characters now reflect, it concludes the value sits behind a size-limited inspection window and automatically prepends that filler to every payload for the parameter — so the real vector always lands past the window. The reported PoC URL includes the filler, so it reproduces as-is. This is automatic; nothing to configure.
+
 ## Combining with encoders
 
 Your `--encoders` list and the WAF's extra encoders are merged. So this:

--- a/src/encoding/pre_encoding.rs
+++ b/src/encoding/pre_encoding.rs
@@ -7,6 +7,24 @@
 
 use super::{base64_encode, url_encode};
 
+/// Length of the benign prefix prepended to overflow a size-limited WAF
+/// inspection window (the `WafWindowPad` transform). Must exceed the WAF's
+/// inspected-byte count for the real vector — which trails the pad — to escape
+/// inspection. Sized for the common "first N bytes of the value" query
+/// inspectors; a WAF inspecting a larger window simply won't be detected as
+/// window-limited (the detection probe in `active_probe_param` won't reflect),
+/// so this never produces a false bypass.
+pub const WAF_WINDOW_PAD_LEN: usize = 256;
+
+/// The benign prefix used by the `WafWindowPad` transform. A run of a single
+/// inert character (no HTML/JS metacharacters, so it can't change the
+/// reflection context) — its only job is to push the real payload past the
+/// WAF's inspection window. Shared by the encoder and the detection probe so
+/// both agree on the exact prefix.
+pub fn waf_window_pad() -> String {
+    "A".repeat(WAF_WINDOW_PAD_LEN)
+}
+
 /// Known pre-encoding types.
 /// Using an enum prevents typo bugs from stringly-typed matching.
 #[derive(Debug, Clone, Copy, PartialEq, Eq)]
@@ -15,6 +33,16 @@ pub enum PreEncodingType {
     DoubleBase64,
     DoubleUrl,
     TripleUrl,
+    /// Not an encoding, but a pre-injection payload transform that rides the
+    /// same "transform before sending, match reflection against the original
+    /// payload" rail: prepend a benign filler prefix so the real vector lands
+    /// past a size-limited WAF inspection window (e.g. AWS WAF-style "only the
+    /// first N bytes are scanned"). Set by `active_probe_param` when a
+    /// window-overflow probe shows that special chars blocked at the value
+    /// start reflect raw once pushed past the window. The prefix is inert
+    /// (`waf_window_pad`), so the original payload still reflects unchanged and
+    /// reflection/DOM matching is unaffected.
+    WafWindowPad,
 }
 
 impl PreEncodingType {
@@ -25,6 +53,7 @@ impl PreEncodingType {
             "2base64" => Some(Self::DoubleBase64),
             "2url" => Some(Self::DoubleUrl),
             "3url" => Some(Self::TripleUrl),
+            "wafpad" => Some(Self::WafWindowPad),
             _ => None,
         }
     }
@@ -36,6 +65,7 @@ impl PreEncodingType {
             Self::DoubleBase64 => "2base64",
             Self::DoubleUrl => "2url",
             Self::TripleUrl => "3url",
+            Self::WafWindowPad => "wafpad",
         }
     }
 
@@ -46,6 +76,7 @@ impl PreEncodingType {
             Self::DoubleBase64 => base64_encode(&base64_encode(payload)),
             Self::DoubleUrl => url_encode(&url_encode(payload)),
             Self::TripleUrl => url_encode(&url_encode(&url_encode(payload))),
+            Self::WafWindowPad => format!("{}{}", waf_window_pad(), payload),
         }
     }
 }

--- a/src/encoding/pre_encoding/tests.rs
+++ b/src/encoding/pre_encoding/tests.rs
@@ -45,11 +45,37 @@ fn test_pre_encoding_type_roundtrip() {
         PreEncodingType::DoubleBase64,
         PreEncodingType::DoubleUrl,
         PreEncodingType::TripleUrl,
+        PreEncodingType::WafWindowPad,
     ] {
         let s = enc.as_str();
         let parsed = PreEncodingType::parse(s).unwrap();
         assert_eq!(&parsed, enc);
     }
+}
+
+#[test]
+fn test_waf_window_pad_prepends_inert_prefix() {
+    // The WAF inspection-window-overflow transform prepends a benign filler so
+    // the real vector lands past a size-limited WAF inspection window. The
+    // original payload must survive verbatim as a suffix (so reflection / DOM
+    // matching against the raw payload still works), and the prefix must carry
+    // no HTML/JS metacharacters that could shift the reflection context.
+    let payload = "<svg onload=alert(1)>";
+    let out = apply_pre_encoding(payload, &Some("wafpad".to_string()));
+
+    let pad = waf_window_pad();
+    assert_eq!(pad.len(), WAF_WINDOW_PAD_LEN);
+    assert_eq!(out, format!("{pad}{payload}"));
+    assert!(
+        out.ends_with(payload),
+        "raw payload must survive as a suffix"
+    );
+    assert!(
+        out.len() > WAF_WINDOW_PAD_LEN,
+        "padded payload must exceed the inspection window"
+    );
+    // The pad itself must be context-inert.
+    assert!(!pad.contains(['<', '>', '"', '\'', '&', '/', '=', ';', '(', ')']));
 }
 
 #[test]

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -779,15 +779,32 @@ pub async fn active_probe_param(
         }
         None => {
             // No reflected segment — the markers never came back. That can be
-            // genuine heavy filtering, or a WAF that blocked the whole request
+            // genuine heavy filtering, a WAF that blocked the whole request
             // because it inspects only the first N bytes of the value and
-            // tripped on the leading special chars. Distinguish them with one
-            // window-overflow probe: re-send the batched probe behind a benign
-            // filler prefix. If the markers + specials now reflect, the param
-            // sits behind a size-limited inspection window — record the pad so
-            // every payload is sent past it; otherwise fall back to the legacy
-            // "all invalid" classification.
-            match window_overflow_probe(&client, target, &param, &semaphore).await {
+            // tripped on the leading special chars, or a server that strips a
+            // fixed prefix/suffix (partial reflection) so only part of a marker
+            // survives.
+            //
+            // Only the *block* case is a window-overflow candidate. Gate on a
+            // genuine block: the batched probe reflected NOTHING, i.e. neither
+            // marker survived. A prefix/suffix-stripping server leaves one
+            // marker intact (discovery already handles those as partial
+            // reflection), and a block page that echoes the payload (e.g. a
+            // reflected-block-page WAF) carries the markers too — neither is a
+            // size-limited inspection window, so skip the probe for them.
+            let genuine_block = batched_response.as_deref().is_none_or(|body| {
+                !body.contains(crate::scanning::markers::open_marker())
+                    && !body.contains(crate::scanning::markers::close_marker())
+            });
+            let window = if genuine_block {
+                // One window-overflow probe: re-send the batched probe behind a
+                // benign filler prefix. If the markers + specials now reflect,
+                // the param sits behind a size-limited inspection window.
+                window_overflow_probe(&client, target, &param, &semaphore).await
+            } else {
+                None
+            };
+            match window {
                 Some((win_valid, win_invalid)) => {
                     valid = win_valid;
                     invalid = win_invalid;
@@ -797,6 +814,8 @@ pub async fn active_probe_param(
                             .to_string(),
                     );
                 }
+                // Genuine filtering / partial strip — keep the legacy
+                // "all invalid" classification.
                 None => invalid.extend_from_slice(SPECIAL_PROBE_CHARS),
             }
         }

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -667,6 +667,58 @@ async fn detect_escaped_quotes_via_probe(
     escaped_quotes_from_response(resp.as_deref()?, valid)
 }
 
+/// One-shot WAF inspection-window-overflow probe. Re-sends the batched
+/// special-char probe behind a benign filler prefix (`waf_window_pad`) so the
+/// markers + special chars land past a size-limited inspection window (the
+/// AWS WAF-style "only the first N bytes are scanned" class). Returns the
+/// `(valid, invalid)` special-char split when the padded probe reflects at
+/// least one special char raw — the signature of a window-limited WAF — and
+/// `None` otherwise (genuine filtering, or no reflection at all).
+///
+/// Skips params that already carry a pre-encoding transform: the pad rides the
+/// `pre_encoding` rail, so applying it would clobber an existing encoding. Such
+/// a param keeps the legacy "all invalid" classification.
+async fn window_overflow_probe(
+    client: &reqwest::Client,
+    target: &Target,
+    param: &Param,
+    semaphore: &Arc<Semaphore>,
+) -> Option<(Vec<char>, Vec<char>)> {
+    if param.pre_encoding.is_some() || param.pre_encoding_pipeline.is_some() {
+        return None;
+    }
+
+    let batched_chars: String = SPECIAL_PROBE_CHARS.iter().collect();
+    let probe = format!(
+        "{}{}{}{}",
+        crate::encoding::pre_encoding::waf_window_pad(),
+        crate::scanning::markers::open_marker(),
+        batched_chars,
+        crate::scanning::markers::close_marker(),
+    );
+
+    let permit = semaphore.acquire().await.expect("acquire semaphore permit");
+    let resp = send_probe_request_for_param(client, target, param, &probe).await;
+    drop(permit);
+
+    let segment = resp.as_deref().and_then(extract_reflected_segment)?;
+    let mut valid = Vec::new();
+    let mut invalid = Vec::new();
+    for &c in SPECIAL_PROBE_CHARS {
+        if char_reflected_in_segment(segment, c) {
+            valid.push(c);
+        } else {
+            invalid.push(c);
+        }
+    }
+    // Only a window-limited WAF if padding actually recovered special chars;
+    // if everything is still stripped, it's genuine filtering, not a window.
+    if valid.is_empty() {
+        return None;
+    }
+    Some((valid, invalid))
+}
+
 /// Coverage safety net: if the batched probe is reflected but **no** char
 /// survives in the reflected segment (likely the server's WAF tripped on the
 /// dense special-char payload, while individual chars would pass), the
@@ -726,10 +778,27 @@ pub async fn active_probe_param(
             }
         }
         None => {
-            // No reflected segment — either the request failed or the
-            // server didn't echo the markers. Mark all chars invalid (same
-            // as the legacy per-char path's failure behavior).
-            invalid.extend_from_slice(SPECIAL_PROBE_CHARS);
+            // No reflected segment — the markers never came back. That can be
+            // genuine heavy filtering, or a WAF that blocked the whole request
+            // because it inspects only the first N bytes of the value and
+            // tripped on the leading special chars. Distinguish them with one
+            // window-overflow probe: re-send the batched probe behind a benign
+            // filler prefix. If the markers + specials now reflect, the param
+            // sits behind a size-limited inspection window — record the pad so
+            // every payload is sent past it; otherwise fall back to the legacy
+            // "all invalid" classification.
+            match window_overflow_probe(&client, target, &param, &semaphore).await {
+                Some((win_valid, win_invalid)) => {
+                    valid = win_valid;
+                    invalid = win_invalid;
+                    param.pre_encoding = Some(
+                        crate::encoding::pre_encoding::PreEncodingType::WafWindowPad
+                            .as_str()
+                            .to_string(),
+                    );
+                }
+                None => invalid.extend_from_slice(SPECIAL_PROBE_CHARS),
+            }
         }
     }
 

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1386,3 +1386,48 @@ async fn active_probe_does_not_set_wafpad_for_position_independent_block() {
         "genuine filtering (stripping past any window) must not be treated as window-limited"
     );
 }
+
+/// Counter-case: a server that strips a fixed PREFIX (first 4 chars) and echoes
+/// the rest. The batched probe's open-marker prefix is eaten, so the segment
+/// isn't found (None arm) — but this is *partial reflection*, not a block: the
+/// close marker survives. The genuine-block guard must skip the window-overflow
+/// probe here, so no `wafpad` is set (a benign pad would otherwise be absorbed
+/// by the strip and falsely look like a window bypass).
+#[tokio::test]
+async fn active_probe_does_not_set_wafpad_for_prefix_strip() {
+    use axum::{Router, extract::Query, response::IntoResponse, routing::get};
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    async fn strip_prefix4(Query(p): Query<HashMap<String, String>>) -> impl IntoResponse {
+        let v = p.get("x").cloned().unwrap_or_default();
+        // Drop the first 4 chars, echo the rest raw — partial reflection.
+        let echoed: String = v.chars().skip(4).collect();
+        format!("<html><body><div class='results'>{echoed}</div></body></html>")
+    }
+
+    let app = Router::new().route("/cat", get(strip_prefix4));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let target = parse_target(&format!("http://{addr}/cat?x=1")).unwrap();
+    let res = active_probe_param(
+        &target,
+        probe_param("x", Location::Query),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    assert_ne!(
+        res.pre_encoding.as_deref(),
+        Some("wafpad"),
+        "a fixed-prefix-stripping server (partial reflection) must not be mistaken for a window WAF"
+    );
+}

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1274,3 +1274,115 @@ fn slice_between_extracts_region() {
     assert_eq!(slice_between("aXXbYYc", "ZZ", "YY"), None);
     assert_eq!(slice_between("aXXb", "XX", "YY"), None);
 }
+
+/// Integration: an AWS-WAF-style inspection-window facade. Only the first 100
+/// bytes of the value are inspected; a `<`/`>` there blocks the whole request
+/// (403, no reflection), but the full value reflects raw — so a vector pushed
+/// past the window slips through (xssmaze `waf-facade/level2`). `active_probe_param`
+/// must detect this via the window-overflow probe: reclassify the angle
+/// brackets as valid and record the `wafpad` pre-encoding so payloads are sent
+/// past the window.
+#[tokio::test]
+async fn active_probe_detects_inspection_window_waf_and_sets_wafpad() {
+    use axum::{Router, extract::Query, http::StatusCode, response::IntoResponse, routing::get};
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    async fn window_waf(Query(p): Query<HashMap<String, String>>) -> impl IntoResponse {
+        let v = p.get("x").cloned().unwrap_or_default();
+        let window: String = v.chars().take(100).collect();
+        if window.contains('<') || window.contains('>') {
+            // Branded block page — note it does NOT echo the value.
+            (
+                StatusCode::FORBIDDEN,
+                "<h1>403 ERROR</h1> Request blocked by AWS WAF".to_string(),
+            )
+        } else {
+            // Reflects the full value raw (markers + specials intact).
+            (
+                StatusCode::OK,
+                format!("<html><body><div class='results'>{v}</div></body></html>"),
+            )
+        }
+    }
+
+    let app = Router::new().route("/cat", get(window_waf));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let target = parse_target(&format!("http://{addr}/cat?x=1")).unwrap();
+    let res = active_probe_param(
+        &target,
+        probe_param("x", Location::Query),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    assert_eq!(
+        res.pre_encoding.as_deref(),
+        Some("wafpad"),
+        "size-limited inspection window should set the window-pad pre-encoding"
+    );
+    let valid = res.valid_specials.clone().unwrap_or_default();
+    assert!(
+        valid.contains(&'<') && valid.contains(&'>'),
+        "angle brackets must be reclassified valid once pushed past the window; got {valid:?}"
+    );
+}
+
+/// Counter-case: a WAF that blocks `<`/`>` *anywhere* in the value (no size
+/// window) must NOT be mistaken for an inspection-window WAF. The batched probe
+/// is blocked (None arm), the window-overflow probe is *also* blocked (padding
+/// can't help), so `window_overflow_probe` returns `None` and no `wafpad` is
+/// set — guarding against a false bypass.
+#[tokio::test]
+async fn active_probe_does_not_set_wafpad_for_position_independent_block() {
+    use axum::{Router, extract::Query, http::StatusCode, response::IntoResponse, routing::get};
+    use std::collections::HashMap;
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    async fn block_anywhere(Query(p): Query<HashMap<String, String>>) -> impl IntoResponse {
+        let v = p.get("x").cloned().unwrap_or_default();
+        // Inspect the WHOLE value, not a leading window — padding never helps.
+        if v.contains('<') || v.contains('>') {
+            (StatusCode::FORBIDDEN, "<h1>403</h1> blocked".to_string())
+        } else {
+            (
+                StatusCode::OK,
+                format!("<html><body><div class='results'>{v}</div></body></html>"),
+            )
+        }
+    }
+
+    let app = Router::new().route("/cat", get(block_anywhere));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let target = parse_target(&format!("http://{addr}/cat?x=1")).unwrap();
+    let res = active_probe_param(
+        &target,
+        probe_param("x", Location::Query),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    assert_ne!(
+        res.pre_encoding.as_deref(),
+        Some("wafpad"),
+        "genuine filtering (stripping past any window) must not be treated as window-limited"
+    );
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1432,11 +1432,18 @@ impl ScanWorkerCtx {
                     // discovery, so the PoC URL points at the actual sink.
                     let base =
                         crate::scanning::url_inject::effective_query_base(&self.target.url, param);
-                    let result_url = crate::scanning::url_inject::build_injected_url(
-                        &base,
-                        param,
+                    // Build the PoC URL from the *as-sent* payload (pre-encoding
+                    // applied — base64 / multi-URL / WAF window-pad) so the
+                    // reported URL actually reproduces the finding.
+                    // `build_injected_url` preserves existing %-encoding, matching
+                    // the dedicated reflection-check PoC path. No-op for the common
+                    // case (no pre-encoding → payload unchanged).
+                    let poc_payload = crate::encoding::pre_encoding::apply_param_encoding(
                         &reflection_payload,
+                        param,
                     );
+                    let result_url =
+                        crate::scanning::url_inject::build_injected_url(&base, param, &poc_payload);
 
                     let reflection_note = reflection_kind_note(kind);
 
@@ -1608,8 +1615,12 @@ impl ScanWorkerCtx {
                     // when the param came from form discovery.
                     let base =
                         crate::scanning::url_inject::effective_query_base(&self.target.url, param);
+                    // PoC URL from the as-sent payload (see reflection path above)
+                    // so window-pad / base64 / multi-URL findings reproduce.
+                    let poc_payload =
+                        crate::encoding::pre_encoding::apply_param_encoding(&dom_payload, param);
                     let result_url =
-                        crate::scanning::url_inject::build_injected_url(&base, param, &dom_payload);
+                        crate::scanning::url_inject::build_injected_url(&base, param, &poc_payload);
 
                     // Determine which evidence path proved exploitability
                     // so the V finding's message reflects the route.


### PR DESCRIPTION
## Summary

Closes the last xssmaze `waf-facade` detection gap (**level2**) — an AWS WAF-style facade that inspects only the **first N bytes** of a parameter value. A vector at the value start trips a 403 (no reflection), so the special-char probe reads the markers as "never came back" and marks every special **invalid**; the adaptive prune then drops all angle-bracket payloads and the param looks unexploitable — even though the exact same vector reflects raw once pushed past the inspection window.

With this, dalfox detects **8/8** waf-facade levels (L3/L5/L8 were closed in #1104).

## How it works

**Detection.** When the batched special-char probe returns *no reflected segment* (the block signature), `active_probe_param` runs one **window-overflow probe**: it re-sends the markers + special chars behind a benign filler prefix. If they now reflect, the param sits behind a size-limited inspection window — so the angle brackets are reclassified **valid** and the param records a `wafpad` pre-encoding.

**Bypass.** `wafpad` is a new `PreEncodingType` that rides the existing *"transform-before-send, match reflection against the original payload"* rail. It prepends an inert filler (`waf_window_pad`, 256 metacharacter-free bytes) so every payload lands past the window. Because the prefix carries no HTML/JS metacharacters, the original payload still reflects unchanged and reflection / DOM verification are unaffected. Reusing `pre_encoding` (instead of a new `Param` field) avoids touching ~117 `Param` literals.

**PoC reproducibility.** The static-V / DOM finding PoC URLs in `scanning::mod` now build from the *as-sent* (pre-encoded) payload, matching the dedicated reflection-check path. Without this the reported reproduction URL omitted the pad (and, for base64 / multi-URL params, the encoding) and wouldn't reproduce the finding. `build_injected_url` preserves existing `%`-encoding, so it's a no-op for the common no-pre-encoding case.

## Safety / guards (no false bypasses)

Detection only fires on the **no-segment block signature**, **skips** params that already carry a pre-encoding transform (so it can't clobber base64/etc.), and treats the result as a window WAF **only when padding actually recovers a special char**. A position-independent block — where padding cannot help — is left at the legacy "all invalid" classification. A WAF whose window is larger than the pad simply won't reflect the padded probe, so it's never mis-flagged (no false bypass, only a missed detection).

## Verification

xssmaze `waf-facade/level2`, benchmark flags (`--skip-mining --scan-timeout 40`): now **type V (verified)**. The reported PoC URL replays verbatim to HTTP 200, the Product Catalog page (not the AWS block), with `<svg onload=alert(1)>` reflected unescaped. All 8 levels green; no regression on L1/L3–L8.

## Tests
- `pre_encoding`: `WafWindowPad` parse/roundtrip + inert-prefix encode.
- `parameter_analysis` (axum mock servers): detects a window-limited WAF and sets `wafpad` + reclassifies `<`/`>` valid; and a counter-case proving a position-independent block does **not** set `wafpad`.
- No regressions: `encoding::` 61, `parameter_analysis::` 108, `scanning::` 690 — all green; `cargo fmt --check` and `cargo clippy --all-targets --all-features -- -D warnings` clean.