### PR TITLE
test(scanner): shared reflect(payload, Transform) fixtures + DOM-evidence matrices (#1124)

### DIFF
--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1032,6 +1032,168 @@ fn test_is_executable_url_attribute_pin_whitelist() {
     }
 }
 
+// ---------------------------------------------------------------------------
+// Payload × transform matrices (issue #1124)
+//
+// The marker-evidence matrix lives with the #1118/#1123 handler-survival fix.
+// These tables extend the same pattern to the *other* DOM-evidence kinds —
+// executable-URL attribute, HTML-structural, and inline-handler breakout — so
+// each kind is exercised against bodies produced by an explicit, reviewable
+// server transform (`reflect(payload, Transform, sink)`) rather than ad-hoc
+// hand-written HTML. Every row documents "what the server did", and the
+// expected verdict is checked against that transform.
+// ---------------------------------------------------------------------------
+use crate::scanning::dom_evidence_fixtures::{Transform, reflect};
+
+#[test]
+fn test_executable_url_evidence_matrix() {
+    // Payload is a bare `javascript:` URL; the sink template decides the
+    // reflection context (navigational vs resource-fetch attribute).
+    let payload = "javascript:alert(1)";
+    let nav = r#"<html><body><a href="{PAYLOAD}">go</a></body></html>"#;
+    let img = r#"<html><body><img src="{PAYLOAD}"></body></html>"#;
+
+    // (label, transform, sink, expected_evidence)
+    let cases: &[(&str, Transform, &str, bool)] = &[
+        ("full reflect into a@href", Transform::Full, nav, true),
+        // HTML-entity encoding does NOT defang a scheme with no markup
+        // metacharacters — the href still navigates. URL/percent encoding is
+        // the real defence here.
+        (
+            "entity-encoded into a@href",
+            Transform::EntityEncoded,
+            nav,
+            true,
+        ),
+        // Percent-encoding breaks the `:` so it is no longer a URL scheme.
+        (
+            "percent-encoded into a@href",
+            Transform::PercentEncoded,
+            nav,
+            false,
+        ),
+        // Schemes are matched case-insensitively, mirroring the browser.
+        ("case-folded into a@href", Transform::CaseFolded, nav, true),
+        // Truncated before `(` — the full payload no longer appears in the value.
+        (
+            "truncated at '(' into a@href",
+            Transform::TruncatedAt("("),
+            nav,
+            false,
+        ),
+        // Same scheme, reflected into a resource-fetch attribute the browser
+        // never executes as code: the "sink" is not actually a sink.
+        ("full reflect into img@src", Transform::Full, img, false),
+    ];
+
+    for (label, transform, sink, expected) in cases {
+        let body = reflect(payload, *transform, sink);
+        assert_eq!(
+            has_dom_evidence(payload, &body),
+            *expected,
+            "executable-URL matrix row `{label}` mismatched on body: {body}"
+        );
+    }
+}
+
+#[test]
+fn test_html_structural_evidence_matrix() {
+    // Payload introduces a real element carrying an event-handler sink.
+    let payload = "<svg onload=alert(1)>";
+    let text_sink = "<html><body>results: {PAYLOAD}</body></html>";
+
+    let cases: &[(&str, Transform, bool)] = &[
+        ("full reflect", Transform::Full, true),
+        // Element survives but the handler that carried the sink is gone.
+        ("handler stripped", Transform::HandlerStripped, false),
+        // Handler attribute present but emptied — no sink call.
+        ("handler blanked", Transform::HandlerBlanked, false),
+        // Angle brackets escaped → inert text, scraper builds no <svg> element.
+        ("entity encoded", Transform::EntityEncoded, false),
+        // Percent escapes are not decoded by the HTML parser → inert text.
+        ("percent encoded", Transform::PercentEncoded, false),
+        // `ALERT` is a distinct (undefined) identifier; JS is case-sensitive.
+        ("case folded", Transform::CaseFolded, false),
+        // Truncated before the handler — element with no usable handler.
+        (
+            "truncated before handler",
+            Transform::TruncatedAt("onload"),
+            false,
+        ),
+    ];
+
+    for (label, transform, expected) in cases {
+        let body = reflect(payload, *transform, text_sink);
+        assert_eq!(
+            has_dom_evidence(payload, &body),
+            *expected,
+            "html-structural matrix row `{label}` mismatched on body: {body}"
+        );
+    }
+}
+
+#[test]
+fn test_inline_handler_breakout_evidence_matrix() {
+    // xss-game L4 shape: the server's own template wraps the reflected payload
+    // inside an existing `on*` handler's JS string argument.
+    let payload = "'-alert(1)-'";
+    let handler_sink = r#"<img onload="startTimer('{PAYLOAD}')">"#;
+    // A non-handler reflection context (server emits no `on*` attribute).
+    let text_sink = "<div>startTimer('{PAYLOAD}')</div>";
+
+    let cases: &[(&str, Transform, &str, bool)] = &[
+        // Raw reflection: the single quotes break the JS string immediately.
+        (
+            "full reflect into on-handler",
+            Transform::Full,
+            handler_sink,
+            true,
+        ),
+        // Server entity-encodes the quote, but the browser decodes `&#39;` at
+        // attribute-parse time, so the breakout still fires (the L4 lesson).
+        (
+            "entity-encoded quote in on-handler",
+            Transform::EntityEncoded,
+            handler_sink,
+            true,
+        ),
+        // Percent escapes stay literal in an HTML attribute → no breakout.
+        (
+            "percent-encoded quote in on-handler",
+            Transform::PercentEncoded,
+            handler_sink,
+            false,
+        ),
+        // `ALERT` is not the real sink under case-sensitive JS.
+        (
+            "case-folded in on-handler",
+            Transform::CaseFolded,
+            handler_sink,
+            false,
+        ),
+        // No `on*` attribute at all → nothing to break out of.
+        (
+            "reflected outside any handler",
+            Transform::Full,
+            text_sink,
+            false,
+        ),
+    ];
+
+    for (label, transform, sink, expected) in cases {
+        let body = reflect(payload, *transform, sink);
+        assert_eq!(
+            classify_dom_evidence(payload, &body),
+            if *expected {
+                Some(DomEvidenceKind::InlineHandlerBreakout)
+            } else {
+                None
+            },
+            "inline-handler matrix row `{label}` mismatched on body: {body}"
+        );
+    }
+}
+
 #[test]
 fn html_structural_evidence_matches_entity_encoded_payload() {
     // WAF-bypass payloads entity-encode the sink chars (`alert&#40;1&#41;`), but

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1053,9 +1053,11 @@ fn test_executable_url_evidence_matrix() {
     let nav = r#"<html><body><a href="{PAYLOAD}">go</a></body></html>"#;
     let img = r#"<html><body><img src="{PAYLOAD}"></body></html>"#;
 
-    // (label, transform, sink, expected_evidence)
-    let cases: &[(&str, Transform, &str, bool)] = &[
-        ("full reflect into a@href", Transform::Full, nav, true),
+    // (label, transform, sink, expected_kind) — pin the exact evidence path so
+    // a regression that confirms via the wrong kind is caught, not just masked.
+    let hit = Some(DomEvidenceKind::ExecutableUrl);
+    let cases: &[(&str, Transform, &str, Option<DomEvidenceKind>)] = &[
+        ("full reflect into a@href", Transform::Full, nav, hit),
         // HTML-entity encoding does NOT defang a scheme with no markup
         // metacharacters — the href still navigates. URL/percent encoding is
         // the real defence here.
@@ -1063,33 +1065,33 @@ fn test_executable_url_evidence_matrix() {
             "entity-encoded into a@href",
             Transform::EntityEncoded,
             nav,
-            true,
+            hit,
         ),
         // Percent-encoding breaks the `:` so it is no longer a URL scheme.
         (
             "percent-encoded into a@href",
             Transform::PercentEncoded,
             nav,
-            false,
+            None,
         ),
         // Schemes are matched case-insensitively, mirroring the browser.
-        ("case-folded into a@href", Transform::CaseFolded, nav, true),
+        ("case-folded into a@href", Transform::CaseFolded, nav, hit),
         // Truncated before `(` — the full payload no longer appears in the value.
         (
             "truncated at '(' into a@href",
             Transform::TruncatedAt("("),
             nav,
-            false,
+            None,
         ),
         // Same scheme, reflected into a resource-fetch attribute the browser
         // never executes as code: the "sink" is not actually a sink.
-        ("full reflect into img@src", Transform::Full, img, false),
+        ("full reflect into img@src", Transform::Full, img, None),
     ];
 
     for (label, transform, sink, expected) in cases {
         let body = reflect(payload, *transform, sink);
         assert_eq!(
-            has_dom_evidence(payload, &body),
+            classify_dom_evidence(payload, &body),
             *expected,
             "executable-URL matrix row `{label}` mismatched on body: {body}"
         );
@@ -1102,30 +1104,31 @@ fn test_html_structural_evidence_matrix() {
     let payload = "<svg onload=alert(1)>";
     let text_sink = "<html><body>results: {PAYLOAD}</body></html>";
 
-    let cases: &[(&str, Transform, bool)] = &[
-        ("full reflect", Transform::Full, true),
+    let hit = Some(DomEvidenceKind::HtmlStructural);
+    let cases: &[(&str, Transform, Option<DomEvidenceKind>)] = &[
+        ("full reflect", Transform::Full, hit),
         // Element survives but the handler that carried the sink is gone.
-        ("handler stripped", Transform::HandlerStripped, false),
+        ("handler stripped", Transform::HandlerStripped, None),
         // Handler attribute present but emptied — no sink call.
-        ("handler blanked", Transform::HandlerBlanked, false),
+        ("handler blanked", Transform::HandlerBlanked, None),
         // Angle brackets escaped → inert text, scraper builds no <svg> element.
-        ("entity encoded", Transform::EntityEncoded, false),
+        ("entity encoded", Transform::EntityEncoded, None),
         // Percent escapes are not decoded by the HTML parser → inert text.
-        ("percent encoded", Transform::PercentEncoded, false),
+        ("percent encoded", Transform::PercentEncoded, None),
         // `ALERT` is a distinct (undefined) identifier; JS is case-sensitive.
-        ("case folded", Transform::CaseFolded, false),
+        ("case folded", Transform::CaseFolded, None),
         // Truncated before the handler — element with no usable handler.
         (
             "truncated before handler",
             Transform::TruncatedAt("onload"),
-            false,
+            None,
         ),
     ];
 
     for (label, transform, expected) in cases {
         let body = reflect(payload, *transform, text_sink);
         assert_eq!(
-            has_dom_evidence(payload, &body),
+            classify_dom_evidence(payload, &body),
             *expected,
             "html-structural matrix row `{label}` mismatched on body: {body}"
         );
@@ -1141,13 +1144,14 @@ fn test_inline_handler_breakout_evidence_matrix() {
     // A non-handler reflection context (server emits no `on*` attribute).
     let text_sink = "<div>startTimer('{PAYLOAD}')</div>";
 
-    let cases: &[(&str, Transform, &str, bool)] = &[
+    let hit = Some(DomEvidenceKind::InlineHandlerBreakout);
+    let cases: &[(&str, Transform, &str, Option<DomEvidenceKind>)] = &[
         // Raw reflection: the single quotes break the JS string immediately.
         (
             "full reflect into on-handler",
             Transform::Full,
             handler_sink,
-            true,
+            hit,
         ),
         // Server entity-encodes the quote, but the browser decodes `&#39;` at
         // attribute-parse time, so the breakout still fires (the L4 lesson).
@@ -1155,28 +1159,28 @@ fn test_inline_handler_breakout_evidence_matrix() {
             "entity-encoded quote in on-handler",
             Transform::EntityEncoded,
             handler_sink,
-            true,
+            hit,
         ),
         // Percent escapes stay literal in an HTML attribute → no breakout.
         (
             "percent-encoded quote in on-handler",
             Transform::PercentEncoded,
             handler_sink,
-            false,
+            None,
         ),
         // `ALERT` is not the real sink under case-sensitive JS.
         (
             "case-folded in on-handler",
             Transform::CaseFolded,
             handler_sink,
-            false,
+            None,
         ),
         // No `on*` attribute at all → nothing to break out of.
         (
             "reflected outside any handler",
             Transform::Full,
             text_sink,
-            false,
+            None,
         ),
     ];
 
@@ -1184,11 +1188,7 @@ fn test_inline_handler_breakout_evidence_matrix() {
         let body = reflect(payload, *transform, sink);
         assert_eq!(
             classify_dom_evidence(payload, &body),
-            if *expected {
-                Some(DomEvidenceKind::InlineHandlerBreakout)
-            } else {
-                None
-            },
+            *expected,
             "inline-handler matrix row `{label}` mismatched on body: {body}"
         );
     }

--- a/src/scanning/dom_evidence_fixtures.rs
+++ b/src/scanning/dom_evidence_fixtures.rs
@@ -1,0 +1,216 @@
+//! Shared test fixtures that model how a real server transforms a reflected
+//! payload before it appears in the response body.
+//!
+//! The DOM-evidence checks (`check_dom_verification`, `js_context_verify`,
+//! `light_verify`) gate the highest-confidence **[V]** finding. Their unit
+//! tests used to hand-write the "response body" by sprinkling the payload into
+//! a minimal wrapper — which silently divorced the fixture from any concrete
+//! server behaviour and let false-positive/false-negative gaps hide (see
+//! issue #1118 / #1124).
+//!
+//! This module makes "what the server did" explicit and reviewable: a fixture
+//! states a [`Transform`] (full reflect, handler stripped, entity/percent
+//! encoded, case-folded, truncated, …) and a sink template, and [`reflect`]
+//! produces the body. The transform — not ad-hoc HTML — is the source of truth
+//! for whether the body should still constitute DOM evidence.
+
+use regex::Regex;
+use std::sync::OnceLock;
+
+/// A documented server-side transformation applied to a reflected payload.
+///
+/// Each variant corresponds to a behaviour observed on real targets, so a
+/// fixture that names one is asserting "a server that does *this* produces
+/// *this* body" — and the expected verdict can be reviewed against it.
+#[derive(Clone, Copy, Debug, PartialEq, Eq)]
+pub(crate) enum Transform<'a> {
+    /// Reflect the payload verbatim, byte-for-byte (no sanitisation).
+    Full,
+    /// Drop every `on*` event-handler attribute (name and value). Models a
+    /// sanitiser that keeps the tag but strips handlers, or the ASP.NET-style
+    /// truncation that severs the `onload=`/`onerror=` after the marker.
+    HandlerStripped,
+    /// Keep `on*` attribute names but blank their values (`onload=""`).
+    HandlerBlanked,
+    /// HTML-entity-encode the metacharacters `& < > " '` — the canonical
+    /// "echoed safely into HTML text/attribute" behaviour.
+    EntityEncoded,
+    /// Percent-encode the payload (server reflected the still-URL-encoded form
+    /// without decoding it). Percent escapes are *not* decoded by the HTML
+    /// parser, so this neutralises markup and JS-string breakouts alike.
+    PercentEncoded,
+    /// ASCII-uppercase every byte (case-folding reverse proxy / template).
+    /// JavaScript identifiers are case-sensitive, so a folded `ALERT(1)` is a
+    /// different (undefined) name and never executes.
+    CaseFolded,
+    /// Truncate the payload at the first occurrence of `needle` (exclusive),
+    /// modelling a length cap or a sink that cuts at a delimiter.
+    TruncatedAt(&'a str),
+    /// Entity-encode only the angle brackets so the payload renders as inert
+    /// text rather than parsed markup.
+    TextOnly,
+}
+
+/// Matches an `on*` event-handler attribute with its value (quoted or bare).
+fn handler_attr_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)\s+on[a-z0-9_-]+\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)"#)
+            .expect("valid handler-attr regex")
+    })
+}
+
+/// Like [`handler_attr_re`] but captures the attribute name so the value can be
+/// blanked while the handler attribute itself stays present.
+fn handler_attr_name_re() -> &'static Regex {
+    static RE: OnceLock<Regex> = OnceLock::new();
+    RE.get_or_init(|| {
+        Regex::new(r#"(?i)(\s+on[a-z0-9_-]+)\s*=\s*(?:"[^"]*"|'[^']*'|[^\s>]+)"#)
+            .expect("valid handler-attr-name regex")
+    })
+}
+
+fn entity_encode(s: &str) -> String {
+    // `&` first so we don't double-encode the escapes we introduce.
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+        .replace('\'', "&#39;")
+}
+
+/// Apply `transform` to `payload`, returning the bytes a server would emit for
+/// the reflected value. This is the only place transformation semantics live.
+pub(crate) fn apply_transform(payload: &str, transform: Transform) -> String {
+    match transform {
+        Transform::Full => payload.to_string(),
+        Transform::HandlerStripped => handler_attr_re().replace_all(payload, "").into_owned(),
+        Transform::HandlerBlanked => handler_attr_name_re()
+            .replace_all(payload, r#"${1}="""#)
+            .into_owned(),
+        Transform::EntityEncoded => entity_encode(payload),
+        Transform::PercentEncoded => urlencoding::encode(payload).into_owned(),
+        Transform::CaseFolded => payload.to_ascii_uppercase(),
+        Transform::TruncatedAt(needle) => payload
+            .split_once(needle)
+            .map(|(head, _)| head.to_string())
+            .unwrap_or_else(|| payload.to_string()),
+        Transform::TextOnly => payload.replace('<', "&lt;").replace('>', "&gt;"),
+    }
+}
+
+/// Produce a response body by applying `transform` to `payload` and
+/// substituting the result into `sink_template` at the `{PAYLOAD}` placeholder.
+///
+/// `sink_template` names the reflection context (an `<a href>`, a `<script>`
+/// string slot, an inline `on*` handler, …), so a single transform can be
+/// exercised across every DOM-evidence kind from one helper.
+pub(crate) fn reflect(payload: &str, transform: Transform, sink_template: &str) -> String {
+    debug_assert!(
+        sink_template.contains("{PAYLOAD}"),
+        "sink template must contain a {{PAYLOAD}} placeholder"
+    );
+    sink_template.replace("{PAYLOAD}", &apply_transform(payload, transform))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn full_reflects_verbatim() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::Full),
+            "<svg onload=alert(1)>"
+        );
+    }
+
+    #[test]
+    fn handler_stripped_drops_event_handlers() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::HandlerStripped),
+            "<svg>"
+        );
+        assert_eq!(
+            apply_transform("<img src=x onerror=alert(1)>", Transform::HandlerStripped),
+            "<img src=x>"
+        );
+        assert_eq!(
+            apply_transform(
+                r#"<img src=x onerror="alert(1)">"#,
+                Transform::HandlerStripped
+            ),
+            "<img src=x>"
+        );
+    }
+
+    #[test]
+    fn handler_blanked_keeps_name_drops_value() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::HandlerBlanked),
+            r#"<svg onload="">"#
+        );
+    }
+
+    #[test]
+    fn entity_encoded_escapes_markup_metacharacters() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::EntityEncoded),
+            "&lt;svg onload=alert(1)&gt;"
+        );
+        assert_eq!(
+            apply_transform("'-alert(1)-'", Transform::EntityEncoded),
+            "&#39;-alert(1)-&#39;"
+        );
+        // `&` is encoded first, so existing ampersands survive faithfully.
+        assert_eq!(apply_transform("a&b", Transform::EntityEncoded), "a&amp;b");
+    }
+
+    #[test]
+    fn percent_encoded_neutralises_quotes_and_angles() {
+        assert_eq!(
+            apply_transform("'-alert(1)-'", Transform::PercentEncoded),
+            "%27-alert%281%29-%27"
+        );
+        // A `javascript:` scheme loses its `:` so it no longer parses as a URL scheme.
+        let encoded = apply_transform("javascript:alert(1)", Transform::PercentEncoded);
+        assert!(!encoded.starts_with("javascript:"), "{encoded}");
+        assert!(encoded.starts_with("javascript%3A"), "{encoded}");
+    }
+
+    #[test]
+    fn case_folded_uppercases_ascii() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::CaseFolded),
+            "<SVG ONLOAD=ALERT(1)>"
+        );
+    }
+
+    #[test]
+    fn truncated_keeps_prefix_before_needle() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::TruncatedAt("onload")),
+            "<svg "
+        );
+        // Needle absent → payload passes through unchanged.
+        assert_eq!(apply_transform("abc", Transform::TruncatedAt("z")), "abc");
+    }
+
+    #[test]
+    fn text_only_encodes_angle_brackets_only() {
+        assert_eq!(
+            apply_transform("<svg onload=alert(1)>", Transform::TextOnly),
+            "&lt;svg onload=alert(1)&gt;"
+        );
+    }
+
+    #[test]
+    fn reflect_substitutes_into_sink_template() {
+        let body = reflect(
+            "javascript:alert(1)",
+            Transform::Full,
+            r#"<a href="{PAYLOAD}">x</a>"#,
+        );
+        assert_eq!(body, r#"<a href="javascript:alert(1)">x</a>"#);
+    }
+}

--- a/src/scanning/js_context_verify/tests.rs
+++ b/src/scanning/js_context_verify/tests.rs
@@ -396,6 +396,80 @@ fn large_script_above_inline_cap_runs_on_large_stack_without_crashing() {
     );
 }
 
+// ---------------------------------------------------------------------------
+// JS-context payload × transform matrix (issue #1124)
+//
+// Extends the #1118/#1123 matrix pattern to the JS-context evidence kind. Each
+// row states how a server transformed the reflected payload (via the shared
+// `reflect` helper) and the verdict that transform should yield, instead of
+// hand-writing the script body per case.
+// ---------------------------------------------------------------------------
+#[test]
+fn test_js_context_evidence_matrix() {
+    use crate::scanning::dom_evidence_fixtures::{Transform, reflect};
+
+    // Payload breaks out of a double-quoted JS string and calls a sink.
+    let payload = "\"-alert(1)-\"";
+    let script_sink = r#"<script>var x = "{PAYLOAD}";</script>"#;
+    // Reflection that never reaches a <script> block.
+    let html_text_sink = "<html><body>{PAYLOAD}</body></html>";
+
+    // (label, transform, sink, expected_evidence)
+    let cases: &[(&str, Transform, &str, bool)] = &[
+        (
+            "full reflect into JS string slot",
+            Transform::Full,
+            script_sink,
+            true,
+        ),
+        // Server entity-encodes the breakout quote; inside <script> the JS
+        // parser does NOT decode `&quot;`, so the payload stays in the string.
+        (
+            "entity-encoded quote in script",
+            Transform::EntityEncoded,
+            script_sink,
+            false,
+        ),
+        // Percent escapes likewise stay literal in JS source → inert.
+        (
+            "percent-encoded in script",
+            Transform::PercentEncoded,
+            script_sink,
+            false,
+        ),
+        // `ALERT` is a distinct, undefined identifier under case-sensitive JS.
+        (
+            "case-folded in script",
+            Transform::CaseFolded,
+            script_sink,
+            false,
+        ),
+        // Truncated before the sink call → no `alert(` survives.
+        (
+            "truncated before sink",
+            Transform::TruncatedAt("alert"),
+            script_sink,
+            false,
+        ),
+        // Same payload reflected as HTML text, outside any <script> block.
+        (
+            "reflected outside any script",
+            Transform::Full,
+            html_text_sink,
+            false,
+        ),
+    ];
+
+    for (label, transform, sink, expected) in cases {
+        let body = reflect(payload, *transform, sink);
+        assert_eq!(
+            has_js_context_evidence(payload, &body),
+            *expected,
+            "js-context matrix row `{label}` mismatched on body: {body}"
+        );
+    }
+}
+
 #[test]
 fn checks_every_payload_occurrence_not_just_the_first() {
     // A benign in-string reflection of the payload precedes the executable

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -23,6 +23,9 @@ pub mod ast_dom_analysis;
 pub mod ast_integration;
 pub mod check_dom_verification;
 pub mod check_reflection;
+/// Shared test-only fixtures modelling server-side reflection transforms.
+#[cfg(test)]
+pub(crate) mod dom_evidence_fixtures;
 pub mod js_context_verify;
 pub mod light_verify;
 pub mod markers;


### PR DESCRIPTION
Closes #1124

## Problem

DOM-evidence unit tests (`check_dom_verification`, `js_context_verify`, …) built the "response body" by hand, sprinkling the payload into a minimal wrapper:

```rust
let body = format!("<html><body>{}</body></html>", class_marker);
```

instead of modelling what a real server did to the **whole** payload (reflect in full, strip the handler, HTML-entity-encode, percent-encode, ASCII case-fold, truncate, …). That style divorces a fixture from any concrete server behaviour and is exactly where the #1118-class false-positive/false-negative gaps hide — these checks gate the highest-confidence **[V]** finding.

## What this does

### 1. Shared transform model (`scanning::dom_evidence_fixtures`, test-only)

A small, reviewable helper so a fixture states *what the server did* rather than hand-writing HTML:

- `Transform` enum: `Full`, `HandlerStripped`, `HandlerBlanked`, `EntityEncoded`, `PercentEncoded`, `CaseFolded`, `TruncatedAt(needle)`, `TextOnly` — each variant documented against the real server behaviour it models.
- `apply_transform(payload, transform)` — the single source of truth for transformation semantics (covered by its own unit tests).
- `reflect(payload, transform, sink_template)` — substitutes the transformed payload into a sink template (`<a href>`, `<script>` string slot, inline `on*` handler, …) so one transform can be exercised across every evidence kind.

### 2. Payload × transform matrices for the *other* evidence kinds

Per AC #3, the marker matrix is #1123's territory; this extends the same pattern to:

| matrix | kind | sample faithful negatives |
|---|---|---|
| `test_executable_url_evidence_matrix` | executable-URL attribute | percent-encoded scheme, truncated URL, `img@src` (resource-fetch, not navigation) |
| `test_html_structural_evidence_matrix` | HTML-structural | handler stripped/blanked, entity/percent-encoded (inert text), case-folded (`ALERT` ≠ `alert`) |
| `test_inline_handler_breakout_evidence_matrix` | inline-handler breakout | percent-encoded quote (no breakout), case-folded, reflected outside any handler; **entity-encoded quote still fires** (browser decodes `&#39;` at attribute-parse time — the xss-game L4 lesson) |
| `test_js_context_evidence_matrix` | JS-context AST | entity/percent-encoded (stays in string literal), case-folded, truncated before sink, reflected outside `<script>` |

Each row covers at least full reflect, handler/sink stripped, entity + percent encoded, and case-folded, and asserts the verdict the modelled transform should produce.

## Acceptance criteria

- ✅ New evidence tests go through the shared transform helper, not ad-hoc string concatenation.
- ✅ Each (non-marker) evidence kind has a payload × transform matrix covering full reflect, handler/sink stripped, encoded (entity + percent), case-folded.
- ✅ No new fixture asserts an evidence verdict that the modelled transform would not actually produce.

The marker-evidence matrix (`test_has_marker_evidence_matrix`) and the ASP.NET truncation HTTP-layer regression ship with the #1118 handler-survival fix in #1123, which is unmerged — this PR deliberately stays off that ground to avoid colliding with it.

## Testing

- `cargo test --lib scanning::` — 815 passed
- `cargo fmt`, `cargo clippy --lib --tests` — clean

https://claude.ai/code/session_01LwqmgwEJFvuHFKFsqHjvyf

---
_Generated by [Claude Code](https://claude.ai/code/session_01LwqmgwEJFvuHFKFsqHjvyf)_