### PR TITLE
refactor(logging): unify debug logging into a single stderr `dbg_log!` macro

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -89,9 +89,7 @@ fn fetch_and_print_remote(provider: &str) -> bool {
                         for p in list.iter() {
                             println!("{}", p);
                         }
-                        if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                            eprintln!("[DBG] {}: {} payloads", provider, count);
-                        }
+                        crate::dbg_log!("{}: {} payloads", provider, count);
                         ok_clone.store(true, std::sync::atomic::Ordering::Relaxed);
                     } else {
                         eprintln!(
@@ -121,9 +119,7 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
             for ev in list.iter() {
                 println!("{}", ev);
             }
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!("[DBG] event-handlers: {} items", list.len());
-            }
+            crate::dbg_log!("event-handlers: {} items", list.len());
             ScanOutcome::Clean
         }
         Some("useful-tags") => {
@@ -131,9 +127,7 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
             for t in list.iter() {
                 println!("{}", t);
             }
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!("[DBG] useful-tags: {} items", list.len());
-            }
+            crate::dbg_log!("useful-tags: {} items", list.len());
             ScanOutcome::Clean
         }
         Some("payloadbox") => {
@@ -155,9 +149,7 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
             for payload in list {
                 println!("{}", payload);
             }
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!("[DBG] uri-scheme: {} payloads", list.len());
-            }
+            crate::dbg_log!("uri-scheme: {} payloads", list.len());
             ScanOutcome::Clean
         }
         Some(other) => {

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -6,7 +6,7 @@
 
 use super::ScanState;
 use super::args::ScanArgs;
-use super::logging::{log_dbg, start_spinner};
+use super::logging::start_spinner;
 use super::preflight::{PreflightOutcome, is_allowed_content_type, preflight_content_type};
 use crate::parameter_analysis::analyze_parameters;
 use crate::target_parser::Target;
@@ -652,7 +652,7 @@ pub(crate) async fn run_preflight_and_analysis(
                             );
                         }
                         if args_clone.format == "plain" && !args_clone.silence {
-                            log_dbg(&format!("{} test cases (reqs) estimated", total));
+                            crate::dbg_log!("{} test cases (reqs) estimated", total);
                         }
                     }
                 }

--- a/src/cmd/scan/logging.rs
+++ b/src/cmd/scan/logging.rs
@@ -4,7 +4,6 @@
 
 use super::args::ScanArgs;
 use std::io::{self, Write};
-use std::sync::atomic::Ordering;
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -26,14 +25,6 @@ pub(crate) fn log_warn(args: &ScanArgs, msg: &str) {
     if args.format == "plain" && !args.silence {
         let ts = chrono::Local::now().format("%-I:%M%p").to_string();
         crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[33mWRN\x1b[0m {}", ts, msg);
-    }
-}
-
-/// DBG log line, gated on the global `--debug` flag (independent of format).
-pub(crate) fn log_dbg(msg: &str) {
-    if crate::DEBUG.load(Ordering::Relaxed) {
-        let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-        crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[35mDBG\x1b[0m {}", ts, msg);
     }
 }
 

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -47,7 +47,7 @@ pub use args::{
     DEFAULT_RATE_LIMIT, DEFAULT_RETRIES, DEFAULT_RETRY_DELAY_MS, DEFAULT_TIMEOUT_SECS,
     DEFAULT_WAF_MIN_CONFIDENCE, DEFAULT_WORKERS, PreflightOptions, ScanArgs,
 };
-pub(crate) use logging::{log_dbg, log_info, log_warn};
+pub(crate) use logging::{log_info, log_warn};
 pub(crate) use validation::validate_numeric_args;
 
 static GLOBAL_ENCODERS: OnceLock<Vec<String>> = OnceLock::new();
@@ -326,14 +326,17 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // isn't news. Operators triaging a MITM/TLS scenario can still surface it
     // with `--debug`, where it lands as a DBG line for any https target in
     // insecure mode. When validation is opted into (`--insecure=false`), nothing
-    // is emitted. `log_dbg` ignores `--silence` (it gates on `--debug` only), so
-    // a deliberately-quiet scan still shows it under debug.
+    // is emitted. `dbg_log!` ignores `--silence` (it gates on `--debug` only) and
+    // writes to stderr, so a deliberately-quiet or JSON scan still shows it under
+    // debug without polluting structured stdout.
     if args.insecure.unwrap_or(true)
         && parsed_targets
             .iter()
             .any(|t| t.url.scheme().eq_ignore_ascii_case("https"))
     {
-        log_dbg("TLS validation disabled (--insecure default); use --insecure=false to enforce");
+        crate::dbg_log!(
+            "TLS validation disabled (--insecure default); use --insecure=false to enforce"
+        );
     }
     // Track targets that were skipped during preflight (content-type mismatch etc.)
     // Map of skipped target URL -> error code explaining why it was skipped.
@@ -608,12 +611,10 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
             args,
             &format!("scan completed in {:.3} seconds", __dalfox_elapsed),
         );
-        if crate::DEBUG.load(Ordering::Relaxed) {
-            log_dbg(&format!(
-                "{} test cases (reqs) sent",
-                crate::REQUEST_COUNT.load(Ordering::Relaxed)
-            ));
-        }
+        crate::dbg_log!(
+            "{} test cases (reqs) sent",
+            crate::REQUEST_COUNT.load(Ordering::Relaxed)
+        );
     }
 
     // A scan where every supplied target failed reachability checks

--- a/src/cmd/scan/preflight.rs
+++ b/src/cmd/scan/preflight.rs
@@ -139,12 +139,11 @@ pub(crate) async fn preflight_content_type(
     let client = match target.build_client() {
         Ok(c) => c,
         Err(e) => {
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!(
-                    "[DBG] preflight: failed to build HTTP client for {}: {}",
-                    target.url, e
-                );
-            }
+            crate::dbg_log!(
+                "preflight: failed to build HTTP client for {}: {}",
+                target.url,
+                e
+            );
             return PreflightOutcome::Unreachable(crate::cmd::error_codes::CONNECTION_FAILED);
         }
     };
@@ -172,14 +171,12 @@ pub(crate) async fn preflight_content_type(
             Err(e) => {
                 let transient = e.is_connect() || e.is_timeout();
                 if transient && attempt < PREFLIGHT_MAX_ATTEMPTS {
-                    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                        eprintln!(
-                            "[DBG] preflight transient {} (attempt {}): {} — retrying",
-                            describe_reqwest_failure(&e),
-                            attempt,
-                            target.url
-                        );
-                    }
+                    crate::dbg_log!(
+                        "preflight transient {} (attempt {}): {} — retrying",
+                        describe_reqwest_failure(&e),
+                        attempt,
+                        target.url
+                    );
                     tokio::time::sleep(Duration::from_millis(PREFLIGHT_RETRY_BACKOFF_MS)).await;
                     continue;
                 }
@@ -188,9 +185,7 @@ pub(crate) async fn preflight_content_type(
                 // distinguish a quiet scan from an unreachable target. Suppressed
                 // when --silence is on; the debug channel always carries it.
                 let reason = describe_reqwest_failure(&e);
-                if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                    eprintln!("[DBG] preflight unreachable: {} ({})", target.url, reason);
-                }
+                crate::dbg_log!("preflight unreachable: {} ({})", target.url, reason);
                 if !args.silence {
                     let ts = chrono::Local::now().format("%-I:%M%p").to_string();
                     crate::ceprintln!(

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -1,4 +1,4 @@
-use super::logging::{log_dbg, log_info, log_warn, start_spinner};
+use super::logging::{log_info, log_warn, start_spinner};
 use super::output::{render_dry_run, render_only_discovery, render_results};
 use super::poc::{build_ast_dom_message, generate_poc, render_finding_block};
 use super::postprocess::{dedupe_ast_results, extract_context};
@@ -1454,9 +1454,9 @@ fn test_log_helpers_emit_in_plain_mode() {
     args.silence = false;
     log_info(&args, "info line");
     log_warn(&args, "warn line");
-    // log_dbg is gated on the global DEBUG flag, which defaults to off here;
-    // calling it exercises the early-return branch without touching globals.
-    log_dbg("debug line");
+    // dbg_log! is gated on the global DEBUG flag, which defaults to off here;
+    // invoking it exercises the gate without touching globals (no stderr output).
+    crate::dbg_log!("debug line");
 }
 
 #[test]

--- a/src/oob/poller.rs
+++ b/src/oob/poller.rs
@@ -112,9 +112,7 @@ async fn poll_once(
     let interactions = match session.poll().await {
         Ok(v) => v,
         Err(e) => {
-            if crate::DEBUG.load(Ordering::Relaxed) {
-                eprintln!("[DBG] OOB poll failed: {e}");
-            }
+            crate::dbg_log!("OOB poll failed: {e}");
             return;
         }
     };

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -780,12 +780,10 @@ pub async fn check_header_discovery(
         // because the operator explicitly asked for them.
         let blanket_echo = detect_blanket_header_echo(target).await;
         if blanket_echo {
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!(
-                    "[DBG] blanket header echo detected (guard reflected); skipping {} common header probes",
-                    COMMON_PROBE_HEADERS.len()
-                );
-            }
+            crate::dbg_log!(
+                "blanket header echo detected (guard reflected); skipping {} common header probes",
+                COMMON_PROBE_HEADERS.len()
+            );
         } else {
             for &hdr in COMMON_PROBE_HEADERS {
                 if existing_names.insert(hdr.to_ascii_lowercase()) {

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -523,9 +523,7 @@ async fn send_probe_request_for_param(
     let body_text = match crate::utils::http::read_body(resp).await {
         Ok(body) => Some(body),
         Err(e) => {
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!("[DBG] discovery response body read failed: {}", e);
-            }
+            crate::dbg_log!("discovery response body read failed: {}", e);
             None
         }
     };

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1580,12 +1580,11 @@ async fn fetch_injection_response_with_client(
                     .and_then(|v| v.to_str().ok())
                     .unwrap_or("");
                 if crate::utils::content_type_is_inert_data(ct) {
-                    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                        eprintln!(
-                            "[DBG] suppressing reflection on inert-data content-type (param={}, content-type={})",
-                            param.name, ct
-                        );
-                    }
+                    crate::dbg_log!(
+                        "suppressing reflection on inert-data content-type (param={}, content-type={})",
+                        param.name,
+                        ct
+                    );
                     return None;
                 }
             }
@@ -1598,12 +1597,11 @@ async fn fetch_injection_response_with_client(
             //     browsers render it as data, not markup.
             if matches!(param.location, Location::Path) {
                 if (300..400).contains(&status_code) {
-                    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                        eprintln!(
-                            "[DBG] suppressing path reflection on 3xx redirect (param={}, status={})",
-                            param.name, status_code
-                        );
-                    }
+                    crate::dbg_log!(
+                        "suppressing path reflection on 3xx redirect (param={}, status={})",
+                        param.name,
+                        status_code
+                    );
                     return None;
                 }
                 let ct = resp
@@ -1619,12 +1617,11 @@ async fn fetch_injection_response_with_client(
                 let executes_as_markup = crate::utils::is_htmlish_content_type(ct)
                     || crate::utils::content_type_primary(ct).as_deref() == Some("image/svg+xml");
                 if !ct.is_empty() && !executes_as_markup {
-                    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                        eprintln!(
-                            "[DBG] suppressing path-injection reflection on non-HTML content-type (param={}, content-type={})",
-                            param.name, ct
-                        );
-                    }
+                    crate::dbg_log!(
+                        "suppressing path-injection reflection on non-HTML content-type (param={}, content-type={})",
+                        param.name,
+                        ct
+                    );
                     return None;
                 }
             }
@@ -1666,23 +1663,21 @@ async fn fetch_injection_response_with_client(
                         &body,
                         payload,
                     ) {
-                        if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                            eprintln!(
-                                "[DBG] suppressing url-echo-only path reflection (param={}, status={})",
-                                param.name, status_code
-                            );
-                        }
+                        crate::dbg_log!(
+                            "suppressing url-echo-only path reflection (param={}, status={})",
+                            param.name,
+                            status_code
+                        );
                         return None;
                     }
                     Some(body)
                 }
                 Err(e) => {
-                    if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                        eprintln!(
-                            "[DBG] reflection response body read failed (param={}): {}",
-                            param.name, e
-                        );
-                    }
+                    crate::dbg_log!(
+                        "reflection response body read failed (param={}): {}",
+                        param.name,
+                        e
+                    );
                     None
                 }
             }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1140,11 +1140,9 @@ fn generate_param_jobs(
             dom_payloads = prune_blocked_raw_angles(dom_payloads, invalid);
             reflection_payloads = hoist_angle_free_payloads(reflection_payloads, invalid);
             dom_payloads = hoist_angle_free_payloads(dom_payloads, invalid);
-            if crate::DEBUG.load(Ordering::Relaxed)
-                && (refl_before != reflection_payloads.len() || dom_before != dom_payloads.len())
-            {
-                eprintln!(
-                    "[DBG] adaptive prune (param={}): reflection {}→{}, dom {}→{} (invalid_specials={:?})",
+            if refl_before != reflection_payloads.len() || dom_before != dom_payloads.len() {
+                crate::dbg_log!(
+                    "adaptive prune (param={}): reflection {}→{}, dom {}→{} (invalid_specials={:?})",
                     param.name,
                     refl_before,
                     reflection_payloads.len(),

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -311,12 +311,12 @@ async fn send_blind_request(target: &Target, param_name: &str, payload: &str, pa
     // out-of-band), but surface transport errors at DEBUG so users can tell a
     // delivery failure apart from a target that simply never calls back.
     crate::record_outbound_request().await;
-    if let Err(e) = request.send().await
-        && crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed)
-    {
-        eprintln!(
-            "[DBG] blind request failed param={} type={}: {}",
-            param_name, param_type, e
+    if let Err(e) = request.send().await {
+        crate::dbg_log!(
+            "blind request failed param={} type={}: {}",
+            param_name,
+            param_type,
+            e
         );
     }
 
@@ -508,12 +508,12 @@ pub async fn blind_scan_forms_with(
                 request = request.body(body);
 
                 crate::record_outbound_request().await;
-                if let Err(e) = request.send().await
-                    && crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed)
-                {
-                    eprintln!(
-                        "[DBG] blind form request failed action={} field_idx={}: {}",
-                        action, field_idx, e
+                if let Err(e) = request.send().await {
+                    crate::dbg_log!(
+                        "blind form request failed action={} field_idx={}: {}",
+                        action,
+                        field_idx,
+                        e
                     );
                 }
 

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -1,0 +1,38 @@
+//! Crate-wide debug logging.
+//!
+//! [`dbg_log!`](crate::dbg_log) is the single entry point for `--debug`
+//! diagnostics. It supersedes the ad-hoc
+//! `if crate::DEBUG.load(..) { eprintln!("[DBG] ..") }` pattern that was
+//! duplicated ~20 times across the scanner, each with a hand-written `[DBG]`
+//! prefix and no timestamp.
+//!
+//! Three properties make it the right default over a plain `eprintln!`:
+//! - **stderr only** — structured stdout (JSON / JSONL / SARIF) is never
+//!   polluted, even under `--debug`. The old per-site `eprintln!`s already did
+//!   this; the short-lived `log_dbg` helper (stdout via `cprintln!`) did not.
+//! - **lazy** — the message is only formatted when `--debug` is active, so the
+//!   macro is cheap to leave in hot per-request paths (reflection / scanning).
+//! - **on-format** — renders in dalfox's `{ts} DBG <msg>` log style, matching
+//!   the `INF` / `WRN` / `WAF` lines, with ANSI stripped under `--no-color`.
+
+/// Emit a `{ts} DBG <msg>` line on stderr when `--debug` (`crate::DEBUG`) is
+/// set. Takes the same arguments as [`format!`]; the message is only built when
+/// debug is active. ANSI is stripped under `--no-color` / `NO_COLOR` because it
+/// routes through [`ceprintln!`](crate::ceprintln).
+///
+/// ```ignore
+/// dbg_log!("preflight unreachable: {} ({})", url, reason);
+/// ```
+#[macro_export]
+macro_rules! dbg_log {
+    ($($arg:tt)*) => {{
+        if $crate::DEBUG.load(::std::sync::atomic::Ordering::Relaxed) {
+            let __ts = ::chrono::Local::now().format("%-I:%M%p").to_string();
+            $crate::ceprintln!(
+                "\x1b[90m{}\x1b[0m \x1b[35mDBG\x1b[0m {}",
+                __ts,
+                ::std::format!($($arg)*)
+            );
+        }
+    }};
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -8,6 +8,7 @@ This module re-exports commonly used helpers so other modules can simply
 pub mod banner;
 pub mod fs;
 pub mod http;
+pub mod log;
 pub mod rate_limit;
 pub mod scan_id;
 pub mod shimmer;

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -283,9 +283,7 @@ pub async fn fingerprint_with_probe(
     let resp = match rb.send().await {
         Ok(r) => r,
         Err(e) => {
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
-                eprintln!("[DBG] waf probe network error for {}: {}", target.url, e);
-            }
+            crate::dbg_log!("waf probe network error for {}: {}", target.url, e);
             return WafDetectionResult::default();
         }
     };


### PR DESCRIPTION
## Summary

Follow-up to #1144. Debug logging was split two ways:

- **~19 sites** hand-rolled `if crate::DEBUG.load(..) { eprintln!("[DBG] ..") }` — stderr, no timestamp, repeated boilerplate.
- The short-lived `log_dbg` helper rendered `{ts} DBG` but routed through `cprintln!` → **stdout**.

The `log_dbg`-on-stdout routing is a footgun: any unguarded call under `--debug` interleaves a DBG line into **JSON / JSONL / SARIF** output on stdout. The v3.1 TLS-insecure diagnostic (added in #1144) was exactly such an unguarded site.

## Change

New `crate::dbg_log!` macro (`src/utils/log.rs`):
- gates on `crate::DEBUG`
- writes to **stderr** via `ceprintln!` → structured stdout never polluted, ANSI stripped under `--no-color`/`NO_COLOR`
- renders the `{ts} DBG <msg>` format (matches `INF`/`WRN`/`WAF`)
- **lazy** — message only formatted when `--debug` is active, so it's cheap in hot per-request paths (reflection/scanning) where a `fn(&format!(..))` would always allocate

Then:
- Migrated all `[DBG]` eprintln sites (payload, preflight, discovery, parameter_analysis, oob poller, xss_blind, check_reflection, scanning, waf) → `dbg_log!`, dropping the per-site DEBUG guard + `[DBG]` prefix.
- Removed `log_dbg` from `cmd::scan::logging`; its callers (TLS diagnostic, reqs sent/estimated) now use `dbg_log!`.

## Verification

```
$ dalfox url --url https://example.com --dry-run --format json --debug
# stdout: valid JSON, 0 DBG lines
# stderr: "1:17PM DBG TLS validation disabled (--insecure default); use --insecure=false to enforce"
$ NO_COLOR=1 … --debug   # stderr DBG line has no ANSI
```

- `cargo clippy --all-targets` clean (no unused `Ordering` imports)
- `cargo test --lib` — 1756 pass