### PR TITLE
chore(deps): migrate rmcp from 1.8.0 to 2.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1988,9 +1988,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d1f571c72940a19d9532fe52dbea8bc9912bf1d766c2970bb824056b86f3f59"
+checksum = "f00a32c3b81b7b254076a65abd5ab2551209146713ba38f73818657e865e9433"
 dependencies = [
  "async-trait",
  "base64",
@@ -2010,9 +2010,9 @@ dependencies = [
 
 [[package]]
 name = "rmcp-macros"
-version = "1.8.0"
+version = "2.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1aad0035b69380782d78ea95b508327e6deaa2235909053e596eea8f27b5e1d5"
+checksum = "2ee70afb7956da9f30d5348a2539b5eb90d9038f834463657ab717076ac3b1ad"
 dependencies = [
  "darling",
  "proc-macro2",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -36,7 +36,7 @@ axum = "0.8"
 sha2 = "0.11"
 hex = "0.4"
 regex = "1"
-rmcp = { version = "1.7.0", features = ["server", "macros"] }
+rmcp = { version = "2.1.0", features = ["server", "macros"] }
 schemars = { version = "1", features = ["derive"] }
 oxc_parser = "0.133.0"
 oxc_ast = "0.133.0"

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -34,7 +34,7 @@ use tokio::sync::Mutex;
 use rmcp::{
     ErrorData,
     handler::server::wrapper::Parameters,
-    model::{CallToolResult, Content},
+    model::{CallToolResult, ContentBlock},
     tool, tool_handler, tool_router,
 };
 
@@ -187,7 +187,7 @@ const PURGE_MIN_INTERVAL_MS: i64 = 60_000;
 
 /// MCP handler state.
 //
-// rmcp 1.x: `#[tool_router]` (line ~507) generates `Self::tool_router()` as an
+// rmcp 1.x/2.x: `#[tool_router]` (line ~507) generates `Self::tool_router()` as an
 // inherent method, and `#[tool_handler]` calls it automatically. No router
 // field is needed; the 0.x pattern of storing `tool_router: ToolRouter<Self>`
 // became unused dead-code in 1.x.
@@ -1310,7 +1310,7 @@ Final results (via get_results_dalfox) include finding type \
             "target": target,
             "status": JobStatus::Queued
         });
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             out.to_string(),
         )]))
     }
@@ -1452,7 +1452,7 @@ Call this repeatedly until status is 'done', 'error', or 'cancelled'."
                         "suggested_poll_interval_ms": suggested_poll_interval_ms,
                     });
                 }
-                Ok(CallToolResult::success(vec![Content::text(
+                Ok(CallToolResult::success(vec![ContentBlock::text(
                     out.to_string(),
                 )]))
             }
@@ -1540,7 +1540,7 @@ status, and result_count."
                 "has_more": end < total,
             }
         });
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             out.to_string(),
         )]))
     }
@@ -1761,7 +1761,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             })
         });
 
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             result.to_string(),
         )]))
     }
@@ -1807,7 +1807,7 @@ still be retrieved via get_results_dalfox."
                     "cancelled": true,
                     "previous_status": previous_status
                 });
-                Ok(CallToolResult::success(vec![Content::text(
+                Ok(CallToolResult::success(vec![ContentBlock::text(
                     out.to_string(),
                 )]))
             }
@@ -1860,7 +1860,7 @@ Terminal scans are also auto-purged after 1 hour."
             "deleted": true,
             "previous_status": previous_status,
         });
-        Ok(CallToolResult::success(vec![Content::text(
+        Ok(CallToolResult::success(vec![ContentBlock::text(
             out.to_string(),
         )]))
     }


### PR DESCRIPTION
## Summary

Migrates `rmcp` from 1.8.0 to 2.1.0, aligning model types with the MCP **2025-11-25** specification.

Supersedes the closed Dependabot PR #1216, which failed CI because `rmcp::model::Content` was removed in v2.

## Changes

- Bump `rmcp` dependency to `2.1.0` in `Cargo.toml` / `Cargo.lock`
- Replace `Content` with `ContentBlock` in MCP tool result construction (`src/mcp/mod.rs`)

The JSON wire format is unchanged (per [rmcp 2.x migration guide](https://github.com/modelcontextprotocol/rust-sdk/discussions/926)); only the Rust API surface required updates.

## Test plan

- [x] `cargo build`
- [x] `cargo test mcp` — 50 tests pass