### PR TITLE
docs(installation): update stale version example from 3.0.0 to 3.1.1

### DIFF
--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -93,7 +93,7 @@ You'll need Rust (2024 edition). Install with [rustup](https://rustup.rs/) if yo
 dalfox --version
 ```
 
-You should see something like `dalfox 3.0.0` along with the Dalfox banner.
+You should see something like `dalfox 3.1.1` along with the Dalfox banner.
 
 ## Update shell completions (optional)
 


### PR DESCRIPTION
## What

The installation guide's verify step shows `dalfox 3.0.0` as the expected output, but the current release is **3.1.1** (published 2026-06-21). A user following the guide would think their install is stale or broken.

## Fix

One-line change in `docs/content/getting-started/installation.md`:

```diff
-You should see something like `dalfox 3.0.0` along with the Dalfox banner.
+You should see something like `dalfox 3.1.1` along with the Dalfox banner.
```

Closes #1168