### PR TITLE
feat(server): unify scan target param on `target`, keep `url` as REST alias

### DIFF
--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -51,7 +51,7 @@ For browser clients that can't set custom headers:
 
 ```bash
 dalfox server --jsonp --callback-param-name callback
-# then GET /scan?url=...&callback=myFunction
+# then GET /scan?target=...&callback=myFunction
 ```
 
 ## Endpoints
@@ -59,7 +59,7 @@ dalfox server --jsonp --callback-param-name callback
 | Method | Path | What it does |
 |--------|------|--------------|
 | `POST` | `/scan` | Submit a new scan (JSON body) |
-| `GET` | `/scan?url=...` | Submit a new scan (query string) |
+| `GET` | `/scan?target=...` | Submit a new scan (query string) |
 | `GET` | `/scan/:id` | Get scan status and results |
 | `DELETE` | `/scan/:id` | Cancel a queued or running scan |
 | `GET` | `/scans` | List all scans (optional `?status=`) |
@@ -74,7 +74,7 @@ curl -X POST http://127.0.0.1:6664/scan \
   -H "X-API-KEY: change-me" \
   -H "Content-Type: application/json" \
   -d '{
-    "url": "https://target.app?q=test",
+    "target": "https://target.app?q=test",
     "options": {
       "worker": 50,
       "timeout": 10,
@@ -83,6 +83,8 @@ curl -X POST http://127.0.0.1:6664/scan \
     }
   }'
 ```
+
+The scan target field is `target` (matching the MCP `scan_with_dalfox` tool and the response payload). The legacy field name `url` is still accepted as an alias — for both the JSON body and the `?target=` / `?url=` query string — so existing clients keep working.
 
 Response:
 

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -41,7 +41,7 @@ pub(crate) async fn start_scan_handler(
 
     // Trim once and use the trimmed value throughout (validation, scan_id,
     // stored target, dispatch) so whitespace variants stay consistent.
-    let url = req.url.trim().to_string();
+    let url = req.target.trim().to_string();
     if url.is_empty() {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,
@@ -257,8 +257,11 @@ pub(crate) async fn get_scan_handler(
     // Trim once and use the trimmed value throughout, so whitespace variants
     // of the same URL validate, hash to the same scan_id, and store the same
     // target consistently.
+    // `target` is the canonical param (matches POST/MCP); `url` stays as a
+    // backwards-compatible alias for existing query-string / JSONP callers.
     let url = params
-        .get("url")
+        .get("target")
+        .or_else(|| params.get("url"))
         .cloned()
         .unwrap_or_default()
         .trim()
@@ -767,7 +770,7 @@ pub(crate) async fn preflight_handler(
         }
     };
 
-    let target_url = req.url.trim().to_string();
+    let target_url = req.target.trim().to_string();
     if target_url.is_empty() || !has_http_scheme(&target_url) {
         let resp = ApiResponse::<serde_json::Value> {
             code: 400,

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -258,9 +258,13 @@ pub(crate) async fn get_scan_handler(
     // of the same URL validate, hash to the same scan_id, and store the same
     // target consistently.
     // `target` is the canonical param (matches POST/MCP); `url` stays as a
-    // backwards-compatible alias for existing query-string / JSONP callers.
+    // backwards-compatible alias for existing query-string / JSONP callers. An
+    // empty `target` (e.g. a templated `?target=&url=...`) falls through to the
+    // alias so it can't shadow a real `url` — preserving the old behavior for
+    // any caller still sending `url`.
     let url = params
         .get("target")
+        .filter(|t| !t.trim().is_empty())
         .or_else(|| params.get("url"))
         .cloned()
         .unwrap_or_default()

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -656,7 +656,7 @@ async fn test_start_scan_handler_unauthorized_and_bad_request_jsonp() {
         HeaderMap::new(),
         Query(params_auth),
         Ok(Json(ScanRequest {
-            url: "http://example.com".to_string(),
+            target: "http://example.com".to_string(),
             options: None,
         })),
     )
@@ -674,7 +674,7 @@ async fn test_start_scan_handler_unauthorized_and_bad_request_jsonp() {
         HeaderMap::new(),
         Query(params_bad_req),
         Ok(Json(ScanRequest {
-            url: "   ".to_string(),
+            target: "   ".to_string(),
             options: None,
         })),
     )
@@ -693,7 +693,7 @@ async fn test_start_scan_handler_success_creates_queued_job() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "http://127.0.0.1:1/".to_string(),
+            target: "http://127.0.0.1:1/".to_string(),
             options: Some(ScanOptions {
                 include_request: Some(true),
                 include_response: Some(true),
@@ -738,7 +738,7 @@ async fn test_start_scan_handler_success_jsonp_response() {
         HeaderMap::new(),
         Query(q),
         Ok(Json(ScanRequest {
-            url: "http://127.0.0.1:1/".to_string(),
+            target: "http://127.0.0.1:1/".to_string(),
             options: None,
         })),
     )
@@ -1631,7 +1631,7 @@ async fn test_preflight_handler_rejects_invalid_url() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "not-http".to_string(),
+            target: "not-http".to_string(),
             options: None,
         })),
     )
@@ -1648,7 +1648,7 @@ async fn test_preflight_handler_requires_auth() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "http://example.com".to_string(),
+            target: "http://example.com".to_string(),
             options: None,
         })),
     )
@@ -1665,7 +1665,7 @@ async fn test_preflight_handler_unreachable_target() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "http://127.0.0.1:1/unreachable".to_string(),
+            target: "http://127.0.0.1:1/unreachable".to_string(),
             options: Some(ScanOptions {
                 timeout: Some(1),
                 ..ScanOptions::default()
@@ -1791,7 +1791,7 @@ async fn test_start_scan_handler_rejects_out_of_range_timeout() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "http://example.com".to_string(),
+            target: "http://example.com".to_string(),
             options: Some(ScanOptions {
                 timeout: Some(9999),
                 ..ScanOptions::default()
@@ -1834,7 +1834,7 @@ async fn test_start_scan_handler_rejects_non_http_url() {
             HeaderMap::new(),
             Query(Map::new()),
             Ok(Json(ScanRequest {
-                url: bad.to_string(),
+                target: bad.to_string(),
                 options: None,
             })),
         )
@@ -2570,7 +2570,7 @@ async fn test_start_scan_handler_503_when_at_capacity() {
         HeaderMap::new(),
         Query(Map::new()),
         Ok(Json(ScanRequest {
-            url: "http://example.com".to_string(),
+            target: "http://example.com".to_string(),
             options: None,
         })),
     )
@@ -2809,5 +2809,38 @@ async fn test_get_scan_handler_analyze_external_js_param_is_accepted() {
     assert!(
         jobs.contains_key(&scan_id),
         "job must be present in the queue after handler returns"
+    );
+}
+
+// Target/URL param unification: `target` is canonical (matches MCP + response),
+// `url` stays as a backwards-compatible alias on the REST surface.
+#[test]
+fn test_scan_request_accepts_target_canonical_and_url_alias() {
+    let from_target: ScanRequest =
+        serde_json::from_str(r#"{"target":"http://a.test/?q=1"}"#).expect("target key parses");
+    assert_eq!(from_target.target, "http://a.test/?q=1");
+
+    let from_url: ScanRequest =
+        serde_json::from_str(r#"{"url":"http://b.test/?q=1"}"#).expect("url alias parses");
+    assert_eq!(from_url.target, "http://b.test/?q=1");
+
+    // Neither key present is a hard error (target is required).
+    assert!(serde_json::from_str::<ScanRequest>(r#"{"options":{}}"#).is_err());
+}
+
+#[tokio::test]
+async fn test_get_scan_handler_accepts_target_query_param() {
+    let state = make_state(None, None, false, false, "cb");
+    let mut params = Map::new();
+    params.insert("target".to_string(), "http://127.0.0.1:1/?q=1".to_string());
+    let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body_string(resp).await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    assert!(
+        parsed["data"]["scan_id"].as_str().is_some(),
+        "a scan submitted via the `target` query param must return a scan_id"
     );
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2844,3 +2844,23 @@ async fn test_get_scan_handler_accepts_target_query_param() {
         "a scan submitted via the `target` query param must return a scan_id"
     );
 }
+
+#[tokio::test]
+async fn test_get_scan_handler_empty_target_falls_through_to_url_alias() {
+    // A present-but-empty `target` must not shadow a real `url`, so a templated
+    // `?target=&url=...` still scans the url (preserves the pre-rename behavior).
+    let state = make_state(None, None, false, false, "cb");
+    let mut params = Map::new();
+    params.insert("target".to_string(), String::new());
+    params.insert("url".to_string(), "http://127.0.0.1:1/?q=1".to_string());
+    let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body_string(resp).await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json body");
+    assert_eq!(
+        parsed["data"]["target"], "http://127.0.0.1:1/?q=1",
+        "empty target must fall through to the url alias"
+    );
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -135,7 +135,11 @@ pub(crate) struct ApiResponse<T> {
 
 #[derive(Debug, Clone, Deserialize)]
 pub(crate) struct ScanRequest {
-    pub(crate) url: String,
+    /// Scan target. Named `target` to match the MCP `scan_with_dalfox` tool and
+    /// the response payload's `target` field; `url` is accepted as a backwards-
+    /// compatible alias so existing REST clients keep working.
+    #[serde(alias = "url")]
+    pub(crate) target: String,
     #[serde(default)]
     pub(crate) options: Option<ScanOptions>,
 }


### PR DESCRIPTION
## Summary

Follow-up to the dogfooding finding that REST and MCP named the scan target differently. The MCP `scan_with_dalfox` tool and **every response payload** (`ResultPayload.target`, the submit `{scan_id, target}`) used **`target`**, but the REST **request** body and query string used **`url`**. Anyone wiring up both surfaces hit the mismatch.

Per the decision: standardize on **`target`**, keep **`url`** working for existing REST clients.

## Changes

- `ScanRequest.url` → **`target`** with `#[serde(alias = "url")]` — POST `/scan` and POST `/preflight` accept `{"target": ...}` (canonical) or `{"url": ...}` (alias).
- GET `/scan` reads the `target` query param, **falling back to `url`**.
- MCP already used `target` — unchanged.
- Docs (`integrations/server.md`) show `target`, with the `url` alias noted.

**Backwards compatible**: every existing client sending `url` (JSON body or query string) keeps working; response shapes are unchanged.

## Verification (live server)

| request | result |
|---|---|
| `POST /scan {"target":...}` | scan_id ✓ |
| `POST /scan {"url":...}` (alias) | scan_id ✓ |
| `GET /scan?target=...` | scan_id ✓ |
| `GET /scan?url=...` (alias) | scan_id ✓ |
| `POST /scan {"options":{}}` (no target) | 400 ✓ |
| `POST /preflight {"target":...}` | 200, params discovered ✓ |

## Testing
- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib` — 1765 pass (added `test_scan_request_accepts_target_canonical_and_url_alias`, `test_get_scan_handler_accepts_target_query_param`)