### PR TITLE
refactor(scanner): align OOB/blind output with log format, demote TLS warning to debug

### DIFF
--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -318,24 +318,22 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Per-target tracking for structured output (target_summary in JSON envelope)
     // Collect all target URLs that will be scanned, then track status per target.
     let all_target_urls: Vec<String> = parsed_targets.iter().map(|t| t.url.to_string()).collect();
-    // One-shot insecure-mode warning. By default dalfox builds its HTTP client
-    // with `danger_accept_invalid_certs(true)` (the `--insecure` flag, on by
+    // Insecure-mode diagnostic. By default dalfox builds its HTTP client with
+    // `danger_accept_invalid_certs(true)` (the `--insecure` flag, on by
     // default) so self-signed / expired / hostname-mismatch certs are silently
-    // trusted. That is intentional for a scanner but ops triaging a MITM
-    // scenario need a signal — print one warning per scan when any https://
-    // target is present AND insecure mode is active. When the operator opts
-    // into validation (`--insecure=false`), no warning is emitted.
-    // Security note must reach the operator even with `--silence` —
-    // silencing is for stdout, this is stderr and tells them about a
-    // deliberate but consequential TLS posture.
+    // trusted. That is intentional for a scanner and already documented on the
+    // flag, so warning on every https scan was just noise — the default posture
+    // isn't news. Operators triaging a MITM/TLS scenario can still surface it
+    // with `--debug`, where it lands as a DBG line for any https target in
+    // insecure mode. When validation is opted into (`--insecure=false`), nothing
+    // is emitted. `log_dbg` ignores `--silence` (it gates on `--debug` only), so
+    // a deliberately-quiet scan still shows it under debug.
     if args.insecure.unwrap_or(true)
         && parsed_targets
             .iter()
             .any(|t| t.url.scheme().eq_ignore_ascii_case("https"))
     {
-        eprintln!(
-            "Warning: TLS certificate validation is disabled (--insecure, on by default); self-signed, expired, or hostname-mismatched certs will be silently trusted. Use --insecure=false to enforce validation."
-        );
+        log_dbg("TLS validation disabled (--insecure default); use --insecure=false to enforce");
     }
     // Track targets that were skipped during preflight (content-type mismatch etc.)
     // Map of skipped target URL -> error code explaining why it was skipped.
@@ -465,40 +463,39 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // whichever channel(s) are configured; the OOB poller is spawned once
     // `stream_findings_enabled` is known (below) and drained before rendering.
     let blind_active = !args.dry_run && !args.only_discovery;
-    let oob_session: Option<Arc<crate::oob::OobSession>> = if blind_active
-        && args.blind_oob_enabled()
-    {
-        match crate::oob::OobSession::start(&args.oob_config()).await {
-            Ok(session) => {
-                if !args.silence && args.format == "plain" {
-                    println!(
-                        "OOB blind XSS armed via interactsh server: {}",
-                        session.server_domain()
+    let oob_session: Option<Arc<crate::oob::OobSession>> =
+        if blind_active && args.blind_oob_enabled() {
+            match crate::oob::OobSession::start(&args.oob_config()).await {
+                Ok(session) => {
+                    log_info(
+                        args,
+                        &format!(
+                            "OOB blind XSS armed via interactsh server: {}",
+                            session.server_domain()
+                        ),
                     );
+                    Some(Arc::new(session))
                 }
-                Some(Arc::new(session))
-            }
-            Err(e) => {
-                if !args.silence {
-                    eprintln!(
-                        "Warning: --blind-oob disabled (could not register with any server): {e}"
+                Err(e) => {
+                    log_warn(
+                        args,
+                        &format!("--blind-oob disabled (could not register with any server): {e}"),
                     );
+                    None
                 }
-                None
             }
-        }
-    } else {
-        None
-    };
+        } else {
+            None
+        };
 
     if blind_active && (args.blind_callback_url.is_some() || oob_session.is_some()) {
-        if let Some(callback_url) = &args.blind_callback_url
-            && !args.silence
-            && args.format == "plain"
-        {
-            println!(
-                "Performing blind XSS scanning with callback URL: {}",
-                callback_url
+        if let Some(callback_url) = &args.blind_callback_url {
+            log_info(
+                args,
+                &format!(
+                    "Performing blind XSS scanning with callback URL: {}",
+                    callback_url
+                ),
             );
         }
         let custom = args.custom_blind_xss_payload.as_deref();
@@ -573,8 +570,11 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // `state.results` before rendering below.
     if let Some(poller) = oob_poller {
         let wait = Duration::from_secs(args.blind_oob_wait());
-        if !args.silence && args.format == "plain" && wait.as_secs() > 0 {
-            println!("Waiting up to {}s for OOB callbacks...", wait.as_secs());
+        if wait.as_secs() > 0 {
+            log_info(
+                args,
+                &format!("Waiting up to {}s for OOB callbacks...", wait.as_secs()),
+            );
         }
         poller.finish(wait).await;
     }

--- a/src/oob/poller.rs
+++ b/src/oob/poller.rs
@@ -133,7 +133,7 @@ async fn poll_once(
         }
         let record = session.registry().lookup(&nonce);
         if !silence {
-            eprintln!("{}", live_line(&it, record.as_ref()));
+            crate::ceprintln!("{}", live_line(&it, record.as_ref()));
         }
         batch.push(build_finding(&it, record.as_ref(), session.server_domain()));
     }
@@ -146,16 +146,21 @@ async fn poll_once(
 }
 
 /// One-line stderr notice when a callback lands (kept off stdout so JSON/SARIF
-/// output stays clean).
+/// output stays clean). Formatted like the rest of dalfox's plain log lines —
+/// gray `{ts}` + a red `OOB` level token (a fired blind callback is a Verified
+/// finding) — and routed through `ceprintln!` so the ANSI is stripped under
+/// `--no-color` / `NO_COLOR`.
 fn live_line(it: &OobInteraction, record: Option<&InjectionRecord>) -> String {
     let proto = if it.protocol.is_empty() {
         "oob"
     } else {
         &it.protocol
     };
+    let ts = chrono::Local::now().format("%-I:%M%p").to_string();
     match record {
         Some(r) => format!(
-            "[OOB] {} callback: param '{}' ({}) on {} — payload {}",
+            "\x1b[90m{}\x1b[0m \x1b[31mOOB\x1b[0m {} callback: param '{}' ({}) on {} — payload {}",
+            ts,
             proto,
             r.param,
             if r.location.is_empty() {
@@ -167,8 +172,8 @@ fn live_line(it: &OobInteraction, record: Option<&InjectionRecord>) -> String {
             r.payload,
         ),
         None => format!(
-            "[OOB] {} callback to {} (no correlated payload)",
-            proto, it.full_id
+            "\x1b[90m{}\x1b[0m \x1b[31mOOB\x1b[0m {} callback to {} (no correlated payload)",
+            ts, proto, it.full_id
         ),
     }
 }


### PR DESCRIPTION
## Summary

Cleans up two logging inconsistencies in the scan path.

### 1. OOB / Blind XSS output now matches the dalfox log format

Plain-mode OOB/blind lifecycle messages were raw `println!`/`eprintln!` with no timestamp or level, so they broke the `{ts} INF/WAF` log stream:

**Before**
```
OOB blind XSS armed via interactsh server: oast.me
11:24AM INF start scan to https://www.hahwul.com/
```
**After**
```
11:24AM INF OOB blind XSS armed via interactsh server: oast.me
11:24AM INF start scan to https://www.hahwul.com/
```

| Message | Change |
|---|---|
| `OOB blind XSS armed ...` | → `log_info` (`INF`) |
| `Performing blind XSS scanning with callback URL: ...` | → `log_info` (`INF`) |
| `Waiting up to Ns for OOB callbacks...` | → `log_info` (`INF`) |
| `Warning: --blind-oob disabled ...` | → `log_warn` (`WRN`) |
| poller callback notice `[OOB] http callback: ...` | → `{ts} OOB ...` (red level token, matching Verified-finding color) |

The poller callback notice stays on **stderr** (keeps JSON/SARIF stdout clean) but now goes through `ceprintln!` so ANSI is stripped under `--no-color`/`NO_COLOR`.

### 2. TLS-insecure warning demoted to `--debug`-only

The startup warning fired a verbose multi-clause `eprintln!` on every https scan. Since `--insecure` is the documented default, that posture isn't news — it was just noise. It's now a concise `--debug`-only DBG line:
```
11:24AM DBG TLS validation disabled (--insecure default); use --insecure=false to enforce
```
`log_dbg` gates on `--debug` (ignoring `--silence`), so operators triaging a MITM/TLS scenario can still surface it.

## Behavior note

The `--blind-oob` registration-failure warning is now **plain-only** (was all-format stderr), symmetric with the plain-only "armed" success line. JSON/SARIF consumers no longer see this soft-fail diagnostic on stderr.

## Testing

- `cargo build` / `cargo clippy` clean
- `cargo test --lib oob` (12) + `cargo test --lib cmd::scan` (150) pass
- No test depended on the changed strings