### PR TITLE
harden(server): explicit Content-Type + nosniff on all API responses; warn on non-loopback no-auth bind

### DIFF
--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -170,6 +170,29 @@ pub async fn run_server(args: ServerArgs) {
         "SERVER",
         &format!("listening on http://{}", addr_str),
     );
+
+    // Loud warning for the most dangerous misconfiguration: a network-reachable
+    // bind with auth disabled. The API scans any submitted URL and POSTs results
+    // to any callback_url, so an unauthenticated non-loopback instance is an open
+    // SSRF / scan-launch relay into whatever network it can reach (cloud metadata
+    // at 169.254.169.254, RFC1918 hosts, etc.). We warn rather than refuse so a
+    // deployment that fronts the server with its own auth/egress controls still
+    // starts. `auth_disabled` mirrors `check_api_key`: an empty key string is
+    // treated as no auth, same as `--api-key` help ("Leave empty to disable").
+    let auth_disabled = state.api_key.as_deref().is_none_or(|s| s.is_empty());
+    if auth_disabled && !addr.ip().is_loopback() {
+        log(
+            &state,
+            "WRN",
+            &format!(
+                "bound to non-loopback address {} with NO API key — the API is an \
+                 unauthenticated SSRF / scan-launch relay reachable by anyone on this \
+                 network. Set --api-key (or DALFOX_API_KEY), or bind to 127.0.0.1.",
+                addr_str
+            ),
+        );
+    }
+
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -69,8 +69,23 @@ pub(crate) fn make_api_response<T: Serialize>(
     let mut cors = build_cors_headers(state, req_headers);
     let cb = extract_jsonp_callback(state, params);
     let (ct, body) = build_response_body(resp, cb.as_deref());
-    if let Some(ct_val) = ct {
-        cors.insert("Content-Type", ct_val.parse().expect("static content-type"));
-    }
+    // Always set an explicit Content-Type so the body is never served as
+    // axum's `String` default of `text/plain; charset=utf-8`:
+    // `application/json` for the normal path, `application/javascript` for
+    // JSONP (chosen by `build_response_body`).
+    let content_type = ct.unwrap_or("application/json; charset=utf-8");
+    cors.insert(
+        "Content-Type",
+        content_type.parse().expect("static content-type"),
+    );
+    // Forbid MIME sniffing on every API response. The body reflects
+    // attacker-influenced input (target URLs, payload/evidence strings, error
+    // messages); `nosniff` stops a browser from re-interpreting a JSON or
+    // JSONP body as HTML and executing it, closing a content-type-confusion
+    // XSS path regardless of how a client loads the response.
+    cors.insert(
+        "X-Content-Type-Options",
+        "nosniff".parse().expect("static nosniff header"),
+    );
     (status, cors, body)
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -379,6 +379,58 @@ async fn test_get_scan_handler_unauthorized_and_bad_request_jsonp() {
 }
 
 #[tokio::test]
+async fn test_responses_set_json_content_type_and_nosniff() {
+    // Non-JSONP responses must carry an explicit application/json Content-Type
+    // (not axum's String default of text/plain) plus X-Content-Type-Options:
+    // nosniff, so an attacker-influenced body can't be MIME-sniffed into HTML.
+    let state = make_state(None, None, false, false, "callback");
+    let resp = health_handler(State(state), HeaderMap::new(), Query(Map::new()))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .starts_with("application/json"),
+        "non-JSONP responses must be application/json"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok()),
+        Some("nosniff"),
+        "every API response must forbid MIME sniffing"
+    );
+}
+
+#[tokio::test]
+async fn test_jsonp_response_keeps_javascript_content_type_with_nosniff() {
+    // The JSONP path keeps application/javascript but must still send nosniff.
+    let state = make_state(None, None, false, true, "cb");
+    let mut q = Map::new();
+    q.insert("cb".to_string(), "myFn".to_string());
+    let resp = health_handler(State(state), HeaderMap::new(), Query(q))
+        .await
+        .into_response();
+    assert!(
+        resp.headers()
+            .get("content-type")
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or("")
+            .starts_with("application/javascript"),
+        "JSONP responses stay application/javascript"
+    );
+    assert_eq!(
+        resp.headers()
+            .get("x-content-type-options")
+            .and_then(|v| v.to_str().ok()),
+        Some("nosniff")
+    );
+}
+
+#[tokio::test]
 async fn test_get_result_handler_not_found_jsonp() {
     let state = make_state(None, None, false, true, "cb");
     let mut q = Map::new();


### PR DESCRIPTION
## Summary

Defense-in-depth hardening for the `dalfox server` HTTP API, from a focused security review of the server/MCP surface. The surface is already extensively hardened by prior passes; these are the two concrete, non-breaking gaps that remained.

### 1. Explicit `Content-Type` + `X-Content-Type-Options: nosniff` on every API response
`make_api_response` previously left the non-JSONP path with no `Content-Type`, so axum served the JSON body as its `String` default `text/plain; charset=utf-8`, with no `nosniff`. Response bodies reflect attacker-influenced input (target URLs, payload/evidence strings, error messages), leaving a residual MIME-sniffing content-type-confusion XSS path.

Now every response sets an explicit type — `application/json` normally, `application/javascript` for JSONP — plus `nosniff`.

### 2. Startup warning on the most dangerous misconfiguration
`run_server` now logs a loud `WRN` when bound to a **non-loopback** address with **auth disabled** (empty/no API key). Such an instance scans any submitted URL and POSTs results to any `callback_url` — an unauthenticated SSRF / scan-launch relay reachable by anyone on the network (cloud metadata, RFC1918 hosts, etc.).

Warns rather than refuses, so a deployment fronted by its own auth/egress controls still starts — mirroring the existing `insecure-tls` warning pattern.

## Not changed (intentional residual risk)
Webhook `callback_url` SSRF and scan-target SSRF are inherent to a URL scanner and documented in `send_terminal_webhook`; mitigation is `--api-key` + egress controls. `remote_payloads`/`remote_wordlists` resolve only registered provider names (no arbitrary-URL fetch), so they are not an SSRF vector.

## Tests
- `test_responses_set_json_content_type_and_nosniff`
- `test_jsonp_response_keeps_javascript_content_type_with_nosniff`

Full `cargo test --lib` (1647 tests) green; `cargo clippy --lib` clean.