### PR TITLE
docs(readme): fix three dead documentation links

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ yay -S dalfox
 paru -S dalfox
 ```
 
-See the [Installation guide](https://dalfox.hahwul.com/docs/installation/) for manual build instructions.
+See the [Installation guide](https://dalfox.hahwul.com/getting-started/installation/) for manual build instructions.
 
 ### Nixpkgs (NixOS)
 
@@ -71,7 +71,7 @@ nix profile install github:hahwul/dalfox
 nix develop github:hahwul/dalfox
 ```
 
-See [Installation guide](https://dalfox.hahwul.com/docs/installation/) for details.
+See [Installation guide](https://dalfox.hahwul.com/getting-started/installation/) for details.
 
 Prebuilt binaries (including statically-linked musl variants for Linux) are available on the [GitHub Releases](https://github.com/hahwul/dalfox/releases) page.
 
@@ -84,7 +84,7 @@ dalfox [mode] [target] [flags]
 * File Mode: `dalfox scan urls.txt --custom-payload mypayloads.txt`
 * Pipeline: `cat urls.txt | dalfox scan --headers "AuthToken: xxx"`
 
-Check the [Usage](https://dalfox.hahwul.com/page/usage/) and [Running](https://dalfox.hahwul.com/page/running/) documents for more examples.
+Check the [Usage](https://dalfox.hahwul.com/reference/cli/) and [Running](https://dalfox.hahwul.com/getting-started/quick-start/) documents for more examples.
 
 ## Contributing
 if you want to contribute to this project, please see [CONTRIBUTING.md](https://github.com/hahwul/dalfox/blob/main/CONTRIBUTING.md) and Pull-Request with cool your contents.


### PR DESCRIPTION
## Summary

Fixes three broken documentation links in `README.md` left over from the v3 docs site restructure. The old URL prefixes (`/docs/installation/`, `/page/usage/`, `/page/running/`) return HTTP 404.

## Changes
- `/docs/installation/` → `/getting-started/installation/` (2 occurrences)
- `/page/usage/` → `/reference/cli/`
- `/page/running/` → `/getting-started/quick-start/`

All replacement URLs verified to resolve (HTTP 200); all old URLs confirmed 404.

Closes #1201
