### PR TITLE
fix(scanner): remaining low-severity correctness, reporting & perf fixes

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -510,7 +510,13 @@ pub(crate) async fn run_preflight_and_analysis(
                         &target.method,
                     );
                     if !lib_findings.is_empty() {
-                        let added = lib_findings.len();
+                        // Count only findings matching --limit-result-type so a
+                        // CWE-1104 (informational) batch can't trip --limit when
+                        // the user is limiting on a different result type.
+                        let added = crate::scanning::count_matching_results(
+                            &lib_findings,
+                            &args_clone.limit_result_type.to_uppercase(),
+                        );
                         let mut guard = results_clone.lock().await;
                         guard.extend(lib_findings);
                         findings_count_clone.fetch_add(added, Ordering::Relaxed);
@@ -533,7 +539,10 @@ pub(crate) async fn run_preflight_and_analysis(
                             target.trusted_types_enforced(),
                         );
                     if !ast_batch.is_empty() {
-                        let added = ast_batch.len();
+                        let added = crate::scanning::count_matching_results(
+                            &ast_batch,
+                            &args_clone.limit_result_type.to_uppercase(),
+                        );
                         let mut guard = results_clone.lock().await;
                         guard.extend(ast_batch);
                         findings_count_clone.fetch_add(added, Ordering::Relaxed);
@@ -551,6 +560,7 @@ pub(crate) async fn run_preflight_and_analysis(
                             &results_clone,
                             &findings_count_clone,
                             ext_batch,
+                            &args_clone.limit_result_type.to_uppercase(),
                         )
                         .await;
                     }

--- a/src/encoding/pipeline.rs
+++ b/src/encoding/pipeline.rs
@@ -316,9 +316,13 @@ fn infer_jwt(value: &str) -> Vec<NestedField> {
             && s.chars()
                 .all(|c| c.is_ascii_alphanumeric() || c == '-' || c == '_')
     }
+    // The signature segment is empty for `alg=none` tokens (`header.payload.`) —
+    // the high-value class this strategy targets — so accept an empty third
+    // segment; only a non-empty signature must be valid base64url. JwtAssemble
+    // already reassembles the empty-signature form.
     if !is_b64url_no_pad(header_b64u)
         || !is_b64url_no_pad(payload_b64u)
-        || !is_b64url_no_pad(sig_b64u)
+        || (!sig_b64u.is_empty() && !is_b64url_no_pad(sig_b64u))
     {
         return Vec::new();
     }

--- a/src/encoding/pipeline/tests.rs
+++ b/src/encoding/pipeline/tests.rs
@@ -457,3 +457,19 @@ fn b64_json_discovery_survives_plus_decoded_to_space() {
         "standard base64-of-JSON discovery must survive '+'->space (enc={enc}, mangled={mangled})"
     );
 }
+
+#[test]
+fn jwt_alg_none_empty_signature_is_discovered() {
+    // alg=none tokens have the canonical `header.payload.` shape with an empty
+    // signature segment — the high-value class this strategy targets. Discovery
+    // must produce nested-field leaves (it previously rejected the empty sig).
+    use base64::{Engine as _, engine::general_purpose::URL_SAFE_NO_PAD};
+    let header = URL_SAFE_NO_PAD.encode(r#"{"alg":"none","typ":"JWT"}"#);
+    let payload = URL_SAFE_NO_PAD.encode(r#"{"sub":"123","name":"alice"}"#);
+    let token = format!("{header}.{payload}."); // empty signature
+    let leaves = infer_nested_pipelines(&token);
+    assert!(
+        !leaves.is_empty(),
+        "alg=none JWT must yield nested-field leaves, got none"
+    );
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -408,6 +408,10 @@ impl DalfoxMcp {
                                 false,
                                 Some(8192),
                             );
+                            // Count + rate-limit the preflight GET like the CLI
+                            // (record_outbound_request), so it isn't missing from
+                            // the job's requests_sent tally.
+                            crate::record_outbound_request().await;
                             if let Ok(resp) = preflight.send().await {
                                 // Read CSP off the response before consuming the
                                 // body so a `require-trusted-types-for` page is
@@ -424,7 +428,10 @@ impl DalfoxMcp {
                                         trusted_types_enforced,
                                     );
                                     if !ast_batch.is_empty() {
-                                        let added = ast_batch.len();
+                                        let added = crate::scanning::count_matching_results(
+                                            &ast_batch,
+                                            &scan_args.limit_result_type.to_uppercase(),
+                                        );
                                         let mut guard = results_arc.lock().await;
                                         guard.extend(ast_batch);
                                         findings_count
@@ -441,6 +448,7 @@ impl DalfoxMcp {
                                         &results_arc,
                                         &findings_count,
                                         ext_batch,
+                                        &scan_args.limit_result_type.to_uppercase(),
                                     )
                                     .await;
                                 }

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -4513,8 +4513,20 @@ impl<'a> DomXssVisitor<'a> {
                 }
             }
 
-            // Check if any argument is tainted
-            for arg in &call.arguments {
+            // Check if any argument is tainted. For the timer / code sinks
+            // (setTimeout / setInterval / execScript) only the FIRST argument is
+            // the executed code — a tainted 2nd `delay` argument
+            // (`setTimeout(fn, location.hash)`) is not exploitable, so consider
+            // index 0 only (mirroring the setAttribute / execCommand
+            // positional special-cases below).
+            let first_arg_only = matches!(
+                func_name.as_str(),
+                "setTimeout" | "setInterval" | "execScript"
+            );
+            for (idx, arg) in call.arguments.iter().enumerate() {
+                if first_arg_only && idx != 0 {
+                    continue;
+                }
                 let (is_arg_tainted, source_hint) = self.argument_taint_and_source(arg);
 
                 if is_arg_tainted {

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4320,3 +4320,23 @@ fn purify_substring_does_not_suppress_unrelated_function() {
         "purify(x) as a whole-segment sanitizer should suppress the finding"
     );
 }
+
+#[test]
+fn settimeout_tainted_delay_argument_is_not_a_sink() {
+    // `setTimeout(fn, location.hash)`: a tainted *delay* (2nd) argument is not
+    // exploitable, so it must NOT be flagged (only argument 0 is executed code).
+    let delay = r#"function fn(){} setTimeout(fn, location.hash);"#;
+    let v_delay = AstDomAnalyzer::new().analyze(delay).unwrap();
+    assert!(
+        !v_delay.iter().any(|v| v.sink.contains("setTimeout")),
+        "tainted delay arg must not flag setTimeout, got {v_delay:?}"
+    );
+    // `setTimeout(location.hash, 100)`: a tainted *code* (1st) argument IS a
+    // sink and must still be flagged.
+    let code = r#"setTimeout(location.hash, 100);"#;
+    let v_code = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        v_code.iter().any(|v| v.sink.contains("setTimeout")),
+        "tainted code arg must still flag setTimeout, got {v_code:?}"
+    );
+}

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1369,7 +1369,14 @@ async fn fetch_injection_response_with_client(
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or("");
-                if !ct.is_empty() && !crate::utils::is_htmlish_content_type(ct) {
+                // `image/svg+xml` executes inline <script>/event handlers on
+                // top-level navigation, so a dynamically-generated SVG that
+                // reflects a path segment is a real sink — allow it alongside
+                // the HTML-ish types (don't open up JSON/JS/raster, which render
+                // as data).
+                let executes_as_markup = crate::utils::is_htmlish_content_type(ct)
+                    || crate::utils::content_type_primary(ct).as_deref() == Some("image/svg+xml");
+                if !ct.is_empty() && !executes_as_markup {
                     if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
                         eprintln!(
                             "[DBG] suppressing path-injection reflection on non-HTML content-type (param={}, content-type={})",

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -110,7 +110,10 @@ pub type ParamPayloadJob = (Param, Vec<String>, Vec<String>);
 /// Count how many results in `results` match the `--limit-result-type` filter.
 /// Returns `results.len()` when filter is `"all"` (default).
 /// `filter` must already be uppercased (normalised once at scan start).
-fn count_matching_results(results: &[crate::scanning::result::Result], filter: &str) -> usize {
+pub(crate) fn count_matching_results(
+    results: &[crate::scanning::result::Result],
+    filter: &str,
+) -> usize {
     if filter == "ALL" {
         return results.len();
     }
@@ -539,15 +542,22 @@ async fn run_ast_dom_analysis(
 /// lock + extend + counter-update sequence shared by every preflight finding
 /// source (libs, initial AST, external JS) across the CLI, server, and MCP
 /// surfaces.
+///
+/// The counter is bumped by the number of findings that match
+/// `limit_result_type` (already-uppercased `--limit-result-type`), mirroring
+/// [`ScanWorkerCtx::flush_results`] — otherwise N preflight findings of a
+/// non-matching type would trip `--limit N` and short-circuit the injection
+/// phase before any matching finding is produced.
 pub(crate) async fn accumulate_findings(
     results: &tokio::sync::Mutex<Vec<crate::scanning::result::Result>>,
     findings_count: &std::sync::atomic::AtomicUsize,
     batch: Vec<crate::scanning::result::Result>,
+    limit_result_type: &str,
 ) {
     if batch.is_empty() {
         return;
     }
-    let added = batch.len();
+    let added = count_matching_results(&batch, limit_result_type);
     results.lock().await.extend(batch);
     findings_count.fetch_add(added, std::sync::atomic::Ordering::Relaxed);
 }
@@ -601,9 +611,13 @@ pub(crate) async fn fetch_and_analyze_external_js(
 
         let rb =
             crate::utils::build_request(client, target, reqwest::Method::GET, script_url, None);
-        let resp = match crate::utils::send_with_retry(rb, scan_args.retries, scan_args.retry_delay)
-            .await
-        {
+        let send_result =
+            crate::utils::send_with_retry(rb, scan_args.retries, scan_args.retry_delay).await;
+        // Count this external-JS fetch (up to MAX_EXTERNAL_JS_FILES per page);
+        // its retries, if any, are counted inside send_with_retry. These GETs
+        // were previously missing from REQUEST_COUNT / the live req/s rate.
+        crate::tick_request_count();
+        let resp = match send_result {
             Ok(r) => r,
             Err(_) => continue,
         };

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -1763,7 +1763,7 @@ async fn test_accumulate_findings_empty_batch_is_noop() {
     let results: tokio::sync::Mutex<Vec<crate::scanning::result::Result>> =
         tokio::sync::Mutex::new(Vec::new());
     let counter = std::sync::atomic::AtomicUsize::new(0);
-    accumulate_findings(&results, &counter, vec![]).await;
+    accumulate_findings(&results, &counter, vec![], "ALL").await;
     assert_eq!(
         counter.load(std::sync::atomic::Ordering::Relaxed),
         0,
@@ -1772,6 +1772,32 @@ async fn test_accumulate_findings_empty_batch_is_noop() {
     assert!(
         results.lock().await.is_empty(),
         "results vec must remain empty for empty batch"
+    );
+}
+
+/// accumulate_findings must bump the limit counter by the number of findings
+/// matching --limit-result-type (like flush_results), not the whole batch —
+/// otherwise non-matching preflight findings trip --limit early.
+#[tokio::test]
+async fn test_accumulate_findings_counts_only_matching_result_type() {
+    let results: tokio::sync::Mutex<Vec<crate::scanning::result::Result>> =
+        tokio::sync::Mutex::new(Vec::new());
+    let counter = std::sync::atomic::AtomicUsize::new(0);
+    let batch = vec![
+        make_result(FindingType::Verified),
+        make_result(FindingType::Reflected),
+        make_result(FindingType::Reflected),
+    ];
+    accumulate_findings(&results, &counter, batch, "V").await;
+    assert_eq!(
+        counter.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "only the single V finding should count toward --limit-result-type V"
+    );
+    assert_eq!(
+        results.lock().await.len(),
+        3,
+        "all findings are still stored regardless of the limit filter"
     );
 }
 

--- a/src/scanning/vuln_libs.rs
+++ b/src/scanning/vuln_libs.rs
@@ -215,7 +215,7 @@ static COMPILED: LazyLock<Vec<CompiledLib>> = LazyLock::new(|| {
 static SCRIPT_SRC_RE: LazyLock<Regex> =
     LazyLock::new(|| Regex::new(r#"(?i)<script\b[^>]*\bsrc\s*=\s*["']?([^"'>\s]+)"#).unwrap());
 static SCRIPT_INLINE_RE: LazyLock<Regex> =
-    LazyLock::new(|| Regex::new(r"(?is)<script\b(?:\s[^>]*)?>(.*?)</script>").unwrap());
+    LazyLock::new(|| Regex::new(r"(?is)<script\b(?:\s[^>]*)?>(.*?)</script\s*>").unwrap());
 
 /// Extract the script-context haystacks from `body`: `(src URLs joined, inline
 /// script bodies joined)`. url-patterns match only the former, inline-patterns

--- a/src/scanning/vuln_libs/tests.rs
+++ b/src/scanning/vuln_libs/tests.rs
@@ -49,6 +49,21 @@ fn detects_jquery_from_cdn_path() {
 }
 
 #[test]
+fn detects_inline_banner_when_script_closes_with_whitespace() {
+    // Regression: SCRIPT_INLINE_RE must accept `</script >` (trailing space),
+    // matching the AST module's `</script\s*>`. A space-padded closing tag
+    // previously dropped the inline banner and its CWE-1104 finding.
+    let body = "<script>/*! jQuery JavaScript Library v1.8.3\n ... */ \n var a=1;</script >";
+    let found = libs(body);
+    assert!(
+        found
+            .iter()
+            .any(|v| v.library == "jQuery" && v.version == "1.8.3"),
+        "inline banner closed by `</script >` should still be detected, got {found:?}"
+    );
+}
+
+#[test]
 fn detects_jquery_from_inline_banner() {
     let body = "<script>/*! jQuery JavaScript Library v1.8.3\n ... */ \n var a=1;</script>";
     let found = libs(body);

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -8,8 +8,37 @@ use std::sync::{Mutex, OnceLock};
 
 static CUSTOM_PAYLOAD_CACHE: OnceLock<Mutex<HashMap<String, Vec<String>>>> = OnceLock::new();
 
-/// Generate dynamic payloads based on the injection context
+/// Per-context catalog cache. The generated catalog depends only on `context`
+/// and the process-stable scan markers (`OnceLock`s in `markers`), so the same
+/// context produces identical payloads for the whole process — yet
+/// `generate_dynamic_payloads` is called once or twice per reflecting param and
+/// per target, rebuilding hundreds of `format!`-allocated strings each time.
+/// Memoize the catalog keyed by the context's `Debug` repr (a stable, unique
+/// key that avoids requiring `Hash`/`Eq` on `InjectionContext`). Callers own and
+/// mutate the returned `Vec`, so we hand back a clone and the cache can't be
+/// corrupted.
+static DYNAMIC_PAYLOAD_CACHE: OnceLock<Mutex<HashMap<String, std::sync::Arc<Vec<String>>>>> =
+    OnceLock::new();
+
+/// Generate dynamic payloads based on the injection context (memoized).
 pub fn generate_dynamic_payloads(context: &InjectionContext) -> Vec<String> {
+    let key = format!("{context:?}");
+    let cache = DYNAMIC_PAYLOAD_CACHE.get_or_init(|| Mutex::new(HashMap::new()));
+    if let Ok(guard) = cache.lock()
+        && let Some(cached) = guard.get(&key)
+    {
+        return cached.as_ref().clone();
+    }
+    let payloads = std::sync::Arc::new(generate_dynamic_payloads_uncached(context));
+    if let Ok(mut guard) = cache.lock() {
+        guard.insert(key, std::sync::Arc::clone(&payloads));
+    }
+    payloads.as_ref().clone()
+}
+
+/// Build the per-context payload catalog from scratch. Wrapped by the memoizing
+/// [`generate_dynamic_payloads`].
+fn generate_dynamic_payloads_uncached(context: &InjectionContext) -> Vec<String> {
     let mut payloads = Vec::new();
 
     match context {

--- a/src/scanning/xss_common/tests.rs
+++ b/src/scanning/xss_common/tests.rs
@@ -478,3 +478,21 @@ fn test_get_dynamic_payloads_custom_string_alert_value() {
         "string alert type must wrap the value in quotes"
     );
 }
+
+#[test]
+fn generate_dynamic_payloads_is_memoized_and_stable() {
+    // The per-context catalog is memoized (process-stable markers), so repeated
+    // calls return identical payloads. The returned Vec is an independent clone,
+    // so mutating it must not corrupt the cache for a later call.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    let first = generate_dynamic_payloads(&ctx);
+    let mut second = generate_dynamic_payloads(&ctx);
+    assert!(!first.is_empty(), "attribute context should yield payloads");
+    assert_eq!(first, second, "memoized catalog must be stable per context");
+    second.clear();
+    let third = generate_dynamic_payloads(&ctx);
+    assert_eq!(
+        first, third,
+        "mutating a returned clone must not corrupt the cache"
+    );
+}

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -499,6 +499,10 @@ pub(crate) async fn run_scan_job(
                             false,
                             Some(8192),
                         );
+                        // Count + rate-limit the preflight GET like the CLI
+                        // (record_outbound_request), so it isn't missing from the
+                        // job's requests_sent tally.
+                        crate::record_outbound_request().await;
                         if let Ok(resp) = preflight.send().await {
                             // Read CSP off the response before the body is
                             // consumed, so a `require-trusted-types-for` page is
@@ -515,7 +519,10 @@ pub(crate) async fn run_scan_job(
                                         trusted_types_enforced,
                                     );
                                 if !ast_batch.is_empty() {
-                                    let added = ast_batch.len();
+                                    let added = crate::scanning::count_matching_results(
+                                        &ast_batch,
+                                        &args.limit_result_type.to_uppercase(),
+                                    );
                                     let mut guard = results.lock().await;
                                     guard.extend(ast_batch);
                                     findings_count
@@ -529,6 +536,7 @@ pub(crate) async fn run_scan_job(
                                     &results,
                                     &findings_count,
                                     ext_batch,
+                                    &args.limit_result_type.to_uppercase(),
                                 )
                                 .await;
                             }

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -320,15 +320,38 @@ fn is_transient_error(e: &reqwest::Error) -> bool {
     e.is_timeout() || e.is_connect()
 }
 
-/// Parse a `Retry-After` header expressed in integer seconds into ms.
-/// Returns `None` for absent or non-integer (HTTP-date) values, in which
-/// case the caller falls back to exponential backoff.
+/// Parse a `Retry-After` header into ms-from-now. Accepts both RFC 7231 forms:
+/// delta-seconds (`Retry-After: 120`) and an HTTP-date (`Retry-After: Wed, 21
+/// Oct 2026 07:28:00 GMT`). A date already in the past yields `0`. Returns
+/// `None` only when the header is absent or unparseable, in which case the
+/// caller falls back to exponential backoff. The returned value is unclamped;
+/// [`decide_retry`] clamps it to [`BACKOFF_CAP_MS`].
 fn parse_retry_after_ms(headers: &reqwest::header::HeaderMap) -> Option<u64> {
-    headers
-        .get("retry-after")
-        .and_then(|v| v.to_str().ok())
-        .and_then(|s| s.trim().parse::<u64>().ok())
-        .map(|secs| secs.saturating_mul(1000))
+    let raw = headers.get("retry-after").and_then(|v| v.to_str().ok())?;
+    let s = raw.trim();
+    // Preferred, most common form: delta-seconds.
+    if let Ok(secs) = s.parse::<u64>() {
+        return Some(secs.saturating_mul(1000));
+    }
+    // Fallback: HTTP-date. Without this a date-form value fell through to a
+    // 1s/2s/4s exponential backoff, burning the 429 retry budget in ~7s and
+    // abandoning a request that would have succeeded after the advertised wait.
+    parse_http_date_retry_ms(s)
+}
+
+/// Milliseconds from now until an HTTP-date `Retry-After`, or `None` if it is
+/// not a parseable IMF-fixdate (`Sun, 06 Nov 1994 08:49:37 GMT`). A past date
+/// yields `0`. The two obsolete date forms (RFC 850, asctime) are rare enough
+/// to skip — modern servers send IMF-fixdate.
+fn parse_http_date_retry_ms(s: &str) -> Option<u64> {
+    // Drop the leading weekday ("Wed, ") and parse the rest without `%a`:
+    // chrono rejects an IMF-fixdate whose weekday is inconsistent with the date,
+    // but a `Retry-After` hint shouldn't be discarded over a server's weekday
+    // typo — the date/time is what matters.
+    let date_part = s.split_once(", ").map(|(_, rest)| rest).unwrap_or(s);
+    let dt = chrono::NaiveDateTime::parse_from_str(date_part, "%d %b %Y %H:%M:%S GMT").ok()?;
+    let delta_ms = (dt.and_utc() - chrono::Utc::now()).num_milliseconds();
+    Some(delta_ms.max(0) as u64)
 }
 
 /// Network-decoupled outcome of a single send attempt, so the retry policy
@@ -491,6 +514,11 @@ pub async fn send_with_retry(
                     state.tr_done += 1;
                 }
                 current_rb = rb;
+                // Count the retry attempt we're about to make. Callers tick the
+                // first attempt themselves; each additional attempt is a real
+                // outbound request that was previously missing from REQUEST_COUNT
+                // (and the live req/s rate).
+                crate::tick_request_count();
             }
         }
     }

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -358,3 +358,26 @@ fn success_and_fatal_never_retry() {
         RetryDecision::Stop
     );
 }
+
+#[test]
+fn parse_retry_after_accepts_seconds_and_http_date() {
+    use reqwest::header::HeaderMap;
+    let with = |val: &str| {
+        let mut h = HeaderMap::new();
+        h.insert("retry-after", val.parse().unwrap());
+        parse_retry_after_ms(&h)
+    };
+    // delta-seconds form (unchanged).
+    assert_eq!(with("120"), Some(120_000));
+    // HTTP-date form (IMF-fixdate) — previously ignored, falling back to a fast
+    // exponential backoff and burning the 429 retry budget.
+    let future = with("Wed, 21 Oct 2099 07:28:00 GMT").expect("future HTTP-date must parse");
+    assert!(
+        future > 0,
+        "future date should yield a positive wait, got {future}"
+    );
+    // A past date means "retry now": 0ms, not None.
+    assert_eq!(with("Wed, 21 Oct 1999 07:28:00 GMT"), Some(0));
+    // Unparseable -> None so the caller falls back to exponential backoff.
+    assert_eq!(with("not-a-date"), None);
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -20,8 +20,8 @@ pub use scan_id::{make_scan_id, make_unique_scan_id, short_scan_id};
 // Re-export http helpers at `crate::utils::*`
 pub use http::{
     apply_header_overrides, apply_headers_ua_cookies, build_preflight_request, build_request,
-    build_request_with_cookie, compose_cookie_header_excluding, is_htmlish_content_type,
-    is_xss_scannable_content_type, send_with_retry,
+    build_request_with_cookie, compose_cookie_header_excluding, content_type_primary,
+    is_htmlish_content_type, is_xss_scannable_content_type, send_with_retry,
 };
 
 // Re-export remote payload/wordlist getters at `crate::utils::*`


### PR DESCRIPTION
## Summary

Final batch of the verified bug-hunt (follow-up to #1115, which fixed all 17 critical/high/medium items). This closes the **8 remaining low-severity items**. Each fix ships with a regression test where unit-testable.

- **lib tests:** 1580 pass (6 new), 0 fail
- `cargo fmt --all -- --check` + `cargo clippy --all-targets --all-features -- -D warnings`: clean
- integration binaries (unit_tests, scan_run_paths_test, …): pass

## Correctness / false-negatives

- **F10** `check_reflection`: allow `image/svg+xml` for Path reflections (SVG executes inline `<script>`/event handlers on top-level navigation) without re-admitting JSON/JS/raster, which still render as data.
- **F11** `encoding/pipeline`: accept `alg=none` JWTs (empty signature segment, `header.payload.`) — the high-value class the JWT nested-field strategy targets; `JwtAssemble` already reassembles the empty-sig form.
- **F12** `ast_dom_analysis`: `setTimeout`/`setInterval`/`execScript` only treat argument 0 (the executed code) as a sink — a tainted *delay* argument (`setTimeout(fn, location.hash)`) is no longer a false positive (mirrors the existing `setAttribute`/`execCommand` positional special-cases).
- **F16** `vuln_libs`: inline-script regex accepts `</script >` (trailing whitespace), matching the AST module's `</script\s*>` — recovers dropped CWE-1104 outdated-component findings.
- **F18** `scanning`: preflight findings (libs / initial AST / external JS) now count toward `--limit` by the `--limit-result-type`-matching count, like `flush_results` — so a non-matching preflight batch can't short-circuit the injection phase. `accumulate_findings` takes the filter; `count_matching_results` is shared across the CLI/server/MCP writers.

## Reporting / pacing

- **F15** `http`: `parse_retry_after_ms` now also accepts an HTTP-date `Retry-After` (was delta-seconds only), so a date-form value no longer falls through to a fast 1s/2s/4s exponential backoff that burned the 429 budget in ~7s. The weekday prefix is stripped rather than validated (a hint shouldn't be discarded over a server's weekday typo); `decide_retry` still clamps to `BACKOFF_CAP_MS`.
- **F14** request counting (`REQUEST_COUNT` / live req/s): `send_with_retry` counts each retry attempt; external-JS fetches and the server/MCP preflight GET are now counted via `record_outbound_request` — closing the audit undercount (throttling was already correct).

## Performance

- **P1** `xss_common`: memoize the per-context dynamic-payload catalog (markers are process-stable) keyed by the context's `Debug` repr, returning a clone — avoids rebuilding hundreds of `format!`-allocated strings on the once-or-twice-per-param job-build path. Callers own/mutate the result, so the cache can't be corrupted.

## Follow-up

Note (carried from #1115): `check_reflection.rs`'s multipart **injection** request builder has the same substring/exact-match gap as the F6 active-probe fix (different code path, not flagged by the hunt) — a candidate follow-up.