### PR TITLE
fix(scan): demote inert encoded-echo reflections (server-escaped output)

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -287,6 +287,14 @@ fn is_in_safe_context_decoded(html: &str, payload: &str) -> bool {
     if is_payload_inert_in_scripts(html, payload) {
         return true;
     }
+    // Inert encoded echo: the server escaped its output (percent- or
+    // entity-encoded the reflection) and the encoded bytes are not inside a
+    // URL-valued attribute. The browser renders such text literally, so the
+    // reflection cannot break out. Covers `encoded_url`-style reflections and
+    // double-encoded structural/quote break-out payloads.
+    if is_inert_encoded_reflection(html, payload) {
+        return true;
+    }
     false
 }
 
@@ -329,6 +337,10 @@ const URL_VALUED_ATTRS: &[&[u8]] = &[
     b"profile",
     b"ping",
     b"archive",
+    // Namespaced SVG URL sink: `<a xlink:href>` / `<use xlink:href>` navigate,
+    // so a `javascript:` scheme there executes. Kept consistent with the AST /
+    // DOM-verification sink lists (mining.rs, ast_dom_analysis, check_dom_verification).
+    b"xlink:href",
 ];
 
 /// True when every occurrence of `marker` in `html` sits inside an HTML
@@ -852,6 +864,114 @@ fn url_encoded_payload_reflects_in_unsafe_url_context(html: &str, payload: &str)
         search_start = next_char_boundary(html, abs + 1);
     }
     false
+}
+
+/// Count of HTML break-out characters (`<`, `>`, `"`, `'`) in `s`. Used to
+/// prove a decode actually *un-escaped* structure (so a `+`→space form-decode,
+/// which neutralizes no HTML-active character, is not mistaken for evidence
+/// that the server escaped its output).
+fn structural_char_count(s: &str) -> usize {
+    s.bytes()
+        .filter(|b| matches!(b, b'<' | b'>' | b'"' | b'\''))
+        .count()
+}
+
+/// True when a reflection that `classify_reflection` matched only after
+/// decoding the whole response body is an inert *encoded echo* — the server
+/// escaped its own output and a browser renders the bytes literally, so the
+/// reflection cannot form markup, an attribute break-out, or an executable
+/// scheme.
+///
+/// Scope: this gate only soundly vets payloads that cannot inject an HTML
+/// TAG (no raw `<`/`>` in any variant) — quote / attribute-value / scheme
+/// break-outs. Deciding whether an escaped `<svg…>` echo co-exists with a
+/// *live* `<svg…>` element requires real HTML parsing (a page's own
+/// `<body>`/`<svg>` markup defeats byte heuristics), which is the DOM /
+/// AST-verification path's job, not the raw-byte report gate's.
+///
+/// Within that scope it rejects EVERY way the payload could still be live;
+/// each of the following keeps the finding (returns false): (a) a payload
+/// variant is present RAW (byte-exact) anywhere; (b) any variant carries a raw
+/// `<`/`>` (a tag payload — out of scope, keep); (c) the reflection lands in an
+/// event-handler (`on*=`) attribute value, where the HTML parser decodes
+/// entities before the JS engine runs them; (d) any decoded occurrence sits
+/// inside a URL-valued attribute.
+///
+/// It suppresses ONLY when a variant surfaces via a decode that genuinely
+/// un-escaped a structural character (`<`, `>`, `"`, `'`) — never via a bare
+/// `+`-to-space form-decode that neutralizes nothing.
+fn is_inert_encoded_reflection(html: &str, payload: &str) -> bool {
+    let variants = payload_variants(payload);
+    // (a) A genuine un-escaped reflection (raw variant present) is never an echo.
+    if variants.iter().any(|v| !v.is_empty() && html.contains(v)) {
+        return false;
+    }
+    // (b) Out of scope: any tag-injecting variant (raw `<`/`>`) is left to the
+    //     DOM/AST verification path — a byte gate cannot tell a fully-escaped
+    //     echo apart from a live element the server reflected with edits.
+    if variants.iter().any(|v| v.contains(['<', '>'])) {
+        return false;
+    }
+    // (c) Event-handler (`on*=`) context: the parser decodes entities before the
+    //     JS engine, so an entity-escaped break-out there executes. Keep — this
+    //     mirrors classify_reflection's own unsafe-context carve-out.
+    if html_entity_reflection_in_unsafe_context(html, &variants) {
+        return false;
+    }
+    // Build the decoded views the classifier matches against, keeping only the
+    // ones that actually un-escaped a structural character (real server escaping
+    // — not a `+`→space whitespace substitution).
+    let html_struct = structural_char_count(html);
+    let mut decoded_forms: Vec<String> = Vec::new();
+    let push_if_unescapes = |forms: &mut Vec<String>, d: String| {
+        if structural_char_count(&d) > html_struct {
+            forms.push(d);
+        }
+    };
+    if let Ok(d) = urlencoding::decode(html)
+        && d.as_ref() != html
+    {
+        push_if_unescapes(&mut decoded_forms, d.into_owned());
+    }
+    let html_dec = decode_html_entities(html);
+    if html_dec != html {
+        if let Ok(d) = urlencoding::decode(&html_dec)
+            && d.as_ref() != html_dec.as_str()
+        {
+            push_if_unescapes(&mut decoded_forms, d.into_owned());
+        }
+        push_if_unescapes(&mut decoded_forms, html_dec);
+    }
+    if let Some(f) = decode_form_urlencoded_like(html) {
+        push_if_unescapes(&mut decoded_forms, f);
+    }
+    // The payload must surface in such a decoded view (confirming an encoded
+    // echo) and no decoded occurrence may sit in a URL attribute.
+    let mut surfaced = false;
+    for decoded in &decoded_forms {
+        let bytes = decoded.as_bytes();
+        for v in &variants {
+            if v.is_empty() {
+                continue;
+            }
+            let mut start = 0;
+            let mut scanned = 0usize;
+            while let Some(pos) = decoded[start..].find(v.as_str()) {
+                surfaced = true;
+                scanned += 1;
+                if scanned > MAX_PAYLOAD_OCCURRENCES {
+                    // Couldn't fully vet occurrences — keep the finding.
+                    return false;
+                }
+                let abs = start + pos;
+                if occurrence_is_in_url_attr(bytes, abs) {
+                    return false;
+                }
+                start = next_char_boundary(decoded, abs + 1);
+            }
+        }
+    }
+    surfaced
 }
 
 /// Determine if payload is reflected in any normalization variant.

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -793,6 +793,10 @@ async fn test_check_reflection_suppresses_inert_js_string_apos_reflection() {
 
 #[tokio::test]
 async fn test_check_reflection_detects_url_encoded_response() {
+    // Tag-payload echo (`<div>%3Csvg…%3E</div>`): out of scope for the inert-
+    // encoded-echo report gate (a byte gate can't tell a dead echo from a live
+    // element), so it remains reported. Soundly suppressing this needs the
+    // DOM/AST verification path.
     let payload = "<svg onload=alert(1)>";
     let addr = start_mock_server("stored").await;
     let target = make_target(addr, "/reflect/url-encoded");
@@ -800,7 +804,7 @@ async fn test_check_reflection_detects_url_encoded_response() {
     let args = default_scan_args();
 
     let found = check_reflection(&target, &param, payload, &args).await;
-    assert!(found, "URL-encoded reflection should be detected");
+    assert!(found, "URL-encoded tag reflection should be detected");
 }
 
 #[tokio::test]
@@ -1565,4 +1569,168 @@ fn cooldown_is_capped_and_ignores_non_block_status() {
     for status in [200u16, 301, 404, 500] {
         assert_eq!(waf_block_cooldown_ms(status, 999, true), 0);
     }
+}
+
+// --- Inert encoded-echo report-gate (is_inert_encoded_reflection) ---
+// Suppression cases (server escaped its output) + soundness boundaries that
+// MUST keep the finding (regression guards for the adversarial-review FNs).
+
+#[test]
+fn test_inert_encoded_reflection_url_encoded_quote_in_body() {
+    // Server percent-encodes a quote break-out's `"` into body text:
+    // `<div>Search: %22;alert(1)//</div>`. A browser renders `%22` literally,
+    // so the reflection is inert and suppressed.
+    let payload = "\";alert(1)//";
+    let html = "<div>Search: %22;alert(1)//</div>";
+    assert!(!html.contains(payload), "raw quote payload must not appear");
+    assert!(
+        is_inert_encoded_reflection(html, payload),
+        "percent-encoded quote echo in body must be inert"
+    );
+    assert!(is_in_safe_context_decoded(html, payload));
+}
+
+#[test]
+fn test_inert_encoded_reflection_skips_tag_payloads() {
+    // Out of scope: a tag-injecting payload (raw `<`/`>` in a variant) is left
+    // to the DOM/AST verification path even when fully escaped, because a byte
+    // gate cannot distinguish a dead echo from a live element. Must NOT suppress.
+    let payload = "<svg onload=alert(1) class=dlxtest>";
+    let html = "<div>%3Csvg%20onload%3Dalert%281%29%20class%3Ddlxtest%3E</div>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "tag payloads are out of scope for this gate and must be kept"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_entity_quote_breakout_in_body() {
+    // Quote break-out payload reflected with its `"` entity-encoded into a
+    // search-results body: `Results for: &quot;;alert(1)//`. The browser shows
+    // a literal quote — no attribute/string break-out — so it is inert.
+    let payload = "\";alert(1)//";
+    let html = "<p>Results for: &quot;;alert(1)//</p>";
+    assert!(!html.contains(payload), "raw quote payload must not appear");
+    assert!(
+        is_inert_encoded_reflection(html, payload),
+        "entity-encoded quote break-out in body must be inert"
+    );
+    assert!(is_in_safe_context_decoded(html, payload));
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_raw_breakout() {
+    // The server did NOT escape: the raw payload variant is present in the
+    // body, so this is a genuine reflection and must not be suppressed.
+    let payload = "<svg onload=alert(1)>";
+    let html = "<div><svg onload=alert(1)></div>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "a raw un-escaped reflection is exploitable and must survive"
+    );
+    assert!(!is_in_safe_context_decoded(html, payload));
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_quote_echo_in_url_attr() {
+    // A percent-encoded quote break-out inside an href value — the one context
+    // a browser percent-decodes — must be kept (cond d), unlike the same echo
+    // in body text which is demoted.
+    let payload = "\";alert(1)//";
+    let html = "<a href=\"%22;alert(1)//\">x</a>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "encoded quote echo inside a URL attribute must be kept"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_xlink_href_scheme() {
+    // Regression (review finding E): xlink:href is an exec-capable SVG URL sink.
+    // A percent-encoded javascript: scheme there must be kept, like href.
+    let payload = "javascript:alert(1)";
+    let html = "<svg><a xlink:href=\"javascript%3Aalert%281%29\"><text>x</text></a></svg>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "javascript: scheme inside xlink:href must be kept"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_event_handler_entity_breakout() {
+    // Regression (review finding A): an entity-encoded quote break-out landing
+    // in an on*= handler value. The HTML parser decodes `&#39;`/`&quot;` while
+    // building the handler, so the JS engine sees a live break-out -> executes.
+    let payload = "');alert(1)//";
+    let html = "<div onclick=\"greet('&#39;);alert(1)//')\">click</div>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "entity-encoded break-out in an event-handler attribute must be kept"
+    );
+    let payload2 = "\";alert(1)//";
+    let html2 = "<a onmouseover=\"x=&quot;&quot;;alert(1)//&quot;\">x</a>";
+    assert!(
+        !is_inert_encoded_reflection(html2, payload2),
+        "quot-encoded break-out in onmouseover must be kept"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_live_tag_masked_by_encoded_echo() {
+    // Regression (review finding B): a LIVE element from the payload is present
+    // raw but not byte-exact (server added id=x), while an encoded copy exists
+    // elsewhere. The global "an encoded echo exists" decision must not hide the
+    // live tag — the raw `<svg` opener keeps the finding.
+    let payload = "<svg onload=alert(1)>";
+    let html = "<div><svg id=x onload=alert(1)></div><!-- %3Csvg%20onload%3Dalert(1)%3E -->";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "a live tag (extra attrs) co-existing with an encoded echo must be kept"
+    );
+    // Canonical-link masking: live <img onerror> + encoded copy in <link href>.
+    let p2 = "<img src=x onerror=alert(1)>";
+    let h2 = "<h1><img src=x onerror=alert(1) data-q=1></h1><link rel=canonical href=\"/s?q=%3Cimg%20src%3Dx%20onerror%3Dalert(1)%3E\">";
+    assert!(
+        !is_inert_encoded_reflection(h2, p2),
+        "canonical-link encoded copy must not mask a live onerror reflection"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_case_folded_live_with_echo() {
+    // Regression (review finding C): a case-folded live element (servers that
+    // upper/lower-case markup; tag/attr names are case-insensitive) co-existing
+    // with an encoded copy must be kept. Marker payload so detection is via the
+    // case-fold path.
+    let payload = "<svg onload=alert(1) class=dalfox>";
+    let html = "<div><SVG ONLOAD=alert(1) CLASS=DALFOX></div>--%3Csvg%20onload%3Dalert(1)%20class%3Ddalfox%3E";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "case-folded live tag must be kept despite a co-existing encoded echo"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_plus_only_form_decode_breakout() {
+    // Regression (review finding D): a `+`->space form-decode un-escapes no
+    // HTML-active char, so it is not evidence of server escaping. The raw
+    // `<svg/onload=alert(1)>` (the `/` is a valid attr separator) is live.
+    let payload = "<svg/onload=alert(1)> z";
+    let html = "<div><svg/onload=alert(1)>+z</div>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "a bare +->space form-decode must not suppress a live raw tag"
+    );
+}
+
+#[test]
+fn test_inert_encoded_reflection_keeps_case_folded_reflection_no_echo() {
+    // The original soundness claim: a case-folded reflection matched via the
+    // marker fallback (decoding surfaces nothing) is never an encoded echo.
+    let payload = "<svg onload=alert(1) class=dalfox>";
+    let html = "<div><SVG ONLOAD=alert(1) CLASS=DALFOX></div>";
+    assert!(
+        !is_inert_encoded_reflection(html, payload),
+        "case-folded live reflection must not be suppressed"
+    );
 }


### PR DESCRIPTION
## What

Improves **reflected-XSS precision** by demoting *inert encoded-echo* reflections — cases where the server escaped its own output (percent/HTML-entity encoded the reflected value) so a browser renders the bytes literally and nothing can break out. Such an echo currently surfaces as a finding even though it is not exploitable.

A new helper `is_inert_encoded_reflection` is added to the report-level exploitability gate `is_in_safe_context_decoded` (which runs after `classify_reflection` and demotes a match to `None`). It suppresses a reflection only when the payload surfaces **solely** by decoding the whole response (the raw bytes are the server's escaped output), the decode genuinely un-escaped a structural character, and the reflection is in an inert context.

Also adds `xlink:href` to `URL_VALUED_ATTRS` — an exec-capable SVG URL sink already recognized by the AST and DOM-verification sink lists, but missing from this list — so a `javascript:` scheme echo there is kept consistently with `href`.

DOM-XSS paths are untouched (separate PR).

## Scope (deliberately narrow, for soundness)

The gate only vets payloads that **cannot inject an HTML tag** (no raw `<`/`>` in any reflection variant) — quote / attribute-value / scheme break-outs.

Soundly deciding whether an escaped `<svg…>` echo co-exists with a **live** `<svg…>` element requires real HTML parsing (a page's own `<body>`/`<svg>` markup defeats byte-level heuristics). That is the DOM / AST-verification path's job, not the raw-byte report gate's, so tag-payload echoes are left as-is.

## Soundness — every "still live" path keeps the finding

Each of these returns `false` (keep), so the gate can never hide a real reflection within its scope:

- a payload variant is present **raw** (byte-exact) anywhere;
- any variant carries a raw `<`/`>` (a tag payload — out of scope);
- the reflection lands in an **event-handler** (`on*=`) value, where the HTML parser decodes entities before the JS engine runs them;
- any decoded occurrence sits inside a **URL-valued attribute** (incl. `xlink:href`).

It suppresses only when a decode actually un-escaped a structural character (`<` `>` `"` `'`) — never a bare `+`→space form-decode that neutralizes nothing.

This boundary was hardened in response to an **adversarial review of the change**: an initial broader version was shown to have false negatives (entity break-outs in `on*=` handlers; a live tag with server-added attributes / case-folding masked by an encoded echo elsewhere). The gate was restricted and re-reviewed; a focused FN-hunt (multiple independent agents constructing in-scope `(html, payload)` cases and tracing them through the code) found **no remaining false negatives**. Each FN class is pinned by a regression test.

## Tests

New unit tests in `check_reflection/tests.rs`:

- suppression: percent-/entity-encoded quote echo in body context;
- keep (regression guards): raw break-out present, `xlink:href` scheme, event-handler entity break-out, live tag masked by an encoded echo, case-folded live reflection, `+`-only form-decode, tag payloads (out of scope), encoded echo inside a URL attribute.

`cargo test --lib` (1729 passing) · `cargo clippy --lib` clean · `cargo fmt --check` clean.

## Notes

- FN reduction was investigated too: dalfox's reflected false-negative rate is already strong on the mock corpus — the apparent FNs there are corpus mislabels (server fully-encodes the output → correctly skipped) or fixture artifacts (one JS-string-context case emits literal double-brace `{{…}}` = unparseable JS; the realistic single-brace form is detected). No risky FN change was made.
- The remaining mock-corpus reflected FPs are predominantly corpus mislabels where dalfox is correct (e.g. `javascript:` in a real `href`, attribute break-outs `strip_tags` does not stop, WAF-sim regex gaps), or tag-payload echoes deferred to the DOM/verification path as noted above.
