### PR TITLE
fix(config): correct stale comment for waf_min_confidence default (0.…

### DIFF
--- a/src/config.rs
+++ b/src/config.rs
@@ -925,7 +925,7 @@ impl Config {
             {
                 args.waf_evasion = v;
             }
-            // Only override when the CLI was left at the default (0.0)
+            // Only override when the CLI was left at the default (0.3)
             // — same precedence pattern as the other numeric overrides
             // so users who pass --waf-min-confidence on the command
             // line keep authority over what the config file says.


### PR DESCRIPTION
Fixes #1200

The comment at `src/config.rs:928` said the CLI default for `waf_min_confidence` was `0.0`, but the actual constant `DEFAULT_WAF_MIN_CONFIDENCE` in `src/cmd/scan/args.rs:42` is `0.3`. Changed `(0.0)` to `(0.3)` to match the constant and the clap help text.