### PR TITLE
fix(cli): apply config, global flags & --include-all in url/file/pipe subcommands

### DIFF
--- a/src/cmd/file.rs
+++ b/src/cmd/file.rs
@@ -25,8 +25,18 @@ fn into_scan_args(args: FileArgs) -> ScanArgs {
     scan_args
 }
 
-pub async fn run_file(args: FileArgs) -> crate::cmd::scan::ScanOutcome {
-    let scan_args = into_scan_args(args);
+pub async fn run_file(
+    args: FileArgs,
+    cli_no_color: bool,
+    cli_silence: bool,
+    config: Option<&crate::config::Config>,
+) -> crate::cmd::scan::ScanOutcome {
+    let scan_args = crate::cmd::scan::finalize_scan_args(
+        into_scan_args(args),
+        cli_no_color,
+        cli_silence,
+        config,
+    );
     crate::cmd::scan::run_scan(&scan_args).await
 }
 

--- a/src/cmd/file/tests.rs
+++ b/src/cmd/file/tests.rs
@@ -43,7 +43,7 @@ async fn test_run_file_executes_scan_path_without_panic() {
         "json",
         "-S",
     ]);
-    run_file(cli.args).await;
+    run_file(cli.args, false, false, None).await;
 
     let _ = std::fs::remove_file(path);
 }

--- a/src/cmd/pipe.rs
+++ b/src/cmd/pipe.rs
@@ -20,8 +20,18 @@ fn into_scan_args(args: PipeArgs) -> ScanArgs {
     scan_args
 }
 
-pub async fn run_pipe(args: PipeArgs) -> crate::cmd::scan::ScanOutcome {
-    let scan_args = into_scan_args(args);
+pub async fn run_pipe(
+    args: PipeArgs,
+    cli_no_color: bool,
+    cli_silence: bool,
+    config: Option<&crate::config::Config>,
+) -> crate::cmd::scan::ScanOutcome {
+    let scan_args = crate::cmd::scan::finalize_scan_args(
+        into_scan_args(args),
+        cli_no_color,
+        cli_silence,
+        config,
+    );
     crate::cmd::scan::run_scan(&scan_args).await
 }
 

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -104,6 +104,34 @@ fn emit_error(format: &str, code: &str, message: &str) {
     }
 }
 
+/// Cross-cutting preamble shared by every scan entry point (`scan`, the bare
+/// no-subcommand path, and the `url`/`file`/`pipe` subcommands) so they behave
+/// identically. Without one shared spot the convenience subcommands silently
+/// diverged — they used to skip config overlay and `--include-all` entirely.
+///
+/// Order matters: fold the global `--no-color`/`--silence` (clap may land them
+/// on either the root `Cli` or the subcommand's `ScanArgs`) *before* the config
+/// overlay, so `apply_to_scan_args_if_default` sees them as already-set when
+/// deciding precedence; expand `--include-all` *after*, so a config-supplied
+/// `include_all` is honored too.
+pub fn finalize_scan_args(
+    mut args: ScanArgs,
+    cli_no_color: bool,
+    cli_silence: bool,
+    config: Option<&crate::config::Config>,
+) -> ScanArgs {
+    args.no_color = args.no_color || cli_no_color;
+    args.silence = args.silence || cli_silence;
+    if let Some(cfg) = config {
+        cfg.apply_to_scan_args_if_default(&mut args);
+    }
+    if args.include_all {
+        args.include_request = true;
+        args.include_response = true;
+    }
+    args
+}
+
 /// Run a scan and return the outcome: `Clean` (no findings), `Findings`, or `Error`.
 pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Compute no-color locally (safe for concurrent server-mode scans)

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -7,7 +7,8 @@ use super::{
     CLI_MAX_DELAY_MS, CLI_MAX_RATE_LIMIT, CLI_MAX_RETRIES, CLI_MAX_RETRY_DELAY_MS,
     CLI_MAX_TIMEOUT_SECS, CLI_MAX_WORKERS, DEFAULT_DELAY_MS, DEFAULT_ENCODERS,
     DEFAULT_MAX_CONCURRENT_TARGETS, DEFAULT_MAX_TARGETS_PER_HOST, DEFAULT_METHOD,
-    DEFAULT_TIMEOUT_SECS, DEFAULT_WORKERS, ScanArgs, ScanOutcome, ScanState, validate_numeric_args,
+    DEFAULT_TIMEOUT_SECS, DEFAULT_WORKERS, ScanArgs, ScanOutcome, ScanState, finalize_scan_args,
+    validate_numeric_args,
 };
 use crate::parameter_analysis::{InjectionContext, Location, Param};
 use crate::scanning::result::{FindingType, Result as ScanResult};
@@ -2040,5 +2041,55 @@ async fn test_run_preflight_and_analysis_analyze_external_js_produces_finding() 
         results.iter().any(|f| f.evidence.contains("sink.js")),
         "finding evidence must reference the external script; findings: {:?}",
         *results
+    );
+}
+
+// finalize_scan_args — the shared preamble that the bare `scan` path and the
+// `url`/`file`/`pipe` subcommands all run. Regression cover for the bug where
+// those subcommands skipped config overlay and `--include-all`.
+#[test]
+fn test_finalize_scan_args_overlays_config_on_default_fields() {
+    let cfg = crate::config::Config {
+        scan: Some(crate::config::ScanConfig {
+            format: Some("jsonl".to_string()),
+            ..Default::default()
+        }),
+    };
+    let mut args = default_scan_args();
+    args.format = "plain".to_string(); // clap default → config may override
+    let out = finalize_scan_args(args, false, false, Some(&cfg));
+    assert_eq!(
+        out.format, "jsonl",
+        "config format applies when arg is default"
+    );
+}
+
+#[test]
+fn test_finalize_scan_args_keeps_explicit_over_config() {
+    let cfg = crate::config::Config {
+        scan: Some(crate::config::ScanConfig {
+            format: Some("jsonl".to_string()),
+            ..Default::default()
+        }),
+    };
+    let mut args = default_scan_args();
+    args.format = "sarif".to_string(); // explicit non-default → config must NOT win
+    let out = finalize_scan_args(args, false, false, Some(&cfg));
+    assert_eq!(out.format, "sarif", "explicit format outranks config");
+}
+
+#[test]
+fn test_finalize_scan_args_folds_globals_and_expands_include_all() {
+    let mut args = default_scan_args();
+    args.no_color = false;
+    args.silence = false;
+    args.include_all = true;
+    args.include_request = false;
+    args.include_response = false;
+    let out = finalize_scan_args(args, /*no_color*/ true, /*silence*/ true, None);
+    assert!(out.no_color && out.silence, "global flags are folded in");
+    assert!(
+        out.include_request && out.include_response,
+        "--include-all expands to request+response"
     );
 }

--- a/src/cmd/url.rs
+++ b/src/cmd/url.rs
@@ -25,8 +25,18 @@ fn into_scan_args(args: UrlArgs) -> ScanArgs {
     scan_args
 }
 
-pub async fn run_url(args: UrlArgs) -> crate::cmd::scan::ScanOutcome {
-    let scan_args = into_scan_args(args);
+pub async fn run_url(
+    args: UrlArgs,
+    cli_no_color: bool,
+    cli_silence: bool,
+    config: Option<&crate::config::Config>,
+) -> crate::cmd::scan::ScanOutcome {
+    let scan_args = crate::cmd::scan::finalize_scan_args(
+        into_scan_args(args),
+        cli_no_color,
+        cli_silence,
+        config,
+    );
     crate::cmd::scan::run_scan(&scan_args).await
 }
 

--- a/src/cmd/url/tests.rs
+++ b/src/cmd/url/tests.rs
@@ -41,5 +41,5 @@ async fn test_run_url_executes_scan_path_without_panic() {
         "json",
         "-S",
     ]);
-    run_url(cli.args).await;
+    run_url(cli.args, false, false, None).await;
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -303,22 +303,15 @@ async fn main() {
     if let Some(command) = cli.command {
         match command {
             Commands::Scan(args) => {
-                let mut args = args;
-                // `--no-color` and `--silence` are global flags on `Cli`
-                // so users can write `dalfox scan URL --silence` or
-                // `dalfox URL --silence` without clap rejecting them.
-                // Mirror the parsed values into `ScanArgs` before the
-                // config layer runs so `apply_to_scan_args_if_default`
-                // sees them as already-set when deciding precedence.
-                args.no_color = args.no_color || cli.no_color;
-                args.silence = args.silence || cli.silence;
-                if let Ok(res) = &config_load {
-                    res.config.apply_to_scan_args_if_default(&mut args);
-                }
-                if args.include_all {
-                    args.include_request = true;
-                    args.include_response = true;
-                }
+                // `--no-color`/`--silence` are global on `Cli`, config defaults
+                // overlay, and `--include-all` expands — all folded in one shared
+                // helper so this path and `url`/`file`/`pipe` stay identical.
+                let args = cmd::scan::finalize_scan_args(
+                    args,
+                    cli.no_color,
+                    cli.silence,
+                    config_load.as_ref().ok().map(|r| &r.config),
+                );
                 outcome = cmd::scan::run_scan(&args).await;
             }
             Commands::Server(args) => {
@@ -337,18 +330,21 @@ async fn main() {
             }
 
             Commands::Url(args) => {
-                outcome = cmd::url::run_url(args).await;
+                let config = config_load.as_ref().ok().map(|r| &r.config);
+                outcome = cmd::url::run_url(args, cli.no_color, cli.silence, config).await;
             }
             Commands::File(args) => {
-                outcome = cmd::file::run_file(args).await;
+                let config = config_load.as_ref().ok().map(|r| &r.config);
+                outcome = cmd::file::run_file(args, cli.no_color, cli.silence, config).await;
             }
             Commands::Pipe(args) => {
-                outcome = cmd::pipe::run_pipe(args).await;
+                let config = config_load.as_ref().ok().map(|r| &r.config);
+                outcome = cmd::pipe::run_pipe(args, cli.no_color, cli.silence, config).await;
             }
         }
     } else {
         // Default to scan
-        let mut args = cmd::scan::ScanArgs {
+        let args = cmd::scan::ScanArgs {
             detect_outdated_libs: false,
             input_type: "auto".to_string(),
             format: "plain".to_string(),
@@ -437,13 +433,15 @@ async fn main() {
             remote_payloads: vec![],
             remote_wordlists: vec![],
         };
-        if let Ok(res) = &config_load {
-            res.config.apply_to_scan_args_if_default(&mut args);
-        }
-        if args.include_all {
-            args.include_request = true;
-            args.include_response = true;
-        }
+        // Same config-overlay + `--include-all` expansion as every other entry
+        // point. `no_color`/`silence` were already set from `cli` above, so the
+        // helper's fold is a no-op here.
+        let args = cmd::scan::finalize_scan_args(
+            args,
+            cli.no_color,
+            cli.silence,
+            config_load.as_ref().ok().map(|r| &r.config),
+        );
 
         // No redundant banner emission here — the earlier
         // post-config-load block already called `print_banner_once`


### PR DESCRIPTION
## Summary

Found by Round-3 dogfooding. The `url`, `file`, and `pipe` entry subcommands called `into_scan_args` → `run_scan` directly, **skipping the cross-cutting preamble** that the bare `scan` path runs. So with any of those subcommands:

- the **config file was silently ignored** — both `--config <file>` and the default `~/.config/dalfox/config.*`. `dalfox url --url X --config c.toml` ran with built-in defaults.
- **`--include-all` did nothing** (findings carried no request/response).
- the global `--no-color` / `--silence` were not folded from the root `Cli`.

`scan` and the no-subcommand default path applied all of this; the convenience subcommands quietly diverged. (Same root cause as #1149's input-type bug.)

## Fix — unify the preamble

Extract it into one shared `cmd::scan::finalize_scan_args(args, no_color, silence, config)` and route **every** entry point through it: `scan`, the default path, and `url`/`file`/`pipe`. The `run_*` functions now take the globals + config and call it **after** `into_scan_args`, so the subcommand's input-type/targets are set first and the config overlay's `if_default` checks don't clobber them.

Precedence is unchanged and now uniform: **explicit non-default CLI value > config > clap default**.

> Note: the pre-existing `if_default` quirk — an explicit CLI value that *equals* the clap default (e.g. `--format plain`) can't override a config value — applies to every path equally, **including `scan`**, and is not changed here.

## Verification (dogfooding)

config `[scan]\nformat = "json"`, no CLI `--format`:

| command | before | after |
|---|---|---|
| `scan URL` | JSON | JSON |
| `URL` (default) | JSON | JSON |
| `url --url URL` | **plain (ignored)** | JSON ✓ |
| `file F` | **plain (ignored)** | JSON ✓ |
| `pipe` (stdin) | **plain (ignored)** | JSON ✓ |

Plus: `url --include-all` now includes the request field; `url --format sarif` still overrides config (CLI wins); `scan`/default unaffected.

## Testing
- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib` — 1763 pass (3 new `finalize_scan_args` tests)