### PR TITLE
fix: code-quality audit fixes (collapse underflow, blind-XSS body, config banner) + residual #1153 self-link FP

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -289,8 +289,26 @@ async fn main() {
         .and_then(|r| r.config.scan.as_ref())
         .and_then(|s| s.silence)
         .unwrap_or(false);
+    // A machine-readable `format` set *only* in the config file (not on the CLI)
+    // must also suppress the banner — otherwise the ASCII banner is prepended to
+    // the JSON/JSONL/SARIF/TOML document on stdout and breaks any pipeline that
+    // configures the format via file rather than `--format`. `is_machine_format`
+    // above only sees CLI args, so fold the config value in the same way
+    // `config_silence` folds the config `silence`.
+    let config_machine_format = config_load
+        .as_ref()
+        .ok()
+        .and_then(|r| r.config.scan.as_ref())
+        .and_then(|s| s.format.as_deref())
+        .map(|f| matches!(f, "json" | "jsonl" | "sarif" | "toml"))
+        .unwrap_or(false);
     let effective_silence = cli.silence || scan_silence || config_silence;
-    if !is_mcp && !is_machine_format && !effective_silence && !is_payload_selector {
+    if !is_mcp
+        && !is_machine_format
+        && !config_machine_format
+        && !effective_silence
+        && !is_payload_selector
+    {
         utils::print_banner_once(env!("CARGO_PKG_VERSION"), color_enabled);
     }
 

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -668,22 +668,58 @@ fn scan_url_value_trapping(hay: &str, variants: &[String]) -> (bool, bool) {
     (found, false)
 }
 
+/// True when any of `variants` (the break-out-bearing forms — each carrying a
+/// raw `<`/`>`/`"`/`'`) appears *literally* in `html` or its URL-decoded view.
+/// A literal reflection of such a form could close the attribute quote or open a
+/// tag, so the URL-value trapping gate must not suppress it. When only the
+/// encoded form of the same payload is reflected (e.g. `%22`/`&quot;` instead of
+/// a raw `"`), no literal break-out byte is present and this returns false.
+fn any_variant_reflected_literally(html: &str, variants: &[String]) -> bool {
+    if variants
+        .iter()
+        .any(|v| !v.is_empty() && html.contains(v.as_str()))
+    {
+        return true;
+    }
+    if html.as_bytes().contains(&b'%')
+        && let Ok(decoded) = urlencoding::decode(html)
+        && decoded.as_ref() != html
+    {
+        return variants
+            .iter()
+            .any(|v| !v.is_empty() && decoded.contains(v.as_str()));
+    }
+    false
+}
+
 /// Suppression gate for issue #1153 (self-/canonical-link echo of arbitrary
-/// params): a payload with no break-out characters (no `<`/`>`/`"`/`'` in any
-/// variant) whose every reflected occurrence sits inside a *quoted* URL-valued
-/// attribute value at a non-scheme-start position cannot execute. It can't close
-/// the quote, open a tag, or change the URL's scheme — it is just inert text in
-/// the path/query/fragment of a link. Covers a bare `javascript:` scheme AND its
-/// WAF-evasion mutations (`java\tscript:`, `javasscriptcript:`, …) that a server
-/// reflects verbatim in a self-link without ever transforming them.
+/// params): a payload whose every reflected occurrence sits inside a *quoted*
+/// URL-valued attribute value at a non-scheme-start position cannot execute. It
+/// can't close the quote, open a tag, or change the URL's scheme — it is just
+/// inert text in the path/query/fragment of a link. Covers a bare `javascript:`
+/// scheme AND its WAF-evasion mutations (`java\tscript:`, `javasscriptcript:`,
+/// `javasscriptcript:top["al"+"\ert"](1)`, …) that a server reflects into a
+/// self-link, whether verbatim or percent-/entity-encoded.
+///
+/// Break-out characters (`<`/`>`/`"`/`'`) are only disqualifying when a variant
+/// carrying them is reflected *literally* (raw or after URL-decoding the body) —
+/// then it could break the attribute and is left to the tag/quote-aware gates /
+/// the reporter. When such a variant exists only because a *decoded* form of the
+/// payload contains a quote (e.g. the entity-encoded `&#x...;` scheme mutation
+/// whose `"` only ever appears as `%22` in the link's query), it is inert and
+/// still suppressed. This closes the residual #1153 FP the original fix missed.
 fn reflection_trapped_in_url_value(html: &str, payload: &str) -> bool {
     let variants = payload_variants(payload);
-    // Any quote/angle in a variant could break the attribute or open a tag —
-    // out of scope here (handled by the tag/quote-aware gates).
-    if variants.iter().any(|v| v.contains(['<', '>', '"', '\''])) {
+    // Partition break-out-free variants (evaluated for trapping) from variants
+    // that carry a raw quote/angle.
+    let (safe, risky): (Vec<String>, Vec<String>) = variants
+        .into_iter()
+        .partition(|v| !v.contains(['<', '>', '"', '\'']));
+    // A break-out variant reflected literally could escape the attribute — keep.
+    if any_variant_reflected_literally(html, &risky) {
         return false;
     }
-    let (mut found, escaped) = scan_url_value_trapping(html, &variants);
+    let (mut found, escaped) = scan_url_value_trapping(html, &safe);
     if escaped {
         return false;
     }
@@ -693,7 +729,7 @@ fn reflection_trapped_in_url_value(html: &str, payload: &str) -> bool {
         && let Ok(decoded) = urlencoding::decode(html)
         && decoded.as_ref() != html
     {
-        let (f2, e2) = scan_url_value_trapping(&decoded, &variants);
+        let (f2, e2) = scan_url_value_trapping(&decoded, &safe);
         if e2 {
             return false;
         }

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1981,6 +1981,68 @@ fn test_trapped_in_url_value_keeps_breakout_and_scheme_start() {
 }
 
 #[test]
+fn test_trapped_in_url_value_suppresses_encoded_scheme_with_quotes_in_self_link() {
+    // Residual #1153 FP (verified against the live binary on a faithful ASP.NET
+    // repro): an entity-encoded, keyword-obfuscated `javascript:` WAF mutation —
+    // here `javascript:a["b"]`, whose *decoded* form carries `"` — is reflected
+    // PERCENT-encoded inside a self-link href query. The raw `"` never appears
+    // (only `%22` inside `%26%23x22%3B`), so it is inert text in the link's
+    // query and must be demoted. The original fix bailed on the decoded `"`.
+    let payload = "&#x6a;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3a;&#x61;&#x5b;&#x22;&#x62;&#x22;&#x5d;";
+    // Sanity: the html-entity-decoded form really does contain a break-out quote.
+    assert!(decode_html_entities(payload).contains('"'));
+    let html = format!(
+        "<link rel=\"canonical\" href=\"/About.aspx?any={enc}\"><a href=\"/About.aspx?any={enc}\">home</a>",
+        enc = urlencoding::encode(payload)
+    );
+    assert!(
+        reflection_trapped_in_url_value(&html, payload),
+        "encoded scheme-with-quotes trapped in a self-link query is inert"
+    );
+    // Drive the FULL gate chain, not just the helper (an earlier gate could
+    // mask this one — see the gate-chain masking lesson).
+    assert!(
+        is_in_safe_context_decoded(&html, payload),
+        "residual #1153 self-link [R] FP must be suppressed end-to-end"
+    );
+}
+
+#[test]
+fn test_trapped_in_url_value_keeps_literal_decoded_quote_breakout() {
+    // Counterpart (no false negative): when a payload's break-out form is
+    // reflected LITERALLY (a raw `"` that can close the attribute) the trapping
+    // gate must NOT suppress it — it is left to the tag/quote-aware gates / the
+    // reporter. The narrow new suppression only ever fires on the *encoded* form.
+    let payload = "&#x6a;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3a;&#x61;&#x5b;&#x22;&#x62;&#x22;&#x5d;";
+    let decoded = decode_html_entities(payload); // javascript:a["b"]
+    assert!(decoded.contains('"'));
+    let html = format!("<a href=\"/p?x={decoded}\">x</a>");
+    assert!(
+        !reflection_trapped_in_url_value(&html, payload),
+        "a literally-reflected raw quote must keep the trapping gate from suppressing"
+    );
+    // And a genuine tag break-out reflected literally is likewise never trapped.
+    let tag = "\"><img src=x onerror=alert(1)>";
+    let tag_html = format!("<a href=\"/p?x={tag}\">x</a>");
+    assert!(!reflection_trapped_in_url_value(&tag_html, tag));
+    assert!(!is_in_safe_context_decoded(&tag_html, tag));
+}
+
+#[test]
+fn test_trapped_in_url_value_keeps_encoded_scheme_at_value_start() {
+    // No false negative: an entity-encoded scheme at the href value START
+    // decodes to `javascript:` in the browser and executes — must be kept even
+    // though it is encoded in the source.
+    let payload = "&#x6a;&#x61;&#x76;&#x61;&#x73;&#x63;&#x72;&#x69;&#x70;&#x74;&#x3a;&#x61;&#x6c;&#x65;&#x72;&#x74;&#x28;&#x31;&#x29;";
+    let html = format!("<a href=\"{payload}\">x</a>");
+    assert!(
+        !reflection_trapped_in_url_value(&html, payload),
+        "entity scheme at the value start is executable and must be kept"
+    );
+    assert!(!is_in_safe_context_decoded(&html, payload));
+}
+
+#[test]
 fn test_occurrence_inside_url_attr_value_handles_query_string() {
     // The href value contains `=`/`?`/`&`; the occurrence is still inside it.
     let h = "<a href=\"/About.aspx?hello=visitor&any=zzmarker\">x</a>";

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1405,17 +1405,26 @@ fn log_waf_block_stats(target: &Target) {
 async fn collapse_target_results(
     results: &Arc<Mutex<Vec<crate::scanning::result::Result>>>,
     findings_count: &Arc<AtomicUsize>,
+    limit_result_type: &str,
     target: &Target,
 ) {
     let mut guard = results.lock().await;
-    let before = guard.len();
     let original = std::mem::take(&mut *guard);
     let target_url_str = target.url.to_string();
+    // Decrement by the drop in *filter-matching* findings, mirroring the add
+    // path (`count_matching_results` in `accumulate`/`record_results`). Using
+    // the raw length delta (`before - after`) would over-decrement whenever the
+    // collapsed entries — always `R` duplicates — don't match
+    // `--limit-result-type` (e.g. `V`/`A`): `findings_count` never counted them,
+    // so subtracting them underflows the unsigned counter to ~usize::MAX and
+    // poisons `limit_reached()` for the rest of a multi-target run (a silent,
+    // hard-to-diagnose scan truncation).
+    let before_matching = count_matching_results(&original, limit_result_type);
     let collapsed = collapse_redundant_reflected(original, &target_url_str);
-    let after = collapsed.len();
+    let after_matching = count_matching_results(&collapsed, limit_result_type);
     *guard = collapsed;
-    if after < before {
-        findings_count.fetch_sub(before - after, Ordering::Relaxed);
+    if after_matching < before_matching {
+        findings_count.fetch_sub(before_matching - after_matching, Ordering::Relaxed);
     }
 }
 
@@ -2383,7 +2392,7 @@ pub async fn run_scanning(
     // Collapse this target's R findings that are already proven by one of
     // its own V findings on the same (param, inject_type), scoped to the
     // current target so other targets' findings are never affected.
-    collapse_target_results(&results, &findings_count, target).await;
+    collapse_target_results(&results, &findings_count, &limit_result_type, target).await;
 
     if let Some(pb) = pb {
         finish_scan_bar(

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -285,6 +285,54 @@ fn test_collapse_keeps_r_for_different_param_or_inject_type() {
     );
 }
 
+#[tokio::test]
+async fn test_collapse_target_results_no_underflow_when_filter_excludes_r() {
+    // Regression: with `--limit-result-type V`, `findings_count` only ever
+    // counted the V findings, but the old collapse subtracted the *raw* drop in
+    // length (the dropped R duplicates). On `usize` that wrapped to ~usize::MAX
+    // and poisoned `limit_reached()` for the rest of a multi-target run.
+    let results = std::sync::Arc::new(tokio::sync::Mutex::new(vec![
+        make_typed_param_result(FindingType::Reflected, "q", "inHTML"),
+        make_typed_param_result(FindingType::Verified, "q", "inHTML"),
+        make_typed_param_result(FindingType::Reflected, "q", "inHTML"),
+    ]));
+    // Under filter "V" only the single V finding was ever counted.
+    let findings_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(1));
+    let target = parse_target("https://example.com/?x=1").unwrap();
+
+    collapse_target_results(&results, &findings_count, "V", &target).await;
+
+    // Two R duplicates dropped, but none matched "V" — counter must be untouched.
+    assert_eq!(
+        findings_count.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "collapse must not decrement findings_count for non-matching (R) drops"
+    );
+    assert_eq!(results.lock().await.len(), 1, "collapse keeps only the V");
+}
+
+#[tokio::test]
+async fn test_collapse_target_results_decrements_matching_r_under_all_filter() {
+    // Counterpart: under "ALL" (or "R") the dropped R duplicates *were* counted,
+    // so the counter must decrement by exactly the matching drop.
+    let results = std::sync::Arc::new(tokio::sync::Mutex::new(vec![
+        make_typed_param_result(FindingType::Reflected, "q", "inHTML"),
+        make_typed_param_result(FindingType::Verified, "q", "inHTML"),
+        make_typed_param_result(FindingType::Reflected, "q", "inHTML"),
+    ]));
+    let findings_count = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(3));
+    let target = parse_target("https://example.com/?x=1").unwrap();
+
+    collapse_target_results(&results, &findings_count, "ALL", &target).await;
+
+    // 3 -> 1 finding: decrement by 2.
+    assert_eq!(
+        findings_count.load(std::sync::atomic::Ordering::Relaxed),
+        1,
+        "collapse must decrement by the matching drop under ALL"
+    );
+}
+
 #[test]
 fn test_collapse_does_not_drop_r_from_other_targets() {
     // V on target A must not drop R on target B even when (param, inject)

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -257,14 +257,31 @@ async fn send_blind_request(target: &Target, param_name: &str, payload: &str, pa
         }
         "body" => {
             if let Some(data) = &target.data {
-                // Simple replace, assuming param=value& format
+                // Parse the form body and replace only the exact-name match's
+                // value, then re-serialize (mirrors the query branch above). The
+                // old `str::replace("{name}=", "{name}={payload}&")` never
+                // removed the original value (`a=1&b=2` -> `a=PAY&1&b=2`,
+                // orphaning `&1`) and matched substring-colliding names (`id`
+                // also rewrote `userid`), corrupting the body and injecting into
+                // the wrong parameter — a silent blind-XSS delivery failure.
+                let mut pairs: Vec<(String, String)> = form_urlencoded::parse(data.as_bytes())
+                    .map(|(k, v)| (k.to_string(), v.to_string()))
+                    .collect();
+                let mut found = false;
+                for pair in &mut pairs {
+                    if pair.0 == param_name {
+                        pair.1 = payload.to_string();
+                        found = true;
+                        break;
+                    }
+                }
+                if !found {
+                    pairs.push((param_name.to_string(), payload.to_string()));
+                }
                 body = Some(
-                    data.replace(
-                        &format!("{}=", param_name),
-                        &format!("{}={}&", param_name, payload),
-                    )
-                    .trim_end_matches('&')
-                    .to_string(),
+                    form_urlencoded::Serializer::new(String::new())
+                        .extend_pairs(&pairs)
+                        .finish(),
                 );
             }
         }

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -134,7 +134,10 @@ async fn test_send_blind_request_mutates_body_header_and_cookie_targets() {
     let records = state.lock().await.clone();
     assert_eq!(records.len(), 3);
     assert_eq!(records[0].method, "POST");
-    assert!(records[0].body.contains("a=BODYPAY"));
+    // Exact body, not a substring: the old naive replace produced the corrupt
+    // `a=BODYPAY&1&b=2` (orphaned `&1`), which a `contains("a=BODYPAY")` check
+    // wrongly accepted. The other pair must survive untouched.
+    assert_eq!(records[0].body, "a=BODYPAY&b=2");
     assert_eq!(
         records[1].headers.get("x-trace").map(String::as_str),
         Some("HDRPAY")
@@ -146,6 +149,37 @@ async fn test_send_blind_request_mutates_body_header_and_cookie_targets() {
             .map(|v| v.contains("session=CKPAY"))
             .unwrap_or(false)
     );
+}
+
+#[tokio::test]
+async fn test_send_blind_request_body_does_not_corrupt_substring_colliding_param() {
+    // `id` must not also rewrite `userid` (the old substring `str::replace`
+    // injected into both, landing the blind payload in the wrong sink).
+    let (addr, state) = start_capture_server().await;
+    let mut target = make_target(addr, "/submit");
+    target.method = "POST".to_string();
+    target.data = Some("id=1&userid=2".to_string());
+
+    send_blind_request(&target, "id", "BODYPAY", "body").await;
+
+    let records = state.lock().await.clone();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].body, "id=BODYPAY&userid=2");
+}
+
+#[tokio::test]
+async fn test_send_blind_request_body_replaces_non_first_param_only() {
+    // Injecting a middle param must leave the surrounding pairs intact.
+    let (addr, state) = start_capture_server().await;
+    let mut target = make_target(addr, "/submit");
+    target.method = "POST".to_string();
+    target.data = Some("a=1&b=2&c=3".to_string());
+
+    send_blind_request(&target, "b", "BODYPAY", "body").await;
+
+    let records = state.lock().await.clone();
+    assert_eq!(records.len(), 1);
+    assert_eq!(records[0].body, "a=1&b=BODYPAY&c=3");
 }
 
 #[tokio::test]

--- a/tests/e2e/config_path_smoke_test.rs
+++ b/tests/e2e/config_path_smoke_test.rs
@@ -34,6 +34,24 @@ fn run_payload_with_xdg_config_home(xdg_home: &Path) -> Output {
         .expect("run dalfox with explicit XDG_CONFIG_HOME")
 }
 
+/// Run a scan against a deliberately invalid target (rejected before any
+/// network I/O) with the output format supplied *only* via `--config`, never on
+/// the CLI. stdin is closed so the scan can't block reading piped targets.
+fn run_scan_with_config(path: &Path) -> Output {
+    Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .args([
+            "--config",
+            path.to_str().expect("utf8 path"),
+            "scan",
+            "not-a-valid-url",
+        ])
+        .stdin(std::process::Stdio::null())
+        .output()
+        .expect("run dalfox scan with explicit --config")
+}
+
+const BANNER_MARK: &str = "████";
+
 #[test]
 fn test_missing_json_config_path_is_created() {
     let dir = unique_temp_dir("cfg-create-json");
@@ -144,6 +162,48 @@ fn test_unreadable_config_path_is_non_fatal_for_payload_command() {
     assert!(
         output.status.success(),
         "directory-as-config read error should not abort payload command"
+    );
+}
+
+#[test]
+fn test_config_set_machine_format_suppresses_banner_on_stdout() {
+    // Regression: `is_machine_format` was computed only from CLI args, so a
+    // `format = "json"` set in the config file (not via `--format`) left the
+    // ASCII banner prepended to the JSON document on stdout, breaking any
+    // pipeline that parses dalfox's machine output.
+    let dir = unique_temp_dir("cfg-machine-format-banner");
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, "[scan]\nformat = \"json\"\n").expect("write json-format config");
+
+    let output = run_scan_with_config(&config_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+
+    assert!(
+        !stdout.contains(BANNER_MARK),
+        "config-set machine format must suppress the banner; stdout was:\n{stdout}"
+    );
+    assert!(
+        stdout.trim_start().starts_with('{'),
+        "config-set json format must emit a clean JSON document; stdout was:\n{stdout}"
+    );
+    serde_json::from_str::<serde_json::Value>(stdout.trim())
+        .expect("config-set json output must parse as JSON");
+}
+
+#[test]
+fn test_config_set_plain_format_keeps_banner() {
+    // Control for the regression above: a non-machine format must still print
+    // the banner, so the suppression is scoped to machine formats only.
+    let dir = unique_temp_dir("cfg-plain-format-banner");
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, "[scan]\nformat = \"plain\"\n")
+        .expect("write plain-format config");
+
+    let output = run_scan_with_config(&config_path);
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        stdout.contains(BANNER_MARK),
+        "plain format must keep the banner; stdout was:\n{stdout}"
     );
 }
 


### PR DESCRIPTION
Fixes surfaced by a full code-quality audit of the scanner, each with regression tests. Four independent commits.

## Correctness fixes (silent false-negatives / corrupted output)

1. **`findings_count` underflow on result collapse** (`scanning/mod.rs`)
   `collapse_target_results` subtracted the raw drop in result count, but the add path only counts results matching `--limit-result-type`. With a filter other than `ALL`/`R` (e.g. `V`/`A`), the collapsed `R` duplicates were never counted, so `fetch_sub` wrapped the unsigned counter to `~usize::MAX` → `limit_reached()` stuck true → the rest of a multi-target scan was silently truncated. Now decrements by the filter-matching delta only.

2. **Blind-XSS body-parameter injection corruption** (`scanning/xss_blind.rs`)
   The `body` param path used a naive `str::replace("{name}=", …)`: it orphaned the original value (`a=1&b=2` → `a=PAY&1&b=2`) and matched substring-colliding names (`id` also rewrote `userid`), so the payload reached the wrong sink or a rejected body. Now parses/rewrites with `form_urlencoded` (mirrors the query path). The old test used a `contains()` assertion that masked the bug — replaced with exact-body `assert_eq!` + collision/non-first-param cases.

3. **Banner leaks into machine output set via config file** (`main.rs`)
   `is_machine_format` was computed only from CLI args, so `format = "json"/jsonl/sarif/toml` set in the **config file** left the ASCII banner prepended to stdout, breaking pipelines. Now folds the config's effective format in, like config-set `silence`.

## FP precision

4. **Residual #1153 self-link scheme false positive** (`scanning/check_reflection.rs`)
   The original #1153 fix demoted a literal `javascript:` self-link echo, but a WAF-mutation variant — an entity-encoded, keyword-obfuscated scheme (`javasscriptcript:top["al"+"\ert"](1)`) reflected percent-encoded in the link's href **query** — still reported `[R]`. `reflection_trapped_in_url_value` bailed because the html-decoded variant carried a `"`, even though that quote only ever appears as `%22` and can't break out. Now only refuses to suppress when a break-out variant is reflected **literally**; an encoded-only reflection trapped in a URL value at a non-scheme-start position is demoted, while a literal break-out or a scheme at the value start is still kept.

## Verification
- Full lib suite **0 failed** (serialized), `cargo clippy --all-targets` **0 warnings**, `cargo fmt` clean.
- #4 verified end-to-end against a faithful ASP.NET-style repro: FP gone in both default and `--waf-bypass auto --waf-evasion` scans; recall preserved (a genuinely vulnerable param still verifies).
- An adversarial false-negative hunt confirmed #4 introduces **no new false negatives** (the FNs it surfaced are pre-existing, unrelated to this change).

_Note: #1153 is already closed; #4 closes a residual variant of the same FP class, not the original report._