### PR TITLE
chore(ci): include bots in CONTRIBUTORS.svg

### DIFF
--- a/.github/workflows/ci-contributors.yml
+++ b/.github/workflows/ci-contributors.yml
@@ -23,7 +23,7 @@ jobs:
         with:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           round: false
-          includeBots: false
+          includeBots: true
           svgPath: docs/static/images/CONTRIBUTORS.svg
           noCommit: true
       - uses: peter-evans/create-pull-request@v8.1.1


### PR DESCRIPTION
## Summary
`docs/static/images/CONTRIBUTORS.svg` was missing several accounts that show prominently on GitHub's contributor graph — `dependabot[bot]` (2nd), `Copilot` (3rd), `github-actions[bot]`, `google-labs-jules[bot]`, `dependabot-preview[bot]`.

Root cause: `includeBots: false` in the workflow drops every account whose GitHub type is `Bot`. (Note: `renovate-bot`/`ImgBotApp`/`n00b-bot` are type `User`, so they were already kept — the filter is by account type, not name.)

This flips it to `includeBots: true`, so the SVG grows from 31 → 36 entries on the next run.

## Note
The SVG itself updates only when the `Contributors` workflow runs (weekly cron, or `workflow_dispatch`). After merge, trigger it manually to regenerate immediately.