### PR TITLE
fix: scanner precision (scheme-mutation FP), query-discovery memory, URL scheme handling

### DIFF
--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -337,12 +337,14 @@ pub struct ScanArgs {
     pub timeout: u64,
 
     #[clap(help_heading = "NETWORK")]
-    /// Hard wall-clock cap per target for the scan stage (post-preflight) in
+    /// Hard wall-clock cap per target for the payload-injection (scan) stage in
     /// seconds. When set, dalfox stops a target's payload-injection stage
     /// once this budget is exceeded — useful when many sequential phases each
     /// pay the per-request `--timeout` cost against a partially-hung
-    /// endpoint. Preflight is bounded separately by per-request `--timeout`.
-    /// 0 disables (default).
+    /// endpoint. Scope note: this caps ONLY the injection stage. The earlier
+    /// preflight and parameter-analysis (discovery + mining) phases are bounded
+    /// separately by `--timeout` × request-count, NOT by this wall-clock cap, so
+    /// a slow target can overshoot this budget during analysis. 0 disables (default).
     #[arg(long, default_value_t = 0)]
     pub scan_timeout: u64,
 

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -300,6 +300,32 @@ pub async fn check_fragment_discovery(target: &Target, reflection_params: Arc<Mu
     }
 }
 
+/// Await a chunk of in-flight query-discovery probe tasks, folding any
+/// discovered params into `batch` / `discovered_names`. Factored out so the
+/// main pass can drain each chunk before spawning the next (see
+/// `QUERY_DISCOVERY_CHUNK`).
+async fn drain_query_discovery_handles(
+    handles: Vec<tokio::task::JoinHandle<Option<Param>>>,
+    batch: &mut Vec<Param>,
+    discovered_names: &mut std::collections::HashSet<String>,
+) {
+    for handle in handles {
+        if let Ok(Some(p)) = handle.await {
+            discovered_names.insert(p.name.clone());
+            batch.push(p);
+        }
+    }
+}
+
+/// Spawn-and-drain the query-discovery reflection pass this many tasks at a
+/// time. Each task captures an injected URL whose construction re-serializes
+/// the entire N-parameter query (O(N) bytes), so accumulating all N handles up
+/// front held O(N²) resident heap (4000 params ≈ 180 MB). Bounding the live
+/// task count caps that to O(CHUNK) without changing which params are probed —
+/// the main pass doesn't gate on `discovered_names`, so chunk boundaries are
+/// invisible to the result. Mirrors the `CHUNK_SIZE` guard in `mining.rs`.
+const QUERY_DISCOVERY_CHUNK: usize = 500;
+
 pub async fn check_query_discovery(
     target: &Target,
     reflection_params: Arc<Mutex<Vec<Param>>>,
@@ -310,6 +336,9 @@ pub async fn check_query_discovery(
     let test_value = crate::scanning::markers::bracketed_marker();
 
     let mut handles = vec![];
+    // Batch collect results to reduce mutex contention.
+    let mut batch: Vec<Param> = Vec::new();
+    let mut discovered_names: std::collections::HashSet<String> = std::collections::HashSet::new();
 
     // Check existing query params for reflection
     for (name, value) in target.url.query_pairs() {
@@ -421,19 +450,21 @@ pub async fn check_query_discovery(
             discovered
         });
         handles.push(handle);
-    }
 
-    // Batch collect results to reduce mutex contention
-    let mut batch: Vec<Param> = Vec::new();
-    let mut discovered_names: std::collections::HashSet<String> = std::collections::HashSet::new();
-    for handle in handles {
-        if let Ok(opt_param) = handle.await
-            && let Some(p) = opt_param
-        {
-            discovered_names.insert(p.name.clone());
-            batch.push(p);
+        // Drain this chunk before spawning more so the live task count (and the
+        // O(N)-sized injected URL each task holds) never exceeds the chunk size.
+        if handles.len() >= QUERY_DISCOVERY_CHUNK {
+            drain_query_discovery_handles(
+                std::mem::take(&mut handles),
+                &mut batch,
+                &mut discovered_names,
+            )
+            .await;
         }
     }
+
+    // Drain the final partial chunk.
+    drain_query_discovery_handles(handles, &mut batch, &mut discovered_names).await;
 
     // Encoding probe: for params not yet discovered, try base64-encoded markers
     let encoding_probes = crate::encoding::pre_encoding::encoding_probes();

--- a/src/payload/xss_html.rs
+++ b/src/payload/xss_html.rs
@@ -158,6 +158,19 @@ pub fn get_mxss_payloads() -> Vec<String> {
     CACHE.clone()
 }
 
+/// `javascript:` scheme prefixes that reconstruct the canonical scheme only
+/// after a server applies a *single-pass* substring strip — `javasscriptcript:`
+/// survives `replace("script", "")` (→ `javascript:`) and `javascriptjavascript:`
+/// survives `replace("javascript", "")` (→ `javascript:`). Emitted verbatim by
+/// [`get_protocol_injection_payloads`] below; recognized by
+/// `check_reflection::decoded_is_dangerous_scheme` so an *un-stripped* (verbatim)
+/// echo of one in an inert position is suppressed instead of being reported as a
+/// false-positive `[R]`. Whitespace-insertion variants (`java\tscript:` …) are
+/// not listed here because the gate already normalizes TAB/LF/CR before matching.
+/// Keep this in sync with the `out.push(...)` lines in the generator.
+pub(crate) const JS_SCHEME_STRIP_MUTATION_PREFIXES: &[&str] =
+    &["javasscriptcript:", "javascriptjavascript:"];
+
 /// Generate protocol-based injection payloads for src/href attributes
 /// (iframe, embed, object, a href, etc.)
 /// These target contexts where a parameter value is placed directly into a `src` or `href`
@@ -182,8 +195,10 @@ pub fn get_protocol_injection_payloads() -> Vec<String> {
             out.push(format!("\njavascript:{}", js)); // leading newline
             // Double-nested javascript: to bypass single-pass removal (e.g. "jajavascriptvascript:")
             out.push(format!("javas\tcript:{}", js));
-            out.push(format!("javasscriptcript:{}", js)); // bypass gsub("javascript","")
-            out.push(format!("javascriptjavascript:{}", js)); // double prefix to survive one-pass strip
+            // Single-pass substring-strip bypasses (see JS_SCHEME_STRIP_MUTATION_PREFIXES).
+            for prefix in JS_SCHEME_STRIP_MUTATION_PREFIXES {
+                out.push(format!("{prefix}{js}"));
+            }
 
             // data: protocol variants
             out.push(format!("data:text/html,<script>{}</script>", js));

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -475,6 +475,16 @@ fn decoded_is_dangerous_scheme(s: &str) -> bool {
         || lower.starts_with("data:text/html")
         || lower.starts_with("data:image/svg")
         || lower.starts_with("vbscript:")
+        // dalfox's own protocol generator emits single-pass strip-bypass
+        // mutations (`javasscriptcript:`, `javascriptjavascript:`). Reflected
+        // verbatim (no server strip), the mutation is not a real scheme and is
+        // inert — but it must still be RECOGNIZED here so the inert-position
+        // gates (`dangerous_scheme_reflection_is_inert`) demote a `value="…"`
+        // echo to None, while `scan_dangerous_scheme_occurrences` keeps it when
+        // it lands at a URL-attr scheme-start (a live WAF-bypass finding).
+        || crate::payload::xss_html::JS_SCHEME_STRIP_MUTATION_PREFIXES
+            .iter()
+            .any(|p| lower.starts_with(p))
 }
 
 /// True when byte offset `at` is the first *effective* character of a

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -1838,6 +1838,67 @@ fn test_scheme_fp_keeps_executable_scheme_start() {
 }
 
 #[test]
+fn test_scheme_fp_suppresses_strip_mutation_in_inert_positions() {
+    // dalfox's own protocol generator emits single-pass strip-bypass mutations
+    // (`javasscriptcript:` survives `replace("script","")`,
+    // `javascriptjavascript:` survives `replace("javascript","")`). Reflected
+    // VERBATIM (no server strip), the mutation is not a real scheme and is inert
+    // — e.g. echoed into a quoted NON-URL attribute (`<input value="...">`), body
+    // text, or a `data-*` attribute. It must be demoted exactly like the
+    // canonical `javascript:` is. Before this fix it surfaced as a [R] false
+    // positive (the sole finding on a properly quote-escaped `value=` route).
+    for (payload, html) in [
+        (
+            "javasscriptcript:alert(1)",
+            "<input value=\"javasscriptcript:alert(1)\">",
+        ),
+        (
+            "javascriptjavascript:alert(1)",
+            "<input value=\"javascriptjavascript:alert(1)\">",
+        ),
+        (
+            "javasscriptcript:alert(1)",
+            "<div>You searched for: javasscriptcript:alert(1)</div>",
+        ),
+        (
+            "javascriptjavascript:alert(1)",
+            "<p data-note=\"javascriptjavascript:alert(1)\">x</p>",
+        ),
+    ] {
+        assert!(
+            dangerous_scheme_reflection_is_inert(html, payload),
+            "inert strip-mutation echo must be demoted: payload={payload} html={html}"
+        );
+        assert!(
+            is_in_safe_context_decoded(html, payload),
+            "inert strip-mutation echo must be suppressed end-to-end: payload={payload} html={html}"
+        );
+    }
+}
+
+#[test]
+fn test_scheme_fp_keeps_strip_mutation_at_url_scheme_start() {
+    // The SAME mutation at a URL-valued attribute scheme-start is a live
+    // WAF-bypass candidate: if the server strips the doubling it reconstructs
+    // `javascript:` and navigates. It must be kept (no false negative).
+    for payload in ["javasscriptcript:alert(1)", "javascriptjavascript:alert(1)"] {
+        for html in [
+            format!("<a href=\"{payload}\">x</a>"),
+            format!("<iframe src=\"{payload}\"></iframe>"),
+        ] {
+            assert!(
+                !dangerous_scheme_reflection_is_inert(&html, payload),
+                "strip-mutation at a URL scheme-start must be kept: {html}"
+            );
+            assert!(
+                !is_in_safe_context_decoded(&html, payload),
+                "strip-mutation at a URL scheme-start must not be suppressed: {html}"
+            );
+        }
+    }
+}
+
+#[test]
 fn test_scheme_fp_keeps_scheme_in_script_navigation_sink() {
     // A dangerous scheme echoed inside a <script> block can feed a JS navigation
     // sink (`location.href = "javascript:..."`) and execute, even though it never

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -201,6 +201,29 @@ pub fn parse_target(s: &str) -> Result<Target, Box<dyn std::error::Error>> {
     let url_str = if lower.starts_with("http://") || lower.starts_with("https://") {
         s.to_string()
     } else {
+        // Reject an explicit non-http(s) authority-form scheme rather than
+        // silently prepending `http://`. Without this, `ftp://127.0.0.1/x`
+        // became `http://ftp//127.0.0.1/x` — the scheme token `ftp` was parsed
+        // as the host and DNS-resolved, surfacing a misleading
+        // DNS_RESOLUTION_FAILED instead of an actionable error. Mirrors the
+        // `http|https`-only restriction the HAR import path already enforces.
+        // Anchored on a contiguous RFC-3986 `scheme://` so scheme-less inputs
+        // (`host:port/path`, `user:pass@host`, or a `://` that appears only
+        // inside the query) keep working unchanged.
+        if let Some(i) = lower.find("://") {
+            let scheme = &lower[..i];
+            let valid_scheme = !scheme.is_empty()
+                && scheme.starts_with(|c: char| c.is_ascii_alphabetic())
+                && scheme
+                    .bytes()
+                    .all(|b| b.is_ascii_alphanumeric() || b == b'+' || b == b'-' || b == b'.');
+            if valid_scheme {
+                return Err(format!(
+                    "unsupported URL scheme '{scheme}://' (only http and https are supported)"
+                )
+                .into());
+            }
+        }
         format!("http://{}", s)
     };
     let url = Url::parse(&url_str)?;
@@ -517,6 +540,47 @@ mod tests {
     #[test]
     fn test_parse_target_invalid_url() {
         assert!(parse_target("invalid url").is_err());
+    }
+
+    /// Explicit non-http(s) authority-form schemes are rejected with an
+    /// actionable error instead of being silently mangled into a bogus host
+    /// (`ftp://127.0.0.1/x` used to become `http://ftp//127.0.0.1/x` and fail
+    /// DNS as if the user's host were down).
+    #[test]
+    fn test_parse_target_rejects_non_http_scheme() {
+        for bad in [
+            "ftp://127.0.0.1/x?q=1",
+            "file:///etc/passwd",
+            "gopher://127.0.0.1/x",
+            "ws://127.0.0.1/x",
+            "FTP://127.0.0.1/x", // case-insensitive
+        ] {
+            let err = parse_target(bad).expect_err("non-http(s) scheme must be rejected");
+            assert!(
+                err.to_string().contains("unsupported URL scheme"),
+                "expected an unsupported-scheme error for {bad}, got: {err}"
+            );
+        }
+    }
+
+    /// Scheme-less inputs that merely *contain* a colon (or a `://` inside the
+    /// query) must keep working — the rejection is anchored on a contiguous
+    /// leading `scheme://`, so these still get the `http://` prefix.
+    #[test]
+    fn test_parse_target_keeps_schemeless_inputs() {
+        for ok in [
+            "127.0.0.1:8771/ctx/vuln_body?q=1",        // host:port
+            "user:pass@127.0.0.1:8771/x",              // userinfo colon
+            "example.com/p?next=https://evil.com&q=1", // `://` only in query
+            "example.com",
+        ] {
+            let t = parse_target(ok).unwrap_or_else(|e| panic!("{ok} should parse, got: {e}"));
+            assert!(
+                t.url.as_str().starts_with("http://"),
+                "{ok} should be prefixed with http://, got {}",
+                t.url.as_str()
+            );
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

Four fixes surfaced by **building dalfox and driving it against a controllable reflection server** (one route per HTML context, `vuln_*` injectable vs `safe_*` properly-escaped), then root-causing and adversarially verifying each lead. Every fix is recall-safe and ships with tests; all 1853 lib tests pass and the full `vuln_*` set still reports `[V]`.

Each bug is its own commit.

### 1. `fix(scanning)` — false `[R]` for `javascript:` WAF strip-mutations
dalfox's own protocol generator emits single-pass strip-bypass mutations (`javasscriptcript:`, `javascriptjavascript:`) that only reconstruct `javascript:` after a server strips the doubled substring. Reflected **verbatim** (no strip) into a quoted non-URL attribute like `<input value="…">`, the mutation is inert, but `decoded_is_dangerous_scheme` didn't recognize it — so it surfaced as the **sole finding on a properly quote-escaped route**, while the canonical `javascript:` was correctly suppressed. Now recognized via a shared `JS_SCHEME_STRIP_MUTATION_PREFIXES` const (single source of truth for generator + gate); demoted in inert positions, still kept (executable) at a URL-attr scheme-start.

### 2. `perf(parameter_analysis)` — query-discovery O(N²) memory
`check_query_discovery` spawned one task per query param up front, each holding an injected URL that re-serializes the whole N-param query → **~200 MB at 4000 params**. Now chunked spawn-and-drain (500 at a time, mirroring `mining.rs`). Peak RSS **~28 MB at N=3000**, identical discovery results (tail-chunk param still found).

### 3. `fix(target_parser)` — reject non-http(s) schemes instead of mangling
`ftp://127.0.0.1/x` was rewritten to `http://ftp//127.0.0.1/x` and DNS-failed as if the user's host were down. Now rejected with an actionable error (mirrors the HAR path's `http|https`-only rule). Scheme-less `host:port` / `user:pass@host` / `://`-in-query are unaffected.

### 4. `docs(scan)` — `--scan-timeout` scope
Clarify the cap wraps only the injection stage; preflight + parameter-analysis are bounded by `--timeout` × request-count.

## Testing
- `cargo test --lib`: 1853 passed, 0 failed (new tests for the scheme-mutation gate and scheme rejection).
- `cargo clippy --lib`: clean. `cargo fmt`: applied.
- End-to-end on the release binary: `safe_attr_dq` FP eliminated (`[R]` → none), all `vuln_*` routes still `[V]`.

## Out of scope (verified, intentionally deferred)
- **Encoded-variant inert FP** (non-default `--encoders 2url`): a naive demotion is recall-unsafe (would suppress percent-encoded `javascript:` at an `<a href>` scheme-start) — deferred.
- **Escaped-endpoint request fan-out** (~6168 req/param): by-design (payload cap working; escaped-exclusion is the documented #1156 recall tradeoff).