### PR TITLE
test: raise coverage for input resolution, blind-XSS helpers, and WAF mutations

### DIFF
--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -763,3 +763,6 @@ fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
     target.ignore_return = args.ignore_return.clone();
     target.workers = args.workers;
 }
+
+#[cfg(test)]
+mod tests;

--- a/src/cmd/scan/input/tests.rs
+++ b/src/cmd/scan/input/tests.rs
@@ -1,0 +1,403 @@
+//! Tests for target input resolution (`resolve_targets`) and its helpers.
+//!
+//! Every case pins an explicit `--input-type` so the resolver never touches
+//! stdin — under `cargo test` stdin is not a TTY, and an `auto` path could
+//! otherwise block or read the harness's stream. The `url`/`file`/`raw-http`/
+//! `har` branches with explicit targets are entirely file/literal-driven.
+
+use super::*;
+use clap::Parser;
+
+#[derive(Parser)]
+struct TestCli {
+    #[command(flatten)]
+    scan: ScanArgs,
+}
+
+/// Parse a `ScanArgs` from a CLI-style token list (the leading binary name is
+/// prepended for you).
+fn args_from(argv: &[&str]) -> ScanArgs {
+    let mut full = Vec::with_capacity(argv.len() + 1);
+    full.push("dalfox");
+    full.extend_from_slice(argv);
+    TestCli::try_parse_from(full)
+        .expect("test args should parse")
+        .scan
+}
+
+/// Write `contents` to a uniquely named temp file and return its path.
+fn tmp_file(name: &str, contents: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "dalfox-input-test-{}-{}-{}",
+        std::process::id(),
+        nanos,
+        name
+    ));
+    std::fs::write(&p, contents).expect("write temp file");
+    p
+}
+
+const SAMPLE_HAR_PATH: &str = concat!(env!("CARGO_MANIFEST_DIR"), "/tests/fixtures/sample.har");
+
+// ── resolve_targets: url mode ───────────────────────────────────────
+
+#[tokio::test]
+async fn url_mode_parses_single_target() {
+    let args = args_from(&["-i", "url", "-S", "https://example.com/?q=1"]);
+    let targets = resolve_targets(&args).await.expect("one URL resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].url.as_str(), "https://example.com/?q=1");
+}
+
+#[tokio::test]
+async fn url_mode_dedupes_identical_targets() {
+    // Same URL twice collapses to one (URL+method dedup), e.g. a noisy pipe.
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "https://example.com/?q=1",
+        "https://example.com/?q=1",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1, "duplicate URL must be deduped");
+}
+
+#[tokio::test]
+async fn url_mode_applies_method_and_header_overrides() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "-X",
+        "POST",
+        "-H",
+        "X-Test: v1",
+        "--user-agent",
+        "DalfoxTest/1.0",
+        "https://example.com/",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+    let t = &targets[0];
+    assert_eq!(t.method, "POST");
+    assert!(t.headers.iter().any(|(k, v)| k == "X-Test" && v == "v1"));
+    assert_eq!(t.user_agent.as_deref(), Some("DalfoxTest/1.0"));
+}
+
+#[tokio::test]
+async fn invalid_input_type_is_an_error() {
+    let args = args_from(&["-i", "bogus", "-S", "https://example.com/"]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+// ── resolve_targets: auto mode (no stdin data) ──────────────────────
+//
+// Under `cargo test` stdin is `/dev/null` (CI) or a TTY (local): the auto
+// path either reads an immediately-empty stream or skips it, so these stay
+// deterministic and never block. They exercise the positional-input
+// classification that the explicit-type cases bypass.
+
+#[tokio::test]
+async fn auto_mode_classifies_url_literal() {
+    let args = args_from(&["-i", "auto", "-S", "https://auto.example/?q=1"]);
+    let targets = resolve_targets(&args).await.expect("auto URL resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].url.host_str(), Some("auto.example"));
+}
+
+#[tokio::test]
+async fn auto_mode_reads_url_list_file() {
+    // A positional arg that is a readable file of URLs is classified as a
+    // target list and expanded line by line.
+    let p = tmp_file(
+        "auto-list",
+        "https://one.example/\n# comment\nhttps://two.example/\n",
+    );
+    let args = args_from(&["-i", "auto", "-S", p.to_str().unwrap()]);
+    let targets = resolve_targets(&args).await.expect("auto file resolves");
+    let _ = std::fs::remove_file(&p);
+    let hosts: Vec<Option<&str>> = targets.iter().map(|t| t.url.host_str()).collect();
+    assert_eq!(hosts, vec![Some("one.example"), Some("two.example")]);
+}
+
+// ── resolve_targets: file mode ──────────────────────────────────────
+
+#[tokio::test]
+async fn file_mode_reads_lines_and_skips_comments_and_blanks() {
+    let p = tmp_file(
+        "targets",
+        "https://a.example/?x=1\n# a comment\n\n  https://b.example/?y=2  \n",
+    );
+    let args = args_from(&["-i", "file", "-S", p.to_str().unwrap()]);
+    let targets = resolve_targets(&args).await.expect("file resolves");
+    let _ = std::fs::remove_file(&p);
+    let urls: Vec<&str> = targets.iter().map(|t| t.url.as_str()).collect();
+    assert_eq!(
+        urls,
+        vec!["https://a.example/?x=1", "https://b.example/?y=2"]
+    );
+}
+
+#[tokio::test]
+async fn file_mode_without_path_is_an_error() {
+    let args = args_from(&["-i", "file", "-S"]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+#[tokio::test]
+async fn file_mode_missing_file_is_an_error() {
+    let args = args_from(&[
+        "-i",
+        "file",
+        "-S",
+        "/dalfox/no/such/target/list/xyz.txt",
+    ]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+// ── resolve_targets: scope filters ──────────────────────────────────
+
+#[tokio::test]
+async fn include_url_keeps_only_matching_targets() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--include-url",
+        ".*/api/.*",
+        "https://example.com/api/users",
+        "https://example.com/page",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+    assert!(targets[0].url.as_str().contains("/api/"));
+}
+
+#[tokio::test]
+async fn exclude_url_drops_matching_targets() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--exclude-url",
+        ".*/admin.*",
+        "https://example.com/admin/panel",
+        "https://example.com/ok",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+    assert!(targets[0].url.as_str().ends_with("/ok"));
+}
+
+#[tokio::test]
+async fn invalid_scope_regex_is_skipped_not_fatal() {
+    // An unparseable --include-url is warned about and dropped; with no other
+    // valid include pattern the filter is a no-op, so the target survives.
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--include-url",
+        "(unbalanced",
+        "https://example.com/",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+}
+
+// ── resolve_targets: out-of-scope domain filters ────────────────────
+
+#[tokio::test]
+async fn out_of_scope_domain_is_excluded() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--out-of-scope",
+        "evil.example",
+        "https://evil.example/",
+        "https://good.example/",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].url.host_str(), Some("good.example"));
+}
+
+#[tokio::test]
+async fn out_of_scope_file_domains_are_excluded() {
+    let p = tmp_file("oos", "evil.example\n# skip me\n\n");
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--out-of-scope-file",
+        p.to_str().unwrap(),
+        "https://evil.example/",
+        "https://good.example/",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].url.host_str(), Some("good.example"));
+}
+
+#[tokio::test]
+async fn all_targets_filtered_out_is_an_error() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--out-of-scope",
+        "example.com",
+        "https://example.com/",
+    ]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+// ── resolve_targets: raw-http + har modes ───────────────────────────
+
+#[tokio::test]
+async fn raw_http_literal_is_parsed() {
+    // A raw request pasted as a positional literal (not a path on disk).
+    let raw = "GET /search?q=1 HTTP/1.1\r\nHost: raw.example\r\n\r\n";
+    let args = args_from(&["-i", "raw-http", "-S", raw]);
+    let targets = resolve_targets(&args).await.expect("raw http resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].url.host_str(), Some("raw.example"));
+    assert_eq!(targets[0].method, "GET");
+}
+
+#[tokio::test]
+async fn raw_http_from_file_is_parsed() {
+    let p = tmp_file(
+        "raw",
+        "POST /login HTTP/1.1\r\nHost: file.example\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nu=a",
+    );
+    let args = args_from(&["-i", "raw-http", "-S", p.to_str().unwrap()]);
+    let targets = resolve_targets(&args).await.expect("raw http file resolves");
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].method, "POST");
+    assert_eq!(targets[0].url.host_str(), Some("file.example"));
+}
+
+#[tokio::test]
+async fn raw_http_invalid_is_an_error() {
+    let args = args_from(&["-i", "raw-http", "-S", "not a real http request"]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+#[tokio::test]
+async fn har_fixture_expands_to_multiple_targets() {
+    let args = args_from(&["-i", "har", "-S", SAMPLE_HAR_PATH]);
+    let targets = resolve_targets(&args).await.expect("HAR resolves");
+    assert_eq!(targets.len(), 2, "fixture has a GET and a POST entry");
+    assert!(targets.iter().any(|t| t.method == "GET"));
+    assert!(targets.iter().any(|t| t.method == "POST"));
+}
+
+#[tokio::test]
+async fn har_invalid_document_is_an_error() {
+    let args = args_from(&["-i", "har", "-S", "{ not valid har }"]);
+    assert!(resolve_targets(&args).await.is_err());
+}
+
+// ── resolve_targets: cookie-from-raw ────────────────────────────────
+
+#[tokio::test]
+async fn cookie_from_raw_appends_cookies_to_targets() {
+    let p = tmp_file(
+        "cookies",
+        "GET / HTTP/1.1\r\nHost: x\r\nCookie: a=1; b=2\r\n\r\n",
+    );
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--cookie-from-raw",
+        p.to_str().unwrap(),
+        "https://example.com/",
+    ]);
+    let targets = resolve_targets(&args).await.expect("resolves");
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(targets.len(), 1);
+    let cookies = &targets[0].cookies;
+    assert!(cookies.iter().any(|(k, v)| k == "a" && v == "1"));
+    assert!(cookies.iter().any(|(k, v)| k == "b" && v == "2"));
+}
+
+// ── load_request_source ─────────────────────────────────────────────
+
+#[test]
+fn load_request_source_reads_existing_file() {
+    let p = tmp_file("src", "raw body contents");
+    let args = args_from(&["-i", "url", "-S", "https://e.example/"]);
+    let out = load_request_source(p.to_str().unwrap(), &args, "raw HTTP request")
+        .expect("existing file reads");
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(out, "raw body contents");
+}
+
+#[test]
+fn load_request_source_treats_non_path_as_literal() {
+    let args = args_from(&["-i", "url", "-S", "https://e.example/"]);
+    let literal = "GET / HTTP/1.1\r\nHost: literal.example\r\n\r\n";
+    let out = load_request_source(literal, &args, "raw HTTP request").expect("literal passes through");
+    assert_eq!(out, literal);
+}
+
+// ── apply_request_cli_overrides ─────────────────────────────────────
+
+#[test]
+fn apply_request_cli_overrides_only_overrides_explicit_flags() {
+    let mut target = crate::target_parser::parse_raw_http_request(
+        "GET /p HTTP/1.1\r\nHost: ov.example\r\n\r\n",
+    )
+    .expect("raw request parses");
+
+    let args = args_from(&[
+        "-i",
+        "raw-http",
+        "-S",
+        "-X",
+        "POST",
+        "-d",
+        "k=v",
+        "-H",
+        "X-Extra: yes",
+        "--user-agent",
+        "Agent/9",
+        "--cookies",
+        "sid=abc",
+        "ignored.example",
+    ]);
+
+    apply_request_cli_overrides(&mut target, &args);
+
+    assert_eq!(target.method, "POST");
+    assert_eq!(target.data.as_deref(), Some("k=v"));
+    assert!(target.headers.iter().any(|(k, v)| k == "X-Extra" && v == "yes"));
+    assert!(target.headers.iter().any(|(k, v)| k == "User-Agent" && v == "Agent/9"));
+    assert_eq!(target.user_agent.as_deref(), Some("Agent/9"));
+    assert!(target.cookies.iter().any(|(k, v)| k == "sid" && v == "abc"));
+}
+
+#[test]
+fn apply_request_cli_overrides_keeps_request_method_without_flag() {
+    let mut target = crate::target_parser::parse_raw_http_request(
+        "DELETE /thing HTTP/1.1\r\nHost: keep.example\r\n\r\n",
+    )
+    .expect("raw request parses");
+
+    // No -X flag: the captured request's own method (DELETE) must survive
+    // rather than being clobbered with the GET default.
+    let args = args_from(&["-i", "raw-http", "-S", "keep.example"]);
+    apply_request_cli_overrides(&mut target, &args);
+    assert_eq!(target.method, "DELETE");
+}

--- a/src/cmd/scan/input/tests.rs
+++ b/src/cmd/scan/input/tests.rs
@@ -152,12 +152,7 @@ async fn file_mode_without_path_is_an_error() {
 
 #[tokio::test]
 async fn file_mode_missing_file_is_an_error() {
-    let args = args_from(&[
-        "-i",
-        "file",
-        "-S",
-        "/dalfox/no/such/target/list/xyz.txt",
-    ]);
+    let args = args_from(&["-i", "file", "-S", "/dalfox/no/such/target/list/xyz.txt"]);
     assert!(resolve_targets(&args).await.is_err());
 }
 
@@ -280,7 +275,9 @@ async fn raw_http_from_file_is_parsed() {
         "POST /login HTTP/1.1\r\nHost: file.example\r\nContent-Type: application/x-www-form-urlencoded\r\n\r\nu=a",
     );
     let args = args_from(&["-i", "raw-http", "-S", p.to_str().unwrap()]);
-    let targets = resolve_targets(&args).await.expect("raw http file resolves");
+    let targets = resolve_targets(&args)
+        .await
+        .expect("raw http file resolves");
     let _ = std::fs::remove_file(&p);
     assert_eq!(targets.len(), 1);
     assert_eq!(targets[0].method, "POST");
@@ -348,7 +345,8 @@ fn load_request_source_reads_existing_file() {
 fn load_request_source_treats_non_path_as_literal() {
     let args = args_from(&["-i", "url", "-S", "https://e.example/"]);
     let literal = "GET / HTTP/1.1\r\nHost: literal.example\r\n\r\n";
-    let out = load_request_source(literal, &args, "raw HTTP request").expect("literal passes through");
+    let out =
+        load_request_source(literal, &args, "raw HTTP request").expect("literal passes through");
     assert_eq!(out, literal);
 }
 
@@ -356,10 +354,9 @@ fn load_request_source_treats_non_path_as_literal() {
 
 #[test]
 fn apply_request_cli_overrides_only_overrides_explicit_flags() {
-    let mut target = crate::target_parser::parse_raw_http_request(
-        "GET /p HTTP/1.1\r\nHost: ov.example\r\n\r\n",
-    )
-    .expect("raw request parses");
+    let mut target =
+        crate::target_parser::parse_raw_http_request("GET /p HTTP/1.1\r\nHost: ov.example\r\n\r\n")
+            .expect("raw request parses");
 
     let args = args_from(&[
         "-i",
@@ -382,8 +379,18 @@ fn apply_request_cli_overrides_only_overrides_explicit_flags() {
 
     assert_eq!(target.method, "POST");
     assert_eq!(target.data.as_deref(), Some("k=v"));
-    assert!(target.headers.iter().any(|(k, v)| k == "X-Extra" && v == "yes"));
-    assert!(target.headers.iter().any(|(k, v)| k == "User-Agent" && v == "Agent/9"));
+    assert!(
+        target
+            .headers
+            .iter()
+            .any(|(k, v)| k == "X-Extra" && v == "yes")
+    );
+    assert!(
+        target
+            .headers
+            .iter()
+            .any(|(k, v)| k == "User-Agent" && v == "Agent/9")
+    );
     assert_eq!(target.user_agent.as_deref(), Some("Agent/9"));
     assert!(target.cookies.iter().any(|(k, v)| k == "sid" && v == "abc"));
 }

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -394,3 +394,163 @@ async fn test_blind_scanning_sends_requests_for_query_body_header_and_cookie() {
             || r.headers.values().any(|v| v.contains("cb.example"))
     }));
 }
+
+// ── pure-helper unit tests ──────────────────────────────────────────
+
+#[test]
+fn location_of_maps_param_types_to_wire_locations() {
+    assert_eq!(location_of("query"), "Query");
+    assert_eq!(location_of("body"), "Body");
+    assert_eq!(location_of("header"), "Header");
+    // Cookies fold into the Header location (a cookie side-channel POC).
+    assert_eq!(location_of("cookie"), "Header");
+    // Unknown tags map to the empty string rather than panicking.
+    assert_eq!(location_of("unknown"), "");
+}
+
+#[test]
+fn is_same_origin_compares_scheme_host_and_port() {
+    let parse = |s: &str| url::Url::parse(s).unwrap();
+    assert!(is_same_origin(
+        &parse("https://a.example/x"),
+        &parse("https://a.example/y?z=1")
+    ));
+    // Default port is equivalent to the explicit default port.
+    assert!(is_same_origin(
+        &parse("https://a.example/"),
+        &parse("https://a.example:443/")
+    ));
+    // Scheme, host, and port differences each break same-origin.
+    assert!(!is_same_origin(
+        &parse("https://a.example/"),
+        &parse("http://a.example/")
+    ));
+    assert!(!is_same_origin(
+        &parse("https://a.example/"),
+        &parse("https://b.example/")
+    ));
+    assert!(!is_same_origin(
+        &parse("https://a.example/"),
+        &parse("https://a.example:8443/")
+    ));
+}
+
+#[test]
+fn build_cookie_header_joins_pairs_or_returns_none() {
+    assert_eq!(build_cookie_header(&[]), None);
+    let cookies = vec![
+        ("a".to_string(), "1".to_string()),
+        ("b".to_string(), "2".to_string()),
+    ];
+    assert_eq!(build_cookie_header(&cookies).as_deref(), Some("a=1; b=2"));
+}
+
+fn injectable(html: &str, selector: &str) -> bool {
+    let frag = scraper::Html::parse_fragment(html);
+    let sel = scraper::Selector::parse(selector).expect("valid selector");
+    let el = frag.select(&sel).next().expect("element present");
+    is_injectable_input(&el)
+}
+
+#[test]
+fn is_injectable_input_accepts_text_bearing_fields() {
+    assert!(injectable("<textarea></textarea>", "textarea"));
+    assert!(injectable("<input type=\"text\">", "input"));
+    assert!(injectable("<input type=\"search\">", "input"));
+    assert!(injectable("<input type=\"email\">", "input"));
+    assert!(injectable("<input type=\"password\">", "input"));
+    // Missing type attribute defaults to text.
+    assert!(injectable("<input>", "input"));
+}
+
+#[test]
+fn is_injectable_input_rejects_non_text_fields() {
+    assert!(!injectable("<input type=\"hidden\">", "input"));
+    assert!(!injectable("<input type=\"checkbox\">", "input"));
+    assert!(!injectable("<input type=\"submit\">", "input"));
+    assert!(!injectable("<input type=\"file\">", "input"));
+    // <select> keeps its option choice rather than taking a payload.
+    assert!(!injectable("<select><option>a</option></select>", "select"));
+}
+
+#[test]
+fn build_send_payloads_static_substitutes_callback_url() {
+    let source = CallbackSource::Static("https://cb.example/hook");
+    let out = build_send_payloads(
+        &source,
+        "\"'><script src={}></script>",
+        "https://target.example/",
+        "q",
+        "Query",
+        "GET",
+    );
+    assert_eq!(out.len(), 1, "static source yields exactly one payload");
+    assert_eq!(out[0], "\"'><script src=https://cb.example/hook></script>");
+}
+
+#[test]
+fn build_blind_templates_falls_back_to_builtin_without_path() {
+    let templates = build_blind_templates(None);
+    assert!(!templates.is_empty());
+    assert!(
+        templates.iter().all(|t| t.contains("{}")),
+        "every built-in template keeps the normalized callback marker"
+    );
+}
+
+fn tmp_template_file(name: &str, contents: &str) -> std::path::PathBuf {
+    let nanos = std::time::SystemTime::now()
+        .duration_since(std::time::UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    let mut p = std::env::temp_dir();
+    p.push(format!(
+        "dalfox-blind-tmpl-{}-{}-{}",
+        std::process::id(),
+        nanos,
+        name
+    ));
+    std::fs::write(&p, contents).expect("write temp template");
+    p
+}
+
+#[test]
+fn build_blind_templates_reads_custom_lines_and_normalizes_marker() {
+    let p = tmp_template_file(
+        "custom",
+        "# comment\n\n<img src={callback}>\n<svg onload=fetch('{callback}')>\n",
+    );
+    let templates = build_blind_templates(Some(p.to_str().unwrap()));
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(templates.len(), 2, "comments and blank lines are dropped");
+    assert_eq!(templates[0], "<img src={}>");
+    assert!(templates[1].contains("{}"));
+    assert!(templates.iter().all(|t| !t.contains("{callback}")));
+}
+
+#[test]
+fn build_blind_templates_drops_lines_without_callback_marker() {
+    // Lines missing {callback} are skipped; the one valid line survives.
+    let p = tmp_template_file("mixed", "<img src=x>\n<b>{callback}</b>\n");
+    let templates = build_blind_templates(Some(p.to_str().unwrap()));
+    let _ = std::fs::remove_file(&p);
+    assert_eq!(templates, vec!["<b>{}</b>".to_string()]);
+}
+
+#[test]
+fn build_blind_templates_falls_back_when_no_usable_lines() {
+    let p = tmp_template_file("nouse", "no placeholder here\nanother bad line\n");
+    let templates = build_blind_templates(Some(p.to_str().unwrap()));
+    let _ = std::fs::remove_file(&p);
+    // No usable line → built-in fallback (which carries the {} marker).
+    assert!(!templates.is_empty());
+    assert!(templates.iter().all(|t| t.contains("{}")));
+}
+
+#[test]
+fn build_blind_templates_falls_back_when_file_unreadable() {
+    let templates = build_blind_templates(Some("/dalfox/no/such/blind/template.txt"));
+    assert!(!templates.is_empty(), "unreadable path falls back to built-in");
+    assert!(templates.iter().all(|t| t.contains("{}")));
+}
+

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -550,7 +550,9 @@ fn build_blind_templates_falls_back_when_no_usable_lines() {
 #[test]
 fn build_blind_templates_falls_back_when_file_unreadable() {
     let templates = build_blind_templates(Some("/dalfox/no/such/blind/template.txt"));
-    assert!(!templates.is_empty(), "unreadable path falls back to built-in");
+    assert!(
+        !templates.is_empty(),
+        "unreadable path falls back to built-in"
+    );
     assert!(templates.iter().all(|t| t.contains("{}")));
 }
-

--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -595,7 +595,10 @@ fn constructor_chain_wraps_argument_with_both_quote_styles() {
     // wrap_js_string onto its escape-single-quotes branch.
     let out = constructor_chain("alert(\"a'b\")");
     assert!(out.starts_with("[].constructor.constructor('"));
-    assert!(out.contains("\\'"), "inner single quote must be escaped: {out}");
+    assert!(
+        out.contains("\\'"),
+        "inner single quote must be escaped: {out}"
+    );
     assert!(out.ends_with(")()"));
 }
 

--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -518,3 +518,91 @@ fn test_citrix_netscaler_strategy() {
     assert!(strategy.mutations.contains(&MutationType::CaseAlternation));
     assert!(strategy.extra_encoders.contains(&"unicode".to_string()));
 }
+
+/// Every mutation variant, used to exercise the `Display` and
+/// `apply_single_mutation` dispatch arms exhaustively.
+const ALL_MUTATIONS: &[MutationType] = &[
+    MutationType::HtmlCommentSplit,
+    MutationType::WhitespaceMutation,
+    MutationType::JsCommentSplit,
+    MutationType::BacktickParens,
+    MutationType::ConstructorChain,
+    MutationType::UnicodeJsEscape,
+    MutationType::MixedHtmlEntities,
+    MutationType::CaseAlternation,
+    MutationType::SlashSeparator,
+    MutationType::HtmlEntityParens,
+    MutationType::SvgAnimateExec,
+    MutationType::ExoticWhitespace,
+];
+
+#[test]
+fn display_renders_every_mutation_type() {
+    // Round-trips the Display arm for each variant (no two collide).
+    let mut seen = std::collections::HashSet::new();
+    for m in ALL_MUTATIONS {
+        let name = m.to_string();
+        assert!(!name.is_empty());
+        assert!(seen.insert(name), "Display names must be unique");
+    }
+    assert_eq!(seen.len(), ALL_MUTATIONS.len());
+}
+
+#[test]
+fn apply_single_mutation_dispatches_and_transforms_every_type() {
+    // A payload that triggers every mutation (HTML tag + attr break + sink
+    // call + parens) so each dispatch arm runs its real transform, not the
+    // no-op fallthrough.
+    let payload = "<svg onload=alert(1)>";
+    for m in ALL_MUTATIONS {
+        let out = apply_single_mutation(payload, m);
+        assert_ne!(out, payload, "{:?} should transform the trigger payload", m);
+    }
+}
+
+#[test]
+fn apply_single_mutation_is_a_no_op_on_inert_text() {
+    // No tag, no sink, no parens → every mutation returns the input
+    // unchanged via its fallthrough branch.
+    let payload = "just some inert text 123";
+    for m in ALL_MUTATIONS {
+        assert_eq!(apply_single_mutation(payload, m), payload, "{:?}", m);
+    }
+}
+
+#[test]
+fn mixed_html_entities_alternates_decimal_and_hex() {
+    // Each successive special char flips between decimal and hex entities.
+    assert_eq!(mixed_html_entities("<<>>"), "&#60;&#x3c;&#62;&#x3e;");
+    assert_eq!(mixed_html_entities("\"\"''"), "&#34;&#x22;&#39;&#x27;");
+}
+
+#[test]
+fn html_comment_split_handles_short_two_letter_tag() {
+    // A 2-letter tag (len < 3) splits after a single character.
+    assert_eq!(html_comment_split("<br x=1>"), "<b<!---->r x=1>");
+}
+
+#[test]
+fn whitespace_mutation_handles_slash_separator() {
+    // A `/`-separated tag/attr break maps to a tab via whitespace_alt_char.
+    assert_eq!(whitespace_mutation("<svg/onload=x>"), "<svg\tonload=x>");
+}
+
+#[test]
+fn constructor_chain_wraps_argument_with_both_quote_styles() {
+    // The call carries both a single and double quote, forcing
+    // wrap_js_string onto its escape-single-quotes branch.
+    let out = constructor_chain("alert(\"a'b\")");
+    assert!(out.starts_with("[].constructor.constructor('"));
+    assert!(out.contains("\\'"), "inner single quote must be escaped: {out}");
+    assert!(out.ends_with(")()"));
+}
+
+#[test]
+fn svg_animate_exec_transforms_uppercase_img_onerror() {
+    // The uppercase ONERROR= prefix branch (and the `<im` short match).
+    let out = svg_animate_exec("<IMG SRC=x ONERROR=alert(1)>");
+    assert!(out.starts_with("<svg><animate onbegin=alert(1)"));
+    assert!(out.contains("dur=1s"));
+}


### PR DESCRIPTION
## Summary

Adds focused unit tests for previously untested **pure logic**. No production code changes — only new `#[cfg(test)]` modules / test functions.

Lib line coverage **79.82% → 80.46%**, with the three touched files moving up sharply:

| File | Before | After |
|------|-------:|------:|
| `cmd/scan/input.rs` | 51.9% | **61.2%** |
| `scanning/xss_blind.rs` | 78.3% | **89.1%** |
| `waf/bypass.rs` | 89.8% | **98.3%** |

**44 new tests**; full `cargo test --lib` suite green (1601 → 1645).

## What's covered

**`cmd/scan/input.rs`** — new test module exercising `resolve_targets` across `url` / `file` / `auto` / `raw-http` / `har` input modes, plus URL+method dedup, `--include-url` / `--exclude-url` scope filters (incl. invalid-regex skip), `--out-of-scope` / `--out-of-scope-file` domain filters, and `--cookie-from-raw` cookie injection. Direct tests for the `load_request_source` and `apply_request_cli_overrides` helpers. Each case pins an explicit `--input-type` so the resolver never blocks on stdin; the two `auto` cases rely only on an immediately-empty stdin (`/dev/null` under CI).

**`scanning/xss_blind.rs`** — direct tests for the pure helpers: `build_blind_templates` (custom-template file parsing, bad-line drop, empty→builtin and unreadable→builtin fallbacks), `location_of`, `is_same_origin`, `build_cookie_header`, `is_injectable_input`, and `build_send_payloads` (static callback).

**`waf/bypass.rs`** — exhaust the `apply_single_mutation` dispatcher and `Display` arms over every `MutationType`, plus `mixed_html_entities` decimal/hex alternation, the short-tag and slash-separator paths, both-quote `constructor_chain` escaping, and the uppercase-`ONERROR=` img→SVG-animate transform.

## Test plan

- `cargo test --lib` — 1645 passed, 0 failed.
- `cargo llvm-cov --lib` — totals and per-file figures above.