### PR TITLE
Fix dlafox typo in probe comments

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -168,7 +168,7 @@ impl Param {
     }
 }
 
-/// Set of special characters to probe with patterns like: dalfox'<char>dlafox"
+/// Set of special characters to probe with patterns like: dalfox'<char>dalfox"
 /// Order preserved for deterministic output.
 pub const SPECIAL_PROBE_CHARS: &[char] = &[
     '/', '\\', '\'', '{', '`', '<', '>', '"', '(', ')', ';', '=', '|', '}', '[', '.', ':', ']',
@@ -179,7 +179,7 @@ pub const SPECIAL_PROBE_CHARS: &[char] = &[
 /// Given a response body that already contains the reflection marker (dynamic nonce),
 /// return (valid, invalid) special chars based on naive presence detection.
 /// TODO:
-/// 1. Actively send mutated payloads per character (e.g. dalfox'<c>dlafox")
+/// 1. Actively send mutated payloads per character (e.g. dalfox'<c>dalfox")
 /// 2. Parse the reflected segment boundaries to avoid false positives
 /// 3. Detect normalization (HTML entity encoding, URL encoding) and still treat as "valid"
 pub fn classify_special_chars(body: &str) -> (Vec<char>, Vec<char>) {


### PR DESCRIPTION
Fixes the project name typo ("dlafox" instead of "dalfox") in two doc comments in `src/parameter_analysis/mod.rs`. The probe pattern comments are now consistent (open + close markers both read "dalfox").

Doc comments only, no behavior change. `cargo build` and `cargo test` should be unaffected.

Closes #1169

## Verification

- `grep -rn dlafox src/ docs/ tests/` returns no matches
- Both comment lines now read `dalfox'<char>dalfox"` / `dalfox'<c>dalfox")`