### PR TITLE
fix(scanning): suppress false [V] for on* handlers on <input type="hidden"> (#1183)

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -117,6 +117,43 @@ fn any_element_has_id_ascii_ci(document: &scraper::Html, marker: &str) -> bool {
         .any(|node| element_id_is(node, marker))
 }
 
+/// Which Dalfox marker forms a payload embeds, derived once from the payload.
+/// Sharing this keeps the per-node marker test (`is_marker_element`) cheap — it
+/// only checks the forms that can actually be present — and gives the marker
+/// gates a single source of truth instead of re-deriving the four booleans.
+struct MarkerFlags {
+    class: bool,
+    legacy_class: bool,
+    id: bool,
+    legacy_id: bool,
+}
+
+impl MarkerFlags {
+    fn from_payload(payload: &str) -> Self {
+        Self {
+            class: payload.contains(crate::scanning::markers::class_marker()),
+            legacy_class: payload_uses_legacy_class_marker(payload),
+            id: payload.contains(crate::scanning::markers::id_marker()),
+            legacy_id: payload_uses_legacy_id_marker(payload),
+        }
+    }
+
+    fn any(&self) -> bool {
+        self.class || self.legacy_class || self.id || self.legacy_id
+    }
+}
+
+/// Whether `node` carries one of the marker forms the payload embeds (per
+/// `flags`). All four comparisons are ASCII case-fold (see `element_class_has`
+/// / `element_id_is`), so a server that case-folds reflected input still
+/// matches.
+fn is_marker_element(node: scraper::ElementRef, flags: &MarkerFlags) -> bool {
+    (flags.class && element_class_has(node, crate::scanning::markers::class_marker()))
+        || (flags.legacy_class && element_class_has(node, "dalfox"))
+        || (flags.id && element_id_is(node, crate::scanning::markers::id_marker()))
+        || (flags.legacy_id && element_id_is(node, "dalfox"))
+}
+
 /// Whether `value` (an `on*` handler value or `<script>` body) carries a
 /// JavaScript sink call, tolerating ASCII case-folding (servers that uppercase
 /// reflected input) and HTML-entity encoding (WAF-bypass payloads like
@@ -222,20 +259,11 @@ fn payload_marker_element_carries_sink(payload: &str) -> bool {
 /// carries a surviving JS sink. Used to gate the marker-evidence path for
 /// payloads whose marker element's own attributes/body ARE the exploit.
 fn marker_element_carries_surviving_sink(payload: &str, document: &scraper::Html) -> bool {
-    let class_marker = crate::scanning::markers::class_marker();
-    let id_marker = crate::scanning::markers::id_marker();
-    let has_class = payload.contains(class_marker);
-    let has_legacy_class = payload_uses_legacy_class_marker(payload);
-    let has_id = payload.contains(id_marker);
-    let has_legacy_id = payload_uses_legacy_id_marker(payload);
+    let flags = MarkerFlags::from_payload(payload);
     let sel = super::selectors::universal();
-    document.select(sel).any(|node| {
-        let is_marker = (has_class && element_class_has(node, class_marker))
-            || (has_legacy_class && element_class_has(node, "dalfox"))
-            || (has_id && element_id_is(node, id_marker))
-            || (has_legacy_id && element_id_is(node, "dalfox"));
-        is_marker && element_carries_surviving_sink(node)
-    })
+    document
+        .select(sel)
+        .any(|node| is_marker_element(node, &flags) && element_carries_surviving_sink(node))
 }
 
 /// Whether the payload's marker rides *only* on `<input type="hidden">`
@@ -254,21 +282,12 @@ fn marker_element_carries_surviving_sink(payload: &str, document: &scraper::Html
 ///   access), so it is left to the presence-only path like `<base>`/`<form>`
 ///   structural markers rather than suppressed here.
 fn marker_only_on_non_firing_hidden_inputs(payload: &str, document: &scraper::Html) -> bool {
-    let class_marker = crate::scanning::markers::class_marker();
-    let id_marker = crate::scanning::markers::id_marker();
-    let has_class = payload.contains(class_marker);
-    let has_legacy_class = payload_uses_legacy_class_marker(payload);
-    let has_id = payload.contains(id_marker);
-    let has_legacy_id = payload_uses_legacy_id_marker(payload);
+    let flags = MarkerFlags::from_payload(payload);
     let sel = super::selectors::universal();
     let mut saw_marker = false;
     let mut saw_handler_on_hidden = false;
     for node in document.select(sel) {
-        let is_marker = (has_class && element_class_has(node, class_marker))
-            || (has_legacy_class && element_class_has(node, "dalfox"))
-            || (has_id && element_id_is(node, id_marker))
-            || (has_legacy_id && element_id_is(node, "dalfox"));
-        if !is_marker {
+        if !is_marker_element(node, &flags) {
             continue;
         }
         saw_marker = true;
@@ -287,14 +306,16 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
     let class_marker = crate::scanning::markers::class_marker();
     let id_marker = crate::scanning::markers::id_marker();
 
-    let has_class = payload.contains(class_marker);
-    let has_legacy_class = payload_uses_legacy_class_marker(payload);
-    let has_id = payload.contains(id_marker);
-    let has_legacy_id = payload_uses_legacy_id_marker(payload);
-
-    if !has_class && !has_legacy_class && !has_id && !has_legacy_id {
+    let flags = MarkerFlags::from_payload(payload);
+    if !flags.any() {
         return false;
     }
+    let MarkerFlags {
+        class: has_class,
+        legacy_class: has_legacy_class,
+        id: has_id,
+        legacy_id: has_legacy_id,
+    } = flags;
 
     let class_ok = if has_class || has_legacy_class {
         let mut found = false;

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -155,6 +155,26 @@ fn element_carries_surviving_sink(node: scraper::ElementRef) -> bool {
     false
 }
 
+/// Whether `node` is a `<input type="hidden">` element. Such inputs have no
+/// rendered box: the browser never lays them out, so they cannot be hovered,
+/// focused, or clicked, and they load no resource. Any `on*` event handler
+/// injected onto a hidden input therefore never fires — verifying it as DOM
+/// evidence is a false positive (issue #1183).
+///
+/// Scope is deliberately limited to `type="hidden"`. Other input types that
+/// look "special" — `submit`, `button`, `image`, `file`, `reset` — are still
+/// rendered and interactive, so their handlers *do* fire; lumping them in here
+/// would suppress genuine findings. `display:none` / the global `hidden`
+/// attribute are intentionally excluded too: detecting them reliably needs CSS
+/// (which a stylesheet or script can override), so gating on them risks false
+/// negatives.
+fn is_hidden_input(node: scraper::ElementRef) -> bool {
+    let v = node.value();
+    v.name().eq_ignore_ascii_case("input")
+        && v.attr("type")
+            .is_some_and(|t| t.trim().eq_ignore_ascii_case("hidden"))
+}
+
 /// Whether the payload attaches an on*-handler / `<script>`-body JS sink
 /// *directly to its marker element*. Parses the payload as an HTML fragment
 /// (appending a closing `>` so breakout payloads such as
@@ -216,6 +236,51 @@ fn marker_element_carries_surviving_sink(payload: &str, document: &scraper::Html
             || (has_legacy_id && element_id_is(node, "dalfox"));
         is_marker && element_carries_surviving_sink(node)
     })
+}
+
+/// Whether the payload's marker rides *only* on `<input type="hidden">`
+/// element(s), at least one of which carries an injected `on*` event-handler
+/// sink. That handler can never fire — a hidden input has no rendered box — so
+/// the reflection is real but inert and must not be upgraded to DOM-verified
+/// (issue #1183). The reflection-finding path still surfaces it as `R`.
+///
+/// Two guards keep this from over-suppressing genuine findings:
+/// - It returns `false` the moment *any* marker-bearing element is **not** a
+///   hidden input (a rendered sibling — `<svg>`/`<img>` from a tag-breakout, a
+///   visible `<input type=text>`, a `<div>` — can execute, so keep the V).
+/// - It requires a *surviving handler* on a hidden input. A bare
+///   `<input type="hidden" id=… name=…>` with no handler is a structural
+///   marker (its only conceivable exploit is DOM clobbering via named-property
+///   access), so it is left to the presence-only path like `<base>`/`<form>`
+///   structural markers rather than suppressed here.
+fn marker_only_on_non_firing_hidden_inputs(payload: &str, document: &scraper::Html) -> bool {
+    let class_marker = crate::scanning::markers::class_marker();
+    let id_marker = crate::scanning::markers::id_marker();
+    let has_class = payload.contains(class_marker);
+    let has_legacy_class = payload_uses_legacy_class_marker(payload);
+    let has_id = payload.contains(id_marker);
+    let has_legacy_id = payload_uses_legacy_id_marker(payload);
+    let sel = super::selectors::universal();
+    let mut saw_marker = false;
+    let mut saw_handler_on_hidden = false;
+    for node in document.select(sel) {
+        let is_marker = (has_class && element_class_has(node, class_marker))
+            || (has_legacy_class && element_class_has(node, "dalfox"))
+            || (has_id && element_id_is(node, id_marker))
+            || (has_legacy_id && element_id_is(node, "dalfox"));
+        if !is_marker {
+            continue;
+        }
+        saw_marker = true;
+        if !is_hidden_input(node) {
+            // A marker on a rendered/interactive element can execute — keep it.
+            return false;
+        }
+        if element_carries_surviving_sink(node) {
+            saw_handler_on_hidden = true;
+        }
+    }
+    saw_marker && saw_handler_on_hidden
 }
 
 fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
@@ -287,6 +352,18 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
     };
 
     if !(class_ok && id_ok) {
+        return false;
+    }
+
+    // Issue #1183: an attribute-injection payload (`" onmouseover=… class=…
+    // x="`) lands the marker — plus an `on*` handler — on a pre-existing
+    // `<input type="hidden">`. The handler never fires (hidden inputs have no
+    // rendered box), so this is reflected-but-inert, not DOM-verified. This
+    // shape slips past the #1118 gate below because the bare payload forms no
+    // element on its own (`payload_marker_element_carries_sink` is false), so
+    // it must be caught here, before the presence-only fall-through. Structural
+    // markers (no surviving handler on the hidden input) are preserved.
+    if marker_only_on_non_firing_hidden_inputs(payload, document) {
         return false;
     }
 
@@ -437,6 +514,14 @@ fn has_html_structural_evidence_in_doc(payload: &str, document: &scraper::Html) 
 
     let selector = selectors::universal();
     for node in document.select(selector) {
+        // Issue #1183: an `on*` handler injected onto a `<input type="hidden">`
+        // never fires (no rendered box), so it is not browser-executable DOM
+        // evidence. Skip the element entirely — a hidden input is a void element
+        // and is never a `<script>`, so the (b) script-body check never applies
+        // to it either.
+        if is_hidden_input(node) {
+            continue;
+        }
         let value = node.value();
         let tag = value.name();
 
@@ -610,6 +695,11 @@ fn has_inline_handler_breakout_evidence(payload: &str, text: &str) -> bool {
     let document = scraper::Html::parse_document(&decoded);
     let selector = selectors::universal();
     for node in document.select(selector) {
+        // Issue #1183: a handler on a `<input type="hidden">` — even one the
+        // payload broke into — never fires, so it is not executable evidence.
+        if is_hidden_input(node) {
+            continue;
+        }
         let value = node.value();
         for (attr_name, attr_value) in value.attrs() {
             if attr_name.len() < 3 || !attr_name.as_bytes()[..2].eq_ignore_ascii_case(b"on") {

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1749,6 +1749,30 @@ fn test_1183_marker_handler_on_uppercase_hidden_input_not_evidence() {
     assert_eq!(classify_dom_evidence(&payload, &body), None);
 }
 
+/// A server that case-folds the *entire* reflected value — marker, handler
+/// name, and sink — into upper case must still be recognised as a hidden-input
+/// handler and suppressed. Both the marker match (`element_class_has`) and the
+/// sink match (`value_carries_js_sink`) are ASCII case-fold, so a reflection
+/// like `CLASS=DLX… ONMOUSEOVER=ALERT(1)` is still inert.
+#[test]
+fn test_1183_marker_handler_on_case_folded_hidden_input_not_evidence() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\" onmouseover=alert(1) class={} x=\"", marker);
+    let reflected = format!(
+        "\" ONMOUSEOVER=ALERT(1) CLASS={} X=\"",
+        marker.to_uppercase()
+    );
+    let body = format!(
+        "<html><body><input TYPE=\"HIDDEN\" VALUE=\"{}\"></body></html>",
+        reflected
+    );
+    assert_eq!(
+        classify_dom_evidence(&payload, &body),
+        None,
+        "a fully case-folded reflection on a hidden input must still suppress [V]"
+    );
+}
+
 /// FN guard: the genuine tag-breakout alternative on the same parameter lands
 /// the marker on a NEW rendered `<svg>` (self-executing). A hidden input next
 /// to it must not suppress the real finding.

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1707,3 +1707,153 @@ fn html_structural_evidence_matches_entity_encoded_payload() {
         "entity-encoded payload should still match the decoded attribute value"
     );
 }
+
+// ── Issue #1183: on* handlers never fire on <input type="hidden"> ──────────
+//
+// A hidden input has no rendered box: it cannot be hovered, focused, or
+// clicked, and it loads no resource, so any injected `on*` handler is inert.
+// DOM verification must not upgrade such reflections to [V]; they remain [R].
+
+/// The exact reported false positive: an attribute-injection payload lands a
+/// marker class + `onmouseover` onto a pre-existing `<input type="hidden">`.
+/// This slips past the #1118 gate (the bare payload forms no element), so it
+/// reached the presence-only marker branch and verified. It must now be inert.
+#[test]
+fn test_1183_marker_handler_on_hidden_input_not_evidence() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\" onmouseover=alert(1) class={} x=\"", marker);
+    let body = format!(
+        "<html><body><input type=\"hidden\" id=\"url\" value=\"{}\"></body></html>",
+        payload
+    );
+    assert!(
+        !has_marker_evidence(&payload, &body),
+        "onmouseover on a hidden input never fires; must not be marker evidence"
+    );
+    assert_eq!(
+        classify_dom_evidence(&payload, &body),
+        None,
+        "the reported FP must classify as no DOM evidence (downgrades V -> R)"
+    );
+}
+
+/// `type` is matched case-insensitively, so `type=HIDDEN` is still suppressed.
+#[test]
+fn test_1183_marker_handler_on_uppercase_hidden_input_not_evidence() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\" onmouseover=alert(1) class={} x=\"", marker);
+    let body = format!(
+        "<html><body><input TYPE=\"HIDDEN\" value=\"{}\"></body></html>",
+        payload
+    );
+    assert_eq!(classify_dom_evidence(&payload, &body), None);
+}
+
+/// FN guard: the genuine tag-breakout alternative on the same parameter lands
+/// the marker on a NEW rendered `<svg>` (self-executing). A hidden input next
+/// to it must not suppress the real finding.
+#[test]
+fn test_1183_marker_kept_for_tag_breakout_beside_hidden_input() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\"><svg/onload=alert(1) class={}>", marker);
+    let body = format!(
+        "<html><body><input type=\"hidden\" value=\"\">\
+         <svg onload=\"alert(1)\" class=\"{}\"></svg>\"></body></html>",
+        marker
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "marker on a rendered svg must stay evidence even with a hidden input present"
+    );
+}
+
+/// FN guard: an `on*` handler injected onto a VISIBLE input (`type=text`) does
+/// fire on hover/focus, so it must stay verified.
+#[test]
+fn test_1183_marker_kept_for_visible_input_handler() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\" onmouseover=alert(1) class={} x=\"", marker);
+    let body = format!(
+        "<html><body><input type=\"text\" value=\"{}\"></body></html>",
+        payload
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "onmouseover on a visible text input fires; must stay marker evidence"
+    );
+}
+
+/// FN guard: a bare hidden input carrying only the marker (no `on*` handler) is
+/// a structural marker (its only conceivable exploit is DOM clobbering). It has
+/// no firing handler to suppress, so presence-only evidence is preserved — same
+/// treatment as <base>/<form> structural markers.
+#[test]
+fn test_1183_marker_kept_for_structural_hidden_input_without_handler() {
+    let id = crate::scanning::markers::id_marker();
+    let payload = format!("<input type=hidden id={} name=evil_var>", id);
+    let body = format!(
+        "<html><body><input type=\"hidden\" id=\"{}\" name=\"evil_var\"></body></html>",
+        id
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "a handler-less hidden-input marker is structural and must stay evidence"
+    );
+}
+
+/// FN guard: when the marker rides on BOTH a hidden input and a visible
+/// element, "every marker element is a hidden input" is false, so the finding
+/// is kept (the visible element can execute).
+#[test]
+fn test_1183_marker_kept_when_on_both_hidden_and_visible() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("<svg onload=alert(1) class={}>", marker);
+    let body = format!(
+        "<html><body><div class=\"{}\">x</div>\
+         <input type=\"hidden\" onmouseover=alert(1) class=\"{}\"></body></html>",
+        marker, marker
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "a marker also present on a rendered element must stay evidence"
+    );
+}
+
+/// Path B (HtmlStructural): a no-marker payload that forms a hidden input with
+/// an `on*` handler must not be HtmlStructural evidence.
+#[test]
+fn test_1183_html_structural_handler_on_hidden_input_not_evidence() {
+    let payload = "<input type=hidden onmouseover=alert(1)>";
+    let body = format!("<html><body>{}</body></html>", payload);
+    assert_eq!(
+        classify_dom_evidence(payload, &body),
+        None,
+        "onmouseover on a hidden input is inert; HtmlStructural must not fire"
+    );
+}
+
+/// Path B FN guard: the same handler on a visible input stays HtmlStructural.
+#[test]
+fn test_1183_html_structural_handler_on_visible_input_is_evidence() {
+    let payload = "<input type=text onmouseover=alert(1)>";
+    let body = format!("<html><body>{}</body></html>", payload);
+    assert_eq!(
+        classify_dom_evidence(payload, &body),
+        Some(DomEvidenceKind::HtmlStructural),
+        "onmouseover on a visible input fires; must stay HtmlStructural evidence"
+    );
+}
+
+/// Path C (InlineHandlerBreakout): breaking into a server handler that sits on
+/// a hidden input is inert. The visible-element counterpart is covered by
+/// `test_classify_dom_evidence_returns_inline_handler_breakout`.
+#[test]
+fn test_1183_inline_breakout_on_hidden_input_not_evidence() {
+    let payload = "'-alert(1)-'";
+    let body = "<input type=hidden onfocus=\"startTimer('&#39;-alert(1)-&#39;');\">".to_string();
+    assert_eq!(
+        classify_dom_evidence(payload, &body),
+        None,
+        "an inline breakout on a hidden input never fires"
+    );
+}


### PR DESCRIPTION
## Summary

Fixes #1183. A reflected payload that lands a marker + event handler inside an `<input type="hidden">` attribute was upgraded to `[V]` (DOM-verified). Hidden inputs have **no rendered box**, so injected handlers (`onmouseover`, `onfocus`, `onclick`, …) never fire — the `[V]` is a false positive. The genuine tag-breakout alternative (`"><svg/onload=alert(1)>`) on the same parameter still verifies.

## Root cause (verified)

The reported shape is an **attribute-injection** payload:

```
" onmouseover=alert(1) class=dlxXXXX x="
```

Parsed on its own it forms no element (it's bare attribute text), so `payload_marker_element_carries_sink()` returns `false` and it **bypasses the issue #1118 marker-sink gate**, verifying via the **presence-only** marker branch in `has_marker_evidence_in_doc`. So the function the issue pointed at (`element_carries_surviving_sink`) is not actually the deciding gate for this shape.

An audit found the same hidden-input blind spot on two adjacent evidence paths (`HtmlStructural`, `InlineHandlerBreakout`).

## Fix

Adds `is_hidden_input()` and makes all three handler-based DOM-evidence paths hidden-input-aware:

- **Marker** — suppress only when **every** marker-bearing element is a hidden input **and** at least one carries a surviving `on*` handler. This preserves:
  - tag-breakout markers on rendered `<svg>`/`<img>` (the real exploit),
  - visible-input (`type=text`) handler injections (they fire),
  - bare structural markers with no handler (DOM-clobbering / `<base>` / `<form>` semantics).
- **HtmlStructural** / **InlineHandlerBreakout** — skip hidden-input nodes.

Suppressing `[V]` downgrades the finding to `[R]` (Reflected, still reported), it is **not** dropped.

### Scope / FN-safety
- Limited to `type="hidden"` only. `submit`/`button`/`image`/`file`/`reset` are rendered and interactive (handlers fire), so they are intentionally **not** included. `display:none` / the global `hidden` attribute are excluded because reliable detection needs CSS analysis (false-negative risk).
- Known accepted limitation: an input a page later un-hides via JS/CSS, or focuses programmatically, can't be judged statically — consistent with the issue's framing.

## Tests

9 regression tests in `check_dom_verification/tests.rs` covering the reported FP (Marker, HtmlStructural, InlineHandlerBreakout) and the FN guards (tag-breakout beside a hidden input, visible input, both-hidden-and-visible, handler-less structural marker, case-folded `type=HIDDEN`).

```
cargo test --lib check_dom_verification   # 74 passed
cargo test --lib scanning::               # 891 passed
cargo clippy --lib                        # clean
```

🤖 Draft — opened for review before finalizing.