### PR TITLE
docs: fix 'dlafox' typo in parameter_analysis probe-pattern comments

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -168,7 +168,7 @@ impl Param {
     }
 }
 
-/// Set of special characters to probe with patterns like: dalfox'<char>dlafox"
+/// Set of special characters to probe with patterns like: dalfox'<char>dalfox"
 /// Order preserved for deterministic output.
 pub const SPECIAL_PROBE_CHARS: &[char] = &[
     '/', '\\', '\'', '{', '`', '<', '>', '"', '(', ')', ';', '=', '|', '}', '[', '.', ':', ']',
@@ -179,7 +179,7 @@ pub const SPECIAL_PROBE_CHARS: &[char] = &[
 /// Given a response body that already contains the reflection marker (dynamic nonce),
 /// return (valid, invalid) special chars based on naive presence detection.
 /// TODO:
-/// 1. Actively send mutated payloads per character (e.g. dalfox'<c>dlafox")
+/// 1. Actively send mutated payloads per character (e.g. dalfox'<c>dalfox")
 /// 2. Parse the reflected segment boundaries to avoid false positives
 /// 3. Detect normalization (HTML entity encoding, URL encoding) and still treat as "valid"
 pub fn classify_special_chars(body: &str) -> (Vec<char>, Vec<char>) {


### PR DESCRIPTION
Fixes two doc-comment typos in `src/parameter_analysis/mod.rs` where the project name was misspelled as `dlafox` instead of `dalfox`. No logic or behavior is affected. Closes #1169.

---

_This contribution was AI-assisted (Claude). It's a small targeted fix — happy to revise, or just close if it's not a direction you want. No offense taken._