### PR TITLE
docs(waf): fix Google Frontend confidence from 0.5 to 0.15

### DIFF
--- a/docs/content/guide/waf-bypass.md
+++ b/docs/content/guide/waf-bypass.md
@@ -92,10 +92,10 @@ Transient failures (5xx, timeouts, connection resets) can be retried with `--ret
 
 ### Filter weak fingerprints
 
-Each fingerprint carries a confidence score (0.0–1.0). Generic markers like `Request blocked` (0.3) or `Server: Google Frontend` (0.5) sometimes false-positive on benign origins. Use `--waf-min-confidence` to discard anything below the threshold:
+Each fingerprint carries a confidence score (0.0–1.0). Generic markers like `Request blocked` (0.3) or `Server: Google Frontend` (0.15) sometimes false-positive on benign origins. Use `--waf-min-confidence` to discard anything below the threshold:
 
 ```bash
-# Keep only confident matches (drops 0.3/0.5 noise)
+# Keep only confident matches (drops 0.3/0.15 noise)
 dalfox https://target.app --waf-min-confidence 0.7
 ```
 


### PR DESCRIPTION
## What

The WAF Bypass guide states the `Server: Google Frontend` fingerprint carries confidence `0.5`, but the actual rule in `src/waf/rules.toml` sets `confidence = 0.15`:

```toml
[[header]]
header = "server"
value_contains = "google frontend"
waf_type = "CloudArmor"
confidence = 0.15
```

The doc was also internally contradictory: at the default `--waf-min-confidence 0.3`, a `0.5` signal would **NOT** be suppressed, yet the same section says it *is* suppressed by default. With the correct value `0.15`, it *is* suppressed (0.15 < 0.3), making the doc consistent.

## Fix

- Corrects the confidence value to `0.15` (matching `rules.toml`)
- Updates the suppression example comment to reflect `0.3/0.15` noise

Closes #1166