### PR TITLE
fix(scanner): demote inert URL-scheme & self-link reflections (#1153)

### DIFF
--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -392,38 +392,17 @@ pub(crate) fn marker_reflects_in_url_attr_only(html: &str, marker: &str) -> bool
     any
 }
 
-/// Walk backwards from byte offset `at` looking for the surrounding HTML
-/// attribute context. Returns `true` when the byte sits inside a quoted
-/// or unquoted attribute value whose attribute name is in
-/// [`URL_VALUED_ATTRS`]. Returns `false` for text content (we hit `>`
-/// before finding `=`) and for non-URL attributes.
-fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
-    if at == 0 || at > bytes.len() {
-        return false;
+/// Given `eq` = the byte index of an attribute's `=`, read the attribute name
+/// immediately to its left (skipping intervening whitespace) and return whether
+/// that name is in [`URL_VALUED_ATTRS`]. The single home for the
+/// name-matching rule shared by every URL-attribute occurrence check.
+fn url_valued_attr_name_before_eq(bytes: &[u8], eq: usize) -> bool {
+    // Skip whitespace between `=` and the attribute name.
+    let mut name_end = eq;
+    while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
+        name_end -= 1;
     }
-    // Phase 1: walk back to find an `=` without crossing a tag boundary.
-    let mut i = at;
-    loop {
-        if i == 0 {
-            return false;
-        }
-        i -= 1;
-        match bytes[i] {
-            b'=' => break,
-            // Crossing a tag boundary means we're outside any attribute.
-            b'<' | b'>' => return false,
-            _ => {}
-        }
-    }
-    // Phase 2: skip backwards over whitespace between `=` and attr name.
-    while i > 0 && bytes[i - 1].is_ascii_whitespace() {
-        i -= 1;
-    }
-    if i == 0 {
-        return false;
-    }
-    // Phase 3: read the attribute name backwards.
-    let name_end = i; // exclusive
+    // Read the attribute name backwards.
     let mut name_start = name_end;
     while name_start > 0 {
         let b = bytes[name_start - 1];
@@ -439,6 +418,32 @@ fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
     URL_VALUED_ATTRS
         .iter()
         .any(|n| name.eq_ignore_ascii_case(n))
+}
+
+/// Walk backwards from byte offset `at` looking for the surrounding HTML
+/// attribute context. Returns `true` when the byte sits inside a quoted
+/// or unquoted attribute value whose attribute name is in
+/// [`URL_VALUED_ATTRS`]. Returns `false` for text content (we hit `>`
+/// before finding `=`) and for non-URL attributes.
+fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
+    if at == 0 || at > bytes.len() {
+        return false;
+    }
+    // Walk back to the attribute's `=` without crossing a tag boundary.
+    let mut i = at;
+    loop {
+        if i == 0 {
+            return false;
+        }
+        i -= 1;
+        match bytes[i] {
+            b'=' => break,
+            // Crossing a tag boundary means we're outside any attribute.
+            b'<' | b'>' => return false,
+            _ => {}
+        }
+    }
+    url_valued_attr_name_before_eq(bytes, i)
 }
 
 /// True when a decoded payload form is a JS-executable URL scheme — the schemes
@@ -503,25 +508,7 @@ fn scheme_at_url_attr_value_start(bytes: &[u8], at: usize) -> bool {
         _ => return false,
     };
     // The token immediately left of `=` must be a URL-valued attribute name.
-    let mut name_end = eq_at;
-    while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
-        name_end -= 1;
-    }
-    let mut name_start = name_end;
-    while name_start > 0 {
-        let b = bytes[name_start - 1];
-        if b.is_ascii_whitespace() || b == b'<' || b == b'/' || b == b'"' || b == b'\'' {
-            break;
-        }
-        name_start -= 1;
-    }
-    if name_start == name_end {
-        return false;
-    }
-    let name = &bytes[name_start..name_end];
-    URL_VALUED_ATTRS
-        .iter()
-        .any(|n| name.eq_ignore_ascii_case(n))
+    url_valued_attr_name_before_eq(bytes, eq_at)
 }
 
 /// Scan `hay` for any reflected variant of a dangerous-scheme payload. Returns
@@ -618,26 +605,7 @@ fn occurrence_inside_url_attr_value(bytes: &[u8], at: usize) -> bool {
                 if k == 0 || bytes[k - 1] != b'=' {
                     return false;
                 }
-                let mut name_end = k - 1;
-                while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
-                    name_end -= 1;
-                }
-                let mut name_start = name_end;
-                while name_start > 0 {
-                    let b = bytes[name_start - 1];
-                    if b.is_ascii_whitespace() || b == b'<' || b == b'/' || b == b'"' || b == b'\''
-                    {
-                        break;
-                    }
-                    name_start -= 1;
-                }
-                if name_start == name_end {
-                    return false;
-                }
-                let name = &bytes[name_start..name_end];
-                return URL_VALUED_ATTRS
-                    .iter()
-                    .any(|n| name.eq_ignore_ascii_case(n));
+                return url_valued_attr_name_before_eq(bytes, k - 1);
             }
             // Crossing a tag boundary means we're not inside an attribute value.
             b'<' | b'>' => return false,

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -563,6 +563,13 @@ fn dangerous_scheme_reflection_is_inert(html: &str, payload: &str) -> bool {
     if variants.iter().any(|v| v.contains(['<', '>'])) {
         return false;
     }
+    // ...and the scheme is not echoed inside a <script> block, where a JS
+    // navigation sink (`location.href = "javascript:..."`) makes it executable
+    // even though it never sits at a URL-attr scheme-start. Leave those to the
+    // JS-context / AST path rather than hiding a real finding.
+    if variant_occurs_in_script_block(html, &variants) {
+        return false;
+    }
     // Scan the raw response and its URL-decoded view (the self-link echo carries
     // the scheme percent-encoded). Any executable occurrence keeps the finding.
     let (mut found, executable) = scan_dangerous_scheme_occurrences(html, &variants);
@@ -749,6 +756,21 @@ fn script_block_ranges(html: &str) -> Vec<(usize, usize)> {
         }
     }
     ranges
+}
+
+/// True when any reflected variant of the payload appears inside a
+/// `<script>...</script>` block. A dangerous URL scheme echoed there can feed a
+/// JS navigation sink (`location.href = "javascript:..."`) where it executes
+/// despite never sitting at a URL-attribute scheme-start, so the inert-scheme
+/// gate must not suppress it (let the JS-context / AST path judge executability).
+fn variant_occurs_in_script_block(html: &str, variants: &[String]) -> bool {
+    let ranges = script_block_ranges(html);
+    ranges.iter().any(|&(s, e)| {
+        let block = &html[s..e];
+        variants
+            .iter()
+            .any(|v| !v.is_empty() && block.contains(v.as_str()))
+    })
 }
 
 /// Helper: every occurrence of `needle` in `haystack` falls inside one of the

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -295,6 +295,21 @@ fn is_in_safe_context_decoded(html: &str, payload: &str) -> bool {
     if is_inert_encoded_reflection(html, payload) {
         return true;
     }
+    // Inert dangerous-scheme echo: a `javascript:`/`vbscript:`/`data:…` payload
+    // that never reflects at the scheme-start of a URL-valued attribute (only in
+    // body text, a non-URL attribute, or the query/fragment of a self-/canonical
+    // link) cannot navigate to the scheme. Cuts the [R] "reflected after
+    // URL/form decoding" false positive in issue #1153.
+    if dangerous_scheme_reflection_is_inert(html, payload) {
+        return true;
+    }
+    // Inert self-link echo: a break-out-free payload trapped inside the
+    // query/path of a quoted URL-valued attribute (a self-/canonical link that
+    // reflects the param verbatim) can't break out. Covers `javascript:` scheme
+    // WAF-evasion mutations the server echoes without transforming (issue #1153).
+    if reflection_trapped_in_url_value(html, payload) {
+        return true;
+    }
     false
 }
 
@@ -424,6 +439,275 @@ fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
     URL_VALUED_ATTRS
         .iter()
         .any(|n| name.eq_ignore_ascii_case(n))
+}
+
+/// True when a decoded payload form is a JS-executable URL scheme — the schemes
+/// a browser runs when one is the scheme of a *navigated* URL. Mirrors the set
+/// in [`url_encoded_payload_reflects_in_unsafe_url_context`].
+///
+/// Normalizes the way a browser does before reading a URL scheme: TAB/LF/CR are
+/// removed from anywhere in the URL and leading C0 control bytes / spaces are
+/// skipped — so a WAF-evasion variant like `java&#9;script:` / `java\tscript:`
+/// still resolves to `javascript:` and is recognized.
+fn decoded_is_dangerous_scheme(s: &str) -> bool {
+    let normalized: String = s
+        .chars()
+        .filter(|c| !matches!(c, '\t' | '\n' | '\r'))
+        .collect();
+    let trimmed = normalized.trim_start_matches(|c: char| (c as u32) < 0x20 || c == ' ');
+    let lower = trimmed.to_ascii_lowercase();
+    lower.starts_with("javascript:")
+        || lower.starts_with("data:text/html")
+        || lower.starts_with("data:image/svg")
+        || lower.starts_with("vbscript:")
+}
+
+/// True when byte offset `at` is the first *effective* character of a
+/// URL-valued attribute's value — so a dangerous scheme starting there is the
+/// URL's scheme and navigates/executes. Browsers strip leading ASCII whitespace
+/// and C0 control bytes (incl. TAB/LF/CR) before parsing the scheme, so those
+/// are skipped. Unlike [`occurrence_is_in_url_attr`] this distinguishes the
+/// scheme position (`href="javascript:…"`, executable) from a mid-value query
+/// position (`href="/p?x=javascript:…"`, an inert self-/canonical-link echo).
+fn scheme_at_url_attr_value_start(bytes: &[u8], at: usize) -> bool {
+    if at > bytes.len() {
+        return false;
+    }
+    // Skip back over characters a browser removes before the scheme.
+    let mut i = at;
+    while i > 0 {
+        let b = bytes[i - 1];
+        if b.is_ascii_whitespace() || b < 0x20 {
+            i -= 1;
+        } else {
+            break;
+        }
+    }
+    if i == 0 {
+        return false;
+    }
+    // The value must open immediately to the left: an unquoted `name=` value, or
+    // a quoted value whose opening quote is itself preceded by `=`.
+    let eq_at = match bytes[i - 1] {
+        b'"' | b'\'' => {
+            let mut k = i - 1;
+            while k > 0 && bytes[k - 1].is_ascii_whitespace() {
+                k -= 1;
+            }
+            if k == 0 || bytes[k - 1] != b'=' {
+                return false;
+            }
+            k - 1
+        }
+        b'=' => i - 1,
+        _ => return false,
+    };
+    // The token immediately left of `=` must be a URL-valued attribute name.
+    let mut name_end = eq_at;
+    while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
+        name_end -= 1;
+    }
+    let mut name_start = name_end;
+    while name_start > 0 {
+        let b = bytes[name_start - 1];
+        if b.is_ascii_whitespace() || b == b'<' || b == b'/' || b == b'"' || b == b'\'' {
+            break;
+        }
+        name_start -= 1;
+    }
+    if name_start == name_end {
+        return false;
+    }
+    let name = &bytes[name_start..name_end];
+    URL_VALUED_ATTRS
+        .iter()
+        .any(|n| name.eq_ignore_ascii_case(n))
+}
+
+/// Scan `hay` for any reflected variant of a dangerous-scheme payload. Returns
+/// `(found, executable)`: `found` is set once any variant appears; `executable`
+/// is set when an occurrence sits at a URL-attr scheme-start (browser would
+/// navigate to the scheme). Bails toward `executable=true` past the occurrence
+/// budget so the cap can only cost extra [R] noise, never a missed bug.
+fn scan_dangerous_scheme_occurrences(hay: &str, variants: &[String]) -> (bool, bool) {
+    let bytes = hay.as_bytes();
+    let mut found = false;
+    for v in variants {
+        if v.is_empty() {
+            continue;
+        }
+        let mut start = 0;
+        let mut scanned = 0usize;
+        while let Some(pos) = hay[start..].find(v.as_str()) {
+            found = true;
+            scanned += 1;
+            if scanned > MAX_PAYLOAD_OCCURRENCES {
+                return (true, true);
+            }
+            let abs = start + pos;
+            if scheme_at_url_attr_value_start(bytes, abs) {
+                return (true, true);
+            }
+            start = next_char_boundary(hay, abs + 1);
+        }
+    }
+    (found, false)
+}
+
+/// Suppression gate for issue #1153: a payload that decodes to a JS-executable
+/// URL scheme (`javascript:` / `vbscript:` / `data:…`) is only exploitable when
+/// it reflects at the *scheme position* of a URL-valued attribute. Reflected in
+/// body text, a non-URL attribute, or merely the query/fragment of another URL
+/// (a self-referencing or canonical link — the common ASP.NET shape that echoes
+/// the raw, percent-encoded query string), it cannot navigate to the scheme and
+/// is inert. Returns true (=> suppress) when the scheme reflects but never at a
+/// scheme-start.
+///
+/// Scope-limited to NON-TAG payloads (no raw `<`/`>` in any variant), matching
+/// [`is_inert_encoded_reflection`]: a tag-bearing `data:text/html,<script>` echo
+/// is left to the DOM/AST verification path, which can prove a live element.
+fn dangerous_scheme_reflection_is_inert(html: &str, payload: &str) -> bool {
+    let variants = payload_variants(payload);
+    // Only applies when a decoded form is a dangerous URL scheme...
+    if !variants.iter().any(|v| decoded_is_dangerous_scheme(v)) {
+        return false;
+    }
+    // ...and the payload cannot inject a tag (those are the DOM path's job).
+    if variants.iter().any(|v| v.contains(['<', '>'])) {
+        return false;
+    }
+    // Scan the raw response and its URL-decoded view (the self-link echo carries
+    // the scheme percent-encoded). Any executable occurrence keeps the finding.
+    let (mut found, executable) = scan_dangerous_scheme_occurrences(html, &variants);
+    if executable {
+        return false;
+    }
+    if let Ok(decoded) = urlencoding::decode(html)
+        && decoded.as_ref() != html
+    {
+        let (f2, x2) = scan_dangerous_scheme_occurrences(&decoded, &variants);
+        if x2 {
+            return false;
+        }
+        found = found || f2;
+    }
+    found
+}
+
+/// True when byte offset `at` sits inside the value of a *quoted* URL-valued
+/// attribute (anywhere in the value — scheme, path, query, or fragment).
+/// Walks back to the value's opening quote without crossing a tag boundary,
+/// then checks the quote opens a URL-valued attribute. Unlike
+/// [`scheme_at_url_attr_value_start`] this does not require the scheme position;
+/// unlike [`occurrence_is_in_url_attr`] it correctly handles values that contain
+/// `=` / `?` / `&` (a self-link's query string).
+fn occurrence_inside_url_attr_value(bytes: &[u8], at: usize) -> bool {
+    if at > bytes.len() {
+        return false;
+    }
+    let mut i = at;
+    while i > 0 {
+        i -= 1;
+        match bytes[i] {
+            b'"' | b'\'' => {
+                // Candidate value-opening quote: require `= name` before it.
+                let mut k = i;
+                while k > 0 && bytes[k - 1].is_ascii_whitespace() {
+                    k -= 1;
+                }
+                if k == 0 || bytes[k - 1] != b'=' {
+                    return false;
+                }
+                let mut name_end = k - 1;
+                while name_end > 0 && bytes[name_end - 1].is_ascii_whitespace() {
+                    name_end -= 1;
+                }
+                let mut name_start = name_end;
+                while name_start > 0 {
+                    let b = bytes[name_start - 1];
+                    if b.is_ascii_whitespace() || b == b'<' || b == b'/' || b == b'"' || b == b'\''
+                    {
+                        break;
+                    }
+                    name_start -= 1;
+                }
+                if name_start == name_end {
+                    return false;
+                }
+                let name = &bytes[name_start..name_end];
+                return URL_VALUED_ATTRS
+                    .iter()
+                    .any(|n| name.eq_ignore_ascii_case(n));
+            }
+            // Crossing a tag boundary means we're not inside an attribute value.
+            b'<' | b'>' => return false,
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Scan helper for [`reflection_trapped_in_url_value`]. Returns
+/// `(found, escaped)`: `escaped` is set if any occurrence is at a URL-attr
+/// scheme-start (potentially executable) or outside a quoted URL-attr value
+/// (body text, non-URL attribute, …) — either means the payload is NOT safely
+/// trapped. Bails toward `escaped=true` past the occurrence budget.
+fn scan_url_value_trapping(hay: &str, variants: &[String]) -> (bool, bool) {
+    let bytes = hay.as_bytes();
+    let mut found = false;
+    for v in variants {
+        if v.is_empty() {
+            continue;
+        }
+        let mut start = 0;
+        let mut scanned = 0usize;
+        while let Some(pos) = hay[start..].find(v.as_str()) {
+            found = true;
+            scanned += 1;
+            if scanned > MAX_PAYLOAD_OCCURRENCES {
+                return (true, true);
+            }
+            let abs = start + pos;
+            if scheme_at_url_attr_value_start(bytes, abs)
+                || !occurrence_inside_url_attr_value(bytes, abs)
+            {
+                return (true, true);
+            }
+            start = next_char_boundary(hay, abs + 1);
+        }
+    }
+    (found, false)
+}
+
+/// Suppression gate for issue #1153 (self-/canonical-link echo of arbitrary
+/// params): a payload with no break-out characters (no `<`/`>`/`"`/`'` in any
+/// variant) whose every reflected occurrence sits inside a *quoted* URL-valued
+/// attribute value at a non-scheme-start position cannot execute. It can't close
+/// the quote, open a tag, or change the URL's scheme — it is just inert text in
+/// the path/query/fragment of a link. Covers a bare `javascript:` scheme AND its
+/// WAF-evasion mutations (`java\tscript:`, `javasscriptcript:`, …) that a server
+/// reflects verbatim in a self-link without ever transforming them.
+fn reflection_trapped_in_url_value(html: &str, payload: &str) -> bool {
+    let variants = payload_variants(payload);
+    // Any quote/angle in a variant could break the attribute or open a tag —
+    // out of scope here (handled by the tag/quote-aware gates).
+    if variants.iter().any(|v| v.contains(['<', '>', '"', '\''])) {
+        return false;
+    }
+    let (mut found, escaped) = scan_url_value_trapping(html, &variants);
+    if escaped {
+        return false;
+    }
+    if let Ok(decoded) = urlencoding::decode(html)
+        && decoded.as_ref() != html
+    {
+        let (f2, e2) = scan_url_value_trapping(&decoded, &variants);
+        if e2 {
+            return false;
+        }
+        found = found || f2;
+    }
+    found
 }
 
 /// Body-aware version of [`should_suppress_path_reflection`]. Lets

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -425,6 +425,16 @@ fn url_valued_attr_name_before_eq(bytes: &[u8], eq: usize) -> bool {
 /// or unquoted attribute value whose attribute name is in
 /// [`URL_VALUED_ATTRS`]. Returns `false` for text content (we hit `>`
 /// before finding `=`) and for non-URL attributes.
+///
+/// This is the LOOSER of the URL-attribute position checks: it matches an
+/// occurrence *anywhere* in the value (scheme, path, query, or fragment).
+/// [`scheme_at_url_attr_value_start`] / [`occurrence_inside_url_attr_value`]
+/// (the #1153 gates in [`is_in_safe_context_decoded`]) deliberately apply the
+/// stricter scheme-position rule downstream, re-suppressing a mid-query
+/// `javascript:` echo that this check keeps. Keep the rules separate — do not
+/// "reconcile" them by tightening this one, or the legitimate
+/// `href="javascript:…"` `[R]` is lost; nor loosen the gates, or the #1153
+/// self-/canonical-link false positive returns.
 fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
     if at == 0 || at > bytes.len() {
         return false;
@@ -576,7 +586,11 @@ fn dangerous_scheme_reflection_is_inert(html: &str, payload: &str) -> bool {
     if executable {
         return false;
     }
-    if let Ok(decoded) = urlencoding::decode(html)
+    // Only pay the full-body URL-decode allocation when the body actually
+    // carries a percent-escape (the self-link echo does); without `%`,
+    // `urlencoding::decode` is a no-op clone. Mirrors `decode_form_urlencoded_like`.
+    if html.as_bytes().contains(&b'%')
+        && let Ok(decoded) = urlencoding::decode(html)
         && decoded.as_ref() != html
     {
         let (f2, x2) = scan_dangerous_scheme_occurrences(&decoded, &variants);
@@ -673,7 +687,10 @@ fn reflection_trapped_in_url_value(html: &str, payload: &str) -> bool {
     if escaped {
         return false;
     }
-    if let Ok(decoded) = urlencoding::decode(html)
+    // Skip the full-body URL-decode allocation unless the body carries a
+    // percent-escape (mirrors `decode_form_urlencoded_like` / the scheme gate).
+    if html.as_bytes().contains(&b'%')
+        && let Ok(decoded) = urlencoding::decode(html)
         && decoded.as_ref() != html
     {
         let (f2, e2) = scan_url_value_trapping(&decoded, &variants);
@@ -859,6 +876,21 @@ fn is_payload_inert_in_scripts(html: &str, payload: &str) -> bool {
         }
     }
     if !matched {
+        return false;
+    }
+
+    // A dangerous URL scheme (`javascript:`/`vbscript:`/`data:…`) echoed RAW in
+    // a <script> block can flow into a JS navigation sink — e.g.
+    // `location.href = "javascript:alert(1)"` — and execute. The AST check below
+    // only flags a sink *call* the payload itself introduces, not a payload that
+    // is a passive string value assigned to a pre-existing sink, so it marks this
+    // inert. Keep the reflection reported instead. This is the authoritative half
+    // of the carve-out mirrored in `dangerous_scheme_reflection_is_inert`: that
+    // gate runs *after* this one in `is_in_safe_context_decoded`, so without this
+    // guard its `<script>` carve-out is unreachable and the finding is suppressed.
+    if candidates.iter().any(|c| decoded_is_dangerous_scheme(c))
+        && variant_occurs_in_script_block(html, &candidates)
+    {
         return false;
     }
 

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1838,6 +1838,25 @@ fn test_scheme_fp_keeps_executable_scheme_start() {
 }
 
 #[test]
+fn test_scheme_fp_keeps_scheme_in_script_navigation_sink() {
+    // A dangerous scheme echoed inside a <script> block can feed a JS navigation
+    // sink (`location.href = "javascript:..."`) and execute, even though it never
+    // sits at a URL-attribute scheme-start. The inert-scheme gate MUST NOT
+    // suppress it — let the JS-context / AST path decide executability.
+    let payload = "javascript:alert(1)";
+    for html in [
+        "<script>location.href = \"javascript:alert(1)\";</script>",
+        "<script>window.location = 'javascript:alert(1)';</script>",
+        "<script>var u = \"javascript:alert(1)\"; location.assign(u);</script>",
+    ] {
+        assert!(
+            !dangerous_scheme_reflection_is_inert(html, payload),
+            "scheme inside <script> must not be demoted as inert: {html}"
+        );
+    }
+}
+
+#[test]
 fn test_scheme_fp_keeps_when_both_inert_and_executable_present() {
     // An inert query echo co-existing with a real scheme-start href: keep.
     let payload = "javascript:alert(1)";

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1748,3 +1748,182 @@ fn test_inert_encoded_reflection_keeps_case_folded_reflection_no_echo() {
         "case-folded live reflection must not be suppressed"
     );
 }
+
+// ---- issue #1153: inert dangerous-scheme reflection (self-/canonical-link
+// echo, body text, non-URL attr) must be demoted; an executable scheme-start
+// in a URL-valued attribute must be kept. ----
+
+#[test]
+fn test_scheme_fp_suppresses_self_link_query_encoded() {
+    // Issue #1153 exact shape: ASP.NET-style canonical/self link echoes the raw
+    // percent-encoded query string, so `javascript:` sits in the QUERY position
+    // of the link's URL (the page's own http scheme), never navigating to it.
+    let payload = "javascript:alert(1)";
+    let html = "<head><link rel=\"canonical\" href=\"/About.aspx?hello=visitor&any=javascript%3Aalert%281%29\"></head><body><a href=\"/About.aspx?any=javascript%3Aalert%281%29\">home</a></body>";
+    assert!(
+        dangerous_scheme_reflection_is_inert(html, payload),
+        "scheme in a self-link query position is inert"
+    );
+    assert!(
+        is_in_safe_context_decoded(html, payload),
+        "issue #1153 self-link [R] FP must be suppressed"
+    );
+}
+
+#[test]
+fn test_scheme_fp_suppresses_tab_obfuscated_scheme_in_self_link() {
+    // WAF-evasion mutation: a TAB inside the scheme (`java\tscript:`). Browsers
+    // strip TAB/LF/CR from URLs, so it is the same `javascript:` scheme — and in
+    // a self-link query position it is just as inert.
+    let payload = "java\tscript:alert(1)";
+    let html = "<a href=\"/About.aspx?any=java%09script%3Aalert%281%29\">home</a>";
+    assert!(
+        dangerous_scheme_reflection_is_inert(html, payload),
+        "tab-obfuscated scheme in a self-link query position is inert"
+    );
+    assert!(is_in_safe_context_decoded(html, payload));
+    // ...but still kept at a real href scheme-start.
+    let exec = "<a href=\"java\tscript:alert(1)\">x</a>";
+    assert!(!dangerous_scheme_reflection_is_inert(exec, payload));
+}
+
+#[test]
+fn test_scheme_fp_suppresses_self_link_query_raw() {
+    let payload = "javascript:alert(1)";
+    let html = "<a href=\"/p?next=javascript:alert(1)\">go</a>";
+    assert!(dangerous_scheme_reflection_is_inert(html, payload));
+    assert!(is_in_safe_context_decoded(html, payload));
+}
+
+#[test]
+fn test_scheme_fp_suppresses_body_text() {
+    // Bare scheme rendered as plain body text never navigates.
+    let payload = "javascript:alert(1)";
+    for html in [
+        "<div>You searched for: javascript:alert(1)</div>",
+        "<div>You searched for: javascript%3Aalert%281%29</div>",
+        "<p data-note=\"javascript:alert(1)\">x</p>", // non-URL attribute
+    ] {
+        assert!(
+            dangerous_scheme_reflection_is_inert(html, payload),
+            "inert scheme echo must be demoted: {html}"
+        );
+        assert!(is_in_safe_context_decoded(html, payload));
+    }
+}
+
+#[test]
+fn test_scheme_fp_keeps_executable_scheme_start() {
+    // A scheme at the start of a URL-valued attribute value navigates/executes
+    // and MUST be kept (no false negative).
+    let payload = "javascript:alert(1)";
+    for html in [
+        "<a href=\"javascript:alert(1)\">x</a>",
+        "<a href=javascript:alert(1)>x</a>", // unquoted
+        "<iframe src=\"javascript:alert(1)\"></iframe>",
+        "<a href=\"  javascript:alert(1)\">x</a>", // browser strips leading ws
+        "<a href=\"\tjavascript:alert(1)\">x</a>", // TAB stripped from URLs
+        "<svg><a xlink:href=\"javascript%3Aalert%281%29\"><text>x</text></a></svg>",
+        "<form action=\"javascript:alert(1)\"></form>",
+    ] {
+        assert!(
+            !dangerous_scheme_reflection_is_inert(html, payload),
+            "executable scheme-start must be kept: {html}"
+        );
+        assert!(
+            !is_in_safe_context_decoded(html, payload),
+            "executable scheme-start must not be suppressed: {html}"
+        );
+    }
+}
+
+#[test]
+fn test_scheme_fp_keeps_when_both_inert_and_executable_present() {
+    // An inert query echo co-existing with a real scheme-start href: keep.
+    let payload = "javascript:alert(1)";
+    let html =
+        "<a href=\"javascript:alert(1)\">x</a><link href=\"/s?u=javascript%3Aalert%281%29\">";
+    assert!(!dangerous_scheme_reflection_is_inert(html, payload));
+}
+
+#[test]
+fn test_scheme_fp_ignores_non_scheme_payloads() {
+    // The gate is scoped to dangerous URL schemes; other payloads are untouched.
+    assert!(!dangerous_scheme_reflection_is_inert(
+        "<div>hello world</div>",
+        "hello world"
+    ));
+    // Tag-bearing data: payload is out of scope (DOM/AST path handles it).
+    assert!(!dangerous_scheme_reflection_is_inert(
+        "<div>data:text/html,&lt;script&gt;</div>",
+        "data:text/html,<script>alert(1)</script>"
+    ));
+}
+
+#[test]
+fn test_scheme_at_url_attr_value_start_positions() {
+    // Direct unit coverage of the position helper.
+    let exec = "<a href=\"javascript:alert(1)\">"; // scheme at value start
+    let pos = exec.find("javascript:").unwrap();
+    assert!(scheme_at_url_attr_value_start(exec.as_bytes(), pos));
+
+    let query = "<a href=\"/p?x=javascript:alert(1)\">"; // mid-value (query)
+    let pos = query.find("javascript:").unwrap();
+    assert!(!scheme_at_url_attr_value_start(query.as_bytes(), pos));
+
+    let body = "<div>javascript:alert(1)</div>"; // not in any attribute
+    let pos = body.find("javascript:").unwrap();
+    assert!(!scheme_at_url_attr_value_start(body.as_bytes(), pos));
+}
+
+#[test]
+fn test_trapped_in_url_value_suppresses_scheme_mutations() {
+    // WAF-evasion scheme mutations a server echoes verbatim into a self-link
+    // query are inert (no quote/angle, not at scheme-start). Issue #1153.
+    let html = "<link rel=\"canonical\" href=\"/About.aspx?any=PAYLOAD\"><a href=\"/About.aspx?any=PAYLOAD\">home</a>";
+    for p in [
+        "javasscriptcript:alert(1)",
+        "java\tscript:alert(1)",
+        "vbscript:msgbox(1)",
+        "data:text/html;base64,x",
+    ] {
+        let h = html.replace("PAYLOAD", p);
+        assert!(
+            reflection_trapped_in_url_value(&h, p),
+            "verbatim self-link echo must be inert: {p}"
+        );
+        assert!(is_in_safe_context_decoded(&h, p));
+    }
+}
+
+#[test]
+fn test_trapped_in_url_value_keeps_breakout_and_scheme_start() {
+    // A quote in the payload could close the attribute -> keep.
+    let q = "<a href=\"/p?x=\";alert(1)\">x</a>";
+    assert!(!reflection_trapped_in_url_value(q, "\";alert(1)"));
+    // Scheme at the value start navigates -> keep.
+    let exec = "<a href=\"javascript:alert(1)\">x</a>";
+    assert!(!reflection_trapped_in_url_value(
+        exec,
+        "javascript:alert(1)"
+    ));
+    // Reflected in body text (not a URL attr) -> not this gate's job.
+    let body = "<div>foobar123</div>";
+    assert!(!reflection_trapped_in_url_value(body, "foobar123"));
+}
+
+#[test]
+fn test_occurrence_inside_url_attr_value_handles_query_string() {
+    // The href value contains `=`/`?`/`&`; the occurrence is still inside it.
+    let h = "<a href=\"/About.aspx?hello=visitor&any=zzmarker\">x</a>";
+    let pos = h.find("zzmarker").unwrap();
+    assert!(occurrence_inside_url_attr_value(h.as_bytes(), pos));
+    // Non-URL attribute value -> false.
+    let h2 = "<input value=\"zzmarker\">";
+    let pos2 = h2.find("zzmarker").unwrap();
+    assert!(!occurrence_inside_url_attr_value(h2.as_bytes(), pos2));
+    // Body text -> false.
+    let h3 = "<p>zzmarker</p>";
+    let pos3 = h3.find("zzmarker").unwrap();
+    assert!(!occurrence_inside_url_attr_value(h3.as_bytes(), pos3));
+}

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1843,6 +1843,13 @@ fn test_scheme_fp_keeps_scheme_in_script_navigation_sink() {
     // sink (`location.href = "javascript:..."`) and execute, even though it never
     // sits at a URL-attribute scheme-start. The inert-scheme gate MUST NOT
     // suppress it — let the JS-context / AST path decide executability.
+    //
+    // This drives the FULL `is_in_safe_context_decoded` path, not just the
+    // dangerous-scheme helper: `is_payload_inert_in_scripts` runs *first* there
+    // and, before the dangerous-scheme guard was added, suppressed all three of
+    // these end-to-end (its AST sink-call check does not model a passive scheme
+    // value assigned to `location.href`), making the helper-level carve-out dead
+    // code. Asserting through `is_in_safe_context_decoded` pins the real behavior.
     let payload = "javascript:alert(1)";
     for html in [
         "<script>location.href = \"javascript:alert(1)\";</script>",
@@ -1852,6 +1859,48 @@ fn test_scheme_fp_keeps_scheme_in_script_navigation_sink() {
         assert!(
             !dangerous_scheme_reflection_is_inert(html, payload),
             "scheme inside <script> must not be demoted as inert: {html}"
+        );
+        assert!(
+            !is_payload_inert_in_scripts(html, payload),
+            "is_payload_inert_in_scripts must not mask a <script> nav-sink scheme: {html}"
+        );
+        assert!(
+            !is_in_safe_context_decoded(html, payload),
+            "<script> nav-sink scheme must survive the full suppression pipeline: {html}"
+        );
+    }
+}
+
+#[test]
+fn test_scheme_fp_non_javascript_schemes_keep_at_scheme_start() {
+    // The other dangerous-scheme families (`data:text/html`, `data:image/svg`,
+    // `vbscript:`) were only exercised on the SUPPRESS path; pin the
+    // executable-KEEP direction too so a typo in those literals or a
+    // scheme-start regression can't silently drop their [R]/static-V.
+    for (payload, exec_html) in [
+        (
+            "data:text/html;base64,PHN2Zz4=",
+            "<iframe src=\"data:text/html;base64,PHN2Zz4=\"></iframe>",
+        ),
+        (
+            "data:image/svg+xml;base64,PHN2Zz4=",
+            "<object data=\"data:image/svg+xml;base64,PHN2Zz4=\"></object>",
+        ),
+        ("vbscript:msgbox(1)", "<a href=\"vbscript:msgbox(1)\">x</a>"),
+    ] {
+        assert!(
+            !dangerous_scheme_reflection_is_inert(exec_html, payload),
+            "scheme at a URL-attr value start must be kept: {exec_html}"
+        );
+        assert!(
+            !is_in_safe_context_decoded(exec_html, payload),
+            "executable scheme-start must not be suppressed: {exec_html}"
+        );
+        // ...and the same scheme echoed in a self-link query position is inert.
+        let inert_html = format!("<a href=\"/p?next={payload}\">go</a>");
+        assert!(
+            dangerous_scheme_reflection_is_inert(&inert_html, payload),
+            "scheme in a self-link query position is inert: {inert_html}"
         );
     }
 }


### PR DESCRIPTION
## Summary

Fixes the false positive reported in #1153: a bare `javascript:alert(1)` injected into a (mined) param was reported as an `[R]` **"reflected after URL/form decoding"** finding when an ASP.NET-style page echoed the raw, percent-encoded query string back into a self-/canonical link:

```html
<link rel="canonical" href="/About.aspx?hello=visitor&any=javascript%3Aalert%281%29">
```

There the `javascript:` text sits in the **query position** of the page's own (http) URL — never at a scheme position — so clicking the link navigates to `About.aspx`, not `javascript:`. It cannot execute. **False positive.**

## Root cause

The reflected-XSS suppression gates (`is_in_safe_context_decoded`) only covered tag/quote payloads and *encoded* echoes (`is_inert_encoded_reflection`, #1133). A **decoded** URL-scheme payload (`javascript:alert(1)`, no `%`) reflected **outside** an executable scheme position fell through every gate:
- `payload_is_fully_url_encoded` only fires for payloads that themselves carry `%`.
- `payload_variants` only *decodes*, so it never matches the `javascript%3A…` actually present in the response.
- the scheme has no structural char to "un-escape", so the decoded-view branch never marks it inert.

## Fix

Two scope-limited, sound gates added to `is_in_safe_context_decoded`:

1. **`dangerous_scheme_reflection_is_inert`** — a `javascript:` / `vbscript:` / `data:text/html` / `data:image/svg` payload (incl. browser-normalized TAB/LF/CR obfuscation like `java\tscript:`) reflected only in body text, a non-URL attribute, or the query/path of a URL is inert.
2. **`reflection_trapped_in_url_value`** — a break-out-free payload (no `<` `>` `"` `'` in any variant) whose **every** occurrence sits inside a *quoted* URL-valued attribute value at a non-scheme-start position can't close the quote, open a tag, or change the scheme. Also covers simple `javascript:` WAF-evasion scheme mutations echoed verbatim.

`scheme_at_url_attr_value_start` / `occurrence_inside_url_attr_value` provide the position awareness: a scheme at a URL-attr **value start** (`<a href="javascript:alert(1)">`, executable) is kept; quote/tag break-outs are untouched.

## Verification
- Built `v3.0.2` and this branch and scanned an ASP.NET-faithful local mock (rejects `<`/`>` with 500 like request validation; reflects non-tag params in a canonical self-link). **3.0.2 emits `R | javascript:alert(1) | reflected after URL/form decoding`; this branch does not.**
- 11 new regression tests; **1777 lib tests pass**, clippy/fmt clean.

## Not addressed here
The "stuck for ~20 minutes" symptom in #1153 is **request amplification** on self-reflecting endpoints (a self-link that echoes every payload makes dalfox pursue every encoder/mutation — thousands of requests/param), not a deadlock. That is handled separately (draft PR to follow). Exotic encodings echoed verbatim by a pathological self-reflecting endpoint (e.g. an entity-encoded synthesis payload containing a quote) are also better addressed by that self-reflection handling than by more per-payload byte heuristics here.

Fixes #1153
