### PR TITLE
fix(scanner,server,mcp): harden against hostile responses (OOM/hang) + server/MCP WAF & remote option parity

### DIFF
--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -53,7 +53,7 @@ pub const DEFAULT_METHOD: &str = "GET";
 /// else at parse time so a typo like `--force-waf cloudflair` doesn't
 /// silently fall into the `WafType::Unknown(other)` bucket and skip
 /// the targeted bypass mutations.
-fn parse_force_waf_arg(s: &str) -> std::result::Result<String, String> {
+pub(crate) fn parse_force_waf_arg(s: &str) -> std::result::Result<String, String> {
     let lower = s.trim().to_ascii_lowercase();
     let known = [
         "cloudflare",

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -39,6 +39,7 @@ mod preflight;
 mod scan_loop;
 mod validation;
 
+pub(crate) use args::parse_force_waf_arg;
 pub use args::{
     CLI_MAX_DELAY_MS, CLI_MAX_RATE_LIMIT, CLI_MAX_RETRIES, CLI_MAX_RETRY_DELAY_MS,
     CLI_MAX_TIMEOUT_SECS, CLI_MAX_WORKERS, DEFAULT_DELAY_MS, DEFAULT_ENCODERS,

--- a/src/cmd/scan/preflight.rs
+++ b/src/cmd/scan/preflight.rs
@@ -244,7 +244,7 @@ pub(crate) async fn preflight_content_type(
     if let Ok(get_resp) = get_req.send().await {
         let get_status = get_resp.status().as_u16();
         let get_headers = get_resp.headers().clone();
-        if let Ok(body) = get_resp.text().await {
+        if let Ok(body) = crate::utils::http::read_body(get_resp).await {
             response_body = Some(body.clone());
 
             // WAF detection from GET response (headers + body). Same

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -419,7 +419,7 @@ impl DalfoxMcp {
                                 // the CLI gets from preflight.
                                 let trusted_types_enforced =
                                     crate::scanning::csp_requires_trusted_types(resp.headers());
-                                if let Ok(body) = resp.text().await {
+                                if let Ok(body) = crate::utils::http::read_body(resp).await {
                                     let ast_batch =
                                     crate::scanning::ast_integration::run_initial_ast_dom_analysis(
                                         &body,
@@ -732,10 +732,49 @@ pub struct ScanWithDalfoxParams {
     /// under a WAF's threshold. Now enforced across all worker tasks.
     #[serde(default)]
     pub rate_limit: u32,
+
+    /// WAF handling mode: "auto" (detect then bypass), "force" (use force_waf),
+    /// or "off" (detect only). Default: "auto"
+    #[serde(default = "default_waf_bypass")]
+    pub waf_bypass: String,
+
+    /// Skip the WAF fingerprinting probe entirely. Default: false
+    #[serde(default)]
+    pub skip_waf_probe: bool,
+
+    /// Force a specific WAF profile (e.g. "cloudflare", "akamai", "modsec")
+    /// instead of detecting one. Default: none.
+    #[serde(default)]
+    pub force_waf: Option<String>,
+
+    /// Enable adaptive WAF evasion. Default: false
+    #[serde(default)]
+    pub waf_evasion: bool,
+
+    /// WAF detection confidence floor in [0.0, 1.0]; fingerprints below this are
+    /// dropped. Default: 0.3
+    #[serde(default = "default_waf_min_confidence")]
+    pub waf_min_confidence: f32,
+
+    /// Fetch remote XSS payloads from providers (e.g. "portswigger",
+    /// "payloadbox"). Default: none.
+    #[serde(default)]
+    pub remote_payloads: Vec<String>,
+
+    /// Fetch remote parameter wordlists from providers (e.g. "burp",
+    /// "assetnote"). Default: none.
+    #[serde(default)]
+    pub remote_wordlists: Vec<String>,
 }
 
 fn default_method() -> String {
     crate::cmd::scan::DEFAULT_METHOD.to_string()
+}
+fn default_waf_bypass() -> String {
+    "auto".to_string()
+}
+fn default_waf_min_confidence() -> f32 {
+    crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE
 }
 fn default_encoders() -> Vec<String> {
     crate::cmd::scan::DEFAULT_ENCODERS
@@ -902,6 +941,13 @@ Final results (via get_results_dalfox) include finding type \
             blind_callback_url,
             workers,
             rate_limit,
+            waf_bypass,
+            skip_waf_probe,
+            force_waf,
+            waf_evasion,
+            waf_min_confidence,
+            remote_payloads,
+            remote_wordlists,
         } = params;
 
         let target = target.trim().to_string();
@@ -950,6 +996,34 @@ Final results (via get_results_dalfox) include finding type \
                 format!(
                     "scan_timeout must be between 0 and {} seconds (got {})",
                     MAX_SCAN_TIMEOUT_SECS, scan_timeout
+                ),
+                None,
+            ));
+        }
+        if !matches!(waf_bypass.as_str(), "auto" | "force" | "off") {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "waf_bypass must be one of auto, force, off (got '{}')",
+                    waf_bypass
+                ),
+                None,
+            ));
+        }
+        // Normalize/validate force_waf against the same WAF-name set the CLI
+        // accepts; the normalized (lowercased) form flows into ScanArgs.
+        let force_waf = match force_waf
+            .as_deref()
+            .map(crate::cmd::scan::parse_force_waf_arg)
+        {
+            Some(Ok(name)) => Some(name),
+            Some(Err(e)) => return Err(ErrorData::invalid_params(e, None)),
+            None => None,
+        };
+        if !(0.0..=1.0).contains(&waf_min_confidence) {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "waf_min_confidence must be between 0.0 and 1.0 (got {})",
+                    waf_min_confidence
                 ),
                 None,
             ));
@@ -1083,21 +1157,33 @@ Final results (via get_results_dalfox) include finding type \
             skip_ast_analysis,
             analyze_external_js,
             hpp: false,
-            waf_bypass: "auto".to_string(),
-            skip_waf_probe: false,
-            force_waf: None,
-            waf_evasion: false,
+            waf_bypass,
+            skip_waf_probe,
+            force_waf,
+            waf_evasion,
             // Per-call request-rate cap, now honored across all worker tasks
             // (see crate::with_job_scopes). 0 = unlimited.
             rate_limit,
             retries: 0,
             retry_delay: 1000,
-            // Match the server/CLI default so MCP doesn't surface low-confidence
-            // WAF fingerprints the other front-ends filter out (was 0.0).
-            waf_min_confidence: crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE,
-            remote_payloads: vec![],
-            remote_wordlists: vec![],
+            waf_min_confidence,
+            remote_payloads,
+            remote_wordlists,
         });
+
+        // Load any requested remote payload/wordlist providers into the global
+        // registries before the scan reads them. Mirrors the REST server and
+        // CLI; without this the `remote_payloads`/`remote_wordlists` fields
+        // would be silently inert on the MCP path.
+        if !scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty() {
+            let _ = crate::utils::init_remote_resources_with_options(
+                &scan_args.remote_payloads,
+                &scan_args.remote_wordlists,
+                Some(scan_args.timeout),
+                scan_args.proxy.clone(),
+            )
+            .await;
+        }
 
         // Run the scan on tokio's managed blocking-threadpool. We still need a
         // current_thread runtime inside because analyze_parameters and the

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -51,6 +51,13 @@ fn default_scan_params(target: &str) -> ScanWithDalfoxParams {
         blind_callback_url: None,
         workers: 1,
         rate_limit: 0,
+        waf_bypass: "auto".to_string(),
+        skip_waf_probe: false,
+        force_waf: None,
+        waf_evasion: false,
+        waf_min_confidence: crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE,
+        remote_payloads: vec![],
+        remote_wordlists: vec![],
     }
 }
 
@@ -478,6 +485,46 @@ fn test_insecure_param_serde_defaults_true() {
     )
     .expect("preflight params with insecure=false deserialize");
     assert!(!pre_off.insecure);
+}
+
+#[test]
+fn test_waf_and_remote_params_serde() {
+    // Omitted WAF / remote fields fall back to the CLI/server defaults instead
+    // of being silently hardcoded inside the scan path.
+    let defaults: ScanWithDalfoxParams =
+        serde_json::from_value(serde_json::json!({ "target": "https://example.com" }))
+            .expect("minimal scan params deserialize");
+    assert_eq!(defaults.waf_bypass, "auto");
+    assert!(!defaults.skip_waf_probe);
+    assert!(defaults.force_waf.is_none());
+    assert!(!defaults.waf_evasion);
+    assert_eq!(
+        defaults.waf_min_confidence,
+        crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE
+    );
+    assert!(defaults.remote_payloads.is_empty());
+    assert!(defaults.remote_wordlists.is_empty());
+
+    // Explicit values deserialize through to the params struct (and thus to
+    // ScanArgs), no longer ignored as they were before.
+    let set: ScanWithDalfoxParams = serde_json::from_value(serde_json::json!({
+        "target": "https://example.com",
+        "waf_bypass": "off",
+        "skip_waf_probe": true,
+        "force_waf": "cloudflare",
+        "waf_evasion": true,
+        "waf_min_confidence": 0.75,
+        "remote_payloads": ["portswigger"],
+        "remote_wordlists": ["burp"],
+    }))
+    .expect("scan params with WAF/remote fields deserialize");
+    assert_eq!(set.waf_bypass, "off");
+    assert!(set.skip_waf_probe);
+    assert_eq!(set.force_waf.as_deref(), Some("cloudflare"));
+    assert!(set.waf_evasion);
+    assert_eq!(set.waf_min_confidence, 0.75);
+    assert_eq!(set.remote_payloads, vec!["portswigger".to_string()]);
+    assert_eq!(set.remote_wordlists, vec!["burp".to_string()]);
 }
 
 #[tokio::test]

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -387,7 +387,7 @@ pub async fn check_query_discovery(
                         escaped_specials: None,
                         js_breakout: None,
                     });
-                } else if let Ok(text) = resp.text().await
+                } else if let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
                     let (valid, invalid) = classify_special_chars(&text);
@@ -459,7 +459,7 @@ pub async fn check_query_discovery(
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
             if let Ok(resp) = request.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 // For pre-encoded params (base64/2base64), skip special char
@@ -543,7 +543,7 @@ pub async fn check_query_discovery(
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
             if let Ok(resp) = request.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 discovered_names.insert(display_name.clone());
@@ -603,7 +603,7 @@ pub async fn check_query_discovery(
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
             if let Ok(resp) = request.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && text.contains(numeric_marker)
             {
                 discovered_names.insert(name.clone());
@@ -650,7 +650,7 @@ pub async fn check_query_discovery(
         let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
         crate::record_outbound_request().await;
         if let Ok(resp) = request.send().await
-            && let Ok(text) = resp.text().await
+            && let Ok(text) = crate::utils::http::read_body(resp).await
             && crate::scanning::markers::classify_probe_reflection(&text).detected()
         {
             let (valid, invalid) = classify_special_chars(&text);
@@ -731,7 +731,7 @@ async fn detect_blanket_header_echo(target: &Target) -> bool {
     let request = crate::utils::apply_header_overrides(base, &overrides);
     crate::record_outbound_request().await;
     match request.send().await {
-        Ok(resp) => match resp.text().await {
+        Ok(resp) => match crate::utils::http::read_body(resp).await {
             Ok(text) => crate::scanning::markers::classify_probe_reflection(&text).detected(),
             Err(_) => false,
         },
@@ -824,7 +824,7 @@ pub async fn check_header_discovery(
             crate::record_outbound_request().await;
             let mut discovered: Option<Param> = None;
             if let Ok(resp) = request.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 let (valid, invalid) = classify_special_chars(&text);
@@ -974,7 +974,7 @@ pub async fn check_path_discovery(
                 //                                       `<td>{uri}</td>`).
                 let status = resp.status().as_u16();
                 if !(300..400).contains(&status)
-                    && let Ok(text) = resp.text().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
                     let exploitable_context = (200..300).contains(&status)
@@ -1009,7 +1009,7 @@ pub async fn check_path_discovery(
                         );
                         crate::record_outbound_request().await;
                         match probe.send().await {
-                            Ok(r) => match r.text().await {
+                            Ok(r) => match crate::utils::http::read_body(r).await {
                                 Ok(t) => t.contains(&needle),
                                 Err(_) => false,
                             },
@@ -1127,7 +1127,7 @@ pub async fn check_cookie_discovery(
             crate::record_outbound_request().await;
             let mut discovered: Option<Param> = None;
             if let Ok(resp) = request.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 let (valid, invalid) = classify_special_chars(&text);
@@ -1191,7 +1191,7 @@ pub async fn check_form_discovery(
     let request = crate::utils::build_request(&client, target, method, target.url.clone(), None);
     crate::record_outbound_request().await;
     let html = match request.send().await {
-        Ok(resp) => match resp.text().await {
+        Ok(resp) => match crate::utils::http::read_body(resp).await {
             Ok(text) => text,
             Err(_) => return,
         },
@@ -1286,7 +1286,7 @@ pub async fn check_form_discovery(
                 .multipart(form);
                 crate::record_outbound_request().await;
                 if let Ok(resp) = rb.send().await
-                    && let Ok(text) = resp.text().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
                     let (valid, invalid) = classify_special_chars(&text);
@@ -1358,7 +1358,7 @@ pub async fn check_form_discovery(
                 );
                 crate::record_outbound_request().await;
                 if let Ok(resp) = rb.send().await
-                    && let Ok(text) = resp.text().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
                     let (valid, invalid) = classify_special_chars(&text);
@@ -1404,7 +1404,7 @@ pub async fn check_form_discovery(
                 let rb = crate::utils::build_request(&client, target, m, test_url.clone(), None);
                 crate::record_outbound_request().await;
                 if let Ok(resp) = rb.send().await
-                    && let Ok(text) = resp.text().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
                     let (valid, invalid) = classify_special_chars(&text);
@@ -1450,7 +1450,7 @@ pub async fn check_form_discovery(
             );
             crate::record_outbound_request().await;
             if let Ok(resp) = rb.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 let (valid, invalid) = classify_special_chars(&text);
@@ -1535,7 +1535,7 @@ pub async fn check_form_discovery(
                     );
                     crate::record_outbound_request().await;
                     if let Ok(resp) = rb.send().await
-                        && let Ok(text) = resp.text().await
+                        && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
                         let (valid, invalid) = classify_special_chars(&text);
@@ -1611,7 +1611,7 @@ pub async fn check_form_discovery(
                     );
                     crate::record_outbound_request().await;
                     if let Ok(resp) = rb.send().await
-                        && let Ok(text) = resp.text().await
+                        && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
                         let (valid, invalid) = classify_special_chars(&text);

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -78,7 +78,7 @@ async fn pre_collapse_query_probe(client: &reqwest::Client, target: &Target) -> 
                 .get("location")
                 .and_then(|v| v.to_str().ok())
                 .is_some_and(|loc| loc.contains(marker));
-        let text = resp.text().await.ok()?;
+        let text = crate::utils::http::read_body(resp).await.ok()?;
         if !location_has_marker && !text.contains(marker) {
             return None;
         }
@@ -745,7 +745,7 @@ pub async fn probe_dictionary_params(
                                 }
                             }
                         }
-                    } else if let Ok(text) = r.text().await {
+                    } else if let Ok(text) = crate::utils::http::read_body(r).await {
                         let mut st = stats_clone.lock().await;
                         st.record_attempt();
                         if crate::scanning::markers::classify_probe_reflection(&text).detected() {
@@ -967,7 +967,7 @@ pub async fn probe_body_params(
 
                 let mut discovered: Option<Param> = None;
                 if let Ok(r) = resp
-                    && let Ok(text) = r.text().await
+                    && let Ok(text) = crate::utils::http::read_body(r).await
                 {
                     let mut st = stats_clone.lock().await;
                     st.record_attempt();
@@ -1122,7 +1122,7 @@ pub async fn probe_response_id_params(
     let __resp = base_request.send().await;
     if let Ok(resp) = __resp
         && !resp.status().is_server_error()
-        && let Ok(text) = resp.text().await
+        && let Ok(text) = crate::utils::http::read_body(resp).await
     {
         // Scope the scraper::Html (which is !Send) strictly to the owning
         // block so the compiler can prove it never crosses any of the
@@ -1229,7 +1229,7 @@ pub async fn probe_response_id_params(
                         }
                         return discovered;
                     }
-                    if let Ok(text) = resp.text().await {
+                    if let Ok(text) = crate::utils::http::read_body(resp).await {
                         let mut st = stats_clone.lock().await;
                         st.record_attempt();
                         if crate::scanning::markers::classify_probe_reflection(&text).detected() {
@@ -1477,7 +1477,7 @@ pub async fn probe_json_body_params(
 
             let mut discovered: Option<Param> = None;
             if let Ok(r) = resp
-                && let Ok(text) = r.text().await
+                && let Ok(text) = crate::utils::http::read_body(r).await
             {
                 let mut st = stats_clone.lock().await;
                 st.record_attempt();
@@ -1696,7 +1696,7 @@ pub async fn probe_multipart_params(
 
             let mut discovered: Option<Param> = None;
             if let Ok(r) = request.send().await
-                && let Ok(text) = r.text().await
+                && let Ok(text) = crate::utils::http::read_body(r).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 let context = detect_injection_context(&text);

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -520,7 +520,7 @@ async fn send_probe_request_for_param(
     } else {
         None
     };
-    let body_text = match resp.text().await {
+    let body_text = match crate::utils::http::read_body(resp).await {
         Ok(body) => Some(body),
         Err(e) => {
             if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
@@ -991,7 +991,7 @@ pub async fn active_probe_param(
             let request_builder = client.request(target.parse_method(), url);
             crate::record_outbound_request().await;
             if let Ok(resp) = request_builder.send().await
-                && let Ok(text) = resp.text().await
+                && let Ok(text) = crate::utils::http::read_body(resp).await
                 && text.contains(&raw_marker)
             {
                 param.pre_encoding = Some(enc_name.to_string());

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -282,7 +282,7 @@ async fn fetch_multiple_text_lists(client: &Client, urls: &[String]) -> String {
         let client = client.clone();
         set.spawn(async move {
             match client.get(&url).send().await {
-                Ok(resp) => match resp.text().await {
+                Ok(resp) => match crate::utils::http::read_body(resp).await {
                     Ok(text) => Some(text),
                     Err(e) => {
                         eprintln!("[remote] failed to read body from {}: {}", url, e);

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -784,7 +784,7 @@ async fn verify_sxss_dom(
                     .get(reqwest::header::CONTENT_TYPE)
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or("");
-                if let Ok(text) = resp.text().await
+                if let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::utils::is_htmlish_content_type(ct)
                     && crate::scanning::check_reflection::classify_reflection(&text, payload)
                         .is_some()
@@ -822,7 +822,7 @@ async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> (bool, Opt
 
     // Both HTML and non-HTML (JSONP, JSON with HTML) content types are accepted
     // as long as there is reflection + marker/executable-URL evidence in the response.
-    if let Ok(text) = resp.text().await
+    if let Ok(text) = crate::utils::http::read_body(resp).await
         && crate::scanning::check_reflection::classify_reflection(&text, payload).is_some()
         && has_dom_evidence(payload, &text)
     {

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -28,6 +28,18 @@ pub use crate::encoding::pre_encoding::apply_pre_encoding;
 /// Maximum number of iterative URL-decode passes when building payload variants.
 const MAX_URL_DECODE_ITERATIONS: usize = 4;
 
+/// Upper bounds for the reflection heuristics' scans over a single response.
+/// Body analysis runs *after* the response is read, so it is not covered by the
+/// request timeout; a hostile page packed with safe tags, `<script>` blocks, or
+/// payload echoes could otherwise drive these O(n)/O(n·m) scans into a
+/// multi-second CPU hang (the loops vet every occurrence against every range).
+/// When a cap is hit we stop early and return the answer that does NOT suppress
+/// a finding (fail toward reporting), so the cap can only ever cost extra [R]
+/// noise on a pathological page — never a missed vulnerability.
+const MAX_SAFE_RANGES: usize = 4096;
+const MAX_SCRIPT_RANGES: usize = 4096;
+const MAX_PAYLOAD_OCCURRENCES: usize = 4096;
+
 /// Purely numeric reflection probe. Sent for parameters that showed no
 /// reflection with the normal alphanumeric markers, to catch injection
 /// points behind letter-stripping filters (e.g. `gsub(/[a-zA-Z]/, "")`),
@@ -173,11 +185,18 @@ fn is_in_safe_context(html: &str, payload: &str) -> bool {
 
     // Build safe-context ranges by scanning for opening/closing safe tags
     let mut safe_ranges: Vec<(usize, usize)> = Vec::new();
-    for &(open_pattern, close_pattern) in SAFE_TAG_PATTERNS {
+    'patterns: for &(open_pattern, close_pattern) in SAFE_TAG_PATTERNS {
         let mut search_pos = 0;
         while let Some(open_start) =
             find_ascii_case_insensitive(html_bytes, open_pattern, search_pos)
         {
+            // Cap the range set: a page with this many safe tags is hostile,
+            // and more ranges only grow memory and the per-occurrence scan
+            // below. Stopping here leaves later occurrences classified as
+            // unsafe, which keeps (does not suppress) the finding.
+            if safe_ranges.len() >= MAX_SAFE_RANGES {
+                break 'patterns;
+            }
             // Find the end of the opening tag '>'
             if let Some(tag_end_offset) = html[open_start..].find('>') {
                 let content_start = open_start + tag_end_offset + 1;
@@ -201,7 +220,14 @@ fn is_in_safe_context(html: &str, payload: &str) -> bool {
     // Check every occurrence of the payload
     let payload_len = payload.len();
     let mut search_start = 0;
+    let mut scanned = 0usize;
     while let Some(pos) = html[search_start..].find(payload) {
+        scanned += 1;
+        if scanned > MAX_PAYLOAD_OCCURRENCES {
+            // Too many echoes to vet individually; treat as not-fully-safe so
+            // the reflection is reported rather than silently suppressed.
+            return false;
+        }
         let abs_pos = search_start + pos;
         let in_safe = safe_ranges
             .iter()
@@ -321,7 +347,14 @@ pub(crate) fn marker_reflects_in_url_attr_only(html: &str, marker: &str) -> bool
     let bytes = html.as_bytes();
     let mut search_start = 0;
     let mut any = false;
+    let mut scanned = 0usize;
     while let Some(pos) = html[search_start..].find(marker) {
+        scanned += 1;
+        if scanned > MAX_PAYLOAD_OCCURRENCES {
+            // Bail toward reporting: `false` means "not exclusively URL-attr",
+            // so the URL-echo suppression does not apply and the finding stays.
+            return false;
+        }
         any = true;
         let abs = search_start + pos;
         if !occurrence_is_in_url_attr(bytes, abs) {
@@ -428,6 +461,13 @@ fn script_block_ranges(html: &str) -> Vec<(usize, usize)> {
     let mut ranges = Vec::new();
     let mut search = 0;
     while let Some(start) = find_ascii_case_insensitive(bytes, open, search) {
+        // Cap the range set. Unlike the unclosed-tag branch below we do NOT
+        // extend to end-of-document here: leaving later regions classified as
+        // non-script keeps payload occurrences there reportable (fail toward
+        // reporting) instead of marking them inert.
+        if ranges.len() >= MAX_SCRIPT_RANGES {
+            break;
+        }
         // Find the end of the opening tag '>'
         let Some(rel) = html[start..].find('>') else {
             break;
@@ -456,7 +496,14 @@ fn all_occurrences_in_ranges(haystack: &str, needle: &str, ranges: &[(usize, usi
     let needle_len = needle.len();
     let mut search = 0;
     let mut found_any = false;
+    let mut scanned = 0usize;
     while let Some(rel) = haystack[search..].find(needle) {
+        scanned += 1;
+        if scanned > MAX_PAYLOAD_OCCURRENCES {
+            // Give up vetting; `false` means "not all occurrences are inside the
+            // ranges", which keeps the finding rather than treating it as inert.
+            return false;
+        }
         let abs = search + rel;
         let in_range = ranges
             .iter()
@@ -771,7 +818,15 @@ fn url_encoded_payload_reflects_in_unsafe_url_context(html: &str, payload: &str)
     }
     let bytes = html.as_bytes();
     let mut search_start = 0;
+    let mut scanned = 0usize;
     while let Some(pos) = html[search_start..].find(payload) {
+        scanned += 1;
+        if scanned > MAX_PAYLOAD_OCCURRENCES {
+            // Couldn't rule out an unsafe-URL-context occurrence within the
+            // scan budget; the caller suppresses only when this is `false`, so
+            // returning `true` keeps the finding (fail toward reporting).
+            return true;
+        }
         let abs = search_start + pos;
         if occurrence_is_in_url_attr(bytes, abs) {
             return true;
@@ -1286,7 +1341,10 @@ async fn fetch_injection_response_with_client(
                 // target_summary.waf.bypass is always empty.
                 let status_code = resp.status().as_u16();
                 apply_injection_waf_accounting(status_code, target, args, streak).await;
-                resp.text().await.ok().filter(|t| !t.is_empty())
+                crate::utils::http::read_body(resp)
+                    .await
+                    .ok()
+                    .filter(|t| !t.is_empty())
             }
             Err(_) => None,
         };
@@ -1306,7 +1364,7 @@ async fn fetch_injection_response_with_client(
 
                 crate::record_outbound_request().await;
                 if let Ok(resp) = check_request.send().await
-                    && let Ok(text) = resp.text().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
                     && !text.is_empty()
                 {
                     if classify_reflection(&text, payload).is_some() {
@@ -1437,7 +1495,7 @@ async fn fetch_injection_response_with_client(
                 // R is preserved while the false V upgrade is blocked.
                 return Some(format!("<html><body>{}</body></html>", location));
             }
-            match resp.text().await {
+            match crate::utils::http::read_body(resp).await {
                 Ok(body) => {
                     // Body-aware Path suppression for 4xx/5xx: keep the
                     // finding when the marker reflects somewhere other than

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1021,6 +1021,23 @@ fn test_safe_context_textarea() {
     assert!(is_in_safe_context(&html, payload));
 }
 
+// A hostile page can echo the payload an unbounded number of times inside a
+// safe tag. Without the per-occurrence cap, vetting every echo against the
+// safe ranges is an O(n·m) CPU hang (body analysis runs after the response is
+// read, so the request timeout doesn't bound it). With the cap, the scan stops
+// early and returns `false` — the fail-toward-reporting answer — so the finding
+// is kept rather than the worker hanging.
+#[test]
+fn test_safe_context_occurrence_cap_bails_toward_reporting() {
+    let payload = "<x>";
+    // > MAX_PAYLOAD_OCCURRENCES echoes, all genuinely inside a safe <textarea>.
+    let inner = payload.repeat(MAX_PAYLOAD_OCCURRENCES + 50);
+    let html = format!("<html><textarea>{inner}</textarea></html>");
+    // Returns promptly (no hang) and does NOT suppress: cap flips the otherwise
+    // "all safe" verdict to `false`.
+    assert!(!is_in_safe_context(&html, payload));
+}
+
 #[test]
 fn test_safe_context_noscript() {
     let payload = "<img src=x onerror=alert(1)>";

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -166,7 +166,7 @@ pub async fn verify_dom_xss_light_with_client(
             .get("Content-Security-Policy")
             .and_then(|v| v.to_str().ok())
             .map(ToString::to_string);
-        if let Ok(text) = resp.text().await {
+        if let Ok(text) = crate::utils::http::read_body(resp).await {
             // 1) Payload reflection present after normalization
             if crate::utils::is_htmlish_content_type(&ct)
                 && crate::scanning::check_reflection::classify_reflection(&text, payload).is_some()

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -624,7 +624,7 @@ pub(crate) async fn fetch_and_analyze_external_js(
         if !resp.status().is_success() {
             continue;
         }
-        let body = match resp.text().await {
+        let body = match crate::utils::http::read_body(resp).await {
             Ok(b) => b,
             Err(_) => continue,
         };

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -265,7 +265,7 @@ pub async fn blind_scan_forms(
     }
     crate::record_outbound_request().await;
     let html = match fetch.send().await {
-        Ok(resp) => match resp.text().await {
+        Ok(resp) => match crate::utils::http::read_body(resp).await {
             Ok(text) => text,
             Err(_) => return,
         },

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -353,6 +353,23 @@ pub(crate) async fn get_scan_handler(
     let skip_ast_analysis = parse_bool_query(&params, "skip_ast_analysis");
     let analyze_external_js = parse_bool_query(&params, "analyze_external_js");
     let detect_outdated_libs = parse_bool_query(&params, "detect_outdated_libs");
+    let waf_bypass = params.get("waf_bypass").cloned();
+    let skip_waf_probe = parse_opt_bool_query(&params, "skip_waf_probe");
+    let force_waf = params.get("force_waf").cloned();
+    let waf_evasion = parse_opt_bool_query(&params, "waf_evasion");
+    // Present-but-unparseable is a 400 (same policy as the numeric params
+    // above); the [0.0, 1.0] range is enforced by `validate_scan_options`.
+    let waf_min_confidence = match parse_num_query::<f32>(&params, "waf_min_confidence") {
+        Ok(v) => v,
+        Err(msg) => {
+            let resp = ApiResponse::<serde_json::Value> {
+                code: 400,
+                msg,
+                data: None,
+            };
+            return make_api_response(&state, &headers, &params, StatusCode::BAD_REQUEST, &resp);
+        }
+    };
 
     let opts = ScanOptions {
         cookie,
@@ -392,6 +409,11 @@ pub(crate) async fn get_scan_handler(
         skip_ast_analysis: Some(skip_ast_analysis),
         analyze_external_js: Some(analyze_external_js),
         detect_outdated_libs: Some(detect_outdated_libs),
+        waf_bypass,
+        skip_waf_probe,
+        force_waf,
+        waf_evasion,
+        waf_min_confidence,
         rate_limit,
         scan_timeout,
     };

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -327,7 +327,13 @@ pub(crate) async fn run_scan_job(
             .clone()
             .unwrap_or_else(|| "auto".to_string()),
         skip_waf_probe: opts.skip_waf_probe.unwrap_or(false),
-        force_waf: opts.force_waf.clone(),
+        // Normalize to the canonical (lowercased) WAF name like the CLI/MCP do;
+        // `validate_scan_options` already rejected unknown names before queuing,
+        // so the fallback is defensive only.
+        force_waf: opts
+            .force_waf
+            .as_deref()
+            .map(|s| crate::cmd::scan::parse_force_waf_arg(s).unwrap_or_else(|_| s.to_string())),
         waf_evasion: opts.waf_evasion.unwrap_or(false),
         // Per-scan outbound request rate (RPS), capped by the server-wide
         // `--rate-limit`. Honored in `run_scanning`'s workers now that they

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -322,17 +322,22 @@ pub(crate) async fn run_scan_job(
         skip_ast_analysis: opts.skip_ast_analysis.unwrap_or(false),
         analyze_external_js: opts.analyze_external_js.unwrap_or(false),
         hpp: false,
-        waf_bypass: "auto".to_string(),
-        skip_waf_probe: false,
-        force_waf: None,
-        waf_evasion: false,
+        waf_bypass: opts
+            .waf_bypass
+            .clone()
+            .unwrap_or_else(|| "auto".to_string()),
+        skip_waf_probe: opts.skip_waf_probe.unwrap_or(false),
+        force_waf: opts.force_waf.clone(),
+        waf_evasion: opts.waf_evasion.unwrap_or(false),
         // Per-scan outbound request rate (RPS), capped by the server-wide
         // `--rate-limit`. Honored in `run_scanning`'s workers now that they
         // re-enter the per-job rate-limiter scope (see crate::with_job_scopes).
         rate_limit: effective_rate_limit(opts.rate_limit, state.rate_limit),
         retries: 0,
         retry_delay: 1000,
-        waf_min_confidence: crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE,
+        waf_min_confidence: opts
+            .waf_min_confidence
+            .unwrap_or(crate::cmd::scan::DEFAULT_WAF_MIN_CONFIDENCE),
         remote_payloads: opts.remote_payloads.clone().unwrap_or_default(),
         remote_wordlists: opts.remote_wordlists.clone().unwrap_or_default(),
 
@@ -510,7 +515,7 @@ pub(crate) async fn run_scan_job(
                             // CLI gets from preflight.
                             let trusted_types_enforced =
                                 crate::scanning::csp_requires_trusted_types(resp.headers());
-                            if let Ok(body) = resp.text().await {
+                            if let Ok(body) = crate::utils::http::read_body(resp).await {
                                 let ast_batch =
                                     crate::scanning::ast_integration::run_initial_ast_dom_analysis(
                                         &body,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1078,6 +1078,7 @@ async fn test_run_scan_job_success_marks_done() {
         detect_outdated_libs: Some(true),
         rate_limit: None,
         scan_timeout: None,
+        ..ScanOptions::default()
     };
 
     let run = tokio::time::timeout(
@@ -1675,6 +1676,57 @@ fn test_validate_scan_options_rejects_out_of_range() {
         ..ScanOptions::default()
     };
     assert!(validate_scan_options(&bad_scan_timeout).is_err());
+}
+
+#[test]
+fn test_validate_scan_options_waf_fields() {
+    // waf_bypass must be one of the CLI's three modes.
+    assert!(
+        validate_scan_options(&ScanOptions {
+            waf_bypass: Some("force".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_ok()
+    );
+    assert!(
+        validate_scan_options(&ScanOptions {
+            waf_bypass: Some("nonsense".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_err()
+    );
+
+    // force_waf is normalized/validated against the shared CLI WAF-name set.
+    assert!(
+        validate_scan_options(&ScanOptions {
+            force_waf: Some("CloudFlare".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_ok()
+    );
+    assert!(
+        validate_scan_options(&ScanOptions {
+            force_waf: Some("notawaf".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_err()
+    );
+
+    // waf_min_confidence is a probability in [0.0, 1.0].
+    assert!(
+        validate_scan_options(&ScanOptions {
+            waf_min_confidence: Some(0.5),
+            ..ScanOptions::default()
+        })
+        .is_ok()
+    );
+    assert!(
+        validate_scan_options(&ScanOptions {
+            waf_min_confidence: Some(1.5),
+            ..ScanOptions::default()
+        })
+        .is_err()
+    );
 }
 
 #[tokio::test]

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -169,6 +169,17 @@ pub(crate) struct ScanOptions {
     pub(crate) analyze_external_js: Option<bool>,
     /// Also report outdated / known-vulnerable JS libraries (informational, CWE-1104).
     pub(crate) detect_outdated_libs: Option<bool>,
+    /// WAF handling mode: "auto" (detect then bypass), "force" (use force_waf),
+    /// or "off" (detect only). Absent keeps the scanner default ("auto").
+    pub(crate) waf_bypass: Option<String>,
+    /// Skip the WAF fingerprinting probe entirely. Absent keeps the default (false).
+    pub(crate) skip_waf_probe: Option<bool>,
+    /// Force a specific WAF profile (e.g. "cloudflare") instead of detecting one.
+    pub(crate) force_waf: Option<String>,
+    /// Enable adaptive WAF evasion. Absent keeps the default (false).
+    pub(crate) waf_evasion: Option<bool>,
+    /// WAF detection confidence floor in [0.0, 1.0]. Absent keeps the default (0.3).
+    pub(crate) waf_min_confidence: Option<f32>,
     /// Per-scan outbound request rate (requests/second; 0 = unlimited). Capped
     /// by the server's `--rate-limit` when set.
     pub(crate) rate_limit: Option<u32>,

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -38,6 +38,26 @@ pub(crate) fn validate_scan_options(opts: &ScanOptions) -> Result<(), String> {
             MAX_SCAN_TIMEOUT_SECS, st
         ));
     }
+    if let Some(mode) = opts.waf_bypass.as_deref()
+        && !matches!(mode, "auto" | "force" | "off")
+    {
+        return Err(format!(
+            "waf_bypass must be one of auto, force, off (got '{}')",
+            mode
+        ));
+    }
+    // Reuse the CLI's WAF-name normalizer so server/CLI accept the same set.
+    if let Some(name) = opts.force_waf.as_deref() {
+        crate::cmd::scan::parse_force_waf_arg(name)?;
+    }
+    if let Some(c) = opts.waf_min_confidence
+        && !(0.0..=1.0).contains(&c)
+    {
+        return Err(format!(
+            "waf_min_confidence must be between 0.0 and 1.0 (got {})",
+            c
+        ));
+    }
     Ok(())
 }
 

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -594,6 +594,13 @@ pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 16 * 1024 * 1024;
 /// Invalid UTF-8 (including a multi-byte codepoint split at the cap boundary)
 /// is replaced via [`String::from_utf8_lossy`], so this never panics. Use in
 /// place of `resp.text().await` on any response from a scanned target.
+///
+/// NOTE: unlike [`reqwest::Response::text`], this does NOT honor a non-UTF-8
+/// `Content-Type` charset label — it always decodes as UTF-8 (lossy). That is
+/// intentional (the cap streams raw bytes), and harmless for ASCII markers /
+/// payloads, but bytes 0x80–0xFF on a declared Latin-1 / Shift-JIS page become
+/// `U+FFFD` here where `text()` would have transcoded them. Modern targets are
+/// overwhelmingly UTF-8, so detection impact is negligible.
 pub(crate) async fn read_body_capped(
     mut resp: reqwest::Response,
     max_bytes: usize,

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -576,5 +576,49 @@ pub async fn send_with_retry(
     }
 }
 
+/// Hard cap on how many bytes of any single response body we buffer into
+/// memory. The reqwest client has a request `timeout` but no body-size limit,
+/// so a hostile (or misbehaving) server can stream an arbitrarily large body
+/// within the timeout window; with the default worker pool buffering many such
+/// bodies concurrently this is an out-of-memory crash vector. 16 MiB is far
+/// larger than any realistic HTML/JS page, so benign detection is unaffected.
+pub(crate) const MAX_RESPONSE_BODY_BYTES: usize = 16 * 1024 * 1024;
+
+/// Read a response body into a `String`, hard-capping at `max_bytes`.
+///
+/// Streams the body chunk-by-chunk (via [`reqwest::Response::chunk`], which is
+/// available without the `stream` feature) and stops — dropping the connection,
+/// so the server cannot keep pushing bytes — once `max_bytes` is reached. This
+/// bounds memory regardless of the advertised or actual `Content-Length`.
+///
+/// Invalid UTF-8 (including a multi-byte codepoint split at the cap boundary)
+/// is replaced via [`String::from_utf8_lossy`], so this never panics. Use in
+/// place of `resp.text().await` on any response from a scanned target.
+pub(crate) async fn read_body_capped(
+    mut resp: reqwest::Response,
+    max_bytes: usize,
+) -> Result<String, reqwest::Error> {
+    let mut buf: Vec<u8> = Vec::new();
+    while let Some(chunk) = resp.chunk().await? {
+        let remaining = max_bytes.saturating_sub(buf.len());
+        if remaining == 0 {
+            break;
+        }
+        let take = remaining.min(chunk.len());
+        buf.extend_from_slice(&chunk[..take]);
+        if buf.len() >= max_bytes {
+            break;
+        }
+    }
+    Ok(String::from_utf8_lossy(&buf).into_owned())
+}
+
+/// Convenience over [`read_body_capped`] using the default
+/// [`MAX_RESPONSE_BODY_BYTES`] cap. Drop-in replacement for `resp.text().await`
+/// on responses from scanned targets.
+pub(crate) async fn read_body(resp: reqwest::Response) -> Result<String, reqwest::Error> {
+    read_body_capped(resp, MAX_RESPONSE_BODY_BYTES).await
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -416,3 +416,59 @@ fn parse_retry_after_accepts_seconds_and_http_date() {
     // Unparseable -> None so the caller falls back to exponential backoff.
     assert_eq!(with("not-a-date"), None);
 }
+
+/// Spawn a one-shot localhost server that replies with `body` and return its
+/// URL. Used to exercise the real `reqwest::Response::chunk()` read path.
+async fn serve_once(body: Vec<u8>) -> String {
+    use tokio::io::{AsyncReadExt, AsyncWriteExt};
+    let listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        if let Ok((mut sock, _)) = listener.accept().await {
+            let mut scratch = [0u8; 1024];
+            let _ = sock.read(&mut scratch).await; // drain the request line/headers
+            let header = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/html\r\nContent-Length: {}\r\nConnection: close\r\n\r\n",
+                body.len()
+            );
+            let _ = sock.write_all(header.as_bytes()).await;
+            let _ = sock.write_all(&body).await;
+            let _ = sock.flush().await;
+        }
+    });
+    format!("http://{addr}/")
+}
+
+#[tokio::test]
+async fn test_read_body_capped_returns_small_body_whole() {
+    crate::ensure_crypto_provider();
+    let url = serve_once(b"hello world".to_vec()).await;
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    let body = read_body_capped(resp, 1024).await.unwrap();
+    assert_eq!(body, "hello world");
+}
+
+#[tokio::test]
+async fn test_read_body_capped_truncates_oversized_body() {
+    crate::ensure_crypto_provider();
+    // 20-byte body, 10-byte cap: exactly the first 10 bytes come back and the
+    // rest of the stream is dropped (no unbounded buffering).
+    let url = serve_once(b"0123456789ABCDEFGHIJ".to_vec()).await;
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    let body = read_body_capped(resp, 10).await.unwrap();
+    assert_eq!(body, "0123456789");
+}
+
+#[tokio::test]
+async fn test_read_body_capped_handles_utf8_split_at_cap() {
+    crate::ensure_crypto_provider();
+    // Body is "a" + 'é' (0x61, 0xC3, 0xA9). A 2-byte cap lands inside the
+    // multi-byte codepoint; from_utf8_lossy must replace it instead of
+    // panicking on a non-char-boundary slice.
+    let url = serve_once(vec![0x61, 0xC3, 0xA9]).await;
+    let resp = reqwest::Client::new().get(&url).send().await.unwrap();
+    let body = read_body_capped(resp, 2).await.unwrap();
+    assert_eq!(body, "a\u{FFFD}");
+}

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -292,7 +292,7 @@ pub async fn fingerprint_with_probe(
 
     let status = resp.status().as_u16();
     let headers = resp.headers().clone();
-    let body_text = resp.text().await.ok();
+    let body_text = crate::utils::http::read_body(resp).await.ok();
 
     let mut result = fingerprint_from_response(&headers, body_text.as_deref(), status);
 


### PR DESCRIPTION
## Why

Stability pass focused on **cutting crashes and removing unintended (silent no-op) behavior** when a scanned target returns adversarial input. dalfox fetches and analyzes hostile pages, so a malicious server can feed it anything. Three Explore hunters swept the tree; findings were hand-verified, keeping 2 real defects + 1 parity gap and discarding 3 false alarms.

## What

### Tier 1 — unbounded response-body reads → OOM crash
~40 production `resp.text().await` sites buffered the entire body with **no size cap**. The reqwest client has a request `timeout` but no body-size limit, so a fast hostile server can stream hundreds of MB–GB within the timeout window; with the default 50-worker pool buffering concurrently, that exhausts memory and kills the scanner.

- New `read_body_capped(resp, max)` / `read_body(resp)` + `MAX_RESPONSE_BODY_BYTES = 16 MiB` in `utils/http.rs`, using `Response::chunk()` (works **without** the reqwest `stream` feature) and dropping the connection at the cap. `from_utf8_lossy` handles a codepoint split at the boundary (no panic).
- All 39 production body reads routed through it. 16 MiB ≫ any realistic page, so detection is unaffected.

### Tier 2 — O(n²) CPU hang in `check_reflection.rs`
Body analysis runs **after** the response is read, so the request timeout doesn't bound it. A page packed with safe tags / `<script>` blocks / payload echoes drives the range collectors and per-occurrence scans into a multi-second hang.

- Caps `MAX_SAFE_RANGES` / `MAX_SCRIPT_RANGES` / `MAX_PAYLOAD_OCCURRENCES` (4096).
- On a cap, each loop returns the value that does **not** suppress a finding (fail toward reporting), verified per call site. A cap can only ever cost extra `[R]` noise on a pathological page — never a missed vulnerability.

### Tier 3 — server/MCP option parity
WAF options (`waf_bypass`, `skip_waf_probe`, `force_waf`, `waf_evasion`, `waf_min_confidence`) were hardcoded on both front-ends; MCP additionally hardcoded `remote_payloads`/`remote_wordlists` to empty **and never called `init_remote_resources`**.

- Exposed on server `ScanOptions` + GET `/scan`, MCP `ScanWithDalfoxParams`, and threaded into the MCP scan path (plus the missing remote-resource init).
- Validation: `waf_bypass` ∈ {auto, force, off}, `waf_min_confidence` ∈ [0, 1], `force_waf` via the shared `parse_force_waf_arg`. All additive with current defaults, so existing callers are unchanged.

### Discarded false alarms
- **regex ReDoS** — `regex = "1"` is linear-time (no backtracking).
- **HAR deep-JSON stack overflow** — serde_json's default recursion limit (128) returns `Err`.
- **HAR cookie/multipart unbounded loops** — HAR is a user-supplied file, not a remote-attacker vector.

No new production panic sites were found (prior AST/slicing hardening was thorough).

## Tests
- +6 tests: capped-body (×3), occurrence-cap regression, server WAF-validation, MCP serde parity.
- `cargo test --lib`: **1591 passing**.
- `cargo clippy --all-targets --all-features -- -D warnings` and `cargo fmt --all -- --check`: clean.