### PR TITLE
test(parameter_analysis): cover untested pure helpers

### DIFF
--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -841,3 +841,107 @@ fn test_dedupe_is_noop_for_unique_entries() {
     assert_eq!(params[0].name, before[0].name);
     assert_eq!(params[1].name, before[1].name);
 }
+
+#[test]
+fn test_dedupe_fills_remaining_metadata_from_duplicate() {
+    // The canonical (first) entry is bare; the duplicate carries every
+    // optional carrier the merge is supposed to graft back in. Exercises
+    // the js_breakout / framework_sink / pre_encoding / form_origin_url
+    // carry-over branches plus the `None`-base arm of the char-set merge
+    // helpers (the existing dedupe tests only cover Some+Some).
+    let mut params = vec![
+        Param {
+            name: "p".to_string(),
+            value: "v".to_string(),
+            location: Location::Query,
+            injection_context: None,
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: None,
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: None,
+            framework_sink: None,
+            escaped_specials: None,
+            js_breakout: None,
+        },
+        Param {
+            name: "p".to_string(),
+            value: String::new(),
+            location: Location::Query,
+            injection_context: None,
+            valid_specials: Some(vec!['<', '>']),
+            invalid_specials: Some(vec!['"']),
+            pre_encoding: Some("url".to_string()),
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: Some("https://origin/form".to_string()),
+            framework_sink: Some("v-html".to_string()),
+            escaped_specials: None,
+            js_breakout: Some("';alert(1)//".to_string()),
+        },
+    ];
+    dedupe_reflection_params(&mut params);
+    assert_eq!(params.len(), 1, "same name+location must collapse");
+    let merged = &params[0];
+    assert_eq!(merged.js_breakout.as_deref(), Some("';alert(1)//"));
+    assert_eq!(merged.framework_sink.as_deref(), Some("v-html"));
+    assert_eq!(merged.pre_encoding.as_deref(), Some("url"));
+    assert_eq!(
+        merged.form_origin_url.as_deref(),
+        Some("https://origin/form")
+    );
+    // None-base char-set merge takes the duplicate's set wholesale.
+    assert_eq!(merged.valid_specials.as_deref(), Some(&['<', '>'][..]));
+    assert_eq!(merged.invalid_specials.as_deref(), Some(&['"'][..]));
+}
+
+#[test]
+fn test_dedupe_keeps_canonical_metadata_over_duplicate() {
+    // When the canonical entry already carries a value, the duplicate's
+    // competing value must not clobber it — guards the `is_none()` carry-over
+    // gate against a future regression that blindly overwrites.
+    let mut params = vec![
+        Param {
+            name: "p".to_string(),
+            value: "v".to_string(),
+            location: Location::Query,
+            injection_context: Some(crate::parameter_analysis::InjectionContext::Html(None)),
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: Some("base-enc".to_string()),
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: Some("https://base/form".to_string()),
+            framework_sink: Some("ng-bind-html".to_string()),
+            escaped_specials: None,
+            js_breakout: Some("base-breakout".to_string()),
+        },
+        Param {
+            name: "p".to_string(),
+            value: String::new(),
+            location: Location::Query,
+            injection_context: Some(crate::parameter_analysis::InjectionContext::Attribute(None)),
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: Some("dup-enc".to_string()),
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: Some("https://dup/form".to_string()),
+            framework_sink: Some("v-html".to_string()),
+            escaped_specials: None,
+            js_breakout: Some("dup-breakout".to_string()),
+        },
+    ];
+    dedupe_reflection_params(&mut params);
+    assert_eq!(params.len(), 1);
+    let merged = &params[0];
+    assert_eq!(merged.pre_encoding.as_deref(), Some("base-enc"));
+    assert_eq!(merged.js_breakout.as_deref(), Some("base-breakout"));
+    assert_eq!(merged.framework_sink.as_deref(), Some("ng-bind-html"));
+    assert_eq!(merged.form_origin_url.as_deref(), Some("https://base/form"));
+}

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1166,3 +1166,29 @@ async fn test_mine_parameters_multipart_survives_same_named_body_param() {
             .collect::<Vec<_>>()
     );
 }
+
+#[test]
+fn test_has_knockout_html_clause_boundary_cases() {
+    // True: `html:` clause at a real binding boundary.
+    assert!(has_knockout_html_clause("html: foo"));
+    assert!(has_knockout_html_clause("text: name, html: bar"));
+    // Semicolon is also a clause separator in Knockout bindings.
+    assert!(has_knockout_html_clause("text: name; html: bar"));
+    // Leading whitespace before the first clause is fine.
+    assert!(has_knockout_html_clause("   html: bar"));
+    // Whitespace is allowed between the `html` token and its `:`.
+    assert!(has_knockout_html_clause("html : bar"));
+    assert!(has_knockout_html_clause("text: name, html\t: bar"));
+    // Case-insensitive token match.
+    assert!(has_knockout_html_clause("HTML: bar"));
+
+    // False: `html:` only appears inside a quoted clause value.
+    assert!(!has_knockout_html_clause("text: 'html: link'"));
+    assert!(!has_knockout_html_clause("text: \"html: link\""));
+    // False: a `html`-prefixed identifier that is not the `html` clause.
+    assert!(!has_knockout_html_clause("htmlish: bar"));
+    assert!(!has_knockout_html_clause("htmlContent: bar"));
+    // False: no html clause at all, and the empty attribute.
+    assert!(!has_knockout_html_clause("text: foo"));
+    assert!(!has_knockout_html_clause(""));
+}

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1522,3 +1522,104 @@ async fn active_probe_path_falls_back_to_per_char_when_batched_breaks_routing() 
         "'/' reshapes the path and must remain invalid (got invalid={invalid:?})"
     );
 }
+
+#[test]
+fn test_param_type_label_covers_every_location() {
+    fn param_at(name: &str, location: Location) -> Param {
+        Param {
+            name: name.to_string(),
+            value: String::new(),
+            location,
+            injection_context: None,
+            valid_specials: None,
+            invalid_specials: None,
+            pre_encoding: None,
+            pre_encoding_pipeline: None,
+            wire_name: None,
+            form_action_url: None,
+            form_origin_url: None,
+            framework_sink: None,
+            escaped_specials: None,
+            js_breakout: None,
+        }
+    }
+
+    let mut target = parse_target("https://example.com").unwrap();
+    target.cookies = vec![("session".to_string(), "abc".to_string())];
+
+    assert_eq!(
+        param_type_label(&param_at("q", Location::Query), &target),
+        "query"
+    );
+    assert_eq!(
+        param_type_label(&param_at("b", Location::Body), &target),
+        "body"
+    );
+    assert_eq!(
+        param_type_label(&param_at("j", Location::JsonBody), &target),
+        "json"
+    );
+    assert_eq!(
+        param_type_label(&param_at("m", Location::MultipartBody), &target),
+        "multipart"
+    );
+    assert_eq!(
+        param_type_label(&param_at("p", Location::Path), &target),
+        "path"
+    );
+    assert_eq!(
+        param_type_label(&param_at("f", Location::Fragment), &target),
+        "fragment"
+    );
+    // A Header-located param whose name matches a configured cookie is a
+    // cookie; any other Header param is a plain header.
+    assert_eq!(
+        param_type_label(&param_at("session", Location::Header), &target),
+        "cookie"
+    );
+    assert_eq!(
+        param_type_label(&param_at("X-Forwarded-For", Location::Header), &target),
+        "header"
+    );
+}
+
+#[test]
+fn test_encoded_variants_maps_every_known_special() {
+    // Each arm of the lookup table contributes at least one canonical
+    // encoding; the existing test only exercised `<` and `"`, leaving the
+    // bulk of the table unverified.
+    let expected: &[(char, &str)] = &[
+        ('<', "&lt;"),
+        ('>', "&gt;"),
+        ('"', "&quot;"),
+        ('\'', "&#39;"),
+        ('(', "&#40;"),
+        (')', "&#41;"),
+        ('{', "&#123;"),
+        ('}', "&#125;"),
+        ('[', "&#91;"),
+        (']', "&#93;"),
+        ('`', "&#96;"),
+        ('/', "&#47;"),
+        ('\\', "&#92;"),
+        (';', "&#59;"),
+        ('=', "&#61;"),
+        ('|', "&#124;"),
+        ('+', "&#43;"),
+        (',', "&#44;"),
+        ('$', "&#36;"),
+        ('-', "&#45;"),
+        ('.', "&#46;"),
+        (':', "&#58;"),
+    ];
+    for (c, enc) in expected {
+        let variants = encoded_variants(*c);
+        assert!(
+            variants.contains(enc),
+            "encoded_variants({c:?}) should include {enc:?}, got {variants:?}"
+        );
+    }
+    // Characters with no special HTML meaning return an empty set.
+    assert!(encoded_variants('a').is_empty());
+    assert!(encoded_variants('0').is_empty());
+}


### PR DESCRIPTION
## Summary

`cargo llvm-cov` flagged several pure helper functions in `parameter_analysis/` as having missing test coverage. This PR adds focused, deterministic unit tests for them — **no production code changes**.

### Gaps closed

- **`dedupe_reflection_params`** (`discovery.rs`) — existing tests only exercised the `injection_context`/`form_action_url` carry-over and the `Some + Some` char-set merge. Added a test that covers the remaining carry-over branches (`js_breakout`, `framework_sink`, `pre_encoding`, `form_origin_url`) and the `None`-base arm of `merge_char_sets`/`intersect_char_sets`, plus a regression guard that canonical metadata is **not** clobbered by a later duplicate.
- **`param_type_label`** (`mod.rs`) — was entirely untested. Now covers every `Location` variant including the cookie-vs-header distinction for `Header`-located params.
- **`encoded_variants`** (`mod.rs`) — the existing test only checked `<` and `"`. Now asserts every match arm of the lookup table plus the empty-set fallback.
- **`has_knockout_html_clause`** (`mining.rs`) — added direct tests for the whitespace-before-colon and `html`-prefixed-non-clause branches and the quoted-substring guard (previously only exercised indirectly).

### Coverage delta (`cargo llvm-cov --lib`, region %)

| Module | Before | After |
|---|---|---|
| `parameter_analysis/mod.rs` | 75.07% | **78.47%** |
| `parameter_analysis/discovery.rs` | 58.89% | 59.52% |
| `parameter_analysis/mining.rs` | 75.79% | 75.89% |
| **Total** | 81.71% | 81.87% |

## Test plan

- `cargo test --lib parameter_analysis` — all pass (117 in module, 5 new)
- `cargo fmt --check` — clean
- `cargo clippy --lib --tests` — no new warnings