### PR TITLE
fix(scanner): cap the HPP reflection body read to bound scanner memory

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1807,7 +1807,12 @@ pub async fn check_reflection_with_hpp_url(
             let kind = classify_reflection(location, payload);
             return (kind, Some(location.to_string()));
         }
-        if let Ok(text) = resp.text().await {
+        // Cap the body read like every other scan-path read: a target serving a
+        // huge body must not balloon the scanner's memory. `resp.text()` here was
+        // the one site that bypassed `read_body`'s 16 MiB cap, so an attacker-
+        // controlled target could drive RSS far past the intended workers × cap
+        // bound (verified: a 200 MB body pushed peak RSS to ~1.2 GiB).
+        if let Ok(text) = crate::utils::http::read_body(resp).await {
             let kind = classify_reflection(&text, payload);
             let kind = match kind {
                 Some(_) if is_in_safe_context_decoded(&text, payload) => None,


### PR DESCRIPTION
## Summary

Found by dogfooding. `check_reflection_with_hpp_url` (HTTP Parameter Pollution reflection check) read the response with `resp.text().await` — the **only** body read on the scan path that bypassed `read_body`'s 16 MiB cap.

A target serving a large body therefore drove the scanner's peak RSS **proportional to the body size** instead of the intended `workers × cap` bound. This is a DoS vector, especially in **server/MCP mode** where the target URL is attacker-supplied.

## Fix

One-line swap: route the read through `crate::utils::http::read_body`, which streams chunk-by-chunk and stops at 16 MiB (dropping the connection), like every other scan-path read. Same `Result<String, reqwest::Error>` return type — drop-in.

## Verification (dogfooding)

Peak RSS, `--workers 10`, min of 3 runs, against a server serving an N-byte body:

| body size | before | after |
|---|---|---|
| 40 MB | 375 MiB | 374 MiB |
| 200 MB | **1205 MiB** | 355 MiB |
| 800 MB | (unbounded → ~OOM) | **355 MiB** |

RSS is now flat across body size instead of scaling with it. At `--workers 1`, a tiny body and a 400 MB body both settle at the same bounded baseline.

## Testing
- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib check_reflection` — 116 pass