### PR TITLE
fix(server,mcp,scanning): resource-safety, REST/MCP parity, and hot-path perf in async scan front-ends

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -198,10 +198,15 @@ impl Job {
 
     /// Total elapsed ms from `started_at_ms` to `finished_at_ms` (or now, for
     /// still-running jobs). `None` if the scan never started.
+    ///
+    /// Both endpoints are wall-clock (`now_ms`) samples, so an NTP/VM clock
+    /// step-back between them could otherwise yield a negative duration in the
+    /// serialized API output; clamp to non-negative. The timestamps themselves
+    /// stay wall-clock because they are API-exposed as unix-ms fields.
     pub fn duration_ms(&self) -> Option<i64> {
         match (self.started_at_ms, self.finished_at_ms) {
-            (Some(s), Some(f)) => Some(f - s),
-            (Some(s), None) => Some(now_ms() - s),
+            (Some(s), Some(f)) => Some((f - s).max(0)),
+            (Some(s), None) => Some((now_ms() - s).max(0)),
             _ => None,
         }
     }

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -123,6 +123,24 @@ pub fn now_ms() -> i64 {
     chrono::Utc::now().timestamp_millis()
 }
 
+/// Non-negative elapsed-ms duration from optional start/finish wall-clock
+/// samples, falling back to `now` when not yet finished. Returns `None` when the
+/// scan never started.
+///
+/// Both endpoints are wall-clock (`now_ms`) samples, so an NTP/VM clock
+/// step-back between them could otherwise yield a negative duration in the
+/// serialized API output; clamp to non-negative. The timestamps themselves stay
+/// wall-clock because they are API-exposed as unix-ms fields. Shared by
+/// [`Job::duration_ms`] and the MCP poll path (which reads a snapshot, not a
+/// `Job`) so the clamp policy has a single source of truth.
+pub fn duration_ms_between(started_at_ms: Option<i64>, finished_at_ms: Option<i64>) -> Option<i64> {
+    match (started_at_ms, finished_at_ms) {
+        (Some(s), Some(f)) => Some((f - s).max(0)),
+        (Some(s), None) => Some((now_ms() - s).max(0)),
+        _ => None,
+    }
+}
+
 /// Parse a lowercase status string back into `JobStatus`. Returns `None` for
 /// unknown values so callers can surface a precise error instead of silently
 /// matching nothing.
@@ -198,17 +216,8 @@ impl Job {
 
     /// Total elapsed ms from `started_at_ms` to `finished_at_ms` (or now, for
     /// still-running jobs). `None` if the scan never started.
-    ///
-    /// Both endpoints are wall-clock (`now_ms`) samples, so an NTP/VM clock
-    /// step-back between them could otherwise yield a negative duration in the
-    /// serialized API output; clamp to non-negative. The timestamps themselves
-    /// stay wall-clock because they are API-exposed as unix-ms fields.
     pub fn duration_ms(&self) -> Option<i64> {
-        match (self.started_at_ms, self.finished_at_ms) {
-            (Some(s), Some(f)) => Some((f - s).max(0)),
-            (Some(s), None) => Some((now_ms() - s).max(0)),
-            _ => None,
-        }
+        duration_ms_between(self.started_at_ms, self.finished_at_ms)
     }
 }
 

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -63,6 +63,16 @@ fn test_duration_ms_computed_from_timestamps() {
 }
 
 #[test]
+fn test_duration_ms_clamps_clock_stepback_to_zero() {
+    // A wall-clock step-back (NTP/VM) between started_at and finished_at must
+    // not surface a negative duration in the serialized API output.
+    let mut job = Job::new_queued("https://example.com".to_string());
+    job.started_at_ms = Some(5_000);
+    job.finished_at_ms = Some(4_000);
+    assert_eq!(job.duration_ms(), Some(0));
+}
+
+#[test]
 fn test_purge_expired_jobs_removes_old_terminal_jobs() {
     let mut jobs = HashMap::new();
     let mut old = Job::new_queued("old".to_string());

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -315,6 +315,15 @@ impl DalfoxMcp {
                     .iter()
                     .filter_map(|h| crate::utils::http::parse_header_line(h))
                     .collect();
+                // Also expose a supplied User-Agent as a header so the
+                // header-reflection probe tests it, matching the CLI and REST
+                // server (both push UA into headers AND user_agent). Without
+                // this, a User-Agent reflection is missed under blanket-echo
+                // targets — an MCP-only false negative for identical input. The
+                // wire header is de-duplicated downstream, so this is safe.
+                if let Some(ua) = scan_args.user_agent.as_deref().filter(|s| !s.is_empty()) {
+                    t.headers.push(("User-Agent".to_string(), ua.to_string()));
+                }
                 t.cookies = scan_args
                     .cookies
                     .iter()
@@ -500,9 +509,13 @@ impl DalfoxMcp {
                             );
                         }
 
-                        // Record discovered param count
+                        // Record the count of params the HTTP scan phase will
+                        // actually test (Fragment params are client-side only and
+                        // spawn no worker), so params_total matches the
+                        // per-parameter workers and estimated_completion_pct
+                        // stays honest. Mirrors the REST server.
                         progress.params_total.store(
-                            target.reflection_params.len() as u32,
+                            crate::scanning::http_scannable_param_count(&target) as u32,
                             std::sync::atomic::Ordering::Relaxed,
                         );
 
@@ -844,6 +857,16 @@ pub struct ListScansDalfoxParams {
     /// Optional status filter: "queued", "running", "done", "error", or "cancelled". Omit to list all.
     #[serde(default)]
     pub status: Option<String>,
+
+    /// Zero-based index of the first scan to return (scans are ordered
+    /// newest-first by queue time). Default: 0.
+    #[serde(default)]
+    pub offset: usize,
+
+    /// Maximum number of scans to return. Omit or set to 0 to return all from
+    /// `offset` onward.
+    #[serde(default)]
+    pub limit: usize,
 }
 
 #[derive(Debug, Serialize, Deserialize, JsonSchema)]
@@ -916,6 +939,13 @@ pub struct PreflightDalfoxParams {
     /// Skip parameter discovery. Default: false
     #[serde(default)]
     pub skip_discovery: bool,
+
+    /// Encoding strategies the subsequent scan will apply to payloads
+    /// (url, html, base64, 2url, 3url, 4url, none). Used only to make the
+    /// estimated_total_requests reflect that scan's fan-out; the default
+    /// matches scan_with_dalfox. Default: ["url", "html"]
+    #[serde(default = "default_encoders")]
+    pub encoders: Vec<String>,
 }
 
 /* ---------------------------
@@ -1073,7 +1103,12 @@ Final results (via get_results_dalfox) include finding type \
             let mut jobs = self.lock_jobs();
             let active = jobs.values().filter(|j| !j.is_terminal()).count();
             if active >= MAX_ACTIVE_SCANS_MCP {
-                return Err(ErrorData::invalid_params(
+                // Transient capacity shedding, not a malformed request: signal it
+                // with internal_error (-32603) so it matches the preflight path
+                // and approximates the REST server's 503 retry semantics, rather
+                // than invalid_params (-32602) which tells a client its input was
+                // wrong and to stop retrying.
+                return Err(ErrorData::internal_error(
                     format!(
                         "at capacity: {} scans already active (max {}); wait for some to finish or cancel/delete them",
                         active, MAX_ACTIVE_SCANS_MCP
@@ -1324,9 +1359,11 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
             Some(snap) => {
                 let (results_slice, pagination) =
                     paginate_results(snap.results.as_deref(), params.offset, params.limit);
+                // Clamp against a wall-clock step-back (NTP/VM) so a poll can
+                // never report a negative duration; mirrors Job::duration_ms.
                 let duration_ms = match (snap.started_at_ms, snap.finished_at_ms) {
-                    (Some(s), Some(f)) => Some(f - s),
-                    (Some(s), None) => Some(now_ms() - s),
+                    (Some(s), Some(f)) => Some((f - s).max(0)),
+                    (Some(s), None) => Some((now_ms() - s).max(0)),
                     _ => None,
                 };
                 let mut out = serde_json::json!({
@@ -1453,12 +1490,28 @@ status, and result_count."
             None => None,
         };
 
-        // Build the response under the lock but only on the JSON values we
-        // need; serialization itself runs after the lock is released.
-        let entries: Vec<serde_json::Value> = {
+        let offset = params.offset;
+        let limit = params.limit;
+        // Build the response under the lock but only on the JSON values we need;
+        // serialization itself runs after the lock is released. Ordered
+        // newest-first and paginated to match the REST `/scans` contract (the
+        // list used to come back in arbitrary HashMap order with no paging).
+        let (total, end, entries): (usize, usize, Vec<serde_json::Value>) = {
             let jobs = self.lock_jobs();
-            jobs.iter()
+            let mut matching: Vec<(&String, &Job)> = jobs
+                .iter()
                 .filter(|(_, job)| filter_status.as_ref().is_none_or(|f| &job.status == f))
+                .collect();
+            matching.sort_by_key(|(_, job)| std::cmp::Reverse(job.queued_at_ms));
+            let total = matching.len();
+            let start = offset.min(total);
+            let end = if limit == 0 {
+                total
+            } else {
+                start.saturating_add(limit).min(total)
+            };
+            let entries = matching[start..end]
+                .iter()
                 .map(|(id, job)| {
                     let mut entry = serde_json::json!({
                         "scan_id": id,
@@ -1471,12 +1524,19 @@ status, and result_count."
                     }
                     entry
                 })
-                .collect()
+                .collect();
+            (total, end, entries)
         };
 
         let out = serde_json::json!({
-            "total": entries.len(),
-            "scans": entries
+            "total": total,
+            "scans": entries,
+            "pagination": {
+                "offset": offset,
+                "limit": limit,
+                "returned": entries.len(),
+                "has_more": end < total,
+            }
         });
         Ok(CallToolResult::success(vec![Content::text(
             out.to_string(),
@@ -1572,10 +1632,10 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             follow_redirects: params.follow_redirects,
             skip_mining: params.skip_mining,
             skip_discovery: params.skip_discovery,
-            encoders: crate::cmd::scan::DEFAULT_ENCODERS
-                .iter()
-                .map(ToString::to_string)
-                .collect(),
+            // Honor the caller's encoders so estimated_total_requests reflects
+            // the fan-out their scan_with_dalfox call will produce, matching the
+            // REST /preflight endpoint (which threads options.encoders through).
+            encoders: params.encoders.clone(),
         });
 
         // Run parameter discovery on tokio's blocking threadpool with a
@@ -1640,7 +1700,13 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                         .reflection_params
                         .iter()
                         .map(|p| {
-                            let payload_count = if let Some(ctx) = &p.injection_context {
+                            let payload_count = if !crate::scanning::param_is_http_scannable(p) {
+                                // Fragment params are client-side only: the HTTP
+                                // scan phase sends no requests for them, so the
+                                // estimate must not bill any (still listed as
+                                // discovered). Mirrors the REST /preflight.
+                                0
+                            } else if let Some(ctx) = &p.injection_context {
                                 crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
                                     .unwrap_or_else(|_| vec![])
                                     .len()
@@ -1762,7 +1828,10 @@ Terminal scans are also auto-purged after 1 hour."
             return Err(ErrorData::invalid_params("scan_id must not be empty", None));
         }
         let mut jobs = self.lock_jobs();
-        let previous_status = match jobs.get(&pid) {
+        // Capture the target alongside the status so the response carries the
+        // same `target` field that REST DELETE-purge and MCP cancel_scan return
+        // (the shape was inconsistent within MCP itself before).
+        let (previous_status, target_url) = match jobs.get(&pid) {
             Some(job) => {
                 if !job.is_terminal() {
                     return Err(ErrorData::invalid_params(
@@ -1773,13 +1842,14 @@ Terminal scans are also auto-purged after 1 hour."
                         None,
                     ));
                 }
-                job.status.clone()
+                (job.status.clone(), job.target_url.clone())
             }
             None => return Err(ErrorData::invalid_params("scan_id not found", None)),
         };
         jobs.remove(&pid);
         let out = serde_json::json!({
             "scan_id": pid,
+            "target": target_url,
             "deleted": true,
             "previous_status": previous_status,
         });

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -316,11 +316,14 @@ impl DalfoxMcp {
                     .filter_map(|h| crate::utils::http::parse_header_line(h))
                     .collect();
                 // Also expose a supplied User-Agent as a header so the
-                // header-reflection probe tests it, matching the CLI and REST
-                // server (both push UA into headers AND user_agent). Without
-                // this, a User-Agent reflection is missed under blanket-echo
-                // targets — an MCP-only false negative for identical input. The
-                // wire header is de-duplicated downstream, so this is safe.
+                // header-reflection probe tests it even on blanket-echo targets:
+                // user-supplied headers are always probed, whereas the common
+                // header sweep (which includes User-Agent) is suppressed when the
+                // target echoes every header. Without this, a User-Agent
+                // reflection is missed — an MCP-only false negative for identical
+                // input. Mirrors the CLI and REST server, which set both fields;
+                // like them, the scan path's `apply_headers_ua_cookies` then sends
+                // both this header entry and `target.user_agent`.
                 if let Some(ua) = scan_args.user_agent.as_deref().filter(|s| !s.is_empty()) {
                     t.headers.push(("User-Agent".to_string(), ua.to_string()));
                 }
@@ -1359,13 +1362,10 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
             Some(snap) => {
                 let (results_slice, pagination) =
                     paginate_results(snap.results.as_deref(), params.offset, params.limit);
-                // Clamp against a wall-clock step-back (NTP/VM) so a poll can
-                // never report a negative duration; mirrors Job::duration_ms.
-                let duration_ms = match (snap.started_at_ms, snap.finished_at_ms) {
-                    (Some(s), Some(f)) => Some((f - s).max(0)),
-                    (Some(s), None) => Some((now_ms() - s).max(0)),
-                    _ => None,
-                };
+                // Shared with Job::duration_ms (single source of truth for the
+                // clock-step-back clamp); the snapshot path can't construct a Job.
+                let duration_ms =
+                    crate::job::duration_ms_between(snap.started_at_ms, snap.finished_at_ms);
                 let mut out = serde_json::json!({
                     "scan_id": pid,
                     "target": snap.target_url,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -538,12 +538,63 @@ async fn test_list_scans_returns_all_jobs() {
     mcp.scan_with_dalfox(Parameters(p2)).await.unwrap();
 
     let resp = mcp
-        .list_scans_dalfox(Parameters(ListScansDalfoxParams { status: None }))
+        .list_scans_dalfox(Parameters(ListScansDalfoxParams {
+            status: None,
+            offset: 0,
+            limit: 0,
+        }))
         .await
         .expect("list_scans should succeed");
     let payload = parse_result_json(&resp);
     assert_eq!(payload["total"], 2);
     assert_eq!(payload["scans"].as_array().unwrap().len(), 2);
+}
+
+#[tokio::test]
+async fn test_list_scans_orders_newest_first_and_paginates() {
+    let mcp = DalfoxMcp::new();
+    {
+        let mut jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+        for (id, q) in [("oldest", 1_000_i64), ("middle", 2_000), ("newest", 3_000)] {
+            let mut job = test_job(JobStatus::Done, Some(vec![]));
+            job.target_url = format!("https://example.com/{id}");
+            job.queued_at_ms = q;
+            jobs.insert(id.to_string(), job);
+        }
+    }
+
+    // Page 1: first two, newest-first.
+    let resp = mcp
+        .list_scans_dalfox(Parameters(ListScansDalfoxParams {
+            status: None,
+            offset: 0,
+            limit: 2,
+        }))
+        .await
+        .expect("list_scans should succeed");
+    let payload = parse_result_json(&resp);
+    assert_eq!(payload["total"], 3);
+    let scans = payload["scans"].as_array().unwrap();
+    assert_eq!(scans.len(), 2);
+    assert_eq!(scans[0]["scan_id"], "newest");
+    assert_eq!(scans[1]["scan_id"], "middle");
+    assert_eq!(payload["pagination"]["returned"], 2);
+    assert_eq!(payload["pagination"]["has_more"], true);
+
+    // Page 2: the remaining (oldest) entry.
+    let resp2 = mcp
+        .list_scans_dalfox(Parameters(ListScansDalfoxParams {
+            status: None,
+            offset: 2,
+            limit: 2,
+        }))
+        .await
+        .expect("list_scans should succeed");
+    let payload2 = parse_result_json(&resp2);
+    let scans2 = payload2["scans"].as_array().unwrap();
+    assert_eq!(scans2.len(), 1);
+    assert_eq!(scans2[0]["scan_id"], "oldest");
+    assert_eq!(payload2["pagination"]["has_more"], false);
 }
 
 #[tokio::test]
@@ -563,6 +614,8 @@ async fn test_list_scans_filters_by_status() {
     let resp = mcp
         .list_scans_dalfox(Parameters(ListScansDalfoxParams {
             status: Some("done".to_string()),
+            offset: 0,
+            limit: 0,
         }))
         .await
         .expect("list_scans should succeed");
@@ -632,6 +685,7 @@ async fn test_preflight_rejects_empty_target() {
         follow_redirects: false,
         skip_mining: false,
         skip_discovery: false,
+        encoders: vec!["url".to_string(), "html".to_string()],
     };
     let err = mcp
         .preflight_dalfox(Parameters(params))
@@ -658,6 +712,7 @@ async fn test_preflight_rejects_non_http_target() {
         follow_redirects: false,
         skip_mining: false,
         skip_discovery: false,
+        encoders: vec!["url".to_string(), "html".to_string()],
     };
     let err = mcp
         .preflight_dalfox(Parameters(params))
@@ -684,6 +739,7 @@ async fn test_preflight_unreachable_target_returns_reachable_false() {
         follow_redirects: false,
         skip_mining: true,
         skip_discovery: true,
+        encoders: vec!["url".to_string(), "html".to_string()],
     };
     let resp = mcp
         .preflight_dalfox(Parameters(params))
@@ -790,7 +846,11 @@ async fn test_list_scans_includes_timestamps() {
         );
     }
     let resp = mcp
-        .list_scans_dalfox(Parameters(ListScansDalfoxParams { status: None }))
+        .list_scans_dalfox(Parameters(ListScansDalfoxParams {
+            status: None,
+            offset: 0,
+            limit: 0,
+        }))
         .await
         .expect("list_scans should succeed");
     let payload = parse_result_json(&resp);
@@ -804,10 +864,9 @@ async fn test_delete_scan_removes_terminal_job() {
     let mcp = DalfoxMcp::new();
     {
         let mut jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
-        jobs.insert(
-            "done-del".to_string(),
-            test_job(JobStatus::Done, Some(vec![])),
-        );
+        let mut job = test_job(JobStatus::Done, Some(vec![]));
+        job.target_url = "https://example.com/?q=x".to_string();
+        jobs.insert("done-del".to_string(), job);
     }
     let resp = mcp
         .delete_scan_dalfox(Parameters(DeleteScanDalfoxParams {
@@ -818,6 +877,8 @@ async fn test_delete_scan_removes_terminal_job() {
     let payload = parse_result_json(&resp);
     assert_eq!(payload["deleted"], true);
     assert_eq!(payload["previous_status"], "done");
+    // The response must carry `target` for parity with REST purge / MCP cancel.
+    assert_eq!(payload["target"], "https://example.com/?q=x");
 
     let jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
     assert!(!jobs.contains_key("done-del"));
@@ -954,6 +1015,8 @@ async fn test_list_scans_rejects_invalid_status_filter() {
     let err = mcp
         .list_scans_dalfox(Parameters(ListScansDalfoxParams {
             status: Some("bogus".to_string()),
+            offset: 0,
+            limit: 0,
         }))
         .await
         .expect_err("unknown status filter must be rejected");

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -232,6 +232,21 @@ pub fn has_remote_wordlists() -> bool {
     REMOTE_WORDS.get().is_some()
 }
 
+/// Collapse a provider->URL expansion to the set of distinct URLs, preserving
+/// first-seen order. Without this, a caller (e.g. an authenticated server/MCP
+/// scan request) that repeats the same provider name N times — `remote_payloads:
+/// ["payloadbox","payloadbox",...]` — expands 1:1 into N copies of each URL,
+/// every one of which `fetch_multiple_text_lists` fetches concurrently and
+/// concatenates: a deterministic memory / file-descriptor amplification from a
+/// single request. Deduping makes name-spam inert (distinct providers are
+/// unaffected, since their URLs differ).
+fn dedup_urls_in_place(urls: Vec<String>) -> Vec<String> {
+    let mut seen = std::collections::HashSet::with_capacity(urls.len());
+    urls.into_iter()
+        .filter(|u| seen.insert(u.clone()))
+        .collect()
+}
+
 /// Build the list of remote URLs for the given payload providers.
 fn collect_payload_provider_urls(providers: &[String]) -> Vec<String> {
     ensure_default_registries();
@@ -245,7 +260,7 @@ fn collect_payload_provider_urls(providers: &[String]) -> Vec<String> {
             urls.extend(lst.clone());
         }
     }
-    urls
+    dedup_urls_in_place(urls)
 }
 
 /// Build the list of remote URLs for the given wordlist providers.
@@ -261,7 +276,7 @@ fn collect_wordlist_provider_urls(providers: &[String]) -> Vec<String> {
             urls.extend(lst.clone());
         }
     }
-    urls
+    dedup_urls_in_place(urls)
 }
 
 /// Concurrently fetch multiple text endpoints and concatenate their contents.

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -240,11 +240,10 @@ pub fn has_remote_wordlists() -> bool {
 /// concatenates: a deterministic memory / file-descriptor amplification from a
 /// single request. Deduping makes name-spam inert (distinct providers are
 /// unaffected, since their URLs differ).
-fn dedup_urls_in_place(urls: Vec<String>) -> Vec<String> {
+fn dedup_urls(mut urls: Vec<String>) -> Vec<String> {
     let mut seen = std::collections::HashSet::with_capacity(urls.len());
-    urls.into_iter()
-        .filter(|u| seen.insert(u.clone()))
-        .collect()
+    urls.retain(|u| seen.insert(u.clone()));
+    urls
 }
 
 /// Build the list of remote URLs for the given payload providers.
@@ -260,7 +259,7 @@ fn collect_payload_provider_urls(providers: &[String]) -> Vec<String> {
             urls.extend(lst.clone());
         }
     }
-    dedup_urls_in_place(urls)
+    dedup_urls(urls)
 }
 
 /// Build the list of remote URLs for the given wordlist providers.
@@ -276,7 +275,7 @@ fn collect_wordlist_provider_urls(providers: &[String]) -> Vec<String> {
             urls.extend(lst.clone());
         }
     }
-    dedup_urls_in_place(urls)
+    dedup_urls(urls)
 }
 
 /// Concurrently fetch multiple text endpoints and concatenate their contents.

--- a/src/payload/remote/tests.rs
+++ b/src/payload/remote/tests.rs
@@ -94,6 +94,27 @@ fn test_collect_payload_urls_known_provider() {
 }
 
 #[test]
+fn test_collect_payload_urls_dedups_repeated_provider_names() {
+    // A caller repeating the same provider name must NOT expand into N copies
+    // of its URLs (that would fan out into N concurrent fetches per URL — a
+    // single-request amplification). The result is the distinct URL set.
+    register_payload_provider(
+        "dedup_probe",
+        vec![
+            "https://example.com/a.txt".to_string(),
+            "https://example.com/b.txt".to_string(),
+        ],
+    );
+    let repeated = vec!["dedup_probe".to_string(); 50];
+    let urls = collect_payload_provider_urls(&repeated);
+    assert_eq!(
+        urls.len(),
+        2,
+        "repeated provider names must collapse to the distinct URL set"
+    );
+}
+
+#[test]
 fn test_has_remote_payloads_initially_depends_on_test_order() {
     // This just checks that the function doesn't panic
     let _ = has_remote_payloads();

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1112,6 +1112,31 @@ fn expand_waf_payloads(
 /// `--max-payloads-per-param` cap. Returns the jobs plus the total payload
 /// count used to size the progress bar (one tick per reflection + DOM
 /// payload).
+/// Whether the HTTP scan phase will actually test `param`.
+///
+/// URL fragments are client-side only — HTTP servers never see them — so
+/// `generate_param_jobs` spawns no worker for `Location::Fragment` params (the
+/// AST DOM analyzer detects `location.hash` sources from response JS
+/// independently, so coverage isn't lost). Async front-ends use this so their
+/// `params_total` matches the number of per-parameter workers actually run
+/// (keeping `estimated_completion_pct` honest) and so preflight estimates don't
+/// bill requests for params that send none.
+pub fn param_is_http_scannable(param: &crate::parameter_analysis::Param) -> bool {
+    !matches!(
+        param.location,
+        crate::parameter_analysis::Location::Fragment
+    )
+}
+
+/// Count of a target's parameters the HTTP scan phase will actually test.
+pub fn http_scannable_param_count(target: &Target) -> usize {
+    target
+        .reflection_params
+        .iter()
+        .filter(|p| param_is_http_scannable(p))
+        .count()
+}
+
 fn generate_param_jobs(
     target: &Target,
     args: &ScanArgs,
@@ -1121,17 +1146,10 @@ fn generate_param_jobs(
     let mut total_tasks = 0u64;
     let mut param_jobs: Vec<ParamPayloadJob> = Vec::with_capacity(target.reflection_params.len());
     for param in &target.reflection_params {
-        // URL fragments are client-side only — HTTP servers never see
-        // them, so reflection probes for `Location::Fragment` params
-        // were pure-waste requests (the dry-run summary said
-        // "discovered" but the scan sent 0 reqs with the param actually
-        // populated). The AST DOM analyzer detects `location.hash`
-        // sources from response JS independently, so skipping the
-        // server-side scan here doesn't lose detection coverage.
-        if matches!(
-            param.location,
-            crate::parameter_analysis::Location::Fragment
-        ) {
+        // URL fragments are client-side only — HTTP servers never see them, so
+        // reflection probes for `Location::Fragment` params would be pure-waste
+        // requests. See `param_is_http_scannable`.
+        if !param_is_http_scannable(param) {
             continue;
         }
         let mut reflection_payloads = if let Some(context) = &param.injection_context {
@@ -2308,7 +2326,17 @@ pub async fn run_scanning(
     };
 
     // === Stage 5 & 6: spawn one worker per parameter (Reflection + DOM) ===
-    let mut handles = vec![];
+    // A `JoinSet` (not a bare `Vec<JoinHandle>`) so that if this scan future is
+    // dropped mid-flight — which happens when an async front-end's `scan_timeout`
+    // budget expires and `run_within_scan_budget` drops the wrapped future — the
+    // in-flight workers are ABORTED on drop rather than detached. A dropped
+    // `JoinHandle` does not abort its task, so the old `Vec` left timed-out
+    // workers parked on the runtime; on MCP's cached current_thread runtime they
+    // would resume during a later, unrelated scan and fire residual probes at
+    // the stale target. The normal-completion path below still drains every
+    // worker to completion, so partial/complete results and the panic tally are
+    // unchanged.
+    let mut handles = tokio::task::JoinSet::new();
     // Capture the per-job task-local scopes (request counter, WAF backoff, rate
     // limiter) bound by the REST/MCP runners. `tokio::spawn` does NOT inherit
     // task-locals, so each worker re-enters them via `with_job_scopes`;
@@ -2359,7 +2387,7 @@ pub async fn run_scanning(
         // Re-enter the per-job scopes inside the spawned worker so the requests
         // it sends are tallied and rate-limited against THIS job, not the
         // process-wide globals (see `JobScopes`). Cheap no-op on the CLI.
-        let handle = tokio::spawn(crate::with_job_scopes(job_scopes.clone(), async move {
+        handles.spawn(crate::with_job_scopes(job_scopes.clone(), async move {
             ctx.scan_param(param_clone, reflection_payloads, dom_payloads)
                 .await;
             // Bump the live completion counter after this parameter is fully
@@ -2370,16 +2398,17 @@ pub async fn run_scanning(
                 done.fetch_add(1, Ordering::Relaxed);
             }
         }));
-        handles.push(handle);
     }
 
     let mut worker_panics = 0usize;
-    for handle in handles {
-        if let Err(e) = handle.await {
+    while let Some(res) = handles.join_next().await {
+        if let Err(e) = res {
             // A JoinError from a worker is almost always a panic inside
             // scan_param (a scanning-pipeline bug). Count it so the caller can
             // mark the scan as partial/failed instead of reporting a clean
-            // `done`; the param's findings are incomplete either way.
+            // `done`; the param's findings are incomplete either way. (Aborts
+            // are not counted: they only occur when the whole scan future is
+            // being dropped on scan_timeout, which the caller already records.)
             if e.is_panic() {
                 worker_panics += 1;
             }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -403,6 +403,27 @@ fn test_collapse_preserves_ast_findings() {
     );
 }
 
+#[test]
+fn test_http_scannable_param_count_excludes_fragment() {
+    // Fragment params are client-side only and generate_param_jobs skips them,
+    // so async front-ends must not count them in params_total (it would make
+    // estimated_completion_pct stall below 100%).
+    let mut target = parse_target("https://example.com/?q=x").expect("parse target");
+    mock_add_reflection_param(&mut target, "q", Location::Query);
+    mock_add_reflection_param(&mut target, "body", Location::Body);
+    mock_add_reflection_param(&mut target, "hash", Location::Fragment);
+
+    assert!(super::param_is_http_scannable(&target.reflection_params[0]));
+    assert!(!super::param_is_http_scannable(
+        &target.reflection_params[2]
+    ));
+    assert_eq!(
+        super::http_scannable_param_count(&target),
+        2,
+        "fragment param must be excluded from the HTTP-scannable count"
+    );
+}
+
 // Mock function for XSS scanning tests (similar to parameter analysis mocks)
 fn mock_add_reflection_param(target: &mut Target, name: &str, location: Location) {
     target.reflection_params.push(Param {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -209,7 +209,13 @@ pub(crate) async fn get_result_handler(
                 finished_at_ms: j.finished_at_ms,
                 duration_ms,
             };
-            log(&state, "RESULT", &format!("id={} status={}", id, j.status));
+            // Only log the terminal fetch. Interim running/queued polls arrive
+            // on a high-frequency client loop, and every `log()` call does a
+            // synchronous open/write/close of the log file — flooding it with no
+            // audit value (the JOB lifecycle lines already record queue/finish).
+            if j.is_terminal() {
+                log(&state, "RESULT", &format!("id={} status={}", id, j.status));
+            }
             let resp = ApiResponse {
                 code: 200,
                 msg: "ok".to_string(),
@@ -905,7 +911,12 @@ pub(crate) async fn preflight_handler(
                     .reflection_params
                     .iter()
                     .map(|p| {
-                        let payload_count = if let Some(ctx) = &p.injection_context {
+                        let payload_count = if !crate::scanning::param_is_http_scannable(p) {
+                            // Fragment params are client-side only: the HTTP scan
+                            // phase sends no requests for them, so the estimate
+                            // must not bill any (they stay listed as discovered).
+                            0
+                        } else if let Some(ctx) = &p.injection_context {
                             crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
                                 .unwrap_or_else(|_| vec![])
                                 .len()

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -90,8 +90,29 @@ fn fail_job_via_fresh_runtime(state: &AppState, job_id: &str, url: &str, msg: St
         log(
             state,
             "ERR",
-            &format!("could not build recovery runtime to fail job {}", job_id),
+            &format!(
+                "could not build recovery runtime to fail job {}; marking it error \
+                 synchronously to reclaim its slot",
+                job_id
+            ),
         );
+        // Even the recovery runtime failed (typically FD/thread exhaustion).
+        // We can't fire the terminal webhook without a runtime, but we MUST
+        // still move the job out of Queued — otherwise purge_expired_jobs never
+        // collects it (it only reaps terminal jobs) and it counts against
+        // max_concurrent_scans permanently until a manual DELETE or restart.
+        // `state.jobs` is a tokio Mutex, but this runs on a spawn_blocking
+        // thread with no runtime entered, so `blocking_lock` is safe here.
+        let mut jobs = state.jobs.blocking_lock();
+        if let Some(job) = jobs.get_mut(job_id)
+            && !job.is_terminal()
+        {
+            job.status = JobStatus::Error;
+            job.error_message = Some(msg);
+            if job.finished_at_ms.is_none() {
+                job.finished_at_ms = Some(now_ms());
+            }
+        }
         return;
     };
     let state = state.clone();
@@ -228,7 +249,10 @@ pub(crate) async fn run_scan_job(
         StartDecision::Missing => return,
     };
 
-    let args = ScanArgs {
+    // Built once behind an `Arc` so the scan future and `run_scanning` share it
+    // by refcount bump instead of deep-cloning this ~70-field struct (mirrors
+    // the MCP path, which already uses `Arc<ScanArgs>`).
+    let args = Arc::new(ScanArgs {
         detect_outdated_libs: opts.detect_outdated_libs.unwrap_or(false),
         // Each REST job scans exactly one caller-supplied URL, with method,
         // headers, cookies, and body provided as explicit request fields — the
@@ -356,7 +380,7 @@ pub(crate) async fn run_scan_job(
         remote_wordlists: opts.remote_wordlists.clone().unwrap_or_default(),
 
         targets: vec![url.clone()],
-    };
+    });
 
     // Initialize remote resources if requested (honor timeout/proxy)
     if !args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty() {
@@ -548,7 +572,10 @@ pub(crate) async fn run_scan_job(
                                         .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
                                 }
                                 let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                                    &client, &target, &body, &args,
+                                    &client,
+                                    &target,
+                                    &body,
+                                    args.as_ref(),
                                 )
                                 .await;
                                 crate::scanning::accumulate_findings(
@@ -562,9 +589,11 @@ pub(crate) async fn run_scan_job(
                         }
                     }
 
-                    let mut silent_args = args.clone();
-                    silent_args.silence = true;
-                    analyze_parameters(&mut target, &silent_args, None).await;
+                    // `args.silence` is already `true` (set at construction), and
+                    // `analyze_parameters` takes `&ScanArgs`, so pass the shared
+                    // Arc directly instead of deep-cloning it just to re-set a
+                    // field that already holds the desired value.
+                    analyze_parameters(&mut target, args.as_ref(), None).await;
 
                     // Bound the per-scan fan-out: a sprawling/hostile target can
                     // expose thousands of params, and scanning spawns O(params ×
@@ -581,14 +610,18 @@ pub(crate) async fn run_scan_job(
                         );
                     }
 
+                    // Count only the params the HTTP scan phase will actually
+                    // test (Fragment params are client-side only and spawn no
+                    // worker), so `params_total` matches the per-parameter
+                    // workers and `estimated_completion_pct` stays honest.
                     progress.params_total.store(
-                        target.reflection_params.len() as u32,
+                        crate::scanning::http_scannable_param_count(&target) as u32,
                         std::sync::atomic::Ordering::Relaxed,
                     );
 
                     scan_report = crate::scanning::run_scanning(
                         &target,
-                        Arc::new(args.clone()),
+                        args.clone(),
                         results.clone(),
                         None,
                         None,

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -113,16 +113,6 @@ impl Target {
             .is_some_and(|c| c.require_trusted_types_for)
     }
 
-    /// Cache key derived from the Target fields that affect Client construction.
-    fn client_cache_key(&self) -> ClientCacheKey {
-        (
-            self.timeout,
-            self.proxy.clone(),
-            self.follow_redirects,
-            self.insecure,
-        )
-    }
-
     /// Build a reqwest Client, falling back to a default Client on error.
     /// Logs a warning in debug mode if the build fails.
     ///
@@ -143,7 +133,30 @@ impl Target {
         // Library consumers may build clients without going through `main()`,
         // so make sure the ring crypto provider is installed first.
         crate::ensure_crypto_provider();
-        let key = self.client_cache_key();
+        // Resolve any proxy up front so the cache key reflects what the client
+        // will ACTUALLY use, not the raw string. A malformed proxy is silently
+        // unusable (matching prior behavior) — but if it still contributed to
+        // the key, each distinct malformed (or merely varied) proxy string
+        // would mint a permanent, never-evicted entry in the process-wide
+        // client cache, growing memory without bound in a long-running
+        // server/MCP daemon. Collapsing unusable proxies onto the no-proxy key
+        // makes garbage-proxy spam inert while keeping the legitimate (small)
+        // proxy keyspace cached.
+        let proxy = self
+            .proxy
+            .as_deref()
+            .and_then(|p| reqwest::Proxy::all(p).ok());
+        let proxy_key = if proxy.is_some() {
+            self.proxy.clone()
+        } else {
+            None
+        };
+        let key = (
+            self.timeout,
+            proxy_key,
+            self.follow_redirects,
+            self.insecure,
+        );
         // Fast path: return a cached Client if one matches the key.
         if let Ok(guard) = client_cache().lock()
             && let Some(c) = guard.get(&key)
@@ -161,9 +174,7 @@ impl Target {
             // enforce TLS certificate validation).
             .danger_accept_invalid_certs(self.insecure);
 
-        if let Some(proxy_url) = &self.proxy
-            && let Ok(proxy) = reqwest::Proxy::all(proxy_url)
-        {
+        if let Some(proxy) = proxy {
             client_builder = client_builder.proxy(proxy);
         }
 


### PR DESCRIPTION
## Summary

Findings from a multi-agent bug/perf hunt over the `server` + `mcp` subsystem (7 dimension finders → adversarial verification → synthesis), implemented as a coherent, low-risk batch. Two medium-risk items are intentionally **deferred** to a follow-up (they touch scan recall / a serialized contract): an in-scan findings/response-body memory cap, and REST `get_result` pagination.

All 1849 lib tests pass; `clippy` + `fmt` clean.

## Resource-safety

- **`scanning`: workers in a `JoinSet`, not a bare `Vec<JoinHandle>`.** On `scan_timeout`, `run_within_scan_budget` drops the scan future; a dropped `JoinHandle` does **not** abort its task, so per-parameter workers were *detached*. On MCP's cached `current_thread` runtime they resumed during a later, unrelated scan and fired residual probes at the stale target (and kept bumping the terminal job's `requests_sent`). A `JoinSet` aborts them on drop. Normal completion still drains every worker, so results + the panic tally are unchanged. (REST was immune only because it drops a fresh runtime per scan.)
- **`payload/remote`: dedup provider→URL expansion.** A request repeating the same provider name N times (`remote_payloads: ["payloadbox", ...×N]`) expanded 1:1 into N copies of each URL, every one fetched concurrently — a deterministic single-request memory/FD amplification. Deduping makes name-spam inert.
- **`target_parser`: resolve proxy before the cache key.** A malformed (or merely varied) proxy string minted a permanent, never-evicted entry in the process-wide client cache. Unusable proxies now collapse onto the no-proxy key.
- **`server`: reclaim the slot on double runtime-build failure.** When the recovery runtime also fails to build, the job stayed `Queued` forever — purge never reaps it and it pinned a `max-concurrent-scans` slot. Now marked `Error` synchronously via `blocking_lock`.

## REST/MCP parity

- **`mcp`: push a supplied User-Agent into headers** (not just `user_agent`) so the header-reflection probe tests it like CLI/REST — fixes an MCP-only false negative under blanket-echo targets.
- **`mcp`: `list_scans_dalfox` orders newest-first + paginates** (`offset`/`limit` + `pagination` object), matching REST `/scans` (was arbitrary `HashMap` order).
- **`mcp`: `preflight_dalfox` honors a caller `encoders` field** so `estimated_total_requests` reflects the real scan fan-out, matching REST `/preflight`.
- **`mcp`: scan at-capacity returns `internal_error`** (retry class) instead of `invalid_params`, matching the preflight path and REST's 503.
- **`mcp`: `delete_scan_dalfox` response includes `target`**, matching REST purge / cancel.
- **`server`+`mcp`: `params_total` counts only HTTP-scannable params.** `Location::Fragment` params are client-side only and spawn no worker, so counting them stalled `estimated_completion_pct` below 100%; preflight estimates now bill 0 requests for them too. Shared via `scanning::{param_is_http_scannable, http_scannable_param_count}`.

## Perf / robustness

- **`server`: `ScanArgs` behind an `Arc`** — drop the redundant `silent_args` deep clone (`silence` is already `true`) and the `Arc::new(args.clone())` deep clone of this ~70-field struct; share by refcount bump, mirroring MCP.
- **`server`: only log the terminal `get_result` fetch** — interim poll logs flooded the log file (open/write/close per poll) with no audit value.
- **`job`+`mcp`: clamp `duration_ms`** against a wall-clock step-back so a poll never reports a negative duration.

## Tests

+4 unit tests (duration clamp, remote dedup, `http_scannable_param_count`, MCP list ordering/pagination) and an extended MCP delete-`target` assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)