### PR TITLE
docs(mcp): document all available encoders in scan_with_dalfox

### DIFF
--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -66,6 +66,15 @@ Submit a scan. Returns immediately.
 }
 ```
 
+`encoders` accepts any combination of the implemented payload encoders:
+`url`, `html`, `htmlpad`, `2url`, `3url`, `4url`, `base64`, `unicode`,
+`zwsp`. The example above shows `["url", "html"]`; add more to increase
+mutation coverage. Order does not matter — the scanner applies encoders
+in a fixed priority order (`url` → `html` → `htmlpad` → `2url` → `3url`
+→ `4url` → `base64` → `unicode` → `zwsp`) and de-duplicates the output.
+Use `["none"]` to disable encoding entirely. Mirrors the `--encoders` /
+`-e` CLI flag.
+
 `insecure` controls TLS certificate validation (default `true`, scanner-friendly):
 set it `false` to enforce certificate validation and reject self-signed or
 expired certs. Mirrors the `--insecure` CLI flag.


### PR DESCRIPTION
## What

The MCP `scan_with_dalfox` tool docs only mention `url` and `html` in the encoders example, but the scanner supports **nine encoders**: `url`, `html`, `htmlpad`, `2url`, `3url`, `4url`, `base64`, `unicode`, and `zwsp` (see `src/encoding/mod.rs`).

A user reading the MCP docs would not know these encoders exist, since the JSON example only shows two.

## Fix

Adds a paragraph after the JSON example that:
- Lists all nine available encoders
- Documents the fixed application priority order (`url` → `html` → `htmlpad` → `2url` → `3url` → `4url` → `base64` → `unicode` → `zwsp`)
- Notes de-duplication behaviour
- Documents the `none` sentinel for disabling encoding
- References the `--encoders` / `-e` CLI flag for consistency

Closes #1165