### PR TITLE
feat(scanner): model Document.parseHTMLUnsafe() + window.open() as DOM-XSS sinks

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -489,6 +489,18 @@ const DOM_SINKS: &[&str] = &[
     "location.href",
     "location.assign",
     "location.replace",
+    // `window.open(url, …)` navigates the opened window to `url`; a
+    // `javascript:` / `data:text/html` scheme there executes script, exactly
+    // like the sibling `location.assign` / `location.replace` navigation
+    // sinks. Only the argument-0 URL position is dangerous (see the
+    // `first_arg_only` gate), so a tainted window-name / features argument is
+    // not treated as a sink. `self` / `globalThis` are the standard global
+    // aliases for `window`. Bare `open(...)` is intentionally excluded — it
+    // collides with `xhr.open` / `indexedDB.open` / `caches.open`, which are
+    // not navigation sinks.
+    "window.open",
+    "self.open",
+    "globalThis.open",
     "src",
     "srcdoc",
     "href",
@@ -506,6 +518,14 @@ const DOM_SINKS: &[&str] = &[
     // parses the argument as HTML with no sanitization, which is exactly the
     // shape of an exploitable injection.
     "setHTMLUnsafe",
+    // `Document.parseHTMLUnsafe(html)` is the parse-to-live-DOM analog of
+    // `setHTMLUnsafe` / `createContextualFragment`: it parses the string into
+    // a detached `Document` with no sanitizer, whose nodes are then adopted
+    // into the page. Matched as a bare method name so both the static
+    // `Document.parseHTMLUnsafe(...)` form and a bare `parseHTMLUnsafe(...)`
+    // are caught. The safe sibling `Document.parseHTML(...)` runs the built-in
+    // Sanitizer and is deliberately not modeled.
+    "parseHTMLUnsafe",
 ];
 
 const DOM_SANITIZERS: &[&str] = &[
@@ -1396,6 +1416,7 @@ impl<'a> DomXssVisitor<'a> {
                 | "document.write"
                 | "document.writeln"
                 | "setHTMLUnsafe"
+                | "parseHTMLUnsafe"
                 | "srcdoc"
                 | "html"
         )
@@ -4518,10 +4539,18 @@ impl<'a> DomXssVisitor<'a> {
             // the executed code — a tainted 2nd `delay` argument
             // (`setTimeout(fn, location.hash)`) is not exploitable, so consider
             // index 0 only (mirroring the setAttribute / execCommand
-            // positional special-cases below).
+            // positional special-cases below). The `*.open` navigation sinks are
+            // the same shape: only argument-0 (the URL) is exploitable; a
+            // tainted window-name (`window.open('/x', location.hash)`) or
+            // features string is not.
             let first_arg_only = matches!(
                 func_name.as_str(),
-                "setTimeout" | "setInterval" | "execScript"
+                "setTimeout"
+                    | "setInterval"
+                    | "execScript"
+                    | "window.open"
+                    | "self.open"
+                    | "globalThis.open"
             );
             for (idx, arg) in call.arguments.iter().enumerate() {
                 if first_arg_only && idx != 0 {

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4340,3 +4340,162 @@ fn settimeout_tainted_delay_argument_is_not_a_sink() {
         "tainted code arg must still flag setTimeout, got {v_code:?}"
     );
 }
+
+// --- Issue #1125: Document.parseHTMLUnsafe() as an HTML-parsing sink ---
+
+#[test]
+fn detects_document_parse_html_unsafe_from_search() {
+    // xssmaze /htmlunsafe/level4/: URLSearchParams source -> parseHTMLUnsafe.
+    let js = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+var doc = Document.parseHTMLUnsafe(q);
+document.getElementById('out').append(...doc.body.childNodes);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "parseHTMLUnsafe"),
+        "Document.parseHTMLUnsafe must be modeled as a sink: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_bare_parse_html_unsafe_from_hash() {
+    // Bare `parseHTMLUnsafe(...)` (destructured off Document) is the same sink.
+    let js = r#"
+var html = decodeURIComponent(location.hash.slice(1));
+var doc = parseHTMLUnsafe(html);
+document.body.append(...doc.body.childNodes);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "parseHTMLUnsafe" && v.source.contains("location.hash")),
+        "bare parseHTMLUnsafe must fire on a tainted argument: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn fetch_text_to_parse_html_unsafe() {
+    // xssmaze /htmlunsafe/level6/: async fetch response -> parseHTMLUnsafe.
+    let js = r#"
+fetch('/api').then(function (r) { return r.text(); })
+  .then(function (t) {
+    var doc = Document.parseHTMLUnsafe(t);
+    document.getElementById('out').append(...doc.body.childNodes);
+  });
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "parseHTMLUnsafe"),
+        "fetch text -> parseHTMLUnsafe must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn parse_html_unsafe_static_argument_is_not_a_sink() {
+    // A static HTML string is not attacker-controlled: must not flag.
+    let js = r#"var doc = Document.parseHTMLUnsafe('<b>hi</b>');"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "parseHTMLUnsafe"),
+        "static parseHTMLUnsafe argument must not be flagged, got {r:?}"
+    );
+}
+
+// --- Issue #1126: window.open() as a navigation sink ---
+
+#[test]
+fn detects_window_open_from_hash() {
+    // xssmaze /navsink/level1/: location.hash -> window.open.
+    let js = r#"
+var target = decodeURIComponent(location.hash.slice(1));
+if (target) { window.open(target); }
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "window.open" && v.source.contains("location.hash")),
+        "window.open of location.hash must be modeled as a sink: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_window_open_from_search_with_target_arg() {
+    // xssmaze /navsink/level2/: URLSearchParams -> window.open(url, '_blank').
+    let js = r#"
+var url = new URLSearchParams(location.search).get('query') || '';
+if (url) { window.open(url, '_blank'); }
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink == "window.open"),
+        "window.open(url, '_blank') must fire on a tainted URL: got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn detects_self_and_global_this_open_aliases() {
+    for (alias, src) in [
+        ("self.open(t)", "self.open"),
+        ("globalThis.open(t)", "globalThis.open"),
+    ] {
+        let js = format!("var t = location.hash; {alias};");
+        let r = AstDomAnalyzer::new().analyze(&js).unwrap();
+        assert!(
+            r.iter().any(|v| v.sink == src),
+            "{src} alias must be modeled as a navigation sink, got {r:?}"
+        );
+    }
+}
+
+#[test]
+fn window_open_tainted_window_name_is_not_a_sink() {
+    // Only argument-0 (the URL) is exploitable. A tainted 2nd `windowName`
+    // argument (`window.open('/x', location.hash)`) must NOT be flagged.
+    let js = r#"window.open('/safe', location.hash);"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "window.open"),
+        "tainted window-name arg must not flag window.open, got {r:?}"
+    );
+}
+
+#[test]
+fn window_open_static_url_is_not_a_sink() {
+    let js = r#"window.open('https://example.com/', '_blank');"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink == "window.open"),
+        "static window.open URL must not be flagged, got {r:?}"
+    );
+}
+
+#[test]
+fn xhr_open_is_not_a_window_open_sink() {
+    // `xhr.open(method, url)` is the XMLHttpRequest API, not a navigation
+    // sink: the bare `open` method name must not collide with `window.open`.
+    let js = r#"
+var xhr = new XMLHttpRequest();
+xhr.open('GET', location.hash);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        !r.iter().any(|v| v.sink.ends_with("open")),
+        "xhr.open must not be treated as a navigation sink, got {r:?}"
+    );
+}


### PR DESCRIPTION
## Summary

The AST DOM-XSS engine's sink table was missing two modern sinks, so a tainted DOM source flowing into them produced **zero findings** while their already-modeled siblings were caught. This adds both, with FP guards.

- **Closes #1125** — `Document.parseHTMLUnsafe()` (parse-to-live-DOM, no sanitizer) was missing, though `setHTMLUnsafe` / `createContextualFragment` were modeled.
- **Closes #1126** — `window.open()` (navigation sink; a `javascript:` / `data:text/html` URL runs in the opened window) was missing, though `location.assign` / `location.replace` were modeled.

## Changes (`src/scanning/ast_dom_analysis.rs`)

1. **`parseHTMLUnsafe`** added to `DOM_SINKS` as a bare method name → catches both `Document.parseHTMLUnsafe(q)` and a destructured `parseHTMLUnsafe(q)`. Also added to `is_trusted_html_sink`, since its IDL accepts `(TrustedHTML or DOMString)` — same Trusted-Types treatment as `setHTMLUnsafe`. The safe sibling `Document.parseHTML()` (built-in Sanitizer) is deliberately not modeled.
2. **`window.open` / `self.open` / `globalThis.open`** added to `DOM_SINKS` (dotted names) and to the `first_arg_only` gate, so **only argument-0 (the URL)** is a sink — a tainted window-name/features argument is not flagged. Bare `open` is intentionally excluded to avoid colliding with `xhr.open` / `indexedDB.open` / `caches.open`.

`DOMParser.parseFromString` (noted as optional in #1125) is intentionally left out — it's commonly used to parse data without DOM insertion, so modeling the parse call itself would be FP-prone.

## Verification — XSSMaze `htmlunsafe` + `navsink`

Both categories now **6/6 detected**, no regressions:

| Endpoint | Source | Sink | Before → After |
|---|---|---|---|
| `htmlunsafe/level4` | `URLSearchParams.get` | `Document.parseHTMLUnsafe` | missed → `[A]` parseHTMLUnsafe |
| `htmlunsafe/level6` | `fetch().text()` | `Document.parseHTMLUnsafe` | missed → `[A]` parseHTMLUnsafe |
| `navsink/level1` | `location.hash` | `window.open` | missed → `[A]` window.open |
| `navsink/level2` | `URLSearchParams.get` | `window.open(url,'_blank')` | missed → `[A]` window.open |

All pre-existing levels (setHTMLUnsafe, location.assign/replace, the reflected `[V]` levels) still fire.

### Note on the `opener` category
`window.open(location.pathname, …)` is now also reported there (because `location.pathname` is a taint source). This is consistent with how `location.assign`/`location.replace` already treat that source, and those pages are genuinely vulnerable (the intended `window.opener → innerHTML/srcdoc` finding still fires) — the "behave as a location assignment" symmetry requested in #1126.

## Tests

- 11 new unit tests: maze shapes + FP guards (static args not flagged, tainted window-name not flagged, `xhr.open` not colliding).
- `cargo test --lib scanning::` → **778 passed**; ast_dom suite **271 passed**; clippy clean; fmt clean.