### PR TITLE
fix(scanner): parse-DoS hardening + XSS false-negative & WAF/lifecycle fixes

### DIFF
--- a/src/encoding/pipeline.rs
+++ b/src/encoding/pipeline.rs
@@ -234,6 +234,14 @@ fn infer_b64_or_b64url_json(value: &str) -> Vec<NestedField> {
 
 /// Strategy: standard-alphabet base64 wrapping a JSON object/array.
 fn infer_b64_json(value: &str) -> Vec<NestedField> {
+    // `query_pairs()` URL-decoding turns a raw `+` in the value into a space, so
+    // a standard-alphabet base64 value carrying `+` arrives space-mangled and
+    // would be rejected. Undo that for the standard-alphabet attempt (url-safe
+    // base64 has no `+`, so its path is unaffected). A non-base64/non-JSON value
+    // still bails at the decode/JSON checks below, so this can't cause a false
+    // discovery.
+    let restored = value.replace(' ', "+");
+    let value = restored.as_str();
     if !looks_like_b64(value, /*allow_url_safe=*/ false) {
         return Vec::new();
     }

--- a/src/encoding/pipeline/tests.rs
+++ b/src/encoding/pipeline/tests.rs
@@ -433,3 +433,27 @@ fn pointer_escapes_special_chars() {
         assert_eq!(parsed[&key], "ZZZ", "field {key} replaced");
     }
 }
+
+#[test]
+fn b64_json_discovery_survives_plus_decoded_to_space() {
+    // `query_pairs()` turns a raw `+` in a base64 value into a space, so a
+    // standard-alphabet base64-of-JSON value carrying `+` arrives space-mangled.
+    // Discovery must still find the leaf (the `+` is restored before decoding).
+    // Pick a JSON whose STANDARD base64 contains a `+`.
+    let mut fixture = None;
+    for len in 1..=12usize {
+        let json = format!(r#"{{"k":"{}"}}"#, ">".repeat(len));
+        let enc = b64(&json);
+        if enc.contains('+') {
+            fixture = Some(enc);
+            break;
+        }
+    }
+    let enc = fixture.expect("a '>'-run JSON whose standard base64 contains '+'");
+    let mangled = enc.replace('+', " "); // simulate query_pairs '+' -> space
+    let leaves = infer_nested_pipelines(&mangled);
+    assert!(
+        !leaves.is_empty(),
+        "standard base64-of-JSON discovery must survive '+'->space (enc={enc}, mangled={mangled})"
+    );
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -403,7 +403,10 @@ impl DalfoxMcp {
                             // and cap the body with `Range: 0-8191` so a large
                             // response can't buffer unbounded into memory.
                             let preflight = crate::utils::build_preflight_request(
-                                &client, &target, false, Some(8192),
+                                &client,
+                                &target,
+                                false,
+                                Some(8192),
                             );
                             if let Ok(resp) = preflight.send().await {
                                 // Read CSP off the response before consuming the

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -397,7 +397,15 @@ impl DalfoxMcp {
                         // hit the REST server, now fixed in both places.
                         if !scan_args.skip_ast_analysis {
                             let client = target.build_client_or_default();
-                            if let Ok(resp) = client.get(target.url.clone()).send().await {
+                            // Mirror the CLI preflight: carry the target's
+                            // headers/cookies/User-Agent (so auth/header/UA-gated
+                            // SPAs are analyzed logged-in, matching CLI findings)
+                            // and cap the body with `Range: 0-8191` so a large
+                            // response can't buffer unbounded into memory.
+                            let preflight = crate::utils::build_preflight_request(
+                                &client, &target, false, Some(8192),
+                            );
+                            if let Ok(resp) = preflight.send().await {
                                 // Read CSP off the response before consuming the
                                 // body so a `require-trusted-types-for` page is
                                 // analyzed with the same Trusted Types awareness

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -418,6 +418,7 @@ async fn send_probe_request_for_param(
         }
         Location::MultipartBody => {
             let mut form = reqwest::multipart::Form::new();
+            let mut placed = false;
             if let Some(d) = &data {
                 for pair in d.split('&') {
                     if let Some((k, v)) = pair.split_once('=') {
@@ -429,18 +430,19 @@ async fn send_probe_request_for_param(
                             .to_string();
                         if k == param_name {
                             form = form.text(k, payload.to_string());
+                            placed = true;
                         } else {
                             form = form.text(k, v);
                         }
                     }
                 }
             }
-            if data.is_none()
-                || !data
-                    .as_ref()
-                    .unwrap_or(&String::new())
-                    .contains(&param_name)
-            {
+            // Append the param as a new field only when the exact-match loop
+            // didn't already inject it. The old `!data.contains(name)` substring
+            // guard skipped this whenever `name` was a substring of another key
+            // or value, sending the probe with no payload (so all specials
+            // classified invalid and the param's <,> payloads were pruned).
+            if !placed {
                 form = form.text(param_name.clone(), payload.to_string());
             }
             request_builder = client

--- a/src/payload/xss_html.rs
+++ b/src/payload/xss_html.rs
@@ -36,7 +36,7 @@ pub fn get_dynamic_xss_html_payloads() -> Vec<String> {
         "<IMG src=x onerror={JS} ClAss={CLASS}>",
         "<sVg onload={JS} claSS={CLASS}>",
         "<sCrIpt/cLaSs={CLASS}>{JS}</scRipT>",
-        "<xmp><p title=\"</xmp><svg/onload={JS}) class={CLASS}>",
+        "<xmp><p title=\"</xmp><svg/onload={JS} class={CLASS}>",
         "<details open ontoggle={JS} class={CLASS}>",
         "<iFrAme/src=JaVAsCrIPt:{JS} ClAss={CLASS}>",
         "</<a/href='><svg/onload={JS} claSS={CLASS}>'>",

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -152,6 +152,43 @@ fn source_nesting_exceeds_limit(source: &str) -> bool {
     false
 }
 
+/// True when `source` must NOT be handed to oxc's `Parser::parse` on a normal
+/// worker stack — either it exceeds [`MAX_ANALYZE_SOURCE_BYTES`] or its
+/// structural nesting could overflow the recursive-descent parser (see
+/// [`source_nesting_exceeds_limit`]). Shared by every oxc parse site so a
+/// hostile `<script>` body can't SIGABRT the process from one of them.
+pub(crate) fn source_exceeds_parse_guards(source: &str) -> bool {
+    source.len() > MAX_ANALYZE_SOURCE_BYTES || source_nesting_exceeds_limit(source)
+}
+
+/// Inputs at or below this size parse safely on a normal worker stack (see
+/// [`INLINE_PARSE_BYTES`]); larger inputs that pass [`source_exceeds_parse_guards`]
+/// should run through [`run_parse_on_large_stack`].
+pub(crate) const SAFE_INLINE_PARSE_BYTES: usize = INLINE_PARSE_BYTES;
+
+/// Run `f` (an oxc parse + collect) on a dedicated thread with a large,
+/// mostly-virtual stack ([`ANALYZE_STACK_BYTES`]) so a deep — but
+/// guard-approved — statement/assignment chain can't overflow the caller's
+/// worker stack. Returns `None` if the thread can't be spawned (rare; the
+/// caller treats that as "skip / inert", never parsing inline, since such an
+/// input could need tens of MiB of stack). `f` must return an owned value.
+pub(crate) fn run_parse_on_large_stack<T, F>(f: F) -> Option<T>
+where
+    T: Send,
+    F: FnOnce() -> T + Send,
+{
+    std::thread::scope(|scope| {
+        match std::thread::Builder::new()
+            .stack_size(ANALYZE_STACK_BYTES)
+            .spawn_scoped(scope, f)
+        {
+            // A panic inside the parse degrades to None rather than aborting.
+            Ok(h) => h.join().ok(),
+            Err(_) => None,
+        }
+    })
+}
+
 /// Represents a potential DOM XSS vulnerability found via AST analysis
 #[derive(Debug, Clone)]
 pub struct DomXssVulnerability {
@@ -1039,8 +1076,12 @@ impl<'a> DomXssVisitor<'a> {
         if func.contains("encode") && func.contains("html") {
             return true;
         }
-        // "purify" or "dompurify"
-        if func.contains("purify") {
+        // "purify"/"dompurify" as a *whole* segment only. Matching "purify" as a
+        // bare substring also fires on unrelated names like `impurifyData`,
+        // `purifyConfig`, or `unpurified`, wrongly clearing taint and hiding real
+        // DOM-XSS. The canonical `DOMPurify.sanitize` form is already covered by
+        // the explicit `DOM_SANITIZERS` allowlist.
+        if func == "purify" || func == "dompurify" {
             return true;
         }
         false
@@ -2605,10 +2646,21 @@ impl<'a> DomXssVisitor<'a> {
             }
             Statement::ForStatement(for_stmt) => {
                 // `init` runs unconditionally; `update`/`body` are conditional.
-                if let Some(ForStatementInit::VariableDeclaration(var_decl)) = &for_stmt.init {
-                    for decl in &var_decl.declarations {
-                        self.walk_variable_declarator(decl);
+                match &for_stmt.init {
+                    Some(ForStatementInit::VariableDeclaration(var_decl)) => {
+                        for decl in &var_decl.declarations {
+                            self.walk_variable_declarator(decl);
+                        }
                     }
+                    // Expression-form init (`for (x = location.hash; …)`): the
+                    // assignment runs unconditionally, so walk it so its taint is
+                    // tracked into the body (otherwise a downstream sink is missed).
+                    Some(init) => {
+                        if let Some(expr) = init.as_expression() {
+                            self.walk_expression(expr);
+                        }
+                    }
+                    None => {}
                 }
                 if let Some(test) = &for_stmt.test {
                     self.walk_expression(test);
@@ -2619,6 +2671,46 @@ impl<'a> DomXssVisitor<'a> {
                 }
                 self.walk_statement(&for_stmt.body);
                 self.branch_depth -= 1;
+            }
+            // `for (x of iterable)`: iterating a tainted iterable yields tainted
+            // elements, so taint the loop binding when the right-hand expression
+            // is tainted. Without this arm the old catch-all `_ => {}` dropped the
+            // body entirely — a false negative for source->sink flows inside this
+            // common (especially minified) loop form.
+            Statement::ForOfStatement(for_of) => {
+                self.walk_expression(&for_of.right);
+                if self.is_tainted(&for_of.right)
+                    && let ForStatementLeft::VariableDeclaration(var_decl) = &for_of.left
+                {
+                    for decl in &var_decl.declarations {
+                        if let BindingPattern::BindingIdentifier(id) = &decl.id {
+                            self.tainted_vars.insert(id.name.to_string());
+                        }
+                    }
+                }
+                self.branch_depth += 1;
+                self.walk_statement(&for_of.body);
+                self.branch_depth -= 1;
+            }
+            // `for (k in obj)` binds property *keys* (strings), not the iterated
+            // values, so don't taint the binding; still walk the iterated
+            // expression and the body so sources/sinks inside them are seen.
+            Statement::ForInStatement(for_in) => {
+                self.walk_expression(&for_in.right);
+                self.branch_depth += 1;
+                self.walk_statement(&for_in.body);
+                self.branch_depth -= 1;
+            }
+            Statement::DoWhileStatement(do_while) => {
+                self.branch_depth += 1;
+                self.walk_statement(&do_while.body);
+                self.branch_depth -= 1;
+                self.walk_expression(&do_while.test);
+            }
+            // A labeled statement (`loop: for (…) …`) just wraps its body; walk
+            // through so the labeled loop/block isn't skipped.
+            Statement::LabeledStatement(labeled) => {
+                self.walk_statement(&labeled.body);
             }
             Statement::FunctionDeclaration(func_decl) => {
                 // Parameterized functions are primarily handled through summaries/call sites.

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4258,3 +4258,65 @@ el.innerHTML = p.createHTML(location.hash);
         "a sole sanitizer return after a side-effect statement is still strict"
     );
 }
+
+#[test]
+fn for_of_taints_loop_binding_from_tainted_iterable() {
+    // for-of over a tainted iterable taints the per-iteration binding, so the
+    // sink inside the body is flagged. The old catch-all `_ => {}` arm dropped
+    // the body entirely (false negative on a common, esp. minified, form).
+    let code = r#"for (const x of [location.hash]) { eval(x); }"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink.contains("eval")),
+        "for-of body sink should be detected, got {vulns:?}"
+    );
+}
+
+#[test]
+fn for_in_do_while_and_labeled_bodies_are_walked() {
+    // do-while body must be walked.
+    let do_while = r#"let h = location.hash; do { document.write(h); } while (false);"#;
+    let v1 = AstDomAnalyzer::new().analyze(do_while).unwrap();
+    assert!(
+        v1.iter().any(|v| v.sink.contains("write")),
+        "do-while body sink should be detected, got {v1:?}"
+    );
+    // labeled loop body must be walked.
+    let labeled = r#"let h = location.hash; outer: for (;;) { document.write(h); break outer; }"#;
+    let v2 = AstDomAnalyzer::new().analyze(labeled).unwrap();
+    assert!(
+        v2.iter().any(|v| v.sink.contains("write")),
+        "labeled loop body sink should be detected, got {v2:?}"
+    );
+}
+
+#[test]
+fn for_loop_expression_init_taint_reaches_sink() {
+    // `for (x = location.hash; …)` runs an unconditional tainting assignment in
+    // the init; the downstream sink must be flagged (init was previously only
+    // walked for the VariableDeclaration form).
+    let code = r#"var x; for (x = location.hash; ; ) { document.write(x); break; }"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink.contains("write")),
+        "for-init expression assignment taint should reach the sink, got {vulns:?}"
+    );
+}
+
+#[test]
+fn purify_substring_does_not_suppress_unrelated_function() {
+    // A name that merely *contains* "purify" (e.g. `impurifyData`) must NOT be
+    // treated as a sanitizer — doing so cleared taint and hid a real DOM-XSS.
+    let code = r#"document.write(impurifyData(location.hash));"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink.contains("write")),
+        "impurifyData must not be treated as a sanitizer, got {vulns:?}"
+    );
+    // Whole-segment `purify`/`dompurify` still sanitize (taint cleared).
+    let sanitized = r#"document.write(purify(location.hash));"#;
+    assert!(
+        AstDomAnalyzer::new().analyze(sanitized).unwrap().is_empty(),
+        "purify(x) as a whole-segment sanitizer should suppress the finding"
+    );
+}

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -298,6 +298,12 @@ fn has_html_structural_evidence_in_doc(payload: &str, document: &scraper::Html) 
         return false;
     }
 
+    // The raw payload may entity-encode its sink chars for WAF bypass (e.g.
+    // `alert&#40;1&#41;`), but scraper decodes the parsed attribute/script text
+    // back to `alert(1)`. Compare against the entity-decoded payload too, else a
+    // genuine breakout gets downgraded to Reflected in WAF-bypass mode.
+    let decoded_payload = decode_html_entities(payload);
+
     let selector = selectors::universal();
     for node in document.select(selector) {
         let value = node.value();
@@ -315,7 +321,7 @@ fn has_html_structural_evidence_in_doc(payload: &str, document: &scraper::Html) 
             if !crate::scanning::js_context_verify::payload_carries_js_sink(trimmed) {
                 continue;
             }
-            if payload.contains(trimmed) {
+            if payload.contains(trimmed) || decoded_payload.contains(trimmed) {
                 return true;
             }
         }
@@ -326,7 +332,7 @@ fn has_html_structural_evidence_in_doc(payload: &str, document: &scraper::Html) 
             let trimmed = text.trim();
             if !trimmed.is_empty()
                 && crate::scanning::js_context_verify::payload_carries_js_sink(trimmed)
-                && payload.contains(trimmed)
+                && (payload.contains(trimmed) || decoded_payload.contains(trimmed))
             {
                 return true;
             }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1030,3 +1030,17 @@ fn test_is_executable_url_attribute_pin_whitelist() {
         );
     }
 }
+
+#[test]
+fn html_structural_evidence_matches_entity_encoded_payload() {
+    // WAF-bypass payloads entity-encode the sink chars (`alert&#40;1&#41;`), but
+    // scraper decodes the parsed attribute back to `alert(1)`. The containment
+    // check must compare against the entity-decoded payload too, otherwise a
+    // genuine breakout is downgraded from Verified to Reflected.
+    let payload = "<svg onload=alert&#40;1&#41; class=dalfox>";
+    let doc = scraper::Html::parse_document(r#"<svg onload="alert(1)" class="dalfox"></svg>"#);
+    assert!(
+        has_html_structural_evidence_in_doc(payload, &doc),
+        "entity-encoded payload should still match the decoded attribute value"
+    );
+}

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -74,6 +74,56 @@ fn waf_block_cooldown_ms(status_code: u16, consecutive: u32, waf_evasion: bool) 
     backoff_ms.min(WAF_BACKOFF_CAP_MS)
 }
 
+/// Adaptive WAF accounting for one injection-response status code, shared by the
+/// normal and stored-XSS (`--sxss`) injection paths.
+///
+/// `streak` is the **per-worker** consecutive-block counter. A single scan fans
+/// out to up to ~50 param workers; they previously shared one (per-scan / global)
+/// counter, so any worker's 2xx reset another worker's accumulating streak and
+/// the `--waf-evasion` escalation almost never fired (and 429/503 storms paced
+/// erratically). The escalation now reads this local counter, while the
+/// process-wide total ([`crate::tick_waf_block`]) and the per-job task-local
+/// stay updated for reporting and cross-scan isolation.
+async fn apply_injection_waf_accounting(
+    status_code: u16,
+    target: &Target,
+    args: &crate::cmd::scan::ScanArgs,
+    streak: &std::sync::atomic::AtomicU32,
+) {
+    use std::sync::atomic::Ordering;
+    let is_waf_block = matches!(status_code, 403 | 406 | 429 | 503);
+    let consecutive = if is_waf_block {
+        // Keep the process-wide total + per-job task-local in sync for reporting
+        // and cross-scan isolation; the value we act on is the per-worker streak.
+        crate::tick_waf_block();
+        streak.fetch_add(1, Ordering::Relaxed) + 1
+    } else {
+        crate::reset_waf_consecutive();
+        streak.store(0, Ordering::Relaxed);
+        0
+    };
+    if is_waf_block {
+        // `waf_block_cooldown_ms` decides whether (and how long) to pause based
+        // on the block class — see its doc comment.
+        let mut backoff_ms = waf_block_cooldown_ms(status_code, consecutive, args.waf_evasion);
+        if backoff_ms > 0 {
+            // Under --waf-evasion, scatter the cooldown by up to +50% so the
+            // backoff itself isn't a fixed, fingerprintable interval.
+            if args.waf_evasion {
+                backoff_ms = backoff_ms
+                    .saturating_add(crate::utils::rate_limit::fast_jitter(backoff_ms / 2 + 1));
+            }
+            sleep(Duration::from_millis(backoff_ms)).await;
+        }
+    }
+    // Per-target bypass effectiveness telemetry. Only counts when bypass is
+    // active for the target (target.mutation_stats is populated during preflight
+    // when a WAF is detected and bypass is on).
+    if let Some(ref stats) = target.mutation_stats {
+        stats.record_request(is_waf_block);
+    }
+}
+
 /// Check whether *all* occurrences of `payload` in `html` fall inside safe tags
 /// (textarea, noscript, style, xmp, plaintext, title).  If the payload appears
 /// at least once outside a safe tag, returns `false`.
@@ -1030,12 +1080,13 @@ async fn fetch_injection_response(
     param: &Param,
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
+    streak: &std::sync::atomic::AtomicU32,
 ) -> Option<String> {
     if args.skip_xss_scanning {
         return None;
     }
     let client = target.build_client_or_default();
-    fetch_injection_response_with_client(&client, target, param, payload, args).await
+    fetch_injection_response_with_client(&client, target, param, payload, args, streak).await
 }
 
 async fn fetch_injection_response_with_client(
@@ -1044,6 +1095,7 @@ async fn fetch_injection_response_with_client(
     param: &Param,
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
+    streak: &std::sync::atomic::AtomicU32,
 ) -> Option<String> {
     if args.skip_xss_scanning {
         return None;
@@ -1232,7 +1284,17 @@ async fn fetch_injection_response_with_client(
         // retrieval-URL path doesn't gate on them either, and we want
         // consistent SXSS evidence semantics.
         let inject_body: Option<String> = match inject_resp {
-            Ok(resp) => resp.text().await.ok().filter(|t| !t.is_empty()),
+            Ok(resp) => {
+                // Mirror the normal path's WAF accounting on the stored-write
+                // response before consuming the body: a 403/406/503 stored-write
+                // block must drive the same --waf-evasion cooldown + consecutive
+                // streak and record bypass telemetry. Without this, SXSS scans
+                // hammer a blocking write endpoint (IP-ban risk) and
+                // target_summary.waf.bypass is always empty.
+                let status_code = resp.status().as_u16();
+                apply_injection_waf_accounting(status_code, target, args, streak).await;
+                resp.text().await.ok().filter(|t| !t.is_empty())
+            }
             Err(_) => None,
         };
 
@@ -1278,37 +1340,8 @@ async fn fetch_injection_response_with_client(
         if let Ok(resp) = inject_resp {
             let status_code = resp.status().as_u16();
 
-            // Track WAF block status codes for adaptive throttling. The
-            // consecutive counter is per-scan when bound (MCP / REST runners)
-            // so one scan's WAF blocks don't slow down unrelated concurrent
-            // scans; CLI falls back to the process-wide counter.
-            let is_waf_block = matches!(status_code, 403 | 406 | 429 | 503);
-            if is_waf_block {
-                let consecutive = crate::tick_waf_block();
-                // `waf_block_cooldown_ms` decides whether (and how long) to
-                // pause based on the block class — see its doc comment.
-                let mut backoff_ms =
-                    waf_block_cooldown_ms(status_code, consecutive, args.waf_evasion);
-                if backoff_ms > 0 {
-                    // Under --waf-evasion, scatter the cooldown by up to +50% so
-                    // the backoff itself isn't a fixed, fingerprintable interval.
-                    if args.waf_evasion {
-                        backoff_ms = backoff_ms.saturating_add(
-                            crate::utils::rate_limit::fast_jitter(backoff_ms / 2 + 1),
-                        );
-                    }
-                    sleep(Duration::from_millis(backoff_ms)).await;
-                }
-            } else {
-                // Reset consecutive block counter on successful response
-                crate::reset_waf_consecutive();
-            }
-            // Per-target bypass effectiveness telemetry. Only counts when
-            // bypass is active for the target (target.mutation_stats is
-            // populated during preflight when WAF detected and bypass on).
-            if let Some(ref stats) = target.mutation_stats {
-                stats.record_request(is_waf_block);
-            }
+            // Adaptive WAF accounting (per-worker streak + cooldown + telemetry).
+            apply_injection_waf_accounting(status_code, target, args, streak).await;
 
             // Skip processing if the status code is in the ignore_return list
             if !args.ignore_return.is_empty() && args.ignore_return.contains(&status_code) {
@@ -1410,13 +1443,10 @@ async fn fetch_injection_response_with_client(
     }
 }
 
-/// Inject `payload`, then classify reflection in the response.
-///
-/// Pass `Some(client)` to reuse a pooled HTTP client (MCP / REST runners);
-/// pass `None` on the CLI path to build a default client per request from
-/// the target. Returns the reflection kind (suppressed to `None` when the
-/// match lands only in a known-safe context) together with the response
-/// body, or `(None, None)` when no response was obtained.
+/// Inject `payload`, then classify reflection in the response. Convenience
+/// entry for tests / one-shot callers: uses a throwaway per-call WAF streak.
+/// Production scan workers call [`check_reflection_with_response_tracked`] with
+/// their own per-worker streak so the adaptive backoff escalates correctly.
 pub async fn check_reflection_with_response(
     client: Option<&Client>,
     target: &Target,
@@ -1424,11 +1454,34 @@ pub async fn check_reflection_with_response(
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
 ) -> (Option<ReflectionKind>, Option<String>) {
+    let streak = std::sync::atomic::AtomicU32::new(0);
+    check_reflection_with_response_tracked(client, target, param, payload, args, &streak).await
+}
+
+/// Inject `payload`, then classify reflection in the response.
+///
+/// Pass `Some(client)` to reuse a pooled HTTP client (MCP / REST runners);
+/// pass `None` on the CLI path to build a default client per request from
+/// the target. Returns the reflection kind (suppressed to `None` when the
+/// match lands only in a known-safe context) together with the response
+/// body, or `(None, None)` when no response was obtained.
+///
+/// `streak` is the caller's per-worker consecutive-WAF-block counter (see
+/// [`apply_injection_waf_accounting`]); one per param worker keeps the
+/// `--waf-evasion` backoff escalation from being reset by sibling workers.
+pub async fn check_reflection_with_response_tracked(
+    client: Option<&Client>,
+    target: &Target,
+    param: &Param,
+    payload: &str,
+    args: &crate::cmd::scan::ScanArgs,
+    streak: &std::sync::atomic::AtomicU32,
+) -> (Option<ReflectionKind>, Option<String>) {
     let text = match client {
         Some(client) => {
-            fetch_injection_response_with_client(client, target, param, payload, args).await
+            fetch_injection_response_with_client(client, target, param, payload, args, streak).await
         }
-        None => fetch_injection_response(target, param, payload, args).await,
+        None => fetch_injection_response(target, param, payload, args, streak).await,
     };
     if let Some(text) = text {
         let kind = classify_reflection(&text, payload);

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -557,12 +557,19 @@ fn gather_sink_spans_in_expression(
     }
 }
 
-/// Locate the payload in the script block as raw substring. Returns the byte
-/// range `[start, end)` if found.
-fn locate_payload(script_src: &str, payload: &str) -> Option<(u32, u32)> {
-    let start = script_src.find(payload)?;
-    let end = start + payload.len();
-    Some((start as u32, end as u32))
+/// True when *any* occurrence of `payload` within `src` introduces a JS sink
+/// call. A benign in-string reflection (e.g. `var s = "…alert(1)…"`) can precede
+/// the genuinely executable breakout occurrence in the same `<script>` block, so
+/// every occurrence is checked — not just `find()`'s first, which downgraded a
+/// real finding to Reflected.
+fn any_payload_occurrence_hits_sink(src: &str, payload: &str) -> bool {
+    if payload.is_empty() {
+        return false;
+    }
+    src.match_indices(payload).any(|(start, _)| {
+        let end = start + payload.len();
+        script_block_has_sink_call_in_range(src, start as u32, end as u32)
+    })
 }
 
 /// Maximum body size (bytes) for which we attempt full-body JS parsing as a
@@ -585,16 +592,13 @@ pub(crate) fn has_js_context_evidence(payload: &str, html: &str) -> bool {
     let mut saw_block = false;
     for block in script_blocks(html) {
         saw_block = true;
-        if let Some((ps, pe)) = locate_payload(block, payload)
-            && script_block_has_sink_call_in_range(block, ps, pe)
-        {
+        if any_payload_occurrence_hits_sink(block, payload) {
             return true;
         }
     }
     if !saw_block
         && html.len() <= JSONP_PARSE_MAX_BYTES
-        && let Some((ps, pe)) = locate_payload(html, payload)
-        && script_block_has_sink_call_in_range(html, ps, pe)
+        && any_payload_occurrence_hits_sink(html, payload)
     {
         return true;
     }

--- a/src/scanning/js_context_verify.rs
+++ b/src/scanning/js_context_verify.rs
@@ -115,6 +115,31 @@ fn hash_block(script_src: &str) -> u64 {
 /// string-literal span. Returns `None` when the source has parser errors
 /// (treated as inert — injected JS that breaks parsing won't execute).
 fn collect_parsed_spans(script_src: &str) -> ParsedSpans {
+    // Guard the oxc parse exactly like `ast_dom_analysis::analyze`: a single
+    // malicious/compromised target can serve a `<script>` body with thousands
+    // of nested brackets or a multi-byte right-leaning chain that overflows
+    // oxc's recursive-descent parser *inside* `.parse()` — a stack overflow
+    // SIGABRTs the whole process (all in-flight scans, server/MCP jobs). Skip
+    // pathological bodies (treated as inert) and run larger-but-approved ones
+    // on a dedicated big-stack thread.
+    if crate::scanning::ast_dom_analysis::source_exceeds_parse_guards(script_src) {
+        return None;
+    }
+    if script_src.len() <= crate::scanning::ast_dom_analysis::SAFE_INLINE_PARSE_BYTES {
+        return collect_spans_on_stack(script_src);
+    }
+    // A spawn failure (`None`) is also treated as inert — we must NOT fall back
+    // to an inline parse, which could overflow the caller's worker stack.
+    crate::scanning::ast_dom_analysis::run_parse_on_large_stack(|| {
+        collect_spans_on_stack(script_src)
+    })
+    .flatten()
+}
+
+/// Parse `script_src` and collect every sink-call span and every string-literal
+/// span. Factored out of [`collect_parsed_spans`] so it can run on a dedicated
+/// large-stack thread for inputs above [`SAFE_INLINE_PARSE_BYTES`].
+fn collect_spans_on_stack(script_src: &str) -> ParsedSpans {
     let allocator = Allocator::default();
     let ret = Parser::new(&allocator, script_src, SourceType::default()).parse();
     if !ret.errors.is_empty() {

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -364,3 +364,42 @@ fn detects_js_sinks_in_advanced_expressions() {
     let html_chain = format!("<script>{}</script>", payload_chain);
     assert!(has_js_context_evidence(payload_chain, &html_chain));
 }
+
+#[test]
+fn deeply_nested_script_is_inert_and_does_not_crash() {
+    // A malicious/compromised target can serve a `<script>` body with thousands
+    // of nested brackets; oxc's recursive-descent parser has no depth guard and
+    // would stack-overflow-SIGABRT the whole process when parsing it. The shared
+    // pre-parse guard must skip such a block (treated as inert) so this returns
+    // false WITHOUT crashing the test process. (A regression here aborts the run
+    // rather than failing the assert — that itself is the signal.)
+    let payload = "alert(1)";
+    let depth = 5000;
+    let nested = format!(
+        "{}{}{}",
+        "(".repeat(depth),
+        payload,
+        ")".repeat(depth)
+    );
+    let html = format!("<script>var x = {};</script>", nested);
+    assert!(
+        !has_js_context_evidence(payload, &html),
+        "over-nested script must be skipped as inert, not parsed"
+    );
+}
+
+#[test]
+fn large_script_above_inline_cap_runs_on_large_stack_without_crashing() {
+    // A guard-approved but large script (above SAFE_INLINE_PARSE_BYTES) must
+    // parse on the dedicated big-stack thread and still verify a genuine sink.
+    let payload = "\"-alert(1)-\"";
+    let filler = "var pad = 1;\n".repeat(400); // ~5 KiB, over the 2 KiB inline cap
+    let html = format!(
+        "<script>{}var c2 = \"{}\";</script>",
+        filler, payload
+    );
+    assert!(
+        has_js_context_evidence(payload, &html),
+        "large-but-valid script should still verify the breakout sink"
+    );
+}

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -375,12 +375,7 @@ fn deeply_nested_script_is_inert_and_does_not_crash() {
     // rather than failing the assert — that itself is the signal.)
     let payload = "alert(1)";
     let depth = 5000;
-    let nested = format!(
-        "{}{}{}",
-        "(".repeat(depth),
-        payload,
-        ")".repeat(depth)
-    );
+    let nested = format!("{}{}{}", "(".repeat(depth), payload, ")".repeat(depth));
     let html = format!("<script>var x = {};</script>", nested);
     assert!(
         !has_js_context_evidence(payload, &html),
@@ -394,10 +389,7 @@ fn large_script_above_inline_cap_runs_on_large_stack_without_crashing() {
     // parse on the dedicated big-stack thread and still verify a genuine sink.
     let payload = "\"-alert(1)-\"";
     let filler = "var pad = 1;\n".repeat(400); // ~5 KiB, over the 2 KiB inline cap
-    let html = format!(
-        "<script>{}var c2 = \"{}\";</script>",
-        filler, payload
-    );
+    let html = format!("<script>{}var c2 = \"{}\";</script>", filler, payload);
     assert!(
         has_js_context_evidence(payload, &html),
         "large-but-valid script should still verify the breakout sink"

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -403,3 +403,17 @@ fn large_script_above_inline_cap_runs_on_large_stack_without_crashing() {
         "large-but-valid script should still verify the breakout sink"
     );
 }
+
+#[test]
+fn checks_every_payload_occurrence_not_just_the_first() {
+    // A benign in-string reflection of the payload precedes the executable
+    // breakout occurrence in the same <script> block. find()'s first-match-only
+    // tested the inert in-string occurrence and missed the real sink; all
+    // occurrences must be checked.
+    let payload = "alert(1)";
+    let html = r#"<script>var s = "alert(1)"; alert(1);</script>"#;
+    assert!(
+        has_js_context_evidence(payload, html),
+        "the executable second occurrence must be detected"
+    );
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -2018,16 +2018,15 @@ pub async fn run_scanning(
             }
             continue;
         }
-        // Early stop if global limit reached
+        // Early stop if global limit reached. Use `break` (not an early
+        // `return`) so the join-drain loop below awaits the already-spawned
+        // workers instead of detaching them: a dropped JoinHandle does NOT
+        // abort its task, so an early return left workers hitting the target
+        // past the stop point, skipped `collapse_target_results` and the
+        // worker-panic tally, and let late findings race the server's result
+        // snapshot. The tail finishes the progress bar with "Completed scanning".
         if ctx.limit_reached() {
-            if let Some(ref pb) = pb {
-                finish_scan_bar(
-                    pb,
-                    console::style("✓").green().to_string(),
-                    format!("Completed scanning {}", target.url),
-                );
-            }
-            return ScanRunReport::default();
+            break;
         }
 
         let ctx = ctx.clone();

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -37,7 +37,7 @@ pub mod xss_common;
 use crate::cmd::scan::ScanArgs;
 use crate::parameter_analysis::Param;
 use crate::scanning::check_dom_verification::check_dom_verification_with_client;
-use crate::scanning::check_reflection::check_reflection_with_response;
+use crate::scanning::check_reflection::check_reflection_with_response_tracked;
 use crate::scanning::result::FindingType;
 use crate::target_parser::Target;
 use indicatif::{MultiProgress, ProgressBar, ProgressStyle};
@@ -1285,6 +1285,12 @@ struct ParamScanState {
     /// DOM XSS already confirmed for this param locally — skip the
     /// remaining DOM payloads.
     dom_found_locally: bool,
+    /// Per-worker consecutive-WAF-block streak driving the `--waf-evasion`
+    /// backoff escalation. Lives on the per-param scan state (one per worker)
+    /// so a single scan's ~50 concurrent workers don't reset each other's
+    /// streak — which previously kept the escalation from ever firing. Threaded
+    /// into `check_reflection_with_response_tracked`.
+    waf_streak: std::sync::atomic::AtomicU32,
 }
 
 /// Shared, cheaply-clonable context handed to each spawned worker. Every
@@ -1426,9 +1432,15 @@ impl ScanWorkerCtx {
         let mut probe_reflected = false;
         let mut probe_response_text: Option<String> = None;
         for pp in probe_payloads {
-            let (kind, response_text) =
-                check_reflection_with_response(Some(client), &self.target, param, pp, &self.args)
-                    .await;
+            let (kind, response_text) = check_reflection_with_response_tracked(
+                Some(client),
+                &self.target,
+                param,
+                pp,
+                &self.args,
+                &state.waf_streak,
+            )
+            .await;
             if kind.is_some() {
                 probe_reflected = true;
                 probe_response_text = response_text;
@@ -1471,12 +1483,13 @@ impl ScanWorkerCtx {
         // letter-stripping filters (e.g., /[a-zA-Z]/ removal).
         if !probe_reflected {
             let numeric_probe = crate::scanning::check_reflection::NUMERIC_PROBE_MARKER;
-            let (kind, _) = check_reflection_with_response(
+            let (kind, _) = check_reflection_with_response_tracked(
                 Some(client),
                 &self.target,
                 param,
                 numeric_probe,
                 &self.args,
+                &state.waf_streak,
             )
             .await;
             if kind.is_some() {
@@ -1523,12 +1536,13 @@ impl ScanWorkerCtx {
                     state.reflection_found_locally = true;
                     (None, None)
                 } else {
-                    check_reflection_with_response(
+                    check_reflection_with_response_tracked(
                         Some(self.client.as_ref()),
                         &self.target,
                         param,
                         &reflection_payload,
                         &self.args,
+                        &state.waf_streak,
                     )
                     .await
                 }

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -487,7 +487,15 @@ pub(crate) async fn run_scan_job(
                     // fails the regular scan path below still runs.
                     if !args.skip_ast_analysis {
                         let client = target.build_client_or_default();
-                        if let Ok(resp) = client.get(target.url.clone()).send().await {
+                        // Mirror the CLI preflight: carry the target's
+                        // headers/cookies/User-Agent (so auth/header/UA-gated
+                        // SPAs are analyzed logged-in, matching CLI findings —
+                        // a bare GET dropped them and analyzed the logged-out
+                        // page) and cap the body with `Range: 0-8191` so a large
+                        // response can't buffer unbounded into server memory.
+                        let preflight =
+                            crate::utils::build_preflight_request(&client, &target, false, Some(8192));
+                        if let Ok(resp) = preflight.send().await {
                             // Read CSP off the response before the body is
                             // consumed, so a `require-trusted-types-for` page is
                             // analyzed with the same Trusted Types awareness the

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -493,8 +493,12 @@ pub(crate) async fn run_scan_job(
                         // a bare GET dropped them and analyzed the logged-out
                         // page) and cap the body with `Range: 0-8191` so a large
                         // response can't buffer unbounded into server memory.
-                        let preflight =
-                            crate::utils::build_preflight_request(&client, &target, false, Some(8192));
+                        let preflight = crate::utils::build_preflight_request(
+                            &client,
+                            &target,
+                            false,
+                            Some(8192),
+                        );
                         if let Ok(resp) = preflight.send().await {
                             // Read CSP off the response before the body is
                             // consumed, so a `require-trusted-types-for` page is

--- a/src/target_parser/har.rs
+++ b/src/target_parser/har.rs
@@ -214,18 +214,8 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
 /// original connection. `Cookie` and `User-Agent` are handled separately by the
 /// caller and are intentionally not listed here.
 fn is_skippable_har_header(name: &str) -> bool {
-    const SKIP: &[&str] = &[
-        "host",
-        "content-length",
-        "accept-encoding",
-        "connection",
-        "proxy-connection",
-        "keep-alive",
-        "transfer-encoding",
-        "upgrade",
-        "te",
-    ];
-    SKIP.iter().any(|s| name.eq_ignore_ascii_case(s))
+    // Single source of truth shared with the raw-HTTP request parser.
+    super::is_skippable_request_header(name)
 }
 
 /// Extract a request body from `postData`, preferring the captured raw `text`

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -244,6 +244,30 @@ pub fn is_raw_http_request(s: &str) -> bool {
     false
 }
 
+/// Request headers that must not be forwarded verbatim from an imported request
+/// (raw HTTP or HAR). `Content-Length`/`Transfer-Encoding` are recomputed by
+/// reqwest from the actual (payload-injected) body — a stale value mis-frames
+/// the request and truncates the body, so injected params are never seen.
+/// `Accept-Encoding` is left to reqwest so its transparent decompression stays
+/// on (a manual value yields compressed gibberish the markers never match).
+/// `Host` is set from the URL and the rest are hop-by-hop headers tied to the
+/// original connection. `Cookie`/`User-Agent` are handled separately by callers
+/// and are intentionally not listed here. Shared with the HAR import path.
+pub(crate) fn is_skippable_request_header(name: &str) -> bool {
+    const SKIP: &[&str] = &[
+        "host",
+        "content-length",
+        "accept-encoding",
+        "connection",
+        "proxy-connection",
+        "keep-alive",
+        "transfer-encoding",
+        "upgrade",
+        "te",
+    ];
+    SKIP.iter().any(|s| name.eq_ignore_ascii_case(s))
+}
+
 /// Parse a raw HTTP request into a Target.
 /// Supports:
 /// - Request line with absolute-form URI: GET http://example.com/path HTTP/1.1
@@ -291,19 +315,26 @@ pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::E
                 host_header = Some(value_trim.clone());
                 // No need to forward Host to reqwest; it sets Host automatically from URL.
             } else if name_trim.eq_ignore_ascii_case("cookie") {
-                // Split cookies into vector
+                // Split cookies into vector. Do NOT also keep the original Cookie
+                // header: leaving it in `headers_vec` makes per-cookie probing
+                // emit both the original and the mutated Cookie (reqwest appends),
+                // so the server may take the un-injected value and the payload
+                // never lands. `apply_headers_ua_cookies` rebuilds a single,
+                // correct Cookie header from `cookies_vec`/overrides — mirror HAR.
                 for kv in value_trim.split(';') {
                     let kv = kv.trim();
                     if let Some((k, v)) = kv.split_once('=') {
                         cookies_vec.push((k.trim().to_string(), v.trim().to_string()));
                     }
                 }
-                // Preserve original Cookie header as well
-                headers_vec.push((name_trim, value_trim));
             } else if name_trim.eq_ignore_ascii_case("user-agent") {
                 user_agent = Some(value_trim.clone());
                 headers_vec.push((name_trim, value_trim));
-            } else {
+            } else if !is_skippable_request_header(&name_trim) {
+                // Drop stale `Content-Length`/`Transfer-Encoding` (reqwest
+                // recomputes them from the injected body — a stale value
+                // truncates it) and hop-by-hop/`Accept-Encoding` headers, the
+                // same set the HAR import path strips.
                 headers_vec.push((name_trim, value_trim));
             }
         }
@@ -685,5 +716,53 @@ mod raw_http_tests {
         assert_eq!(t.method, "POST");
         assert_eq!(t.url.as_str(), "http://example.com/submit");
         assert_eq!(t.data.as_deref(), Some("a=1&b=2"));
+    }
+
+    #[test]
+    fn raw_http_strips_stale_framing_and_accept_encoding_headers() {
+        // A stale Content-Length / Transfer-Encoding must NOT be forwarded:
+        // reqwest recomputes them and a stale value truncates the
+        // payload-injected body (body-param XSS silently missed). Accept-Encoding
+        // must be dropped so reqwest's transparent decompression stays on.
+        let raw = "POST /submit HTTP/1.1\r\nHost: example.com\r\nContent-Length: 7\r\nTransfer-Encoding: chunked\r\nAccept-Encoding: gzip\r\nConnection: keep-alive\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\na=1&b=2";
+        let t = parse_raw_http_request(raw).expect("should parse");
+        for stripped in [
+            "content-length",
+            "transfer-encoding",
+            "accept-encoding",
+            "connection",
+        ] {
+            assert!(
+                !t.headers
+                    .iter()
+                    .any(|(k, _)| k.eq_ignore_ascii_case(stripped)),
+                "{stripped} must be stripped, got {:?}",
+                t.headers
+            );
+        }
+        // A normal header survives verbatim.
+        assert!(
+            t.headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        );
+    }
+
+    #[test]
+    fn raw_http_does_not_retain_original_cookie_header() {
+        // The Cookie header is split into `cookies` only; keeping it in `headers`
+        // too made per-cookie probing emit both the original and the mutated
+        // Cookie (reqwest appends), so the payload could fail to land.
+        let raw = "GET /p HTTP/1.1\r\nHost: example.com\r\nCookie: sid=abc; a=b\r\n\r\n";
+        let t = parse_raw_http_request(raw).expect("should parse");
+        assert!(
+            !t.headers
+                .iter()
+                .any(|(k, _)| k.eq_ignore_ascii_case("cookie")),
+            "original Cookie header must not be retained in headers, got {:?}",
+            t.headers
+        );
+        assert!(t.cookies.iter().any(|(k, v)| k == "sid" && v == "abc"));
+        assert!(t.cookies.iter().any(|(k, v)| k == "a" && v == "b"));
     }
 }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -85,8 +85,15 @@ pub fn apply_headers_ua_cookies(
     target: &Target,
     cookie_header: Option<String>,
 ) -> RequestBuilder {
-    // Apply user provided headers first
+    // Apply user provided headers first. Skip `Accept-Encoding`: setting it
+    // manually disables reqwest's transparent decompression, so the body comes
+    // back as raw gzip/deflate/br bytes and every reflection/marker check
+    // silently fails (scan-wide false negatives). Leaving it unset keeps
+    // decompression on, mirroring the HAR import path's `is_skippable_har_header`.
     for (k, v) in &target.headers {
+        if k.eq_ignore_ascii_case("accept-encoding") {
+            continue;
+        }
         rb = rb.header(k, v);
     }
 

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -193,6 +193,33 @@ fn test_build_preflight_request_head_ignores_range() {
     );
 }
 
+#[test]
+fn user_accept_encoding_header_is_dropped_to_keep_decompression() {
+    // A user-supplied Accept-Encoding (-H or raw-request import) disables
+    // reqwest's transparent decompression, so the body returns as raw gzip/br
+    // bytes and every reflection/marker check silently fails. It must be dropped
+    // while unrelated headers are preserved.
+    let mut target = parse_target("https://example.com/path").unwrap();
+    target.headers = vec![
+        ("Accept-Encoding".to_string(), "gzip".to_string()),
+        ("X-Keep".to_string(), "1".to_string()),
+    ];
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let req = build_preflight_request(&client, &target, false, None)
+        .build()
+        .expect("request should build");
+    assert!(
+        req.headers().get("Accept-Encoding").is_none(),
+        "user Accept-Encoding must be dropped so decompression stays on"
+    );
+    assert_eq!(
+        req.headers().get("X-Keep").and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "unrelated user headers must be preserved"
+    );
+}
+
 // ---- retry policy (decide_retry / next_backoff_ms) ----
 
 #[test]


### PR DESCRIPTION
## Summary

A verified bug-hunt across the scanner produced 25 findings (adversarially reviewed; the top ones empirically reproduced). This PR fixes **all 17 critical/high/medium items** in two batches. Each fix ships with a regression test where unit-testable. The 8 remaining items are all **low** severity and are left for a follow-up.

- **lib tests:** 1574 pass (12 new), 0 fail
- `cargo clippy --all-targets -- -D warnings`: clean
- integration binaries (unit_tests, scan_run_paths_test, …): pass

## Robustness

- **R1 (critical):** a second, unguarded oxc parse of server `<script>` bodies in `js_context_verify` could stack-overflow-SIGABRT the **whole process** on deeply-nested JS (one malicious response takes down all in-flight/server/MCP work). Reuses `ast_dom_analysis`'s guards via new shared `pub(crate)` helpers (`source_exceeds_parse_guards` / `SAFE_INLINE_PARSE_BYTES` / `run_parse_on_large_stack`): skip pathological blocks, big-stack-thread the rest.

## Correctness / false-negatives

- **F1 (high):** raw-http parser forwarded stale `Content-Length`/`Transfer-Encoding`, truncating payload-injected POST bodies → body-param XSS silently missed. Now strips them (+ `Accept-Encoding` + hop-by-hop) via a shared `is_skippable_request_header`; HAR path delegates.
- **F2 (high):** the taint walker's catch-all arm skipped `for-of`/`for-in`/`do-while`/labeled bodies; added arms + for-loop expression-form init; for-of binding is tainted when the iterated expression is tainted.
- **F4:** `js_context_verify` now checks **every** payload occurrence in a `<script>` block (not `find()`'s first), so a benign in-string reflection preceding the executable breakout no longer downgrades a real finding.
- **F5:** removed a stray `)` in an mXSS template that produced a non-executing handler reported as Verified.
- **F6:** multipart active-probe uses an explicit `placed` flag instead of a `!data.contains(name)` substring guard.
- **F7:** restore `+` (mangled to space by `query_pairs`) before the standard-alphabet base64-of-JSON discovery attempt.
- **F9:** raw-http parser no longer retains the original `Cookie` header (caused duplicate Cookie on per-cookie probes).
- **F13:** `is_likely_sanitizer_name` matches `purify`/`dompurify` as a whole segment, not a bare substring (`impurifyData`/`purifyConfig` no longer wrongly clear taint).
- **F17:** HtmlStructural evidence now compares against the entity-decoded payload too, so a WAF-bypass entity-encoded payload (`alert&#40;1&#41;`) isn't downgraded from Verified to Reflected.
- **S1:** drop a user-supplied `Accept-Encoding` so reqwest's transparent decompression stays on (a manual value made every reflection check fail scan-wide).
- **F3 / R2:** server/MCP initial AST fetch now uses `build_preflight_request` — carrying the target's headers/cookies/UA (auth/UA-gated SPAs analyzed logged-in, matching CLI) with a `Range: 0-8191` body cap (bounds server memory).

## Throttling / scan lifecycle

- **C1:** `--limit` early stop now `break`s instead of returning, so in-flight workers are drained (not detached), results collapsed, and panics tallied.
- **C2:** the consecutive-WAF-block streak driving `--waf-evasion` backoff escalation is now **per-worker** (on `ParamScanState`) instead of a scan-wide counter that ~50 concurrent workers reset for each other; process-wide total + per-job task-local stay updated for reporting.
- **C3:** the stored-XSS (`--sxss`) path now runs the same WAF accounting on the stored-write response (backoff + streak + bypass telemetry) via a shared helper.

## Not included (follow-up)

8 low-severity items: F10 (svg+xml path content-type), F11 (`alg=none` JWT), F12 (`setTimeout` delay-arg FP), F14 (request-count undercount), F15 (HTTP-date `Retry-After`), F16 (`</script >` regex), F18 (preflight findings vs `--limit-result-type`), P1 (payload-catalog memoization).

Note: `check_reflection.rs`'s multipart **injection** builder has the same substring/exact gap as F6 (different code path, not flagged by the hunt) — candidate follow-up.