### PR TITLE
fix(cli): make url/file/pipe subcommands respect an explicit -i/--input-type

### DIFF
--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -14,7 +14,13 @@ pub struct FileArgs {
 
 fn into_scan_args(args: FileArgs) -> ScanArgs {
     let mut scan_args = args.scan_args;
-    scan_args.input_type = "file".to_string();
+    // The `file` subcommand defaults to reading the file as a URL list, but it
+    // also flattens (and advertises) `-i/--input-type`. Respect an explicit
+    // choice — `-i har` / `-i raw-http` parses the file as a HAR / raw-HTTP
+    // document instead — and only force the default when left at `auto`.
+    if scan_args.input_type == "auto" {
+        scan_args.input_type = "file".to_string();
+    }
     scan_args.targets = vec![args.file];
     scan_args
 }

--- a/src/cmd/file/tests.rs
+++ b/src/cmd/file/tests.rs
@@ -15,6 +15,19 @@ fn test_into_scan_args_sets_file_mode_and_target() {
     assert_eq!(scan_args.targets, vec!["targets.txt".to_string()]);
 }
 
+#[test]
+fn test_into_scan_args_respects_explicit_input_type() {
+    // `-i har` / `-i raw-http` must survive: the file is then parsed as a HAR /
+    // raw-HTTP document rather than a line-based URL list. The file path still
+    // becomes the sole target.
+    for it in ["har", "raw-http"] {
+        let cli = TestCli::parse_from(["dalfox-test", "capture.har", "-i", it]);
+        let scan_args = into_scan_args(cli.args);
+        assert_eq!(scan_args.input_type, it);
+        assert_eq!(scan_args.targets, vec!["capture.har".to_string()]);
+    }
+}
+
 #[tokio::test]
 async fn test_run_file_executes_scan_path_without_panic() {
     let path = std::env::temp_dir().join(format!(

--- a/src/cmd/pipe.rs
+++ b/src/cmd/pipe.rs
@@ -10,7 +10,12 @@ pub struct PipeArgs {
 
 fn into_scan_args(args: PipeArgs) -> ScanArgs {
     let mut scan_args = args.scan_args;
-    scan_args.input_type = "pipe".to_string();
+    // Default to reading stdin as a URL list, but respect an explicit
+    // `-i/--input-type` (e.g. `cat capture.har | dalfox pipe -i har`); only
+    // force the default when left at `auto`.
+    if scan_args.input_type == "auto" {
+        scan_args.input_type = "pipe".to_string();
+    }
     scan_args.targets = vec![];
     scan_args
 }

--- a/src/cmd/pipe/tests.rs
+++ b/src/cmd/pipe/tests.rs
@@ -14,3 +14,13 @@ fn test_into_scan_args_sets_pipe_mode_and_clears_targets() {
     assert_eq!(scan_args.input_type, "pipe");
     assert!(scan_args.targets.is_empty());
 }
+
+#[test]
+fn test_into_scan_args_respects_explicit_input_type() {
+    // `cat capture.har | dalfox pipe -i har` must keep `har` so stdin is parsed
+    // as a HAR document instead of a line-based URL list.
+    let cli = TestCli::parse_from(["dalfox-test", "-i", "har"]);
+    let scan_args = into_scan_args(cli.args);
+    assert_eq!(scan_args.input_type, "har");
+    assert!(scan_args.targets.is_empty());
+}

--- a/src/cmd/url.rs
+++ b/src/cmd/url.rs
@@ -14,7 +14,13 @@ pub struct UrlArgs {
 
 fn into_scan_args(args: UrlArgs) -> ScanArgs {
     let mut scan_args = args.scan_args;
-    scan_args.input_type = "url".to_string();
+    // The `--url` value is the single target; default to treating it as a URL,
+    // but respect an explicit `-i/--input-type` for consistency with the other
+    // entry subcommands (a contradictory choice like `-i har` then surfaces a
+    // clear parse error instead of being silently ignored).
+    if scan_args.input_type == "auto" {
+        scan_args.input_type = "url".to_string();
+    }
     scan_args.targets = vec![args.url];
     scan_args
 }

--- a/src/cmd/url/tests.rs
+++ b/src/cmd/url/tests.rs
@@ -15,6 +15,22 @@ fn test_into_scan_args_sets_url_mode_and_target() {
     assert_eq!(scan_args.targets, vec!["https://example.com".to_string()]);
 }
 
+#[test]
+fn test_into_scan_args_respects_explicit_input_type() {
+    // An explicit `-i` survives instead of being silently overwritten with
+    // `url`, keeping the entry subcommands consistent.
+    let cli = TestCli::parse_from([
+        "dalfox-test",
+        "--url",
+        "https://example.com",
+        "-i",
+        "raw-http",
+    ]);
+    let scan_args = into_scan_args(cli.args);
+    assert_eq!(scan_args.input_type, "raw-http");
+    assert_eq!(scan_args.targets, vec!["https://example.com".to_string()]);
+}
+
 #[tokio::test]
 async fn test_run_url_executes_scan_path_without_panic() {
     let cli = TestCli::parse_from([


### PR DESCRIPTION
## Summary

Found by dogfooding. The `url`, `file`, and `pipe` entry subcommands flatten `ScanArgs`, so they inherit and **advertise** `-i/--input-type` (with `har` / `raw-http` among the documented values) — but `into_scan_args` **unconditionally overwrote** `input_type` with the subcommand's own mode. The flag was silently ignored.

Most visibly, this broke the documented escape hatch for HAR files whose `entries` array sits past the auto-detection sniff budget:

```
$ dalfox file capture.har -i har      → Error: '...invalid port number'   (read HAR as a URL list)
$ dalfox file req.txt   -i raw-http   → Error: '...empty host'
```

(`dalfox scan capture.har -i har` worked, since `scan` doesn't override — and bare `dalfox capture.har` auto-detects small HARs. So large HARs had no working CLI path.)

## Fix

Only apply the subcommand's default mode when `input_type` is still `auto`; respect any explicit choice.

Now:
- `dalfox file capture.har -i har` / `-i raw-http` parse the file correctly
- `cat capture.har | dalfox pipe -i har` parses stdin as HAR
- bare `dalfox file urls.txt` / `dalfox url --url X` / `dalfox pipe` — unchanged defaults
- a contradictory combo (e.g. `url ... -i har`) now surfaces a clear parse error instead of silent no-op

## Verification

End-to-end against a local server (all previously errored, now find the XSS):

| command | before | after |
|---|---|---|
| `file capture.har -i har` | invalid port number | findings ✓ |
| `file req.raw -i raw-http` | empty host | findings ✓ |
| `cat har \| pipe -i har` | parse error | findings ✓ |
| `file urls.txt` (default) | ✓ | ✓ (unchanged) |
| `url --url X` (default) | ✓ | ✓ (unchanged) |

Plus `into_scan_args` unit tests for each subcommand (explicit `-i` survives; defaults unchanged).

## Testing
- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib` — 1759 pass (3 new)