### PR TITLE
fix(scan): report --output write failure via stderr and exit code

### DIFF
--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -594,7 +594,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // and format-specific rendering to stdout or --output file.
     let scan_elapsed = __dalfox_scan_start.elapsed();
     let total_requests = crate::REQUEST_COUNT.load(Ordering::Relaxed);
-    let final_results = output::render_results(
+    let (final_results, output_write_failed) = output::render_results(
         args,
         &state,
         &all_target_urls,
@@ -632,6 +632,14 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         !skipped.is_empty() && all_target_urls.iter().all(|u| skipped.contains_key(u))
     };
     if all_unreachable {
+        return ScanOutcome::Error;
+    }
+
+    // A requested `--output` file that couldn't be written is a hard failure,
+    // same as an all-unreachable run: the operator asked for results on disk and
+    // didn't get them. Report it via the exit code so scripts don't read it as a
+    // clean/successful pass.
+    if output_write_failed {
         return ScanOutcome::Error;
     }
 

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -204,7 +204,7 @@ pub(crate) async fn render_results(
     scan_elapsed: std::time::Duration,
     total_requests: u64,
     stream_findings_enabled: bool,
-) -> Vec<Result> {
+) -> (Vec<Result>, bool) {
     let results = state.results.clone();
     let skipped_targets = state.skipped_targets.clone();
     let target_meta = state.target_meta.clone();
@@ -433,6 +433,7 @@ pub(crate) async fn render_results(
         output
     };
 
+    let mut output_write_failed = false;
     if let Some(output_path) = &args.output {
         // Surface `..` traversal so the operator notices before a
         // pipeline silently writes into a parent directory. We don't
@@ -454,9 +455,15 @@ pub(crate) async fn render_results(
                 }
             }
             Err(e) => {
-                if !args.silence {
-                    eprintln!("Error writing to file {}: {}", output_path, e);
-                }
+                // A failed `--output` write is a hard failure, not a log line:
+                // the operator asked for the results in a file and won't get
+                // them. Surface it even under `--silence` (it goes to stderr, so
+                // machine stdout stays clean) and propagate so the exit code
+                // becomes Error instead of a misleading success — otherwise a
+                // CI step like `dalfox -o out.json -S && use out.json` proceeds
+                // against a missing or stale file with zero indication.
+                eprintln!("Error writing to file {}: {}", output_path, e);
+                output_write_failed = true;
             }
         }
     } else {
@@ -466,5 +473,5 @@ pub(crate) async fn render_results(
         crate::cprintln!("{}", output_content);
     }
 
-    final_results
+    (final_results, output_write_failed)
 }

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -1430,7 +1430,7 @@ async fn test_render_results_stdout_path_returns_results() {
         a
     };
     let state = make_scan_state(vec![reflected_result("https://example.com", "q", "<x>")]);
-    let final_results = render_results(
+    let (final_results, write_failed) = render_results(
         &args,
         &state,
         &["https://example.com".to_string()],
@@ -1440,6 +1440,37 @@ async fn test_render_results_stdout_path_returns_results() {
     )
     .await;
     assert_eq!(final_results.len(), 1);
+    assert!(!write_failed, "stdout path never reports a write failure");
+}
+
+#[tokio::test]
+async fn test_render_results_reports_output_write_failure() {
+    // An `--output` path that can't be written (parent dir doesn't exist) must
+    // be reported via the returned flag so the caller can exit with an error —
+    // even under `--silence`, where the stderr message alone wouldn't reach a
+    // script checking the exit code.
+    let mut args = default_scan_args(); // format=json, silence=true
+    args.output = Some(
+        std::env::temp_dir()
+            .join("dalfox-no-such-dir-xyz")
+            .join("out.json")
+            .to_string_lossy()
+            .to_string(),
+    );
+    let state = make_scan_state(vec![reflected_result("https://example.com", "q", "<x>")]);
+    let (_results, write_failed) = render_results(
+        &args,
+        &state,
+        &["https://example.com".to_string()],
+        std::time::Duration::from_millis(1),
+        1,
+        true,
+    )
+    .await;
+    assert!(
+        write_failed,
+        "unwritable --output path must report a write failure"
+    );
 }
 
 // ─────────────────────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Found by Round-2 dogfooding. A failed `--output` write was swallowed two ways (`src/cmd/scan/output.rs`):
1. The `Error writing to file ...` message was printed **only when `--silence` was off**.
2. Either way the process still exited with the scan outcome (`0` clean / `1` findings).

So `dalfox ... -S -o results.json` against an unwritable path (missing parent dir, permission denied, full disk, path-is-a-directory) produced **no file, no message, and a success exit code**. A CI step like `dalfox -o out.json -S && use out.json` then ran against a missing/stale file with zero indication.

## Fix

Treat it like the existing *all-targets-unreachable* case — which this very file already maps to exit 2 for the same "scripts must see hard failures" reason:

- `render_results` now returns `(results, output_write_failed)`.
- The write-failure stderr message is emitted **unconditionally** (it's a hard error, not a log line; stderr keeps machine stdout clean).
- `run_scan` returns `ScanOutcome::Error` (exit 2) when the write failed.

Success path unchanged: a writable `-o` still exits 0/1, and the `Results written to` notice stays gated behind `--silence`.

## Verification (dogfooding)

| case | before | after |
|---|---|---|
| `-o <unwritable>` (no `-S`) | exit 1, error shown | **exit 2**, error shown |
| `-o <unwritable>` (`-S`) | exit 1, **silent** | **exit 2**, error shown |
| `-o <writable>` (`-S`) | exit 1, file written | exit 1, file written (unchanged) |

## Testing
- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib` — 1760 pass (new `test_render_results_reports_output_write_failure`)