### PR TITLE
fix(scanner): require payload handler/sink to survive on marker element before [V] (#1118)

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -82,25 +82,131 @@ fn payload_has_any_marker(payload: &str) -> bool {
 /// attributes are case-sensitive when matched as CSS selectors), so this
 /// scan is the only way to surface marker evidence on servers that
 /// case-fold the entire reflected input.
+/// Whether an element carries `marker` as one of its whitespace-separated
+/// class tokens under ASCII case-fold comparison.
+fn element_class_has(node: scraper::ElementRef, marker: &str) -> bool {
+    node.value().attr("class").is_some_and(|cls| {
+        cls.split_ascii_whitespace()
+            .any(|c| c.eq_ignore_ascii_case(marker))
+    })
+}
+
 fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     let selector = super::selectors::universal();
-    document.select(selector).any(|node| {
-        node.value().attr("class").is_some_and(|cls| {
-            cls.split_ascii_whitespace()
-                .any(|c| c.eq_ignore_ascii_case(marker))
-        })
-    })
+    document
+        .select(selector)
+        .any(|node| element_class_has(node, marker))
 }
 
 /// Like `any_element_has_class_ascii_ci`, but compares the element's `id`
 /// attribute as a whole token. HTML id values are not whitespace-separated
 /// lists, so the comparison is over the trimmed attribute value.
+/// Whether an element's `id` attribute equals `marker` (trimmed, ASCII
+/// case-fold).
+fn element_id_is(node: scraper::ElementRef, marker: &str) -> bool {
+    node.value()
+        .attr("id")
+        .is_some_and(|id| id.trim().eq_ignore_ascii_case(marker))
+}
+
 fn any_element_has_id_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     let selector = super::selectors::universal();
-    document.select(selector).any(|node| {
-        node.value()
-            .attr("id")
-            .is_some_and(|id| id.trim().eq_ignore_ascii_case(marker))
+    document
+        .select(selector)
+        .any(|node| element_id_is(node, marker))
+}
+
+/// Whether `value` (an `on*` handler value or `<script>` body) carries a
+/// JavaScript sink call, tolerating ASCII case-folding (servers that uppercase
+/// reflected input) and HTML-entity encoding (WAF-bypass payloads like
+/// `alert&#40;1&#41;`), mirroring the decode handling in
+/// [`has_html_structural_evidence_in_doc`].
+fn value_carries_js_sink(value: &str) -> bool {
+    use crate::scanning::js_context_verify::payload_carries_js_sink as sink;
+    sink(value)
+        || sink(&value.to_ascii_lowercase())
+        || sink(&decode_html_entities(value))
+        || sink(&decode_html_entities(&value.to_ascii_lowercase()))
+}
+
+/// Whether `node`'s own attributes/body carry a surviving JS sink: an `on*`
+/// event-handler attribute whose value is a sink call, or a `<script>` element
+/// whose text body is a sink call. This is the "active ingredient" a
+/// handler/script-body marker template attaches *directly to the marker
+/// element*; if it did not survive the server's reflection, the marker class
+/// alone is not proof of execution (issue #1118).
+fn element_carries_surviving_sink(node: scraper::ElementRef) -> bool {
+    let v = node.value();
+    for (name, val) in v.attrs() {
+        if name.len() >= 3
+            && name.as_bytes()[..2].eq_ignore_ascii_case(b"on")
+            && value_carries_js_sink(val)
+        {
+            return true;
+        }
+    }
+    if v.name().eq_ignore_ascii_case("script") {
+        let text: String = node.text().collect();
+        if value_carries_js_sink(&text) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether the payload attaches an on*-handler / `<script>`-body JS sink
+/// *directly to its marker element*. Parses the payload as an HTML fragment
+/// (appending a closing `>` so breakout payloads such as
+/// `'"><svg/class=… onload=…//` still yield the element) and also the
+/// entity-decoded form, then inspects the element carrying the class/id marker.
+///
+/// Returns `false` for structural markers — base-href injection, DOM-clobbering
+/// containers (`<form id=…>`, `<object data=javascript:…>`) — where the marker
+/// element's mere presence is the exploit and there is no on*/script sink on it
+/// to verify, so those keep presence-only evidence.
+fn payload_marker_element_carries_sink(payload: &str) -> bool {
+    let class_marker = crate::scanning::markers::class_marker();
+    let id_marker = crate::scanning::markers::id_marker();
+    let decoded = decode_html_entities(payload);
+    for candidate in [payload, decoded.as_str()] {
+        let normalized = if candidate.trim_end().ends_with('>') {
+            candidate.to_string()
+        } else {
+            format!("{candidate}>")
+        };
+        let frag = scraper::Html::parse_fragment(&normalized);
+        let sel = super::selectors::universal();
+        let hit = frag.select(sel).any(|node| {
+            let is_marker = element_class_has(node, class_marker)
+                || element_class_has(node, "dalfox")
+                || element_id_is(node, id_marker)
+                || element_id_is(node, "dalfox");
+            is_marker && element_carries_surviving_sink(node)
+        });
+        if hit {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether at least one element carrying one of the payload's markers also
+/// carries a surviving JS sink. Used to gate the marker-evidence path for
+/// payloads whose marker element's own attributes/body ARE the exploit.
+fn marker_element_carries_surviving_sink(payload: &str, document: &scraper::Html) -> bool {
+    let class_marker = crate::scanning::markers::class_marker();
+    let id_marker = crate::scanning::markers::id_marker();
+    let has_class = payload.contains(class_marker);
+    let has_legacy_class = payload_uses_legacy_class_marker(payload);
+    let has_id = payload.contains(id_marker);
+    let has_legacy_id = payload_uses_legacy_id_marker(payload);
+    let sel = super::selectors::universal();
+    document.select(sel).any(|node| {
+        let is_marker = (has_class && element_class_has(node, class_marker))
+            || (has_legacy_class && element_class_has(node, "dalfox"))
+            || (has_id && element_id_is(node, id_marker))
+            || (has_legacy_id && element_id_is(node, "dalfox"));
+        is_marker && element_carries_surviving_sink(node)
     })
 }
 
@@ -172,7 +278,24 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
         true
     };
 
-    class_ok && id_ok
+    if !(class_ok && id_ok) {
+        return false;
+    }
+
+    // Issue #1118: when the payload attached its exploit (an `on*` handler or a
+    // `<script>` body sink) directly to the marker element, the marker class
+    // surviving is not enough — a server that reflects a *truncated* copy of the
+    // payload (e.g. ASP.NET `ValidateRequest` error pages) can preserve the
+    // marker class while dropping the handler, parsing into a real element that
+    // carries our marker but executes nothing. Require the sink to have survived
+    // on at least one marker-bearing element before treating this as DOM
+    // evidence. Structural markers (base-href, DOM-clobbering containers) carry
+    // no such sink on the marker element and keep presence-only evidence.
+    if payload_marker_element_carries_sink(payload) {
+        return marker_element_carries_surviving_sink(payload, document);
+    }
+
+    true
 }
 
 pub(crate) fn has_marker_evidence(payload: &str, text: &str) -> bool {

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -76,12 +76,6 @@ fn payload_has_any_marker(payload: &str) -> bool {
         || payload_uses_legacy_id_marker(payload)
 }
 
-/// Returns `true` when at least one element's whitespace-separated class
-/// list contains `marker` under ASCII case-fold comparison. The standard
-/// CSS class selector path used elsewhere is case-sensitive (HTML5 class
-/// attributes are case-sensitive when matched as CSS selectors), so this
-/// scan is the only way to surface marker evidence on servers that
-/// case-fold the entire reflected input.
 /// Whether an element carries `marker` as one of its whitespace-separated
 /// class tokens under ASCII case-fold comparison.
 fn element_class_has(node: scraper::ElementRef, marker: &str) -> bool {
@@ -91,6 +85,12 @@ fn element_class_has(node: scraper::ElementRef, marker: &str) -> bool {
     })
 }
 
+/// Returns `true` when at least one element's whitespace-separated class
+/// list contains `marker` under ASCII case-fold comparison. The standard
+/// CSS class selector path used elsewhere is case-sensitive (HTML5 class
+/// attributes are case-sensitive when matched as CSS selectors), so this
+/// scan is the only way to surface marker evidence on servers that
+/// case-fold the entire reflected input.
 fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     let selector = super::selectors::universal();
     document
@@ -98,9 +98,6 @@ fn any_element_has_class_ascii_ci(document: &scraper::Html, marker: &str) -> boo
         .any(|node| element_class_has(node, marker))
 }
 
-/// Like `any_element_has_class_ascii_ci`, but compares the element's `id`
-/// attribute as a whole token. HTML id values are not whitespace-separated
-/// lists, so the comparison is over the trimmed attribute value.
 /// Whether an element's `id` attribute equals `marker` (trimmed, ASCII
 /// case-fold).
 fn element_id_is(node: scraper::ElementRef, marker: &str) -> bool {
@@ -109,6 +106,9 @@ fn element_id_is(node: scraper::ElementRef, marker: &str) -> bool {
         .is_some_and(|id| id.trim().eq_ignore_ascii_case(marker))
 }
 
+/// Like `any_element_has_class_ascii_ci`, but compares the element's `id`
+/// attribute as a whole token. HTML id values are not whitespace-separated
+/// lists, so the comparison is over the trimmed attribute value.
 fn any_element_has_id_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
     let selector = super::selectors::universal();
     document
@@ -167,8 +167,15 @@ fn element_carries_surviving_sink(node: scraper::ElementRef) -> bool {
 fn payload_marker_element_carries_sink(payload: &str) -> bool {
     let class_marker = crate::scanning::markers::class_marker();
     let id_marker = crate::scanning::markers::id_marker();
+    // Inspect the raw payload and, only when it differs, its entity-decoded form
+    // (WAF-bypass payloads encode the sink chars). Skipping the no-op decoded
+    // pass avoids re-parsing an identical fragment.
     let decoded = decode_html_entities(payload);
-    for candidate in [payload, decoded.as_str()] {
+    let mut candidates = vec![payload];
+    if decoded != payload {
+        candidates.push(decoded.as_str());
+    }
+    for candidate in candidates {
         let normalized = if candidate.trim_end().ends_with('>') {
             candidate.to_string()
         } else {

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -783,6 +783,166 @@ fn test_classify_dom_evidence_none_when_handler_truncated() {
     assert_eq!(classify_dom_evidence(&payload, &body), None);
 }
 
+/// Issue #1118 coverage matrix for `has_marker_evidence`.
+///
+/// The bug slipped past the original suite because the fixtures sprinkled the
+/// marker into a hand-written body (`<img class="MARKER">`) instead of faithfully
+/// modelling what the server did to the *whole* payload. This table pins the
+/// verdict for each payload family against an explicit server transformation —
+/// full reflection, handler stripped/blanked/neutralised, marker as text only,
+/// multiple classes, multiple elements, ASCII case-fold, and entity-encoded
+/// sinks — so a regression in either direction (false [V] or lost recall) fails
+/// a named row.
+#[test]
+fn test_has_marker_evidence_matrix() {
+    let cm = crate::scanning::markers::class_marker();
+    let im = crate::scanning::markers::id_marker();
+    let up = cm.to_uppercase();
+
+    // (name, payload, reflected body, expected evidence)
+    let cases: Vec<(&str, String, String, bool)> = vec![
+        // ── handler templates: sink lives on the marker element ──
+        (
+            "svg_onload_full",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg onload=alert() class=\"{cm}\"></svg>"),
+            true,
+        ),
+        (
+            "svg_onload_handler_stripped",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg class=\"{cm}\"></svg>"),
+            false,
+        ),
+        (
+            "svg_onload_handler_blanked",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg onload=\"\" class=\"{cm}\"></svg>"),
+            false,
+        ),
+        (
+            "svg_onload_handler_neutralised",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg onload=\"void(0)\" class=\"{cm}\"></svg>"),
+            false,
+        ),
+        (
+            "breakout_class_first_full",
+            format!("'\"><svg/class={cm} onload=alert()//"),
+            format!("<svg class=\"{cm}\" onload=\"alert()//\"></svg>"),
+            true,
+        ),
+        (
+            "breakout_class_first_truncated",
+            format!("'\"><svg/class={cm} onload=alert()//"),
+            format!("<svg class=\"{cm}\"></svg>"),
+            false,
+        ),
+        (
+            "img_onerror_full",
+            format!("<img src=x onerror=alert(1) class={cm}>"),
+            format!("<img src=x onerror=alert(1) class=\"{cm}\">"),
+            true,
+        ),
+        (
+            "img_onerror_stripped",
+            format!("<img src=x onerror=alert(1) class={cm}>"),
+            format!("<img src=x class=\"{cm}\">"),
+            false,
+        ),
+        // ── script-body template: sink lives in the <script> body ──
+        (
+            "script_body_full",
+            format!("<script class={cm}>alert(1)</script>"),
+            format!("<script class=\"{cm}\">alert(1)</script>"),
+            true,
+        ),
+        (
+            "script_body_emptied",
+            format!("<script class={cm}>alert(1)</script>"),
+            format!("<script class=\"{cm}\"></script>"),
+            false,
+        ),
+        // ── marker placement / parsing edge cases ──
+        (
+            "marker_among_multiple_classes",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg onload=alert() class=\"a {cm} b\"></svg>"),
+            true,
+        ),
+        (
+            "marker_as_text_only_no_element",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<p>blocked input: class={cm} onlo...</p>"),
+            false,
+        ),
+        (
+            "multiple_markers_one_carries_handler",
+            format!("<svg onload=alert() class={cm}>"),
+            format!("<svg class=\"{cm}\"></svg><svg onload=alert() class=\"{cm}\"></svg>"),
+            true,
+        ),
+        // ── structural markers: presence is the exploit, no sink to verify ──
+        (
+            "structural_base_id",
+            format!("<base href=//evil/ id={im}>"),
+            format!("<base href=\"//evil/\" id=\"{im}\">"),
+            true,
+        ),
+        (
+            "structural_clobber_form",
+            format!(
+                "<form id={im} class={cm}><input name=action value=\"javascript:alert(1)\"></form>"
+            ),
+            format!(
+                "<form id=\"{im}\" class=\"{cm}\"><input name=action value=\"javascript:alert(1)\"></form>"
+            ),
+            true,
+        ),
+        // ── legacy `dalfox` marker ──
+        (
+            "legacy_dalfox_full",
+            "<img class=dalfox src=x onerror=alert(1)>".to_string(),
+            "<img class=\"dalfox\" src=x onerror=alert(1)>".to_string(),
+            true,
+        ),
+        (
+            "legacy_dalfox_stripped",
+            "<img class=dalfox src=x onerror=alert(1)>".to_string(),
+            "<img class=\"dalfox\">".to_string(),
+            false,
+        ),
+        // ── server uppercases every reflected byte (ASCII case-fold) ──
+        (
+            "casefold_handler_survives",
+            format!("<img src=x onerror=alert(1) class={cm}>"),
+            format!("<IMG SRC=X ONERROR=ALERT(1) CLASS=\"{up}\">"),
+            true,
+        ),
+        (
+            "casefold_handler_stripped",
+            format!("<img src=x onerror=alert(1) class={cm}>"),
+            format!("<IMG CLASS=\"{up}\">"),
+            false,
+        ),
+        // ── WAF-bypass: entity-encoded sink decodes to a live handler ──
+        (
+            "entity_encoded_sink_survives",
+            format!("<svg onload=alert&#40;1&#41; class={cm}>"),
+            format!("<svg onload=\"alert(1)\" class=\"{cm}\"></svg>"),
+            true,
+        ),
+    ];
+
+    for (name, payload, body, expected) in cases {
+        assert_eq!(
+            has_marker_evidence(&payload, &body),
+            expected,
+            "case `{name}`: payload={payload:?} body={body:?}"
+        );
+    }
+}
+
 #[test]
 fn test_has_executable_url_attribute_evidence_detects_iframe_src_protocol() {
     let payload = "javascript:alert(1)";

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -611,15 +611,110 @@ fn test_has_marker_evidence_requires_payload_marker() {
 fn test_has_marker_evidence_detects_class_marker_element() {
     let marker = crate::scanning::markers::class_marker();
     let payload = format!("<img src=x onerror=alert(1) class={}>", marker);
-    let body = format!("<html><body><img class=\"{}\"></body></html>", marker);
+    // The payload attaches its sink (onerror) to the marker element, so the
+    // marker class is evidence only when the handler also survives (issue #1118).
+    let body = format!(
+        "<html><body><img src=x onerror=alert(1) class=\"{}\"></body></html>",
+        marker
+    );
     assert!(has_marker_evidence(&payload, &body));
 }
 
 #[test]
 fn test_has_marker_evidence_detects_legacy_dalfox_class_marker_element() {
     let payload = "<img class=\"dalfox\" src=x onerror=alert(1)>";
-    let body = "<html><body><img class=\"dalfox\"></body></html>";
+    let body = "<html><body><img class=\"dalfox\" src=x onerror=alert(1)></body></html>";
     assert!(has_marker_evidence(payload, body));
+}
+
+/// Issue #1118: a server that reflects a *truncated* copy of the payload can
+/// preserve the marker class while dropping the `on*` handler. The marker
+/// element parses, but the handler never survives, so this is NOT exploitable
+/// and must not count as marker evidence.
+#[test]
+fn test_has_marker_evidence_demoted_when_handler_truncated() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("'\"><svg/class={} onload=alert()//", marker);
+    // ASP.NET ValidateRequest-style error page: the raw reflection is cut off
+    // right before `onload`, so the parsed svg carries the marker class but no
+    // handler.
+    let body = format!(
+        "<html><body><header>A potentially dangerous Request.Form value was \
+         detected (q=\"...&gt;&lt;svg/class={} onlo...\").</header>\
+         <svg class=\"{}\"></svg></body></html>",
+        marker, marker
+    );
+    assert!(
+        !has_marker_evidence(&payload, &body),
+        "marker class without the payload's surviving handler must not be evidence"
+    );
+}
+
+/// Issue #1118 (counter-case): when the same payload's handler DOES survive on
+/// the marker element, the finding is genuinely exploitable and stays evidence.
+#[test]
+fn test_has_marker_evidence_kept_when_handler_survives() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("'\"><svg/class={} onload=alert()//", marker);
+    let body = format!(
+        "<html><body><svg class=\"{}\" onload=\"alert()\"></svg></body></html>",
+        marker
+    );
+    assert!(has_marker_evidence(&payload, &body));
+}
+
+/// Issue #1118 (no regression): structural markers whose exploit is the
+/// element's mere presence — base-href injection, DOM-clobbering containers —
+/// carry no on*/script sink on the marker element, so presence-only evidence is
+/// preserved.
+#[test]
+fn test_has_marker_evidence_kept_for_structural_markers() {
+    let id = crate::scanning::markers::id_marker();
+    let class = crate::scanning::markers::class_marker();
+
+    // base-href injection — no sink on the marker element.
+    let base_payload = format!("<base href=//evil.example/ id={}>", id);
+    let base_body = format!(
+        "<html><head><base href=\"//evil.example/\" id=\"{}\"></head></html>",
+        id
+    );
+    assert!(
+        has_marker_evidence(&base_payload, &base_body),
+        "base-href marker presence is the exploit; must stay evidence"
+    );
+
+    // DOM-clobbering form container — the sink lives in a child input, not on
+    // the marker element itself.
+    let form_payload = format!(
+        "<form id={} class={}><input name=\"action\" value=\"javascript:alert(1)\"></form>",
+        id, class
+    );
+    let form_body = format!(
+        "<html><body><form id=\"{}\" class=\"{}\"><input name=\"action\" \
+         value=\"javascript:alert(1)\"></form></body></html>",
+        id, class
+    );
+    assert!(
+        has_marker_evidence(&form_payload, &form_body),
+        "clobbering container marker presence is the exploit; must stay evidence"
+    );
+}
+
+/// Issue #1118 (script-body family): a `<script class=marker>sink</script>`
+/// payload whose body is truncated away leaves the marker class on an empty
+/// script — no sink survives, so it is not evidence.
+#[test]
+fn test_has_marker_evidence_demoted_when_script_body_truncated() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("<script class={}>alert(1)</script>", marker);
+    let body = format!(
+        "<html><body><script class=\"{}\"></script></body></html>",
+        marker
+    );
+    assert!(
+        !has_marker_evidence(&payload, &body),
+        "marker class on an empty script (sink body dropped) must not be evidence"
+    );
 }
 
 #[test]

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -717,6 +717,72 @@ fn test_has_marker_evidence_demoted_when_script_body_truncated() {
     );
 }
 
+/// Issue #1118 (script-body counter-case): when the `<script>` body sink
+/// survives on the marker element, the finding stays evidence.
+#[test]
+fn test_has_marker_evidence_kept_when_script_body_survives() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("<script class={}>alert(1)</script>", marker);
+    let body = format!(
+        "<html><body><script class=\"{}\">alert(1)</script></body></html>",
+        marker
+    );
+    assert!(has_marker_evidence(&payload, &body));
+}
+
+/// Issue #1118 (id-marker symmetry): the handler-survival gate applies to id
+/// markers too, not only class markers.
+#[test]
+fn test_has_marker_evidence_demoted_when_id_handler_truncated() {
+    let id = crate::scanning::markers::id_marker();
+    let payload = format!("<svg onload=alert() id={}>", id);
+    let truncated = format!("<html><body><svg id=\"{}\"></svg></body></html>", id);
+    assert!(
+        !has_marker_evidence(&payload, &truncated),
+        "id-marker element without the surviving handler must not be evidence"
+    );
+    let survived = format!(
+        "<html><body><svg id=\"{}\" onload=\"alert()\"></svg></body></html>",
+        id
+    );
+    assert!(has_marker_evidence(&payload, &survived));
+}
+
+/// Issue #1118 (WAF-bypass): payloads entity-encode the sink chars
+/// (`alert&#40;1&#41;`); scraper decodes the parsed handler back to `alert(1)`.
+/// The co-survival check must compare against the decoded value too — a genuine
+/// breakout stays evidence, while a truncated one is still demoted.
+#[test]
+fn test_has_marker_evidence_entity_encoded_sink() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("<svg onload=alert&#40;1&#41; class={}>", marker);
+    let survived = format!(
+        "<html><body><svg onload=\"alert(1)\" class=\"{}\"></svg></body></html>",
+        marker
+    );
+    assert!(
+        has_marker_evidence(&payload, &survived),
+        "decoded handler sink on the marker element should still be evidence"
+    );
+    let truncated = format!("<html><body><svg class=\"{}\"></svg></body></html>", marker);
+    assert!(
+        !has_marker_evidence(&payload, &truncated),
+        "entity-encoded payload with the handler dropped must be demoted"
+    );
+}
+
+/// Issue #1118: the public entry point used by the scan worker
+/// (`classify_dom_evidence`) must return `None` for a truncated-handler
+/// reflection — no fallback evidence path (HTML-structural, JS-context, inline
+/// breakout) should rescue it into a false [V].
+#[test]
+fn test_classify_dom_evidence_none_when_handler_truncated() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("'\"><svg/class={} onload=alert()//", marker);
+    let body = format!("<html><body><svg class=\"{}\"></svg></body></html>", marker);
+    assert_eq!(classify_dom_evidence(&payload, &body), None);
+}
+
 #[test]
 fn test_has_executable_url_attribute_evidence_detects_iframe_src_protocol() {
     let payload = "javascript:alert(1)";

--- a/src/scanning/light_verify/tests.rs
+++ b/src/scanning/light_verify/tests.rs
@@ -196,6 +196,31 @@ async fn test_verify_dom_xss_light_marker_element_present_without_payload() {
     assert_eq!(note, Some("marker element present".to_string()));
 }
 
+/// Issue #1118: path #2 ("marker element present") has no reflection gate, so
+/// it was the one surface where a marker-only reflection became a false [V].
+/// `/marker-only` echoes `<div class="MARKER">ok</div>` regardless of input —
+/// the marker class survives but the payload's `onload` handler never does.
+/// With the handler-survival gate, a sink-bearing payload must no longer verify
+/// here (contrast the test above, whose payload carries no sink and stays
+/// presence-only).
+#[tokio::test]
+async fn test_verify_dom_xss_light_marker_without_surviving_handler_demoted() {
+    let marker = crate::scanning::markers::class_marker().to_string();
+    let addr = start_mock_server(&marker).await;
+    let target = make_target(addr, "/marker-only", None, None);
+    let param = make_param(Location::Query, "q");
+    let payload = format!("'\"><svg/class={} onload=alert()//", marker);
+    let client = test_client();
+
+    let (verified, _response, _note) =
+        verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
+
+    assert!(
+        !verified,
+        "marker class without the payload's surviving handler must not verify"
+    );
+}
+
 #[tokio::test]
 async fn test_verify_dom_xss_light_sets_csp_hint_when_inline_handlers_blocked() {
     let marker = crate::scanning::markers::class_marker().to_string();

--- a/src/scanning/light_verify/tests.rs
+++ b/src/scanning/light_verify/tests.rs
@@ -70,6 +70,22 @@ async fn marker_only_html(State(state): State<TestState>) -> Html<String> {
     ))
 }
 
+/// Models an ASP.NET `ValidateRequest`-style error page (issue #1118): the raw
+/// submitted value is echoed unencoded but cut off right before the event
+/// handler, so the parsed element keeps the marker class while the `onload=` /
+/// `onerror=` handler never survives.
+async fn truncate_before_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
+    let q = params.get("q").cloned().unwrap_or_default();
+    let cut = q
+        .find("onload")
+        .or_else(|| q.find("onerror"))
+        .map(|i| &q[..i])
+        .unwrap_or(q.as_str());
+    Html(format!(
+        "<html><body><header>blocked: {cut}</header></body></html>"
+    ))
+}
+
 async fn csp_html() -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -121,6 +137,7 @@ async fn start_mock_server(class_marker: &str) -> SocketAddr {
     let app = Router::new()
         .route("/reflect", get(reflect_html))
         .route("/marker-only", get(marker_only_html))
+        .route("/truncate", get(truncate_before_handler))
         .route("/csp", get(csp_html))
         .route("/redirect", get(redirect_route))
         .route("/header", get(reflect_header))
@@ -218,6 +235,49 @@ async fn test_verify_dom_xss_light_marker_without_surviving_handler_demoted() {
     assert!(
         !verified,
         "marker class without the payload's surviving handler must not verify"
+    );
+}
+
+/// Issue #1118 end-to-end at the HTTP layer: the `/truncate` route faithfully
+/// reproduces the reported scenario (raw value echoed, cut before the handler).
+/// This is the test that would have caught the original bug — the marker class
+/// reaches the DOM but the handler does not, so it must not verify.
+#[tokio::test]
+async fn test_verify_dom_xss_light_truncated_handler_reflection_demoted() {
+    let marker = crate::scanning::markers::class_marker().to_string();
+    let addr = start_mock_server(&marker).await;
+    let target = make_target(addr, "/truncate", None, None);
+    let param = make_param(Location::Query, "q");
+    let payload = format!("'\"><svg/class={} onload=alert()//", marker);
+    let client = test_client();
+
+    let (verified, _response, _note) =
+        verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
+
+    assert!(
+        !verified,
+        "truncated-handler reflection must not verify (issue #1118)"
+    );
+}
+
+/// Counter-case to the truncation test: when the same handler payload is
+/// reflected in full, the handler survives on the marker element and the
+/// candidate genuinely verifies.
+#[tokio::test]
+async fn test_verify_dom_xss_light_full_handler_reflection_verifies() {
+    let marker = crate::scanning::markers::class_marker().to_string();
+    let addr = start_mock_server(&marker).await;
+    let target = make_target(addr, "/reflect", None, None);
+    let param = make_param(Location::Query, "q");
+    let payload = format!("<svg onload=alert(1) class={}>", marker);
+    let client = test_client();
+
+    let (verified, _response, _note) =
+        verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
+
+    assert!(
+        verified,
+        "fully-reflected handler on the marker element must verify"
     );
 }
 


### PR DESCRIPTION
Closes #1118

## Summary

Marker-based DOM verification upgraded a finding to **[V]** purely because an element carrying our runtime marker class/id was present in the response — it never checked that the payload's *event handler / sink* survived on that element. A server that reflects a **truncated** copy of the payload (e.g. an ASP.NET `ValidateRequest` error page that echoes the offending value unencoded but cut short) preserves the marker class while dropping the `onload=`/`onerror=` handler. The parser builds a real element with our marker but no handler, and the scan reported a false **[V]**.

## Analysis (what actually reproduces)

While investigating I confirmed the gap empirically and also mapped which code paths are exposed:

- **The gap is real:** for a truncated body `…<svg class="dlx…"></svg>` (no `onload`), `has_marker_evidence` / `classify_dom_evidence` return `true` / `Some(Marker)`.
- **Main reflection→V paths are partly masked today:** the dedicated Stage 6 (`verify_normal_dom`) and the static V-upgrade (`scanning/mod.rs`) both gate on `classify_reflection(...).is_some()`, which requires the **full** payload (incl. `onload=alert()//`) to be reflected. A purely-truncated reflection fails that gate, so those paths return `found=false`.
- **The one genuinely unguarded surface is `light_verify` path #2** (`light_verify.rs:179-184`), which returns verified on marker presence alone with **no** reflection gate. Hardening `has_marker_evidence` closes it directly.
- Note: the issue's `Environment: v2.12.0` is a mis-tag — v2 is Go and has no such file. The cited `src/scanning/check_dom_verification.rs` is v3; this targets current `main` (v3.0.2).

## Fix

When the payload attaches its exploit directly to the marker element (an `on*` handler whose value is a JS sink, or a `<script>` body sink), require that sink to have **survived on at least one marker-bearing element** before counting it as DOM evidence.

The required "active ingredient" is derived from the payload: it is parsed as an HTML fragment (with a trailing `>` appended so breakout payloads like `'"><svg/class=… onload=…//` still yield the element) plus its entity-decoded form, then the marker element is inspected. Sink matching tolerates ASCII case-folding (servers that uppercase input) and HTML-entity encoding (WAF bypass), mirroring `has_html_structural_evidence_in_doc`.

### No regression for structural markers
A naive "always require an `on*` handler" (as suggested in the issue) would break legitimate marker-only payloads. Those are explicitly preserved:

| Payload family | Sink on marker element? | Behavior |
|---|---|---|
| `<svg onload=alert() class=…>` | yes (`on*`) | handler must survive (fixes FP) |
| `<script class=…>alert(1)</script>` | yes (body) | body sink must survive |
| `<base href=//evil id=…>` | no | **presence-only kept** |
| `<form id=…><input value=javascript:…></form>` (clobbering) | no (sink in child) | **presence-only kept** |
| `<object data=javascript:… id=…>` | exec-URL (separate path) | kept |

## Tests

Named regression tests + a 20-row payload×transform matrix, plus an HTTP-layer reproduction:

- `…_demoted_when_handler_truncated` / `…_kept_when_handler_survives` — truncated vs full handler
- `…_demoted_when_script_body_truncated` / `…_kept_when_script_body_survives` — script-body family
- `…_demoted_when_id_handler_truncated` — id-marker symmetry
- `…_entity_encoded_sink` — WAF-bypass decode branch (kept when decoded handler survives, demoted when truncated)
- `…_kept_for_structural_markers` — base-href + clobbering form → still evidence
- `test_classify_dom_evidence_none_when_handler_truncated` — the entry point the scan worker calls
- `test_has_marker_evidence_matrix` — payload family × explicit server transform (full / stripped / blanked / neutralised / breakout / case-fold both ways / entity-encoded / text-only / multi-element)
- `light_verify` `/truncate` route — reproduces the ASP.NET case at the HTTP layer through the exposed path #2 (the test that would have caught the original bug), with a full-reflection counter-case
- Existing `test_check_dom_verification_marker_survives_case_fold` still passes

Full lib suite: **1659 passed, 0 failed**; clippy + fmt clean.

> A follow-up to audit the rest of the DOM-evidence fixtures (they sprinkle the marker into hand-written bodies instead of modelling a real server transform — which is how this bug shipped) and apply the matrix/transform approach to the other evidence kinds is tracked in #1124.

## Considered & deferred

**Relaxing the reflection gate (gate ①).** The dedicated Stage 6 (`verify_normal_dom`) and the static V-upgrade gate V on `classify_reflection(...).is_some()` **and** `has_dom_evidence(...)`. The first gate requires the *full* payload to be reflected, so a server that strips a prefix/suffix but leaves a self-contained executable fragment surfaces as **R**, not **V** — a narrow recall-on-V gap.

We considered loosening gate ① now that `has_dom_evidence`'s marker path is sound, but are **deferring** it:

- It's defense-in-depth: two independent gates back each other up; loosening would put the full FP burden on `has_dom_evidence` across all five evidence kinds at once (the four non-marker paths would need a re-audit of their self-containment under "full payload not reflected").
- The FN is bounded — these cases still report as **R**, and payload synthesis already emits prefix-free variants that reflect in full at many sites.
- It's a hypothesis, not a measured defect. Better captured as a metric in the effectiveness snapshot ("real exploitable sites that surface R-only due to gate ①") and revisited with data than opened as speculative tech-debt.

So this PR keeps gate ① conservative and only makes gate ② sound. Marked **draft** pending review of that scope.
