### PR TITLE
refactor(logging): route server/MCP bypass sites through their structured loggers

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -78,7 +78,10 @@ where
             {
                 Ok(rt) => *slot = Some(rt),
                 Err(e) => {
-                    eprintln!("[MCP][ERR] runtime build failed for tag={}: {}", tag, e);
+                    DalfoxMcp::log(
+                        "ERR",
+                        &format!("runtime build failed for tag={}: {}", tag, e),
+                    );
                     return None;
                 }
             }
@@ -214,6 +217,11 @@ impl DalfoxMcp {
     }
 
     fn log(level: &str, msg: &str) {
+        // MCP speaks JSON-RPC over stdout, so every diagnostic goes to stderr.
+        // Sanitize first: messages embed attacker-supplied bytes (scan target
+        // URLs, error/panic strings), and a raw CR/LF would let a submitter
+        // forge a fabricated `[ts] [LVL] ...` line on the operator's console.
+        let msg = crate::utils::log::sanitize_log_message(msg);
         let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S");
         eprintln!("[{}] [{}] {}", ts, level, msg);
     }
@@ -1242,7 +1250,7 @@ Final results (via get_results_dalfox) include finding type \
                     "unknown panic payload".to_string()
                 };
                 let msg = format!("scan task panicked: {}", payload);
-                eprintln!("[MCP][ERR] {} scan_id={}", msg, sid_for_recovery);
+                Self::log("ERR", &format!("{} scan_id={}", msg, sid_for_recovery));
                 mark_job_error_sync(&jobs_for_recovery, &sid_for_recovery, msg);
             }
         });

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -26,7 +26,7 @@ pub(crate) fn spawn_scan_task(
             Ok(r) => r,
             Err(e) => {
                 let msg = format!("scan runtime build failed: {}", e);
-                eprintln!("[server] {} for job {}", msg, job_id);
+                log(&state, "ERR", &format!("{} for job {}", msg, job_id));
                 fail_job_via_fresh_runtime(&state, &job_id, &url, msg);
                 return;
             }
@@ -57,7 +57,11 @@ pub(crate) fn spawn_scan_task(
                 "unknown panic payload".to_string()
             };
             let msg = format!("scan task panicked: {}", payload);
-            eprintln!("[server] {} (job_id={})", msg, job_id_for_recovery);
+            log(
+                &state_for_recovery,
+                "ERR",
+                &format!("{} (job_id={})", msg, job_id_for_recovery),
+            );
             // The scan runtime itself is still valid after a panic inside the
             // future, so reuse it for the recovery write rather than spinning
             // up a second runtime just to update one map entry.
@@ -83,9 +87,10 @@ fn fail_job_via_fresh_runtime(state: &AppState, job_id: &str, url: &str, msg: St
         .enable_all()
         .build()
     else {
-        eprintln!(
-            "[server] could not build recovery runtime to fail job {}",
-            job_id
+        log(
+            state,
+            "ERR",
+            &format!("could not build recovery runtime to fail job {}", job_id),
         );
         return;
     };

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -210,7 +210,11 @@ pub async fn run_server(args: ServerArgs) {
     // requests before returning; previously the server ignored Ctrl-C
     // outright and required SIGKILL, leaking any in-flight scans and
     // their webhook subscribers' terminal callbacks.
-    let shutdown_signal = async {
+    // Clone for the shutdown future: `state` is borrowed again below for the
+    // serve-error log, so the future can't take it by reference (it outlives
+    // this point) or by move.
+    let shutdown_state = state.clone();
+    let shutdown_signal = async move {
         #[cfg(unix)]
         {
             use tokio::signal::unix::{SignalKind, signal};
@@ -225,13 +229,17 @@ pub async fn run_server(args: ServerArgs) {
         {
             let _ = tokio::signal::ctrl_c().await;
         }
-        eprintln!("[server] shutdown signal received — draining in-flight requests");
+        log(
+            &shutdown_state,
+            "SERVER",
+            "shutdown signal received — draining in-flight requests",
+        );
     };
     if let Err(e) = axum::serve(listener, app)
         .with_graceful_shutdown(shutdown_signal)
         .await
     {
-        eprintln!("server error: {}", e);
+        log(&state, "ERR", &format!("server error: {}", e));
     }
 }
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2585,6 +2585,7 @@ async fn test_start_scan_handler_503_when_at_capacity() {
 
 #[test]
 fn test_sanitize_log_message_escapes_crlf() {
+    use crate::utils::log::sanitize_log_message;
     // F11: clean strings are passed through unchanged (borrowed)...
     assert_eq!(sanitize_log_message("clean line").as_ref(), "clean line");
     // ...but CR/LF that could forge a log line are escaped, tab preserved.

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -196,33 +196,12 @@ pub(crate) fn at_capacity_response(state: &AppState) -> ApiResponse<serde_json::
     }
 }
 
-/// Defang ASCII control characters in a (possibly user-controlled) log message
-/// so a submitter can't forge extra log lines. Log calls embed the target URL
-/// and error strings, which carry attacker-supplied bytes; `has_http_scheme`
-/// only checks the prefix, so an embedded `\n`/`\r` would otherwise inject a
-/// whole fabricated `[ts] [LVL] ...` line into the file and onto stdout.
-/// CR/LF become `\n`/`\r`; other C0 controls become `\xNN`; tab is kept. Returns
-/// a borrowed string on the common (clean) path so non-injecting logs allocate
-/// nothing.
-pub(crate) fn sanitize_log_message(msg: &str) -> std::borrow::Cow<'_, str> {
-    if !msg.bytes().any(|b| b < 0x20 && b != b'\t') {
-        return std::borrow::Cow::Borrowed(msg);
-    }
-    let mut out = String::with_capacity(msg.len() + 8);
-    for c in msg.chars() {
-        match c {
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push('\t'),
-            c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
-            c => out.push(c),
-        }
-    }
-    std::borrow::Cow::Owned(out)
-}
-
+/// Emit a structured server log line — gray `{ts}` + colored `{level}` token +
+/// message — to stdout and, when `--log-file` is set, append it to that file.
+/// The message is run through [`sanitize_log_message`](crate::utils::log::sanitize_log_message)
+/// first because it embeds attacker-supplied bytes (target URLs, error strings).
 pub(crate) fn log(state: &AppState, level: &str, message: &str) {
-    let message = sanitize_log_message(message);
+    let message = crate::utils::log::sanitize_log_message(message);
     let message = message.as_ref();
     let ts = chrono::Local::now().format("%Y-%m-%d %H:%M:%S").to_string();
     let (color, lvl) = match level {

--- a/src/utils/log.rs
+++ b/src/utils/log.rs
@@ -36,3 +36,28 @@ macro_rules! dbg_log {
         }
     }};
 }
+
+/// Neutralize log-injection bytes before a message is written to a log sink
+/// (terminal, stderr, or a log file). Both the HTTP server and the MCP server
+/// embed attacker-supplied bytes in log lines — target URLs and error/panic
+/// strings — and a raw `\n`/`\r` would otherwise let a submitter forge an
+/// entire fabricated `[ts] [LVL] ...` line into the file or onto the operator's
+/// console. CR/LF become `\n`/`\r`; other C0 controls become `\xNN`; tab is
+/// kept. Returns a borrowed string on the common (clean) path so non-injecting
+/// logs allocate nothing.
+pub(crate) fn sanitize_log_message(msg: &str) -> std::borrow::Cow<'_, str> {
+    if !msg.bytes().any(|b| b < 0x20 && b != b'\t') {
+        return std::borrow::Cow::Borrowed(msg);
+    }
+    let mut out = String::with_capacity(msg.len() + 8);
+    for c in msg.chars() {
+        match c {
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push('\t'),
+            c if (c as u32) < 0x20 => out.push_str(&format!("\\x{:02x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    std::borrow::Cow::Owned(out)
+}


### PR DESCRIPTION
## Summary

Follow-up to #1144 / #1145, finishing the logging cleanup on the **server** and **MCP** surfaces.

Both have a proper structured logger:
- `server::util::log` → `{ts} {LVL} msg`, **stdout** + optional `--log-file`, **CRLF-sanitized**
- `DalfoxMcp::log` → `[ts] [LVL] msg`, **stderr** (stdout is the JSON-RPC channel, must stay clean)

…but several diagnostics bypassed them with ad-hoc `eprintln!("[server] …")` / `eprintln!("[MCP][ERR] …")` — wrong stream, no timestamp/level, no sanitization, and (server) missing from the log file.

## Changes

**Route bypass sites through the structured logger:**
- **server/mod.rs** — graceful-shutdown notice + serve error. The shutdown future takes a `state.clone()` since `state` is borrowed again for the serve-error log.
- **server/job_runner.rs** — runtime-build-fail, task-panic, recovery-runtime-fail (all had `AppState`/clone in scope).
- **mcp/mod.rs** — thread-runtime build failure + scan-task panic → `DalfoxMcp::log("ERR", …)` (stays on stderr — protocol-safe).

**Harden + de-duplicate the sanitizer:**
- Moved `sanitize_log_message` from `server::util` → `crate::utils::log` (the shared logging module from #1145), so both servers depend on a neutral util instead of MCP reaching into `server`.
- `DalfoxMcp::log` now sanitizes too — it logs the same attacker-influenced bytes (scan URLs, panic payloads) the server logger already defends against (CRLF log-line forgery).

**Left as raw `eprintln!`** (intentional): the pre-`AppState` startup/config errors — invalid bind address, invalid allowed-origins regex/wildcard. No logger exists that early.

## Verification

```
$ dalfox server --host 127.0.0.1 --port 8771   # then SIGINT
2026-06-15 14:05:46 SERVER listening on http://127.0.0.1:8771
2026-06-15 14:05:46 SERVER shutdown signal received — draining in-flight requests
```
(shutdown line was previously a raw `[server] …` on stderr; now structured on stdout + log file)

- `cargo clippy --all-targets` clean
- `cargo test --lib` — 1756 pass (single-threaded; the 2 HAR-input flakes under parallel runs are the known shared-global-state issue, unrelated)