### PR TITLE
fix(oob): --blind-oob no longer swallows the target URL; harden OOB server list + nonce correlation

### DIFF
--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -596,8 +596,14 @@ pub struct PreflightOptions {
 pub struct BlindOobArgs {
     #[clap(help_heading = "XSS SCANNING")]
     /// Enable OOB blind XSS via interactsh. Optional comma-separated server
-    /// domains (default: public servers). Example: --blind-oob oast.fun,oast.me
-    #[arg(long = "blind-oob", value_delimiter = ',', num_args = 0..)]
+    /// domains (default: public servers). Example: --blind-oob=oast.fun,oast.me
+    ///
+    /// `require_equals` is deliberate: with a bare `num_args = 0..` this option
+    /// would greedily swallow the following positional target
+    /// (`dalfox --blind-oob https://t` would treat `https://t` as a server name
+    /// and leave no scan target). Forcing the `=` form keeps bare `--blind-oob`
+    /// (default mesh) working while never consuming the URL.
+    #[arg(long = "blind-oob", value_delimiter = ',', num_args = 0.., require_equals = true)]
     pub blind_oob: Option<Vec<String>>,
 
     #[clap(help_heading = "XSS SCANNING")]
@@ -623,13 +629,27 @@ impl ScanArgs {
     }
 
     /// Candidate OOB server domains: the user's list, or the public mesh.
+    ///
+    /// Entries are trimmed and blanks dropped, so `--blind-oob=`,
+    /// `--blind-oob=,,`, or stray whitespace (`--blind-oob=" oast.fun , "`)
+    /// degrade to a clean list (or the public mesh) instead of attempting a
+    /// doomed registration against an empty host.
     pub fn blind_oob_servers(&self) -> Vec<String> {
-        match &self.oob.blind_oob {
-            Some(list) if !list.is_empty() => list.clone(),
-            _ => crate::oob::DEFAULT_SERVERS
+        let cleaned: Vec<String> = self
+            .oob
+            .blind_oob
+            .iter()
+            .flatten()
+            .map(|s| s.trim().to_string())
+            .filter(|s| !s.is_empty())
+            .collect();
+        if cleaned.is_empty() {
+            crate::oob::DEFAULT_SERVERS
                 .iter()
                 .map(|s| s.to_string())
-                .collect(),
+                .collect()
+        } else {
+            cleaned
         }
     }
 
@@ -800,12 +820,12 @@ mod arg_parser_tests {
         assert_eq!(bare.scan.oob.blind_oob.as_deref(), Some(&[][..]));
         assert_eq!(bare.scan.blind_oob_servers(), crate::oob::DEFAULT_SERVERS);
 
-        // Explicit comma-separated servers + secret + wait.
+        // Explicit comma-separated servers (the `=` form is required) + secret
+        // + wait.
         let full = TestCli::try_parse_from([
             "dalfox",
             "https://e.com",
-            "--blind-oob",
-            "oast.fun,oast.me",
+            "--blind-oob=oast.fun,oast.me",
             "--blind-oob-secret",
             "tok",
             "--blind-oob-wait",
@@ -816,6 +836,71 @@ mod arg_parser_tests {
         assert_eq!(full.scan.blind_oob_servers(), vec!["oast.fun", "oast.me"]);
         assert_eq!(full.scan.blind_oob_secret(), Some("tok"));
         assert_eq!(full.scan.blind_oob_wait(), 12);
+    }
+
+    #[test]
+    fn blind_oob_never_swallows_positional_target() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            scan: ScanArgs,
+        }
+
+        // Regression: `--blind-oob` before the target must NOT eat the URL.
+        // Without `require_equals` a bare `num_args = 0..` greedily consumes the
+        // following positional, leaving the scan with no target.
+        let bare_before = TestCli::try_parse_from(["dalfox", "--blind-oob", "https://e.com"])
+            .expect("bare --blind-oob before target");
+        assert!(bare_before.scan.blind_oob_enabled());
+        assert_eq!(bare_before.scan.targets, vec!["https://e.com".to_string()]);
+        assert_eq!(
+            bare_before.scan.blind_oob_servers(),
+            crate::oob::DEFAULT_SERVERS
+        );
+
+        // Same with an explicit `=` server list before the target.
+        let list_before =
+            TestCli::try_parse_from(["dalfox", "--blind-oob=oast.fun,oast.me", "https://e.com"])
+                .expect("--blind-oob=list before target");
+        assert_eq!(list_before.scan.targets, vec!["https://e.com".to_string()]);
+        assert_eq!(
+            list_before.scan.blind_oob_servers(),
+            vec!["oast.fun", "oast.me"]
+        );
+    }
+
+    #[test]
+    fn blind_oob_blank_server_list_falls_back_to_mesh() {
+        use clap::Parser;
+
+        #[derive(Parser)]
+        struct TestCli {
+            #[command(flatten)]
+            scan: ScanArgs,
+        }
+
+        // `--blind-oob=` / `--blind-oob=,,` / stray whitespace must still enable
+        // OOB but degrade to the public mesh rather than registering an empty
+        // host. Enabled is keyed on presence, so each is still "on".
+        for arg in ["--blind-oob=", "--blind-oob=,,", "--blind-oob= , "] {
+            let cli = TestCli::try_parse_from(["dalfox", "https://e.com", arg])
+                .unwrap_or_else(|e| panic!("parse {arg}: {e}"));
+            assert!(cli.scan.blind_oob_enabled(), "{arg} should enable OOB");
+            assert_eq!(
+                cli.scan.blind_oob_servers(),
+                crate::oob::DEFAULT_SERVERS,
+                "{arg} should fall back to the default mesh"
+            );
+        }
+
+        // A list with one real entry and surrounding blanks keeps just the real
+        // one, trimmed.
+        let mixed =
+            TestCli::try_parse_from(["dalfox", "https://e.com", "--blind-oob= oast.fun ,,"])
+                .expect("mixed blank/real list");
+        assert_eq!(mixed.scan.blind_oob_servers(), vec!["oast.fun"]);
     }
 
     #[test]

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -597,12 +597,12 @@ pub struct BlindOobArgs {
     #[clap(help_heading = "XSS SCANNING")]
     /// Enable OOB blind XSS via interactsh. Optional comma-separated server
     /// domains (default: public servers). Example: --blind-oob=oast.fun,oast.me
-    ///
-    /// `require_equals` is deliberate: with a bare `num_args = 0..` this option
-    /// would greedily swallow the following positional target
-    /// (`dalfox --blind-oob https://t` would treat `https://t` as a server name
-    /// and leave no scan target). Forcing the `=` form keeps bare `--blind-oob`
-    /// (default mesh) working while never consuming the URL.
+    //
+    // `require_equals` is deliberate (kept out of `--help`): with a bare
+    // `num_args = 0..` this option would greedily swallow the following
+    // positional target (`dalfox --blind-oob https://t` would treat `https://t`
+    // as a server name and leave no scan target). Forcing the `=` form keeps
+    // bare `--blind-oob` (default mesh) working while never consuming the URL.
     #[arg(long = "blind-oob", value_delimiter = ',', num_args = 0.., require_equals = true)]
     pub blind_oob: Option<Vec<String>>,
 

--- a/src/oob/interactsh/mod.rs
+++ b/src/oob/interactsh/mod.rs
@@ -160,8 +160,14 @@ impl InteractshClient {
 
     /// Recover the 13-char nonce from an interaction's `full-id`
     /// (`<corr><nonce>.<server>`), or `None` if it isn't one of ours.
+    ///
+    /// The leftmost label is lowercased before matching: a recursive resolver may
+    /// apply DNS-0x20 case randomization, so a DNS callback's `full-id` can arrive
+    /// as e.g. `AbC...XyZ.oast.fun` even though we minted a lowercase host. Both
+    /// the correlation-id and the nonce alphabet are lowercase, so folding case
+    /// only ever recovers a correlation that would otherwise be missed.
     pub fn extract_nonce(&self, full_id: &str) -> Option<String> {
-        let label = full_id.split('.').next()?;
+        let label = full_id.split('.').next()?.to_ascii_lowercase();
         let rest = label.strip_prefix(&self.correlation_id)?;
         if rest.is_empty() {
             return None;
@@ -322,5 +328,13 @@ mod tests {
             Some(nonce.as_str())
         );
         assert!(client.extract_nonce("someoneelses.oast.fun").is_none());
+
+        // DNS-0x20: a resolver may upper/mixed-case the label; correlation must
+        // still recover the (lowercase) nonce.
+        let shouty = format!("{}{}.OAST.FUN", client.correlation_id(), nonce).to_ascii_uppercase();
+        assert_eq!(
+            client.extract_nonce(&shouty).as_deref(),
+            Some(nonce.as_str())
+        );
     }
 }


### PR DESCRIPTION
## Summary

A detailed review of the recently added `--blind-oob` / `--blind-oob-*` (OAST/interactsh) blind-XSS feature turned up one high-impact CLI bug and two correctness/robustness gaps in the OOB correlation path. This PR fixes all three with regression tests. No behavior change for users who already pass servers via the `=` form.

## 1. `--blind-oob` swallowed the target URL (high impact)

`--blind-oob` was declared with a bare greedy `num_args = 0..` and no `require_equals`. clap then treats it as variadic and **eats the following positional**:

```
dalfox --blind-oob https://target.com      # https://target.com parsed as a SERVER name → targets=[] → scan does nothing
dalfox --blind-oob oast.fun https://target # both parsed as servers → no target
```

Putting flags before the positional URL is extremely common, so this silently broke a very natural invocation.

**Fix:** adopt the exact convention already used by `--insecure` in this codebase — `require_equals = true`. This preserves all three states and never consumes the positional:

| Invocation | Result |
|---|---|
| _(absent)_ | `None` — OOB disabled |
| `--blind-oob` | `Some([])` — enabled, public mesh |
| `--blind-oob=oast.fun,oast.me` | `Some([...])` — enabled, explicit servers |
| `--blind-oob https://t` | OOB on (mesh), **`https://t` kept as the target** |

The only syntax change: explicit servers must use `--blind-oob=a,b` instead of the space form (help text updated accordingly).

## 2. Blank server entries → doomed registration

`blind_oob_servers()` only checked `vec.is_empty()`, so `--blind-oob=`, `--blind-oob=,,`, or stray whitespace yielded a list like `[""]` and the client tried (and failed) to register against an empty host, silently disabling OOB. Entries are now trimmed and blanks dropped, degrading cleanly to the public mesh.

## 3. DNS-0x20 case randomization broke nonce correlation

A recursive resolver may apply [DNS-0x20](https://datatracker.ietf.org/doc/html/draft-vixie-dnsext-dns0x20-00) case randomization, so a DNS callback's `full-id` can arrive as `AbC...XyZ.oast.fun` even though we minted a lowercase host. `extract_nonce()` did a case-sensitive `strip_prefix`, so such callbacks failed to correlate back to their `(target, param, payload)`. It now lowercases the leftmost label first (both the correlation-id and nonce alphabet are lowercase, so this only ever *recovers* a correlation).

## Verification

- Confirmed via the live interactsh source that the client's **AES-256-CTR** + RSA-OAEP(SHA-256) crypto matches the server (no crypto bug — the round-trip test is both self-consistent and server-accurate).
- New tests: `blind_oob_never_swallows_positional_target`, `blind_oob_blank_server_list_falls_back_to_mesh`, plus a mixed-case branch in the `extract_nonce` round-trip test.
- `cargo test --lib` (oob + arg + config groups), `cargo clippy --lib`, and `cargo fmt` all clean.

## Out of scope (noted for follow-up)

`send_blind_request`'s body-param injection uses `data.replace("p=", "p=PAY&")`, which leaves the original value dangling and can substring-match sibling params (`q` matches `qq=`). This is pre-existing in the shared static `-b` path and is left for a separate, dedicated change to avoid touching long-stable code here.
