### PR TITLE
Fix just build/dev comments in CONTRIBUTING

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -15,8 +15,8 @@ Thanks for helping make Dalfox better! Here's the short version.
 Dalfox v3 is written in Rust. The Go (v2.x) sources live on the [`v2` branch](https://github.com/hahwul/dalfox/tree/v2) and only receive critical security backports.
 
 ```bash
-just build    # cargo build
-just dev      # cargo run
+just build    # cargo build --release
+just dev      # cargo build (debug)
 just test     # unit + integration tests
 ```
 


### PR DESCRIPTION
Fixes the inline comments in CONTRIBUTING.md that describe what the `just build` and `just dev` recipes run. The current comments are inaccurate (cargo build / cargo run) and the justfile actually runs cargo build --release and cargo build (debug). No recipe runs cargo run.

Only CONTRIBUTING.md is changed, the justfile is unchanged.

Closes #1171

## Verification

- The inline comments in CONTRIBUTING.md match what the justfile recipes run
- No recipe is described as running cargo run