### PR TITLE
feat: add --insecure TLS flag (default on) for scan/server/mcp (#1111)

### DIFF
--- a/docs/content/getting-started/configuration.md
+++ b/docs/content/getting-started/configuration.md
@@ -91,6 +91,7 @@ Anything that has a CLI flag under `dalfox scan` can live in the `[scan]` table.
 | `headers` | `["Accept: text/html"]` | Extra request headers |
 | `user_agent` | `"Dalfox Scanner"` | Default User-Agent |
 | `waf_bypass` | `"auto"` | WAF bypass mode (`auto`, `force`, `off`) |
+| `insecure` | `true` | Skip TLS certificate verification (`false` to enforce) |
 | `follow_redirects` | `true` | Follow 3xx responses |
 
 See the [Config File reference](../../reference/config/) for every key.

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -182,6 +182,7 @@ Returns version, `auth_required`, and the list of supported endpoints. Good for 
     "callback_url": "https://your-webhook.example/dalfox",
     "param": ["q", "id:query"],
     "proxy": "http://127.0.0.1:8080",
+    "insecure": true,
     "follow_redirects": false,
     "skip_mining": false,
     "skip_discovery": false,
@@ -196,6 +197,9 @@ Fields mirror the CLI flags. See the [CLI reference](../../reference/cli/) for m
 `detect_outdated_libs` is opt-in (default `false`): set it `true` to also report
 outdated / known-vulnerable JS libraries as informational `[I]` findings
 (CWE-1104, 0 extra requests). The same key works as a `GET /scan` query parameter.
+`insecure` defaults to `true` (TLS certificate verification is skipped, matching
+the CLI scanner default); send `"insecure": false` (or `?insecure=false` on
+`GET /scan`) to enforce certificate validation.
 
 `rate_limit` caps the scan's outbound requests/second (`0` = unlimited, the
 default), enforced across all worker tasks. The server-wide `--rate-limit` flag

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -123,6 +123,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--retries` | — | `0` | Retry failed requests on HTTP 5xx and transient transport errors (timeouts, connection resets) up to this many times (`0` = off). HTTP 429 is always retried regardless. |
 | `--retry-delay` | — | `1000` | Base delay (ms) for the exponential backoff between `--retries` attempts (doubles each attempt, capped internally). A server `Retry-After` header takes precedence on 429. |
 | `--proxy` | — | — | Proxy URL (`http://`, `socks5://`) |
+| `--insecure` | — | `true` | Skip TLS/SSL certificate verification (accept self-signed, expired, or hostname-mismatched certs). On by default for scanner use; pass `--insecure=false` to enforce certificate validation. |
 | `--follow-redirects` | `-F` | false | Follow 3xx responses |
 | `--ignore-return` | — | — | HTTP status codes to ignore |
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -74,6 +74,7 @@ rate_limit = 0
 retries = 0
 retry_delay = 1000
 # proxy = "http://127.0.0.1:8080"
+insecure = true
 follow_redirects = false
 ignore_return = []
 
@@ -181,6 +182,7 @@ debug = false
 | `retries` | int | `0` | Retry 5xx / transient transport errors this many times (`0` = off; 429 always retried) |
 | `retry_delay` | int | `1000` | Base backoff (ms) between `retries` attempts (exponential) |
 | `proxy` | string | — | Proxy URL |
+| `insecure` | bool | `true` | Skip TLS certificate verification; set `false` to enforce validation |
 | `follow_redirects` | bool | `false` | Follow 3xx responses |
 | `ignore_return` | array | `[]` | HTTP status codes to ignore |
 

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -717,7 +717,10 @@ mod arg_parser_tests {
         // `--insecure=false` opts into TLS certificate validation.
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=false"])
             .expect("parse with --insecure=false");
-        assert!(!cli.scan.insecure, "insecure=false should disable insecure mode");
+        assert!(
+            !cli.scan.insecure,
+            "insecure=false should disable insecure mode"
+        );
 
         // Boolish values are accepted on the `=` form.
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=true"])

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -369,6 +369,21 @@ pub struct ScanArgs {
     pub proxy: Option<String>,
 
     #[clap(help_heading = "NETWORK")]
+    /// Skip TLS/SSL certificate verification, accepting self-signed, expired,
+    /// or hostname-mismatched certs. Enabled by default for scanner use; pass
+    /// `--insecure=false` to enforce certificate validation. Example: --insecure=false
+    #[arg(
+        long,
+        num_args = 0..=1,
+        require_equals = true,
+        default_value_t = true,
+        default_missing_value = "true",
+        action = clap::ArgAction::Set,
+        value_parser = clap::builder::BoolishValueParser::new(),
+    )]
+    pub insecure: bool,
+
+    #[clap(help_heading = "NETWORK")]
     /// Follow HTTP redirects. Example: -F
     #[arg(short = 'F', long)]
     pub follow_redirects: bool,
@@ -598,6 +613,10 @@ impl ScanArgs {
             scan_timeout: 0,
             delay: 0,
             proxy: opts.proxy,
+            // Preflight only inspects content-type/parameters; like the scan
+            // path it trusts self-signed / staging certs by default so
+            // discovery isn't blocked by an internal TLS posture.
+            insecure: true,
             follow_redirects: opts.follow_redirects,
             ignore_return: vec![],
             output: None,
@@ -672,6 +691,41 @@ mod arg_parser_tests {
         ])
         .expect("encoders htmlpad,unicode,zwsp should be accepted");
         assert_eq!(cli.scan.encoders, vec!["htmlpad", "unicode", "zwsp"]);
+    }
+
+    #[test]
+    fn insecure_defaults_true_and_accepts_explicit_values() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            scan: ScanArgs,
+        }
+
+        // Omitted: scanner trusts certs by default.
+        let cli = TestCli::try_parse_from(["dalfox", "https://example.com"])
+            .expect("parse without --insecure");
+        assert!(cli.scan.insecure, "insecure should default to true");
+
+        // Bare `--insecure` keeps it on (and does NOT swallow the positional).
+        let cli = TestCli::try_parse_from(["dalfox", "--insecure", "https://example.com"])
+            .expect("parse with bare --insecure");
+        assert!(cli.scan.insecure);
+        assert_eq!(cli.scan.targets, vec!["https://example.com".to_string()]);
+
+        // `--insecure=false` opts into TLS certificate validation.
+        let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=false"])
+            .expect("parse with --insecure=false");
+        assert!(!cli.scan.insecure, "insecure=false should disable insecure mode");
+
+        // Boolish values are accepted on the `=` form.
+        let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=true"])
+            .expect("parse with --insecure=true");
+        assert!(cli.scan.insecure);
+        let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=0"])
+            .expect("parse with --insecure=0");
+        assert!(!cli.scan.insecure);
     }
 
     #[test]

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -372,16 +372,20 @@ pub struct ScanArgs {
     /// Skip TLS/SSL certificate verification, accepting self-signed, expired,
     /// or hostname-mismatched certs. Enabled by default for scanner use; pass
     /// `--insecure=false` to enforce certificate validation. Example: --insecure=false
+    ///
+    /// Stored as Option so presence is distinguishable from the default:
+    /// `None` means the user didn't pass the flag (config may set it; the
+    /// effective value is `unwrap_or(true)`), while `Some(_)` is an explicit
+    /// CLI choice that always wins over config — in either direction.
     #[arg(
         long,
         num_args = 0..=1,
         require_equals = true,
-        default_value_t = true,
         default_missing_value = "true",
         action = clap::ArgAction::Set,
         value_parser = clap::builder::BoolishValueParser::new(),
     )]
-    pub insecure: bool,
+    pub insecure: Option<bool>,
 
     #[clap(help_heading = "NETWORK")]
     /// Follow HTTP redirects. Example: -F
@@ -621,8 +625,9 @@ impl ScanArgs {
             // Preflight only inspects content-type/parameters; it defaults to
             // trusting self-signed / staging certs (callers pass `true`) so
             // discovery isn't blocked by an internal TLS posture, but the value
-            // is now caller-controlled rather than hardcoded.
-            insecure: opts.insecure,
+            // is now caller-controlled rather than hardcoded. The caller always
+            // has a concrete bool here, so record it as an explicit choice.
+            insecure: Some(opts.insecure),
             follow_redirects: opts.follow_redirects,
             ignore_return: vec![],
             output: None,
@@ -709,32 +714,35 @@ mod arg_parser_tests {
             scan: ScanArgs,
         }
 
-        // Omitted: scanner trusts certs by default.
+        // Omitted: None (unspecified). The effective value is unwrap_or(true)
+        // at the consumption points, but presence must be distinguishable so
+        // config / CLI precedence can be resolved correctly.
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com"])
             .expect("parse without --insecure");
-        assert!(cli.scan.insecure, "insecure should default to true");
+        assert_eq!(cli.scan.insecure, None, "omitted --insecure should be None");
 
-        // Bare `--insecure` keeps it on (and does NOT swallow the positional).
+        // Bare `--insecure` => Some(true) (and does NOT swallow the positional).
         let cli = TestCli::try_parse_from(["dalfox", "--insecure", "https://example.com"])
             .expect("parse with bare --insecure");
-        assert!(cli.scan.insecure);
+        assert_eq!(cli.scan.insecure, Some(true));
         assert_eq!(cli.scan.targets, vec!["https://example.com".to_string()]);
 
         // `--insecure=false` opts into TLS certificate validation.
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=false"])
             .expect("parse with --insecure=false");
-        assert!(
-            !cli.scan.insecure,
-            "insecure=false should disable insecure mode"
+        assert_eq!(
+            cli.scan.insecure,
+            Some(false),
+            "insecure=false should be Some(false)"
         );
 
         // Boolish values are accepted on the `=` form.
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=true"])
             .expect("parse with --insecure=true");
-        assert!(cli.scan.insecure);
+        assert_eq!(cli.scan.insecure, Some(true));
         let cli = TestCli::try_parse_from(["dalfox", "https://example.com", "--insecure=0"])
             .expect("parse with --insecure=0");
-        assert!(!cli.scan.insecure);
+        assert_eq!(cli.scan.insecure, Some(false));
     }
 
     #[test]
@@ -820,7 +828,7 @@ mod arg_parser_tests {
         assert!(args.skip_xss_scanning);
         assert!(args.skip_ast_analysis);
         assert!(args.silence);
-        assert!(args.insecure);
+        assert_eq!(args.insecure, Some(true));
         // skip_mining fans out to all three mining toggles.
         assert!(args.skip_mining && args.skip_mining_dict && args.skip_mining_dom);
     }
@@ -845,8 +853,9 @@ mod arg_parser_tests {
             skip_discovery: false,
             encoders: vec![],
         });
-        assert!(
-            !validate.insecure,
+        assert_eq!(
+            validate.insecure,
+            Some(false),
             "insecure=false must thread through for_preflight"
         );
     }

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -568,6 +568,11 @@ pub struct PreflightOptions {
     pub user_agent: Option<String>,
     pub timeout: u64,
     pub proxy: Option<String>,
+    /// Skip TLS certificate verification for the preflight reachability probe
+    /// and discovery requests. Defaults to the scanner posture (`true`) at the
+    /// call sites; threaded through so server/MCP preflight honor the caller's
+    /// `--insecure` choice instead of silently forcing it on.
+    pub insecure: bool,
     pub follow_redirects: bool,
     pub skip_mining: bool,
     pub skip_discovery: bool,
@@ -613,10 +618,11 @@ impl ScanArgs {
             scan_timeout: 0,
             delay: 0,
             proxy: opts.proxy,
-            // Preflight only inspects content-type/parameters; like the scan
-            // path it trusts self-signed / staging certs by default so
-            // discovery isn't blocked by an internal TLS posture.
-            insecure: true,
+            // Preflight only inspects content-type/parameters; it defaults to
+            // trusting self-signed / staging certs (callers pass `true`) so
+            // discovery isn't blocked by an internal TLS posture, but the value
+            // is now caller-controlled rather than hardcoded.
+            insecure: opts.insecure,
             follow_redirects: opts.follow_redirects,
             ignore_return: vec![],
             output: None,
@@ -793,6 +799,7 @@ mod arg_parser_tests {
     #[test]
     fn for_preflight_sets_discovery_only_shape() {
         let args = ScanArgs::for_preflight(PreflightOptions {
+            insecure: true,
             target: "https://example.com".to_string(),
             param: vec!["q".to_string()],
             method: "GET".to_string(),
@@ -813,14 +820,42 @@ mod arg_parser_tests {
         assert!(args.skip_xss_scanning);
         assert!(args.skip_ast_analysis);
         assert!(args.silence);
+        assert!(args.insecure);
         // skip_mining fans out to all three mining toggles.
         assert!(args.skip_mining && args.skip_mining_dict && args.skip_mining_dom);
+    }
+
+    #[test]
+    fn for_preflight_threads_insecure_choice() {
+        // The caller's insecure choice must flow into the preflight ScanArgs,
+        // not be silently forced to true.
+        let validate = ScanArgs::for_preflight(PreflightOptions {
+            insecure: false,
+            target: "https://example.com".to_string(),
+            param: vec![],
+            method: "GET".to_string(),
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            user_agent: None,
+            timeout: 10,
+            proxy: None,
+            follow_redirects: false,
+            skip_mining: false,
+            skip_discovery: false,
+            encoders: vec![],
+        });
+        assert!(
+            !validate.insecure,
+            "insecure=false must thread through for_preflight"
+        );
     }
 
     #[test]
     fn for_preflight_clamps_out_of_range_timeout_to_default() {
         // 0 and >=300 both fall back to the default timeout.
         let zero = ScanArgs::for_preflight(PreflightOptions {
+            insecure: true,
             target: "https://example.com".to_string(),
             param: vec![],
             method: "GET".to_string(),
@@ -838,6 +873,7 @@ mod arg_parser_tests {
         assert_eq!(zero.timeout, DEFAULT_TIMEOUT_SECS);
 
         let huge = ScanArgs::for_preflight(PreflightOptions {
+            insecure: true,
             target: "https://example.com".to_string(),
             param: vec![],
             method: "GET".to_string(),

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -494,7 +494,7 @@ pub(crate) async fn resolve_targets(
                     target.timeout = args.timeout;
                     target.delay = args.delay;
                     target.proxy = args.proxy.clone();
-                    target.insecure = args.insecure;
+                    target.insecure = args.insecure.unwrap_or(true);
                     target.follow_redirects = args.follow_redirects;
                     target.ignore_return = args.ignore_return.clone();
                     target.workers = args.workers;
@@ -758,7 +758,7 @@ fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
     target.timeout = args.timeout;
     target.delay = args.delay;
     target.proxy = args.proxy.clone();
-    target.insecure = args.insecure;
+    target.insecure = args.insecure.unwrap_or(true);
     target.follow_redirects = args.follow_redirects;
     target.ignore_return = args.ignore_return.clone();
     target.workers = args.workers;

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -494,6 +494,7 @@ pub(crate) async fn resolve_targets(
                     target.timeout = args.timeout;
                     target.delay = args.delay;
                     target.proxy = args.proxy.clone();
+                    target.insecure = args.insecure;
                     target.follow_redirects = args.follow_redirects;
                     target.ignore_return = args.ignore_return.clone();
                     target.workers = args.workers;
@@ -757,6 +758,7 @@ fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
     target.timeout = args.timeout;
     target.delay = args.delay;
     target.proxy = args.proxy.clone();
+    target.insecure = args.insecure;
     target.follow_redirects = args.follow_redirects;
     target.ignore_return = args.ignore_return.clone();
     target.workers = args.workers;

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -317,21 +317,23 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Per-target tracking for structured output (target_summary in JSON envelope)
     // Collect all target URLs that will be scanned, then track status per target.
     let all_target_urls: Vec<String> = parsed_targets.iter().map(|t| t.url.to_string()).collect();
-    // One-shot insecure-mode warning. dalfox unconditionally uses
-    // `danger_accept_invalid_certs(true)` (target_parser/mod.rs:106) and
-    // `danger_accept_invalid_hostnames(...)` so self-signed / expired /
-    // hostname-mismatch certs are silently trusted. That is intentional
-    // for a scanner but ops triaging a MITM scenario need a signal —
-    // print one warning per scan when any https:// target is present.
+    // One-shot insecure-mode warning. By default dalfox builds its HTTP client
+    // with `danger_accept_invalid_certs(true)` (the `--insecure` flag, on by
+    // default) so self-signed / expired / hostname-mismatch certs are silently
+    // trusted. That is intentional for a scanner but ops triaging a MITM
+    // scenario need a signal — print one warning per scan when any https://
+    // target is present AND insecure mode is active. When the operator opts
+    // into validation (`--insecure=false`), no warning is emitted.
     // Security note must reach the operator even with `--silence` —
     // silencing is for stdout, this is stderr and tells them about a
     // deliberate but consequential TLS posture.
-    if parsed_targets
-        .iter()
-        .any(|t| t.url.scheme().eq_ignore_ascii_case("https"))
+    if args.insecure
+        && parsed_targets
+            .iter()
+            .any(|t| t.url.scheme().eq_ignore_ascii_case("https"))
     {
         eprintln!(
-            "Warning: TLS certificate validation is disabled (scanner mode); self-signed, expired, or hostname-mismatched certs will be silently trusted"
+            "Warning: TLS certificate validation is disabled (--insecure, on by default); self-signed, expired, or hostname-mismatched certs will be silently trusted. Use --insecure=false to enforce validation."
         );
     }
     // Track targets that were skipped during preflight (content-type mismatch etc.)

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -327,7 +327,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Security note must reach the operator even with `--silence` —
     // silencing is for stdout, this is stderr and tells them about a
     // deliberate but consequential TLS posture.
-    if args.insecure
+    if args.insecure.unwrap_or(true)
         && parsed_targets
             .iter()
             .any(|t| t.url.scheme().eq_ignore_ascii_case("https"))

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -24,6 +24,7 @@ use tokio::sync::Mutex;
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -24,7 +24,7 @@ use tokio::sync::Mutex;
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/config.rs
+++ b/src/config.rs
@@ -95,6 +95,10 @@ pub struct ScanConfig {
     pub retries: Option<u32>,
     pub retry_delay: Option<u64>,
     pub proxy: Option<String>,
+    /// Skip TLS/SSL certificate verification. Omitted (None) keeps the
+    /// scanner default of `true` (insecure); set `false` to enforce
+    /// certificate validation.
+    pub insecure: Option<bool>,
     pub follow_redirects: Option<bool>,
     pub ignore_return: Option<Vec<u16>>,
     // ENGINE
@@ -275,6 +279,9 @@ impl Config {
             if let Some(v) = &scan.proxy {
                 args.proxy = Some(v.clone());
             }
+            if let Some(v) = scan.insecure {
+                args.insecure = v;
+            }
             if let Some(v) = scan.follow_redirects {
                 args.follow_redirects = v;
             }
@@ -411,6 +418,13 @@ impl Config {
                 && args.proxy.is_none()
             {
                 args.proxy = Some(v.clone());
+            }
+            // `insecure` defaults to true; only honor the config value while
+            // the flag is still at that default (mirrors apply_if_default).
+            if let Some(v) = scan.insecure
+                && args.insecure
+            {
+                args.insecure = v;
             }
             if let Some(v) = scan.scan_timeout
                 && args.scan_timeout == 0
@@ -700,6 +714,15 @@ impl Config {
                 && args.proxy.is_none()
             {
                 args.proxy = Some(v.clone());
+            }
+            // `insecure` defaults to true, so "still at default" means
+            // `args.insecure == true`. A CLI `--insecure=false` therefore
+            // wins over the config file; config only takes effect when the
+            // user left the flag untouched.
+            if let Some(v) = scan.insecure
+                && args.insecure
+            {
+                args.insecure = v;
             }
             if let Some(v) = scan.follow_redirects
                 && !args.follow_redirects
@@ -1011,6 +1034,7 @@ pub fn default_toml_template() -> String {
 # scan_timeout = 0           # hard wall-clock cap per target for the scan stage in seconds
 # delay = 0                  # milliseconds
 # proxy = "http://127.0.0.1:8080"  # also used for remote provider fetches
+# insecure = true            # skip TLS certificate verification (default true); set false to enforce validation
 # follow_redirects = false
 
 # ENGINE

--- a/src/config.rs
+++ b/src/config.rs
@@ -280,7 +280,7 @@ impl Config {
                 args.proxy = Some(v.clone());
             }
             if let Some(v) = scan.insecure {
-                args.insecure = v;
+                args.insecure = Some(v);
             }
             if let Some(v) = scan.follow_redirects {
                 args.follow_redirects = v;
@@ -419,12 +419,13 @@ impl Config {
             {
                 args.proxy = Some(v.clone());
             }
-            // `insecure` defaults to true; only honor the config value while
-            // the flag is still at that default (mirrors apply_if_default).
+            // `insecure` is None unless the user passed --insecure; only fill
+            // it from config when the CLI left it unspecified, so an explicit
+            // CLI choice (either direction) always wins (mirrors apply_if_default).
             if let Some(v) = scan.insecure
-                && args.insecure
+                && args.insecure.is_none()
             {
-                args.insecure = v;
+                args.insecure = Some(v);
             }
             if let Some(v) = scan.scan_timeout
                 && args.scan_timeout == 0
@@ -715,14 +716,16 @@ impl Config {
             {
                 args.proxy = Some(v.clone());
             }
-            // `insecure` defaults to true, so "still at default" means
-            // `args.insecure == true`. A CLI `--insecure=false` therefore
-            // wins over the config file; config only takes effect when the
-            // user left the flag untouched.
+            // `insecure` is `None` unless the user passed `--insecure[=…]`, so
+            // config only applies when the flag was left off. An explicit CLI
+            // value — `--insecure=true` *or* `--insecure=false` — is `Some(_)`
+            // and therefore always wins over the config file, in either
+            // direction. (A plain `bool` couldn't express this: it can't tell
+            // an explicit `--insecure=true` apart from the default.)
             if let Some(v) = scan.insecure
-                && args.insecure
+                && args.insecure.is_none()
             {
-                args.insecure = v;
+                args.insecure = Some(v);
             }
             if let Some(v) = scan.follow_redirects
                 && !args.follow_redirects

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::Ordering;
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "plain".to_string(),
@@ -439,39 +439,61 @@ fn test_apply_to_scan_args_if_default_insecure_precedence() {
     scan.insecure = Some(false);
     let cfg = Config { scan: Some(scan) };
 
-    // Case 1: CLI left insecure at its clap default (true) -> config flips it off.
+    // Case 1: CLI left --insecure unspecified (None) -> config flips it off.
     let mut args = default_scan_args();
-    assert!(args.insecure);
+    args.insecure = None;
     cfg.apply_to_scan_args_if_default(&mut args);
-    assert!(
-        !args.insecure,
-        "config insecure=false should apply when CLI is default"
+    assert_eq!(
+        args.insecure,
+        Some(false),
+        "config insecure=false should apply when CLI left it unspecified"
     );
 
-    // Case 2: CLI explicitly disabled it (false) -> config (also false) is a no-op,
-    // but more importantly a config of Some(true) must NOT re-enable it.
+    // Case 2: CLI explicitly disabled it (Some(false)) -> a config of Some(true)
+    // must NOT re-enable it; the explicit CLI choice wins.
     let mut scan_on = full_scan_config();
     scan_on.insecure = Some(true);
     let cfg_on = Config {
         scan: Some(scan_on),
     };
     let mut args = default_scan_args();
-    args.insecure = false; // user passed --insecure=false
+    args.insecure = Some(false); // user passed --insecure=false
     cfg_on.apply_to_scan_args_if_default(&mut args);
-    assert!(
-        !args.insecure,
+    assert_eq!(
+        args.insecure,
+        Some(false),
         "CLI --insecure=false must win over config insecure=true"
     );
 
-    // Case 3: config omits insecure (None) -> default-true is preserved.
+    // Case 3 (the precedence gap Copilot flagged): CLI explicitly *enabled* it
+    // (Some(true)) while config sets false -> CLI must win and stay insecure.
+    // A plain bool couldn't express this; Option<bool> can.
+    let mut scan_off = full_scan_config();
+    scan_off.insecure = Some(false);
+    let cfg_off = Config {
+        scan: Some(scan_off),
+    };
+    let mut args = default_scan_args();
+    args.insecure = Some(true); // user passed --insecure / --insecure=true
+    cfg_off.apply_to_scan_args_if_default(&mut args);
+    assert_eq!(
+        args.insecure,
+        Some(true),
+        "CLI --insecure=true must win over config insecure=false"
+    );
+
+    // Case 4: config omits insecure (None) + CLI unspecified -> stays None,
+    // and the effective value defaults to insecure (true).
     let cfg_none = Config {
         scan: Some(full_scan_config()),
     };
     let mut args = default_scan_args();
+    args.insecure = None;
     cfg_none.apply_to_scan_args_if_default(&mut args);
+    assert_eq!(args.insecure, None);
     assert!(
-        args.insecure,
-        "omitted config insecure keeps the scanner default (true)"
+        args.insecure.unwrap_or(true),
+        "omitted config + CLI keeps the scanner default (true)"
     );
 }
 
@@ -483,7 +505,7 @@ fn test_apply_to_scan_args_unconditional_overrides_insecure() {
     let cfg = Config { scan: Some(scan) };
     let mut args = default_scan_args();
     cfg.apply_to_scan_args(&mut args);
-    assert!(!args.insecure);
+    assert_eq!(args.insecure, Some(false));
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -443,17 +443,25 @@ fn test_apply_to_scan_args_if_default_insecure_precedence() {
     let mut args = default_scan_args();
     assert!(args.insecure);
     cfg.apply_to_scan_args_if_default(&mut args);
-    assert!(!args.insecure, "config insecure=false should apply when CLI is default");
+    assert!(
+        !args.insecure,
+        "config insecure=false should apply when CLI is default"
+    );
 
     // Case 2: CLI explicitly disabled it (false) -> config (also false) is a no-op,
     // but more importantly a config of Some(true) must NOT re-enable it.
     let mut scan_on = full_scan_config();
     scan_on.insecure = Some(true);
-    let cfg_on = Config { scan: Some(scan_on) };
+    let cfg_on = Config {
+        scan: Some(scan_on),
+    };
     let mut args = default_scan_args();
     args.insecure = false; // user passed --insecure=false
     cfg_on.apply_to_scan_args_if_default(&mut args);
-    assert!(!args.insecure, "CLI --insecure=false must win over config insecure=true");
+    assert!(
+        !args.insecure,
+        "CLI --insecure=false must win over config insecure=true"
+    );
 
     // Case 3: config omits insecure (None) -> default-true is preserved.
     let cfg_none = Config {
@@ -461,7 +469,10 @@ fn test_apply_to_scan_args_if_default_insecure_precedence() {
     };
     let mut args = default_scan_args();
     cfg_none.apply_to_scan_args_if_default(&mut args);
-    assert!(args.insecure, "omitted config insecure keeps the scanner default (true)");
+    assert!(
+        args.insecure,
+        "omitted config insecure keeps the scanner default (true)"
+    );
 }
 
 #[test]

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -3,6 +3,7 @@ use std::sync::atomic::Ordering;
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "plain".to_string(),
@@ -85,6 +86,7 @@ fn default_scan_args() -> crate::cmd::scan::ScanArgs {
 
 fn full_scan_config() -> ScanConfig {
     ScanConfig {
+        insecure: None,
         input_type: Some("file".to_string()),
         format: Some("jsonl".to_string()),
         output: Some("result.jsonl".to_string()),
@@ -427,6 +429,50 @@ fn test_apply_to_scan_args_if_default_waf_precedence() {
     cfg.apply_to_scan_args_if_default(&mut args);
     assert_eq!(args.waf_bypass, "force");
     assert_eq!(args.force_waf.as_deref(), Some("akamai"));
+}
+
+#[test]
+fn test_apply_to_scan_args_if_default_insecure_precedence() {
+    // `insecure` defaults to true, so config can only flip it to false while
+    // the user left the flag untouched; an explicit `--insecure=false` wins.
+    let mut scan = full_scan_config();
+    scan.insecure = Some(false);
+    let cfg = Config { scan: Some(scan) };
+
+    // Case 1: CLI left insecure at its clap default (true) -> config flips it off.
+    let mut args = default_scan_args();
+    assert!(args.insecure);
+    cfg.apply_to_scan_args_if_default(&mut args);
+    assert!(!args.insecure, "config insecure=false should apply when CLI is default");
+
+    // Case 2: CLI explicitly disabled it (false) -> config (also false) is a no-op,
+    // but more importantly a config of Some(true) must NOT re-enable it.
+    let mut scan_on = full_scan_config();
+    scan_on.insecure = Some(true);
+    let cfg_on = Config { scan: Some(scan_on) };
+    let mut args = default_scan_args();
+    args.insecure = false; // user passed --insecure=false
+    cfg_on.apply_to_scan_args_if_default(&mut args);
+    assert!(!args.insecure, "CLI --insecure=false must win over config insecure=true");
+
+    // Case 3: config omits insecure (None) -> default-true is preserved.
+    let cfg_none = Config {
+        scan: Some(full_scan_config()),
+    };
+    let mut args = default_scan_args();
+    cfg_none.apply_to_scan_args_if_default(&mut args);
+    assert!(args.insecure, "omitted config insecure keeps the scanner default (true)");
+}
+
+#[test]
+fn test_apply_to_scan_args_unconditional_overrides_insecure() {
+    // The unconditional apply always honors a present config value.
+    let mut scan = full_scan_config();
+    scan.insecure = Some(false);
+    let cfg = Config { scan: Some(scan) };
+    let mut args = default_scan_args();
+    cfg.apply_to_scan_args(&mut args);
+    assert!(!args.insecure);
 }
 
 #[test]

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,6 +379,10 @@ async fn main() {
             scan_timeout: 0,
             delay: cmd::scan::DEFAULT_DELAY_MS,
             proxy: None,
+            // Scanner default: skip TLS verification. The bare `dalfox <TARGET>`
+            // path takes no `--insecure` flag (only global flags are accepted
+            // here), so config can still flip this via apply_to_scan_args_if_default.
+            insecure: true,
             follow_redirects: false,
             ignore_return: vec![],
             output: None,

--- a/src/main.rs
+++ b/src/main.rs
@@ -379,10 +379,11 @@ async fn main() {
             scan_timeout: 0,
             delay: cmd::scan::DEFAULT_DELAY_MS,
             proxy: None,
-            // Scanner default: skip TLS verification. The bare `dalfox <TARGET>`
-            // path takes no `--insecure` flag (only global flags are accepted
-            // here), so config can still flip this via apply_to_scan_args_if_default.
-            insecure: true,
+            // Bare `dalfox <TARGET>` path takes no `--insecure` flag (only
+            // global flags are accepted here), so leave it unspecified (None);
+            // config can set it via apply_to_scan_args_if_default and the
+            // effective value defaults to insecure (true) when building targets.
+            insecure: None,
             follow_redirects: false,
             ignore_return: vec![],
             output: None,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -273,7 +273,7 @@ impl DalfoxMcp {
                 t.timeout = scan_args.timeout;
                 t.delay = scan_args.delay;
                 t.proxy = scan_args.proxy.clone();
-                t.insecure = scan_args.insecure;
+                t.insecure = scan_args.insecure.unwrap_or(true);
                 t.follow_redirects = scan_args.follow_redirects;
                 t.ignore_return = scan_args.ignore_return.clone();
                 t.workers = scan_args.workers;
@@ -1017,7 +1017,9 @@ Final results (via get_results_dalfox) include finding type \
             scan_timeout,
             delay,
             proxy,
-            insecure,
+            // params.insecure is a concrete bool (default true via serde); record
+            // it as an explicit choice so it flows through unchanged.
+            insecure: Some(insecure),
             follow_redirects,
             ignore_return: vec![],
             output: None,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -273,6 +273,7 @@ impl DalfoxMcp {
                 t.timeout = scan_args.timeout;
                 t.delay = scan_args.delay;
                 t.proxy = scan_args.proxy.clone();
+                t.insecure = scan_args.insecure;
                 t.follow_redirects = scan_args.follow_redirects;
                 t.ignore_return = scan_args.ignore_return.clone();
                 t.workers = scan_args.workers;
@@ -633,6 +634,12 @@ pub struct ScanWithDalfoxParams {
     #[serde(default)]
     pub follow_redirects: bool,
 
+    /// Skip TLS/SSL certificate verification (accept self-signed, expired, or
+    /// hostname-mismatched certs). Default: true. Set false to enforce
+    /// certificate validation.
+    #[serde(default = "default_true")]
+    pub insecure: bool,
+
     /// HTTP/SOCKS proxy URL. Example: "http://127.0.0.1:8080"
     #[serde(default)]
     pub proxy: Option<String>,
@@ -701,6 +708,12 @@ fn default_timeout() -> u64 {
 }
 fn default_workers() -> usize {
     crate::cmd::scan::DEFAULT_WORKERS
+}
+/// Default for the `insecure` param: TLS verification is skipped by default
+/// (scanner posture), matching the CLI `--insecure` default and the REST
+/// server. Clients pass `"insecure": false` to enforce certificate validation.
+fn default_true() -> bool {
+    true
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -784,6 +797,11 @@ pub struct PreflightDalfoxParams {
     #[serde(default)]
     pub follow_redirects: bool,
 
+    /// Skip TLS/SSL certificate verification. Default: true. Set false to
+    /// enforce certificate validation.
+    #[serde(default = "default_true")]
+    pub insecure: bool,
+
     /// Skip parameter mining. Default: false
     #[serde(default)]
     pub skip_mining: bool,
@@ -831,6 +849,7 @@ Final results (via get_results_dalfox) include finding type \
             scan_timeout,
             delay,
             follow_redirects,
+            insecure,
             proxy,
             include_request,
             include_response,
@@ -984,6 +1003,7 @@ Final results (via get_results_dalfox) include finding type \
             scan_timeout,
             delay,
             proxy,
+            insecure,
             follow_redirects,
             ignore_return: vec![],
             output: None,
@@ -1349,6 +1369,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                 t.method = params.method.clone();
                 t.timeout = params.timeout;
                 t.proxy = params.proxy.clone();
+                t.insecure = params.insecure;
                 t.follow_redirects = params.follow_redirects;
                 t.user_agent = params.user_agent.clone();
                 // Shared parsers: reject empty header names and `;`-split +

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -308,6 +308,20 @@ impl DalfoxMcp {
             }
         };
 
+        // Insecure-TLS posture signal. MCP jobs run silenced (no stderr
+        // warning like the CLI), so log the fact when an https target is
+        // scanned with certificate validation disabled (the default unless the
+        // caller sent insecure=false), mirroring the REST server's job log.
+        if target.insecure && target.url.scheme().eq_ignore_ascii_case("https") {
+            Self::log(
+                "JOB",
+                &format!(
+                    "insecure-tls scan_id={} url={} (TLS certificate validation disabled; set insecure=false to enforce)",
+                    scan_id, url
+                ),
+            );
+        }
+
         // Reachability gate, mirroring preflight_dalfox and the REST server:
         // a parseable-but-unreachable target otherwise finishes `done` with 0
         // findings, which a client can't distinguish from "scanned, no XSS".
@@ -1409,6 +1423,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             user_agent: params.user_agent.clone(),
             timeout: params.timeout,
             proxy: params.proxy.clone(),
+            insecure: params.insecure,
             follow_redirects: params.follow_redirects,
             skip_mining: params.skip_mining,
             skip_discovery: params.skip_discovery,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -26,6 +26,7 @@ fn test_job(status: JobStatus, results: Option<Vec<SanitizedResult>>) -> Job {
 
 fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
     ScanWithDalfoxParams {
+        insecure: true,
         target: target.to_string(),
         param: vec![],
         method: "GET".to_string(),
@@ -55,6 +56,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
 
 fn default_scan_args(target: &str) -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -451,6 +453,33 @@ async fn test_scan_with_dalfox_ignores_cookie_from_raw_field() {
     assert!(payload["scan_id"].as_str().is_some());
 }
 
+#[test]
+fn test_insecure_param_serde_defaults_true() {
+    // Omitted `insecure` defaults to true (scanner posture) for both the scan
+    // and preflight params; an explicit `false` opts into TLS validation.
+    let scan: ScanWithDalfoxParams =
+        serde_json::from_value(serde_json::json!({ "target": "https://example.com" }))
+            .expect("minimal scan params deserialize");
+    assert!(scan.insecure, "scan insecure should default to true");
+
+    let scan_off: ScanWithDalfoxParams = serde_json::from_value(
+        serde_json::json!({ "target": "https://example.com", "insecure": false }),
+    )
+    .expect("scan params with insecure=false deserialize");
+    assert!(!scan_off.insecure);
+
+    let pre: PreflightDalfoxParams =
+        serde_json::from_value(serde_json::json!({ "target": "https://example.com" }))
+            .expect("minimal preflight params deserialize");
+    assert!(pre.insecure, "preflight insecure should default to true");
+
+    let pre_off: PreflightDalfoxParams = serde_json::from_value(
+        serde_json::json!({ "target": "https://example.com", "insecure": false }),
+    )
+    .expect("preflight params with insecure=false deserialize");
+    assert!(!pre_off.insecure);
+}
+
 #[tokio::test]
 async fn test_list_scans_returns_all_jobs() {
     let mcp = DalfoxMcp::new();
@@ -542,6 +571,7 @@ async fn test_cancel_scan_rejects_unknown_id() {
 async fn test_preflight_rejects_empty_target() {
     let mcp = DalfoxMcp::new();
     let params = PreflightDalfoxParams {
+        insecure: true,
         target: "".to_string(),
         param: vec![],
         method: "GET".to_string(),
@@ -567,6 +597,7 @@ async fn test_preflight_rejects_empty_target() {
 async fn test_preflight_rejects_non_http_target() {
     let mcp = DalfoxMcp::new();
     let params = PreflightDalfoxParams {
+        insecure: true,
         target: "ftp://example.com".to_string(),
         param: vec![],
         method: "GET".to_string(),
@@ -592,6 +623,7 @@ async fn test_preflight_rejects_non_http_target() {
 async fn test_preflight_unreachable_target_returns_reachable_false() {
     let mcp = DalfoxMcp::new();
     let params = PreflightDalfoxParams {
+        insecure: true,
         target: "http://127.0.0.1:1/?q=test".to_string(),
         param: vec![],
         method: "GET".to_string(),

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -56,7 +56,7 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
 
 fn default_scan_args(target: &str) -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -10,7 +10,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -10,6 +10,7 @@ use std::net::{Ipv4Addr, SocketAddr};
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -7,7 +7,7 @@ use tokio::time::{Duration, sleep};
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -7,6 +7,7 @@ use tokio::time::{Duration, sleep};
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -29,6 +29,7 @@ fn mock_mine_parameters(_target: &mut Target, _args: &ScanArgs) {
 fn test_analyze_parameters_with_mock_mining() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -123,6 +124,7 @@ fn test_analyze_parameters_with_mock_mining() {
 fn test_analyze_parameters_skip_mining() {
     let target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -209,6 +211,7 @@ fn test_analyze_parameters_skip_mining() {
 fn test_probe_body_params_mock() {
     let mut target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -370,6 +373,7 @@ fn test_check_cookie_discovery_mock() {
 fn test_cookie_from_raw() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -477,6 +481,7 @@ fn test_cookie_from_raw() {
 fn test_cookie_from_raw_no_file() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -892,6 +897,7 @@ fn test_ensure_explicit_params_skips_unsynthesizable_specs() {
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -29,7 +29,7 @@ fn mock_mine_parameters(_target: &mut Target, _args: &ScanArgs) {
 fn test_analyze_parameters_with_mock_mining() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -124,7 +124,7 @@ fn test_analyze_parameters_with_mock_mining() {
 fn test_analyze_parameters_skip_mining() {
     let target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -211,7 +211,7 @@ fn test_analyze_parameters_skip_mining() {
 fn test_probe_body_params_mock() {
     let mut target = parse_target("https://example.com").unwrap();
     let _args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -373,7 +373,7 @@ fn test_check_cookie_discovery_mock() {
 fn test_cookie_from_raw() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -481,7 +481,7 @@ fn test_cookie_from_raw() {
 fn test_cookie_from_raw_no_file() {
     let mut target = parse_target("https://example.com").unwrap();
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -897,7 +897,7 @@ fn test_ensure_explicit_params_skips_unsynthesizable_specs() {
 
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -39,6 +39,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -39,7 +39,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -39,6 +39,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -39,7 +39,7 @@ fn make_param() -> Param {
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -8,7 +8,7 @@ use crate::target_parser::parse_target;
 /// `realworld_level1_shape_v_upgrade` test exercises the full pipeline.
 fn integration_scan_args(skip_xss: bool) -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -376,7 +376,7 @@ fn mock_add_reflection_param(target: &mut Target, name: &str, location: Location
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -867,7 +867,7 @@ async fn test_xss_scanning_get_query() {
     mock_add_reflection_param(&mut target, "q", Location::Query);
 
     let args = crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -971,7 +971,7 @@ async fn test_xss_scanning_post_body() {
     mock_add_reflection_param(&mut target, "data", Location::Body);
 
     let args = crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1090,7 +1090,7 @@ async fn test_run_scanning_with_reflection_params() {
     });
 
     let args = crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1362,7 +1362,7 @@ async fn test_run_scanning_empty_params() {
     let target = parse_target("https://example.com").unwrap();
 
     let args = crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1485,7 +1485,7 @@ async fn start_ext_js_server(js_body: &'static str) -> std::net::SocketAddr {
 
 fn ext_js_scan_args(analyze: bool) -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -8,6 +8,7 @@ use crate::target_parser::parse_target;
 /// `realworld_level1_shape_v_upgrade` test exercises the full pipeline.
 fn integration_scan_args(skip_xss: bool) -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -375,6 +376,7 @@ fn mock_add_reflection_param(target: &mut Target, name: &str, location: Location
 
 fn default_scan_args() -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -865,6 +867,7 @@ async fn test_xss_scanning_get_query() {
     mock_add_reflection_param(&mut target, "q", Location::Query);
 
     let args = crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -968,6 +971,7 @@ async fn test_xss_scanning_post_body() {
     mock_add_reflection_param(&mut target, "data", Location::Body);
 
     let args = crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1086,6 +1090,7 @@ async fn test_run_scanning_with_reflection_params() {
     });
 
     let args = crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1357,6 +1362,7 @@ async fn test_run_scanning_empty_params() {
     let target = parse_target("https://example.com").unwrap();
 
     let args = crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),
@@ -1479,6 +1485,7 @@ async fn start_ext_js_server(js_body: &'static str) -> std::net::SocketAddr {
 
 fn ext_js_scan_args(analyze: bool) -> crate::cmd::scan::ScanArgs {
     crate::cmd::scan::ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/src/scanning/xss_common/tests.rs
+++ b/src/scanning/xss_common/tests.rs
@@ -372,7 +372,7 @@ fn test_load_custom_payloads_caches_by_path() {
 
 fn base_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/scanning/xss_common/tests.rs
+++ b/src/scanning/xss_common/tests.rs
@@ -372,6 +372,7 @@ fn test_load_custom_payloads_caches_by_path() {
 
 fn base_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -809,6 +809,7 @@ pub(crate) async fn preflight_handler(
                     user_agent: opts.user_agent.clone(),
                     timeout: timeout_secs,
                     proxy: opts.proxy.clone(),
+                    insecure: opts.insecure.unwrap_or(true),
                     follow_redirects: opts.follow_redirects.unwrap_or(false),
                     skip_mining: opts.skip_mining.unwrap_or(false),
                     skip_discovery: opts.skip_discovery.unwrap_or(false),

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -382,6 +382,9 @@ pub(crate) async fn get_scan_handler(
         callback_url: params.get("callback_url").cloned(),
         param: param_list,
         proxy,
+        // Absent ?insecure leaves None so the scan path applies its
+        // insecure-by-default; ?insecure=false opts into TLS validation.
+        insecure: parse_opt_bool_query(&params, "insecure"),
         follow_redirects: Some(follow_redirects),
         skip_mining: Some(skip_mining),
         skip_discovery: Some(skip_discovery),

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -288,6 +288,9 @@ pub(crate) async fn run_scan_job(
         scan_timeout: effective_scan_timeout(opts.scan_timeout, state.scan_timeout),
         delay: opts.delay.unwrap_or(0),
         proxy: opts.proxy.clone(),
+        // Default to insecure (skip TLS verification) like the CLI scan path,
+        // unless the request explicitly opts into validation via insecure=false.
+        insecure: opts.insecure.unwrap_or(true),
         follow_redirects: opts.follow_redirects.unwrap_or(false),
         ignore_return: vec![],
 
@@ -378,6 +381,7 @@ pub(crate) async fn run_scan_job(
             t.timeout = args.timeout;
             t.delay = args.delay;
             t.proxy = args.proxy.clone();
+            t.insecure = args.insecure;
             t.follow_redirects = args.follow_redirects;
             t.ignore_return = args.ignore_return.clone();
             t.workers = args.workers;
@@ -719,6 +723,7 @@ pub(crate) fn hydrate_preflight_target(
     t.timeout = timeout_secs;
     t.user_agent = opts.user_agent.clone();
     t.proxy = opts.proxy.clone();
+    t.insecure = opts.insecure.unwrap_or(true);
     t.follow_redirects = opts.follow_redirects.unwrap_or(false);
     // Parse via the shared helper so preflight rejects empty header names the
     // same way the scan path does (a bare `:value` is dropped, not forwarded).

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -288,9 +288,10 @@ pub(crate) async fn run_scan_job(
         scan_timeout: effective_scan_timeout(opts.scan_timeout, state.scan_timeout),
         delay: opts.delay.unwrap_or(0),
         proxy: opts.proxy.clone(),
-        // Default to insecure (skip TLS verification) like the CLI scan path,
-        // unless the request explicitly opts into validation via insecure=false.
-        insecure: opts.insecure.unwrap_or(true),
+        // Pass the request's choice through verbatim (None => unspecified);
+        // the effective value defaults to insecure (true) when the Target's
+        // client is built, matching the CLI scan path.
+        insecure: opts.insecure,
         follow_redirects: opts.follow_redirects.unwrap_or(false),
         ignore_return: vec![],
 
@@ -381,7 +382,7 @@ pub(crate) async fn run_scan_job(
             t.timeout = args.timeout;
             t.delay = args.delay;
             t.proxy = args.proxy.clone();
-            t.insecure = args.insecure;
+            t.insecure = args.insecure.unwrap_or(true);
             t.follow_redirects = args.follow_redirects;
             t.ignore_return = args.ignore_return.clone();
             t.workers = args.workers;

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -399,6 +399,22 @@ pub(crate) async fn run_scan_job(
         }
     };
 
+    // Insecure-TLS posture signal. The CLI prints a one-shot stderr warning;
+    // server jobs run silenced, so surface the same fact in the job log when an
+    // https target is scanned with certificate validation disabled (the
+    // default unless the request sent `insecure=false`). Ops triaging a MITM
+    // scenario can then see it per job.
+    if target.insecure && target.url.scheme().eq_ignore_ascii_case("https") {
+        log(
+            &state,
+            "JOB",
+            &format!(
+                "insecure-tls id={} url={} (TLS certificate validation disabled; send insecure=false to enforce)",
+                job_id, url
+            ),
+        );
+    }
+
     // Reachability gate. A parseable-but-unreachable target (connection
     // refused, DNS failure, TLS error, timeout) otherwise runs the full
     // pipeline and finishes `done` with 0 findings — indistinguishable from

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1067,6 +1067,7 @@ async fn test_run_scan_job_success_marks_done() {
         callback_url: None,
         param: None,
         proxy: None,
+        insecure: None,
         follow_redirects: None,
         skip_mining: None,
         skip_discovery: None,
@@ -2519,6 +2520,37 @@ fn test_parse_bool_query_accepts_common_truthy_forms() {
         assert!(!parse_bool_query(&p, "flag"), "should reject {v:?}");
     }
     assert!(!parse_bool_query(&Map::new(), "absent"));
+}
+
+#[test]
+fn test_parse_opt_bool_query_preserves_absent() {
+    // Absent -> None (so callers can apply a non-false default like insecure).
+    assert_eq!(parse_opt_bool_query(&Map::new(), "insecure"), None);
+    // Present truthy / falsy values map to Some(bool).
+    for v in ["1", "true", "yes", "on", " TRUE "] {
+        let mut p = Map::new();
+        p.insert("insecure".to_string(), v.to_string());
+        assert_eq!(parse_opt_bool_query(&p, "insecure"), Some(true), "{v:?}");
+    }
+    for v in ["0", "false", "no", "off", ""] {
+        let mut p = Map::new();
+        p.insert("insecure".to_string(), v.to_string());
+        assert_eq!(parse_opt_bool_query(&p, "insecure"), Some(false), "{v:?}");
+    }
+}
+
+#[test]
+fn test_hydrate_preflight_target_insecure_default_and_override() {
+    // Absent insecure -> scanner default (true). Explicit false -> validate.
+    let mut opts = ScanOptions::default();
+    let t = hydrate_preflight_target("https://example.com", &opts, 10)
+        .expect("hydrate default");
+    assert!(t.insecure, "preflight target should default to insecure=true");
+
+    opts.insecure = Some(false);
+    let t = hydrate_preflight_target("https://example.com", &opts, 10)
+        .expect("hydrate insecure=false");
+    assert!(!t.insecure, "insecure=false must propagate to the target");
 }
 
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2543,13 +2543,15 @@ fn test_parse_opt_bool_query_preserves_absent() {
 fn test_hydrate_preflight_target_insecure_default_and_override() {
     // Absent insecure -> scanner default (true). Explicit false -> validate.
     let mut opts = ScanOptions::default();
-    let t = hydrate_preflight_target("https://example.com", &opts, 10)
-        .expect("hydrate default");
-    assert!(t.insecure, "preflight target should default to insecure=true");
+    let t = hydrate_preflight_target("https://example.com", &opts, 10).expect("hydrate default");
+    assert!(
+        t.insecure,
+        "preflight target should default to insecure=true"
+    );
 
     opts.insecure = Some(false);
-    let t = hydrate_preflight_target("https://example.com", &opts, 10)
-        .expect("hydrate insecure=false");
+    let t =
+        hydrate_preflight_target("https://example.com", &opts, 10).expect("hydrate insecure=false");
     assert!(!t.insecure, "insecure=false must propagate to the target");
 }
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -151,6 +151,10 @@ pub(crate) struct ScanOptions {
     pub(crate) param: Option<Vec<String>>,
     /// HTTP/SOCKS proxy URL.
     pub(crate) proxy: Option<String>,
+    /// Skip TLS/SSL certificate verification. Absent (None) keeps the scanner
+    /// default of `true` (accept self-signed / staging certs); set `false` to
+    /// enforce certificate validation.
+    pub(crate) insecure: Option<bool>,
     /// Follow HTTP redirects (3xx).
     pub(crate) follow_redirects: Option<bool>,
     /// Skip parameter mining (DOM and dictionary-based discovery).

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -87,6 +87,24 @@ pub(crate) fn parse_bool_query(params: &HashMap<String, String>, key: &str) -> b
     })
 }
 
+/// Like [`parse_bool_query`] but preserves the present/absent distinction:
+/// returns `None` when the key is absent and `Some(bool)` when present. Used
+/// for flags whose default is *not* `false` (e.g. `insecure`, which defaults
+/// to true), so the caller can apply its own default only when the query
+/// parameter was omitted.
+pub(crate) fn parse_opt_bool_query(
+    params: &HashMap<String, String>,
+    key: &str,
+) -> Option<bool> {
+    params.get(key).map(|v| {
+        let v = v.trim();
+        v == "1"
+            || v.eq_ignore_ascii_case("true")
+            || v.eq_ignore_ascii_case("yes")
+            || v.eq_ignore_ascii_case("on")
+    })
+}
+
 /// Admit a new scan and insert a queued `Job` for `url` under a single
 /// jobs-lock, or return `None` when the server is already at its
 /// `max_concurrent_scans` capacity (`0` = unlimited). Counting active

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -92,10 +92,7 @@ pub(crate) fn parse_bool_query(params: &HashMap<String, String>, key: &str) -> b
 /// for flags whose default is *not* `false` (e.g. `insecure`, which defaults
 /// to true), so the caller can apply its own default only when the query
 /// parameter was omitted.
-pub(crate) fn parse_opt_bool_query(
-    params: &HashMap<String, String>,
-    key: &str,
-) -> Option<bool> {
+pub(crate) fn parse_opt_bool_query(params: &HashMap<String, String>, key: &str) -> Option<bool> {
     params.get(key).map(|v| {
         let v = v.trim();
         v == "1"

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -425,7 +425,10 @@ mod tests {
     #[test]
     fn test_parse_target_defaults_to_insecure() {
         let target = parse_target("https://example.com").unwrap();
-        assert!(target.insecure, "insecure must default to true (scanner mode)");
+        assert!(
+            target.insecure,
+            "insecure must default to true (scanner mode)"
+        );
     }
 
     #[test]

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -9,11 +9,11 @@ mod har;
 pub use har::{is_har_content, parse_har};
 
 /// Cache key capturing the inputs that affect Client construction:
-/// timeout, optional proxy URL, and follow-redirects policy. The
-/// scheme/host are NOT part of the key because reqwest::Client manages
-/// per-host connection pools internally — one Client safely serves any
-/// number of hosts.
-type ClientCacheKey = (u64, Option<String>, bool);
+/// timeout, optional proxy URL, follow-redirects policy, and whether TLS
+/// certificate verification is skipped (`insecure`). The scheme/host are
+/// NOT part of the key because reqwest::Client manages per-host connection
+/// pools internally — one Client safely serves any number of hosts.
+type ClientCacheKey = (u64, Option<String>, bool, bool);
 
 /// Process-wide cache of reqwest::Clients keyed by ClientCacheKey. Each
 /// cached entry is cheap to clone (reqwest::Client is internally Arc'd).
@@ -55,6 +55,12 @@ pub struct Target {
     /// analysis; consumed by the reflection / DOM injection paths so the hint
     /// actually paces requests instead of only surfacing in JSON meta.
     pub waf_extra_delay_ms: u64,
+    /// Skip TLS/SSL certificate verification when building the HTTP client
+    /// (`danger_accept_invalid_certs`). Defaults to `true` so the scanner
+    /// trusts self-signed / expired / hostname-mismatched certs out of the
+    /// box (`--insecure`); set to `false` (`--insecure=false`) to enforce
+    /// certificate validation.
+    pub insecure: bool,
 }
 
 impl Target {
@@ -85,6 +91,9 @@ impl Target {
             tech_info: None,
             mutation_stats: None,
             waf_extra_delay_ms: 0,
+            // Scanner default: trust self-signed / staging certs unless the
+            // caller explicitly opts into validation (`--insecure=false`).
+            insecure: true,
         }
     }
 
@@ -96,7 +105,12 @@ impl Target {
 
     /// Cache key derived from the Target fields that affect Client construction.
     fn client_cache_key(&self) -> ClientCacheKey {
-        (self.timeout, self.proxy.clone(), self.follow_redirects)
+        (
+            self.timeout,
+            self.proxy.clone(),
+            self.follow_redirects,
+            self.insecure,
+        )
     }
 
     /// Build a reqwest Client, falling back to a default Client on error.
@@ -133,7 +147,9 @@ impl Target {
         // is harmless (the loser's value is dropped on insert).
         let mut client_builder = Client::builder()
             .timeout(Duration::from_secs(self.timeout))
-            .danger_accept_invalid_certs(true); // Insecure mode for scanner
+            // Insecure mode for scanner (default on; `--insecure=false` to
+            // enforce TLS certificate validation).
+            .danger_accept_invalid_certs(self.insecure);
 
         if let Some(proxy_url) = &self.proxy
             && let Ok(proxy) = reqwest::Proxy::all(proxy_url)
@@ -339,6 +355,7 @@ mod tests {
     const REUSE_TIMEOUT: u64 = 60_001;
     const DISTINCT_TIMEOUT_A: u64 = 60_002;
     const DISTINCT_TIMEOUT_B: u64 = 60_003;
+    const INSECURE_TIMEOUT: u64 = 60_004;
 
     /// Count cached Clients whose key carries `timeout`. Scoping by a
     /// per-test-unique timeout isolates the measurement from any other test
@@ -346,7 +363,7 @@ mod tests {
     fn cache_entries_with_timeout(timeout: u64) -> usize {
         client_cache()
             .lock()
-            .map(|g| g.keys().filter(|(t, _, _)| *t == timeout).count())
+            .map(|g| g.keys().filter(|(t, _, _, _)| *t == timeout).count())
             .unwrap_or(0)
     }
 
@@ -379,6 +396,36 @@ mod tests {
         let _ = a.build_client().unwrap();
         assert_eq!(cache_entries_with_timeout(a.timeout), 1);
         assert_eq!(cache_entries_with_timeout(b.timeout), 1);
+    }
+
+    /// `insecure` is part of the Client cache key, so toggling TLS
+    /// verification yields two distinct cached Clients rather than silently
+    /// reusing one built with the other posture.
+    #[test]
+    fn test_client_cache_separates_on_insecure() {
+        let mut secure = parse_target("https://example.com").unwrap();
+        secure.timeout = INSECURE_TIMEOUT;
+        secure.insecure = false;
+        let mut insecure = parse_target("https://example.com").unwrap();
+        insecure.timeout = INSECURE_TIMEOUT;
+        insecure.insecure = true;
+        let _ = secure.build_client().unwrap();
+        let _ = insecure.build_client().unwrap();
+        // Rebuild to confirm reuse (no third entry created).
+        let _ = secure.build_client().unwrap();
+        assert_eq!(
+            cache_entries_with_timeout(INSECURE_TIMEOUT),
+            2,
+            "secure and insecure clients must not share a cache entry"
+        );
+    }
+
+    /// Scanner default: a freshly parsed target trusts invalid certs unless
+    /// the caller opts into validation.
+    #[test]
+    fn test_parse_target_defaults_to_insecure() {
+        let target = parse_target("https://example.com").unwrap();
+        assert!(target.insecure, "insecure must default to true (scanner mode)");
     }
 
     #[test]

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,7 +10,7 @@ use dalfox::cmd::scan::ScanArgs;
 /// Factory function to create default ScanArgs for testing
 pub fn create_test_scan_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/tests/common/mod.rs
+++ b/tests/common/mod.rs
@@ -10,6 +10,7 @@ use dalfox::cmd::scan::ScanArgs;
 /// Factory function to create default ScanArgs for testing
 pub fn create_test_scan_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "auto".to_string(),
         format: "json".to_string(),

--- a/tests/escaped_quote_probe_test.rs
+++ b/tests/escaped_quote_probe_test.rs
@@ -156,7 +156,7 @@ async fn analyze_parameters_covers_discovery_constructors_and_debug_line() {
     target.cookies = vec![("sid".to_string(), "seed".to_string())];
 
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -273,7 +273,7 @@ async fn run_scan_inject_marker_covers_marker_param_constructors() {
     let out = std::env::temp_dir().join(format!("dlfx_marker_{}.json", addr.port()));
 
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/escaped_quote_probe_test.rs
+++ b/tests/escaped_quote_probe_test.rs
@@ -156,6 +156,7 @@ async fn analyze_parameters_covers_discovery_constructors_and_debug_line() {
     target.cookies = vec![("sid".to_string(), "seed".to_string())];
 
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -272,6 +273,7 @@ async fn run_scan_inject_marker_covers_marker_param_constructors() {
     let out = std::env::temp_dir().join(format!("dlfx_marker_{}.json", addr.port()));
 
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/functional/analyze_external_js_test.rs
+++ b/tests/functional/analyze_external_js_test.rs
@@ -143,7 +143,7 @@ fn make_scan_args(
         path.replace(['/', '.'], "_"),
     ));
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/functional/analyze_external_js_test.rs
+++ b/tests/functional/analyze_external_js_test.rs
@@ -143,6 +143,7 @@ fn make_scan_args(
         path.replace(['/', '.'], "_"),
     ));
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -1030,7 +1030,7 @@ async fn run_scan_test(
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -1156,7 +1156,7 @@ async fn run_discovery_once(opts: DiscoveryOpts) -> bool {
     target.workers = 10;
 
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -2632,7 +2632,7 @@ async fn run_libscan(addr: SocketAddr, case_id: u32, detect_libs: bool) -> Vec<s
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         // The opt-in outdated-library detector is gated by this flag.
         detect_outdated_libs: detect_libs,
         input_type: "url".to_string(),

--- a/tests/functional/xss_mock_server.rs
+++ b/tests/functional/xss_mock_server.rs
@@ -1030,6 +1030,7 @@ async fn run_scan_test(
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -1155,6 +1156,7 @@ async fn run_discovery_once(opts: DiscoveryOpts) -> bool {
     target.workers = 10;
 
     let args = ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),
@@ -2630,6 +2632,7 @@ async fn run_libscan(addr: SocketAddr, case_id: u32, detect_libs: bool) -> Vec<s
     let out_path_str = out_path.to_string_lossy().to_string();
 
     let args = ScanArgs {
+        insecure: true,
         // The opt-in outdated-library detector is gated by this flag.
         detect_outdated_libs: detect_libs,
         input_type: "url".to_string(),

--- a/tests/observed_js_breakout_test.rs
+++ b/tests/observed_js_breakout_test.rs
@@ -46,7 +46,7 @@ async fn nested_object_handler(Query(p): Query<HashMap<String, String>>) -> Html
 
 fn base_args(url: String, out: String) -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/observed_js_breakout_test.rs
+++ b/tests/observed_js_breakout_test.rs
@@ -46,6 +46,7 @@ async fn nested_object_handler(Query(p): Query<HashMap<String, String>>) -> Html
 
 fn base_args(url: String, out: String) -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/request_count_probe.rs
+++ b/tests/request_count_probe.rs
@@ -25,7 +25,7 @@ use dalfox::cmd::scan::{self, ScanArgs};
 
 fn make_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/request_count_probe.rs
+++ b/tests/request_count_probe.rs
@@ -25,6 +25,7 @@ use dalfox::cmd::scan::{self, ScanArgs};
 
 fn make_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/scan_run_paths_test.rs
+++ b/tests/scan_run_paths_test.rs
@@ -12,6 +12,7 @@ use tokio::net::TcpListener;
 
 fn base_scan_args() -> ScanArgs {
     ScanArgs {
+        insecure: true,
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),

--- a/tests/scan_run_paths_test.rs
+++ b/tests/scan_run_paths_test.rs
@@ -12,7 +12,7 @@ use tokio::net::TcpListener;
 
 fn base_scan_args() -> ScanArgs {
     ScanArgs {
-        insecure: true,
+        insecure: Some(true),
         detect_outdated_libs: false,
         input_type: "url".to_string(),
         format: "json".to_string(),


### PR DESCRIPTION
Closes #1111

## Summary

dalfox hardcoded `danger_accept_invalid_certs(true)` in its HTTP client, so self-signed / staging certs were always trusted — but there was **no way to enforce TLS validation** and no documented control. This makes the TLS posture a first-class, configurable option while keeping the scanner-friendly default (per the maintainer's comment on #1111 and v2 behavior).

- **`--insecure` CLI flag, default `true`.** Pass `--insecure=false` to enforce certificate validation. Implemented as an optional-value bool (`require_equals` + `BoolishValueParser`) so `dalfox scan --insecure URL` does **not** swallow the positional target.
- **`Target` plumbing.** `insecure` is now part of the Client cache key, and `build_client` passes `self.insecure` to `danger_accept_invalid_certs(...)`.
- **Config file.** New `ScanConfig.insecure` with default-true precedence across all three apply paths; CLI `--insecure=false` still wins over config. Documented in the TOML template + reference docs.
- **server.** `ScanOptions.insecure` via JSON body and `?insecure=` query string. Absent ⇒ insecure-by-default (`unwrap_or(true)`); send `false` to validate.
- **MCP.** `insecure` param (default `true`) on both `scan_with_dalfox` and `preflight_dalfox`.
- **Warning gating.** The one-shot "TLS certificate validation is disabled" stderr warning now only prints when insecure mode is actually active, and points to `--insecure=false`.

> server/mcp scan insecurely by default unless the request or config opts out — matching the issue's requirement ("config 등에서 별도로 처리하지 않는 경우").

## Testing

- `cargo build`, `cargo clippy --all-targets` — clean.
- `cargo test --lib` — all green (one unrelated parallel-state HAR flake passes on rerun).
- Added unit tests: CLI flag parsing (`--insecure` / `--insecure=false` / boolish / positional), Client cache-key separation, config-apply precedence, MCP serde defaults, server query parse + preflight hydration.
- **End-to-end:** against a local self-signed HTTPS server — default trusts the cert and scans; `--insecure=false` correctly fails the TLS handshake (`UNREACHABLE ... TLS handshake failed`) with no warning emitted.

## Usage

```bash
# default: skip TLS verification (self-signed / staging certs OK)
dalfox url https://target.example/?q=1

# enforce certificate validation
dalfox url https://target.example/?q=1 --insecure=false
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)