### PR TITLE
ci(contributors): exclude bot accounts from CONTRIBUTORS.svg

### DIFF
--- a/.github/workflows/ci-contributors.yml
+++ b/.github/workflows/ci-contributors.yml
@@ -24,6 +24,7 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           round: false
           includeBots: true
+          excludeUsers: dependabot[bot],github-actions[bot],Copilot
           svgPath: docs/static/images/CONTRIBUTORS.svg
           noCommit: true
       - uses: peter-evans/create-pull-request@v8.1.1


### PR DESCRIPTION
## What

Add `excludeUsers` to the `wow-actions/contributors-list` step in the Contributors workflow to keep automation bots out of the generated `CONTRIBUTORS.svg`:

- `dependabot[bot]`
- `github-actions[bot]`
- `Copilot`

## Why

`includeBots: true` (added in #1142) pulls every bot into the contributors image, including automation accounts that aren't really contributors. `excludeUsers` filters out those specific accounts while still allowing other legitimate bot contributors.

## Notes

- `includeBots: true` is intentionally kept — only the three named accounts are excluded. If we ever want to drop *all* bots, switching to `includeBots: false` would be simpler.
- `excludeUsers` reference: https://github.com/wow-actions/contributors-list