### PR TITLE
feat(payload): recall fixes for raw-JS-expression and regex-literal reflected-XSS contexts

### DIFF
--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -184,10 +184,18 @@ const JS_COMMENT_TEMPLATES: &[&str] = &[
 ];
 
 /// Raw JavaScript context (e.g. `var x = INJECT;`): no string to break out of.
+///
+/// The two `/`-led templates close an enclosing **regex literal** (`var re =
+/// /^INJECT$/`) before running the payload: `compute_js_breakout` deliberately
+/// treats `/` only as division/comment (never a regex delimiter), so it never
+/// emits these — but a reflection inside a regex literal is a real, if uncommon,
+/// JS sink. `/;{JS}//` → `…/^/;alert(1)//$/…` (regex `/^/`, then the statement).
 const JS_RAW_TEMPLATES: &[&str] = &[
     "{JS}",
     ";{JS};",
     ";{JS}//",
+    "/;{JS}//",
+    "/;{JS};/",
     "</script><svg onload={JS} class={CLASS}>",
 ];
 
@@ -229,13 +237,37 @@ fn templates_for(context: &InjectionContext) -> Vec<&'static str> {
             }
             t
         }
-        InjectionContext::Javascript(delim) => match delim {
-            Some(DelimiterType::SingleQuote) => JS_SQ_TEMPLATES.to_vec(),
-            Some(DelimiterType::DoubleQuote) => JS_DQ_TEMPLATES.to_vec(),
-            Some(DelimiterType::Backtick) => JS_BACKTICK_TEMPLATES.to_vec(),
-            Some(DelimiterType::Comment) => JS_COMMENT_TEMPLATES.to_vec(),
-            None => JS_RAW_TEMPLATES.to_vec(),
-        },
+        InjectionContext::Javascript(delim) => {
+            let mut t = match delim {
+                Some(DelimiterType::SingleQuote) => JS_SQ_TEMPLATES.to_vec(),
+                Some(DelimiterType::DoubleQuote) => JS_DQ_TEMPLATES.to_vec(),
+                Some(DelimiterType::Backtick) => JS_BACKTICK_TEMPLATES.to_vec(),
+                Some(DelimiterType::Comment) => JS_COMMENT_TEMPLATES.to_vec(),
+                None => JS_RAW_TEMPLATES.to_vec(),
+            };
+            // The quote-delimiter heuristic only looks for the nearest matching
+            // quote, so it mis-classifies a raw JS *expression* position — a
+            // template-literal `${ … }` substitution, or an object-literal value
+            // slot `{"k": …}` — as a single/double/backtick string. There every
+            // string-breakout template is a syntax error, so also offer the
+            // bare-expression payload `{JS}` (`alert(1)`), which executes directly
+            // in expression position. In a genuine string context it reflects as
+            // inert string text and never AST-verifies (promotion requires the
+            // injected call to overlap the payload span — see
+            // `js_context_verify::has_js_context_evidence`), so this is strictly
+            // recall-additive with no false-positive risk.
+            if matches!(
+                delim,
+                Some(
+                    DelimiterType::SingleQuote
+                        | DelimiterType::DoubleQuote
+                        | DelimiterType::Backtick
+                )
+            ) {
+                t.push("{JS}");
+            }
+            t
+        }
         InjectionContext::Css(delim) => match delim {
             Some(DelimiterType::SingleQuote) => CSS_SQ_TEMPLATES.to_vec(),
             Some(DelimiterType::DoubleQuote) => CSS_DQ_TEMPLATES.to_vec(),


### PR DESCRIPTION
A browser-ground-truthed recall audit closed two real false-negative classes in the JS-context payload synthesis. Method: ideate diverse reflected-XSS scenarios → live dalfox scan of each against a mock → **real headless Chrome** confirmation of every miss (alert() dialog). dalfox already caught 30/42 scenarios (mXSS, srcdoc, scheme obfuscation, rawtext, blocklist reconstruction); this PR closes the two clean, FP-safe gaps.

## Fixes
**C1 — raw JS expression position.** A value reflected into a template-literal `${ … }` substitution or an object-literal value slot (`{"limit": …}`) is JS *code*, not a string. The quote-delimiter heuristic mis-infers a string context, where every string-breakout template is a syntax error, so nothing verified. `templates_for` now also offers the bare-expression payload `alert(1)` for single/double/backtick JS contexts.

**C3 — regex-literal context.** `var re = /^…$/`: `compute_js_breakout` never treats `/` as a regex delimiter, so it never closed the literal. Added `/;{JS}//` and `/;{JS};/` to the raw JS template set.

## False-positive safety
Both changes are strictly additive and structurally FP-safe: promotion to `[V]` requires the injected call to AST-overlap the payload span (`has_js_context_evidence`), so a bare `alert(1)` reflected inside a genuine string literal never verifies. Verified with a headless-Chrome harness:
- The missed cases (template-literal `${}`, object-literal value, regex literal) now report `[V]`.
- Genuine escaped string contexts (double/single-quoted JS string under full HTML-escaping) produce **no new findings**.

## Verification
- Full lib suite **1822 passed, 0 failed**; `cargo clippy --all-targets` **0 warnings**; `cargo fmt` clean.
- Recall harness: 30/42 → **36/42** caught (the 4 newly-closed all browser-confirmed executable).
- New unit tests pin the bare-expression payload for JS string contexts and the regex breakout for the raw JS context (incl. survival under an angle-bracket filter).

_Out of scope (deferred): exec-sink data-flow (location/setTimeout/javascript: href — high FP risk, needs taint), client-side template injection (Angular/Vue — framework-dependent), and a noscript doubled-keyword breakout (needs the template in the adaptive synthesis path)._