### PR TITLE
feat(scan): support HTTP QUERY method (RFC 10008)

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -78,7 +78,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--data` | `-d` | — | Request body |
 | `--headers` | `-H` | — | Extra HTTP header (repeatable) |
 | `--cookies` | — | — | Cookie (repeatable) |
-| `--method` | `-X` | `GET` | HTTP method override |
+| `--method` | `-X` | `GET` | HTTP method override (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY` / RFC 10008) |
 | `--user-agent` | — | — | Custom User-Agent |
 | `--cookie-from-raw` | — | — | Load cookies from a raw HTTP request file |
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -145,7 +145,7 @@ debug = false
 | `data` | string | — | Request body |
 | `headers` | array | `[]` | HTTP headers |
 | `cookies` | array | `[]` | Cookie strings |
-| `method` | string | `"GET"` | HTTP method |
+| `method` | string | `"GET"` | HTTP method (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY`) |
 | `user_agent` | string | — | User-Agent override |
 | `cookie_from_raw` | string | — | Raw-request file for cookies |
 

--- a/skills/dalfox/references/cli.md
+++ b/skills/dalfox/references/cli.md
@@ -36,6 +36,8 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 
 | Flag | Purpose |
 |------|---------|
+| `-X, --method` | HTTP method override: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY` (RFC 10008; body-capable, safe/idempotent). Body params preserve the target method (e.g. `-X QUERY -d '…'`) |
+| `-d, --data` | Request body (form or JSON) |
 | `-p, --param` | Restrict to specific params (supports `name:location` hints) |
 | `--include-url` | Regex whitelist (multiple) |
 | `--exclude-url` | Regex blacklist (multiple) |

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -145,9 +145,10 @@ fn parse_http_method_arg(s: &str) -> std::result::Result<String, String> {
     }
     let upper = trimmed.to_ascii_uppercase();
     match upper.as_str() {
-        "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "OPTIONS" | "PATCH" => Ok(upper),
+        // QUERY is RFC 10008 (safe/idempotent body-bearing method).
+        "GET" | "POST" | "PUT" | "DELETE" | "HEAD" | "OPTIONS" | "PATCH" | "QUERY" => Ok(upper),
         other => Err(format!(
-            "unsupported HTTP method '{}' (expected one of: GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH)",
+            "unsupported HTTP method '{}' (expected one of: GET, POST, PUT, DELETE, HEAD, OPTIONS, PATCH, QUERY)",
             other
         )),
     }
@@ -1020,6 +1021,8 @@ mod arg_parser_tests {
             ("head", "HEAD"),
             ("options", "OPTIONS"),
             ("patch", "PATCH"),
+            ("query", "QUERY"),
+            ("  Query ", "QUERY"),
         ] {
             assert_eq!(parse_http_method_arg(input).unwrap(), expected);
         }

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -964,7 +964,8 @@ pub async fn probe_body_params(
             let client_clone = client.clone();
             let url = target.url.clone();
 
-            let parsed_method = reqwest::Method::POST;
+            let parsed_method =
+                crate::scanning::url_inject::body_location_method(&target.method);
             let target_clone = arc_target.clone();
             let delay = target.delay;
             let semaphore_clone = semaphore.clone();
@@ -1460,7 +1461,7 @@ pub async fn probe_json_body_params(
         let client_clone = client.clone();
         let url = target.url.clone();
 
-        let parsed_method = reqwest::Method::POST;
+        let parsed_method = crate::scanning::url_inject::body_location_method(&target.method);
         let target_clone = arc_target.clone();
         let delay = target.delay;
         let semaphore_clone = semaphore.clone();
@@ -1724,14 +1725,11 @@ pub async fn probe_multipart_params(
                 form = form.text(field_name.clone(), marker.to_string());
             }
 
-            let request = crate::utils::build_request(
-                &client_clone,
-                &target_clone,
-                reqwest::Method::POST,
-                url,
-                None,
-            )
-            .multipart(form);
+            let method =
+                crate::scanning::url_inject::body_location_method(&target_clone.method);
+            let request =
+                crate::utils::build_request(&client_clone, &target_clone, method, url, None)
+                    .multipart(form);
             crate::record_outbound_request().await;
 
             let mut discovered: Option<Param> = None;

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -472,12 +472,10 @@ pub fn detect_framework_html_sink(text: &str, marker: &str) -> Option<&'static s
                 "data-bind" if has_knockout_html_clause(value) => Some("data-bind"),
                 _ => None,
             };
-            match sink {
-                Some(s) => match found {
-                    Some(prev) if prev != s => return None,
-                    _ => found = Some(s),
-                },
-                None => return None,
+            let s = sink?;
+            match found {
+                Some(prev) if prev != s => return None,
+                _ => found = Some(s),
             }
         }
     }

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -964,8 +964,7 @@ pub async fn probe_body_params(
             let client_clone = client.clone();
             let url = target.url.clone();
 
-            let parsed_method =
-                crate::scanning::url_inject::body_location_method(&target.method);
+            let parsed_method = crate::scanning::url_inject::body_location_method(&target.method);
             let target_clone = arc_target.clone();
             let delay = target.delay;
             let semaphore_clone = semaphore.clone();
@@ -1725,8 +1724,7 @@ pub async fn probe_multipart_params(
                 form = form.text(field_name.clone(), marker.to_string());
             }
 
-            let method =
-                crate::scanning::url_inject::body_location_method(&target_clone.method);
+            let method = crate::scanning::url_inject::body_location_method(&target_clone.method);
             let request =
                 crate::utils::build_request(&client_clone, &target_clone, method, url, None)
                     .multipart(form);

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -774,7 +774,7 @@ impl Drop for TempWordlist {
 
 async fn reflect_all_query_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
     let mut body = String::from("<html><body>");
-    for (_, v) in params.iter() {
+    for v in params.values() {
         body.push_str(&format!("<div>{}</div>", v));
     }
     body.push_str("</body></html>");

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -259,9 +259,13 @@ async fn send_probe_request_for_param(
     let form_action_url = param.form_action_url.clone();
     let ignore_return = target.ignore_return.clone();
 
-    // Force POST for Body/JsonBody/MultipartBody params even when default target method is GET
+    // Body-bearing locations: preserve body-capable target methods (POST/PUT/
+    // PATCH/QUERY/…); force POST only when the target verb is body-less (GET),
+    // which is the form-discovery path. See `body_location_method`.
     let req_method = match location {
-        Location::Body | Location::JsonBody | Location::MultipartBody => reqwest::Method::POST,
+        Location::Body | Location::JsonBody | Location::MultipartBody => {
+            crate::scanning::url_inject::body_location_method(&target.method)
+        }
         _ => parsed_method,
     };
 

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -259,12 +259,12 @@ async fn send_probe_request_for_param(
     let form_action_url = param.form_action_url.clone();
     let ignore_return = target.ignore_return.clone();
 
-    // Body-bearing locations: preserve body-capable target methods (POST/PUT/
-    // PATCH/QUERY/…); force POST only when the target verb is body-less (GET),
-    // which is the form-discovery path. See `body_location_method`.
+    // Body-bearing locations: form-discovered sinks stay POST; own-body
+    // params preserve body-capable methods (POST/PUT/PATCH/QUERY/…). See
+    // `body_location_method_for_param`.
     let req_method = match location {
         Location::Body | Location::JsonBody | Location::MultipartBody => {
-            crate::scanning::url_inject::body_location_method(&target.method)
+            crate::scanning::url_inject::body_location_method_for_param(&target.method, param)
         }
         _ => parsed_method,
     };

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -851,7 +851,7 @@ fn build_body_request(
             urlencoding::encode(encoded_payload)
         ))
     };
-    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
@@ -884,7 +884,7 @@ fn build_json_body_request(
     } else {
         Some(serde_json::json!({ &param.name: encoded_payload }).to_string())
     };
-    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
@@ -919,7 +919,7 @@ fn build_multipart_request(
     } else {
         form = form.text(param.name.clone(), encoded_payload.to_string());
     }
-    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
 }
 

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -851,7 +851,8 @@ fn build_body_request(
             urlencoding::encode(encoded_payload)
         ))
     };
-    let base = crate::utils::build_request(client, target, reqwest::Method::POST, parsed_url, body);
+    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
         &[(
@@ -883,7 +884,8 @@ fn build_json_body_request(
     } else {
         Some(serde_json::json!({ &param.name: encoded_payload }).to_string())
     };
-    let base = crate::utils::build_request(client, target, reqwest::Method::POST, parsed_url, body);
+    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
         &[("Content-Type".to_string(), "application/json".to_string())],
@@ -917,8 +919,8 @@ fn build_multipart_request(
     } else {
         form = form.text(param.name.clone(), encoded_payload.to_string());
     }
-    crate::utils::build_request(client, target, reqwest::Method::POST, parsed_url, None)
-        .multipart(form)
+    let method = crate::scanning::url_inject::body_location_method(&target.method);
+    crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
 }
 
 fn build_url_inject_request(

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1684,9 +1684,10 @@ async fn fetch_injection_response_with_client(
             )
         }
         Location::Body => {
-            // Body injection: use form action URL if available, else original URL
-            // Force POST for body params even if the original target method was GET
-            let method = reqwest::Method::POST;
+            // Body injection: use form action URL if available, else original URL.
+            // Preserve body-capable methods (POST/PUT/PATCH/QUERY/…); force POST
+            // only for body-less targets (form-discovery path).
+            let method = crate::scanning::url_inject::body_location_method(&target.method);
             let parsed_url = param
                 .form_action_url
                 .as_ref()
@@ -1723,9 +1724,9 @@ async fn fetch_injection_response_with_client(
             rb.header("Content-Type", "application/x-www-form-urlencoded")
         }
         Location::JsonBody => {
-            // JSON body injection: use form action URL if available, else original URL
-            // Force POST for JSON body params
-            let method = reqwest::Method::POST;
+            // JSON body injection: use form action URL if available, else original URL.
+            // Preserve body-capable methods; force POST for body-less targets.
+            let method = crate::scanning::url_inject::body_location_method(&target.method);
             let parsed_url = param
                 .form_action_url
                 .as_ref()
@@ -1752,7 +1753,7 @@ async fn fetch_injection_response_with_client(
             rb.header("Content-Type", "application/json")
         }
         Location::MultipartBody => {
-            let method = reqwest::Method::POST;
+            let method = crate::scanning::url_inject::body_location_method(&target.method);
             let parsed_url = param
                 .form_action_url
                 .as_ref()

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1685,9 +1685,9 @@ async fn fetch_injection_response_with_client(
         }
         Location::Body => {
             // Body injection: use form action URL if available, else original URL.
-            // Preserve body-capable methods (POST/PUT/PATCH/QUERY/…); force POST
-            // only for body-less targets (form-discovery path).
-            let method = crate::scanning::url_inject::body_location_method(&target.method);
+            // Form-discovered sinks stay POST; own-body preserves QUERY/PUT/….
+            let method =
+                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
             let parsed_url = param
                 .form_action_url
                 .as_ref()
@@ -1725,8 +1725,9 @@ async fn fetch_injection_response_with_client(
         }
         Location::JsonBody => {
             // JSON body injection: use form action URL if available, else original URL.
-            // Preserve body-capable methods; force POST for body-less targets.
-            let method = crate::scanning::url_inject::body_location_method(&target.method);
+            // Form-discovered sinks stay POST; own-body preserves QUERY/PUT/….
+            let method =
+                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
             let parsed_url = param
                 .form_action_url
                 .as_ref()
@@ -1753,7 +1754,8 @@ async fn fetch_injection_response_with_client(
             rb.header("Content-Type", "application/json")
         }
         Location::MultipartBody => {
-            let method = crate::scanning::url_inject::body_location_method(&target.method);
+            let method =
+                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
             let parsed_url = param
                 .form_action_url
                 .as_ref()

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -26,7 +26,8 @@ pub async fn verify_dom_xss_light_with_client(
     payload: &str,
 ) -> (bool, Option<String>, Option<String>) {
     let default_method = target.parse_method();
-    let body_method = crate::scanning::url_inject::body_location_method(&target.method);
+    let body_method =
+        crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     let request = match param.location {
         Location::Header => {
             let parsed_url = target.url.clone();

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -25,14 +25,15 @@ pub async fn verify_dom_xss_light_with_client(
     param: &Param,
     payload: &str,
 ) -> (bool, Option<String>, Option<String>) {
-    let method = target.parse_method();
+    let default_method = target.parse_method();
+    let body_method = crate::scanning::url_inject::body_location_method(&target.method);
     let request = match param.location {
         Location::Header => {
             let parsed_url = target.url.clone();
             let rb = crate::utils::build_request(
                 client,
                 target,
-                method,
+                default_method,
                 parsed_url,
                 target.data.clone(),
             );
@@ -71,7 +72,7 @@ pub async fn verify_dom_xss_light_with_client(
                     urlencoding::encode(payload)
                 ))
             };
-            crate::utils::build_request(client, target, method, parsed_url, body)
+            crate::utils::build_request(client, target, body_method, parsed_url, body)
         }
         Location::JsonBody => {
             let parsed_url = param
@@ -94,7 +95,7 @@ pub async fn verify_dom_xss_light_with_client(
             } else {
                 Some(serde_json::json!({ &param.name: payload }).to_string())
             };
-            let rb = crate::utils::build_request(client, target, method, parsed_url, body);
+            let rb = crate::utils::build_request(client, target, body_method, parsed_url, body);
             rb.header("Content-Type", "application/json")
         }
         Location::MultipartBody => {
@@ -123,7 +124,8 @@ pub async fn verify_dom_xss_light_with_client(
             } else {
                 form = form.text(param.name.clone(), payload.to_string());
             }
-            crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
+            crate::utils::build_request(client, target, body_method, parsed_url, None)
+                .multipart(form)
         }
         _ => {
             // GET form discovery sets form_action_url; light-verify must
@@ -133,7 +135,13 @@ pub async fn verify_dom_xss_light_with_client(
             let inject_url =
                 crate::scanning::url_inject::build_injected_url(&base_url, param, payload);
             let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
-            crate::utils::build_request(client, target, method, parsed_url, target.data.clone())
+            crate::utils::build_request(
+                client,
+                target,
+                default_method,
+                parsed_url,
+                target.data.clone(),
+            )
         }
     };
 

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2495,7 +2495,7 @@ fn build_request_text_body_replaces_in_existing_form_data() {
     };
     let param = req_param("pass", "secret", Location::Body);
     let req = super::build_request_text(&target, &param, "PAY");
-    // Body location forces POST and a form content type.
+    // Body-capable methods are preserved; form content type is set.
     assert!(req.starts_with("POST /login "), "req:\n{req}");
     assert!(
         req.contains("Content-Type: application/x-www-form-urlencoded"),
@@ -2504,6 +2504,21 @@ fn build_request_text_body_replaces_in_existing_form_data() {
     assert!(req.contains("user=alice"), "req:\n{req}");
     assert!(req.contains("pass=PAY"), "req:\n{req}");
     assert!(req.contains("Content-Length: "), "req:\n{req}");
+}
+
+#[test]
+fn build_request_text_body_preserves_query_method() {
+    // RFC 10008 QUERY: body injection must not force POST.
+    let target = Target {
+        method: "QUERY".to_string(),
+        data: Some("filter=foo&q=seed".to_string()),
+        ..target_for("https://example.com/search")
+    };
+    let param = req_param("q", "seed", Location::Body);
+    let req = super::build_request_text(&target, &param, "PAY");
+    assert!(req.starts_with("QUERY /search "), "req:\n{req}");
+    assert!(req.contains("filter=foo"), "req:\n{req}");
+    assert!(req.contains("q=PAY"), "req:\n{req}");
 }
 
 #[test]

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -106,29 +106,40 @@ pub fn effective_query_base(target_url: &url::Url, param: &Param) -> url::Url {
     target_url.clone()
 }
 
-/// Method used for Body / JsonBody / MultipartBody injection.
+/// Method used when mining/injecting against the target's own request body
+/// (`-d` / imported body) without a form-discovery context.
 ///
-/// Body-less verbs (GET/HEAD/OPTIONS/TRACE) still force POST — that is the
-/// form-discovery path where the page was loaded with GET but fields submit
-/// as POST. Body-capable verbs (POST/PUT/PATCH/DELETE/QUERY/…) are preserved
-/// so scans like `-X QUERY -d '…'` actually send QUERY (RFC 10008).
+/// Body-less verbs (GET/HEAD/OPTIONS/TRACE) force POST. Body-capable verbs
+/// (POST/PUT/PATCH/DELETE/QUERY/…) are preserved so scans like
+/// `-X QUERY -d '…'` actually send QUERY (RFC 10008).
 pub fn body_location_method(target_method: &str) -> reqwest::Method {
     match target_method.trim().to_ascii_uppercase().as_str() {
         "" | "GET" | "HEAD" | "OPTIONS" | "TRACE" => reqwest::Method::POST,
-        other => other
-            .parse()
-            .unwrap_or(reqwest::Method::POST),
+        other => other.parse().unwrap_or(reqwest::Method::POST),
     }
 }
 
+/// Method used for Body / JsonBody / MultipartBody injection for a concrete
+/// param. HTML form-discovered sinks (`form_action_url` set) always submit as
+/// POST — forms never use QUERY/PUT/etc. Own-body params fall through to
+/// [`body_location_method`].
+pub fn body_location_method_for_param(target_method: &str, param: &Param) -> reqwest::Method {
+    if param.form_action_url.is_some() {
+        return reqwest::Method::POST;
+    }
+    body_location_method(target_method)
+}
+
 /// HTTP method that will actually be used to send a payload-bearing
-/// request for `param`. Body-bearing locations use [`body_location_method`];
-/// other locations keep the target's own method. Finding metadata must match
-/// the verb that is actually sent.
+/// request for `param`. Body-bearing locations use
+/// [`body_location_method_for_param`]; other locations keep the target's own
+/// method. Finding metadata must match the verb that is actually sent.
 pub fn effective_method(target_method: &str, param: &Param) -> String {
     match param.location {
         Location::Body | Location::JsonBody | Location::MultipartBody => {
-            body_location_method(target_method).as_str().to_string()
+            body_location_method_for_param(target_method, param)
+                .as_str()
+                .to_string()
         }
         _ => target_method.to_string(),
     }

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -106,13 +106,30 @@ pub fn effective_query_base(target_url: &url::Url, param: &Param) -> url::Url {
     target_url.clone()
 }
 
+/// Method used for Body / JsonBody / MultipartBody injection.
+///
+/// Body-less verbs (GET/HEAD/OPTIONS/TRACE) still force POST — that is the
+/// form-discovery path where the page was loaded with GET but fields submit
+/// as POST. Body-capable verbs (POST/PUT/PATCH/DELETE/QUERY/…) are preserved
+/// so scans like `-X QUERY -d '…'` actually send QUERY (RFC 10008).
+pub fn body_location_method(target_method: &str) -> reqwest::Method {
+    match target_method.trim().to_ascii_uppercase().as_str() {
+        "" | "GET" | "HEAD" | "OPTIONS" | "TRACE" => reqwest::Method::POST,
+        other => other
+            .parse()
+            .unwrap_or(reqwest::Method::POST),
+    }
+}
+
 /// HTTP method that will actually be used to send a payload-bearing
-/// request for `param`. Body-bearing locations are always POSTed (see
-/// `check_reflection::build_test_request`), independent of the target's
-/// own method — so finding metadata should reflect POST, not GET.
+/// request for `param`. Body-bearing locations use [`body_location_method`];
+/// other locations keep the target's own method. Finding metadata must match
+/// the verb that is actually sent.
 pub fn effective_method(target_method: &str, param: &Param) -> String {
     match param.location {
-        Location::Body | Location::JsonBody | Location::MultipartBody => "POST".to_string(),
+        Location::Body | Location::JsonBody | Location::MultipartBody => {
+            body_location_method(target_method).as_str().to_string()
+        }
         _ => target_method.to_string(),
     }
 }

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -496,6 +496,65 @@ fn effective_query_base_uses_form_action_for_query_params() {
 }
 
 #[test]
+fn body_location_method_forces_post_for_bodyless_verbs() {
+    for verb in ["GET", "get", "HEAD", "OPTIONS", "TRACE", "", "  "] {
+        assert_eq!(
+            body_location_method(verb),
+            reqwest::Method::POST,
+            "expected POST for body-less verb {verb:?}"
+        );
+    }
+}
+
+#[test]
+fn body_location_method_preserves_body_capable_verbs() {
+    for (verb, expected) in [
+        ("POST", "POST"),
+        ("PUT", "PUT"),
+        ("PATCH", "PATCH"),
+        ("DELETE", "DELETE"),
+        ("QUERY", "QUERY"),
+        ("query", "QUERY"),
+        ("  Query ", "QUERY"),
+    ] {
+        assert_eq!(
+            body_location_method(verb).as_str(),
+            expected,
+            "expected {expected} for {verb:?}"
+        );
+    }
+}
+
+#[test]
+fn effective_method_body_locations_respect_query_method() {
+    let mut param = Param {
+        name: "q".into(),
+        value: "".into(),
+        location: Location::Body,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    for loc in [Location::Body, Location::JsonBody, Location::MultipartBody] {
+        param.location = loc;
+        assert_eq!(effective_method("QUERY", &param), "QUERY");
+        assert_eq!(effective_method("GET", &param), "POST");
+        assert_eq!(effective_method("PUT", &param), "PUT");
+    }
+    param.location = Location::Query;
+    assert_eq!(effective_method("QUERY", &param), "QUERY");
+    assert_eq!(effective_method("GET", &param), "GET");
+}
+
+#[test]
 fn effective_query_base_uses_form_action_for_body_locations() {
     let target = make_url("https://example.com/page");
     let mut param = Param {

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -555,6 +555,37 @@ fn effective_method_body_locations_respect_query_method() {
 }
 
 #[test]
+fn form_discovered_body_params_always_post_even_on_query_target() {
+    // HTML forms submit as POST regardless of how the page was loaded
+    // (QUERY/PUT/…). Without this, -X QUERY would mis-verb form fields.
+    let mut param = Param {
+        name: "comment".into(),
+        value: "".into(),
+        location: Location::Body,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: Some("https://example.com/submit".to_string()),
+        form_origin_url: Some("https://example.com/page".to_string()),
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    for loc in [Location::Body, Location::JsonBody, Location::MultipartBody] {
+        param.location = loc;
+        assert_eq!(
+            body_location_method_for_param("QUERY", &param),
+            reqwest::Method::POST
+        );
+        assert_eq!(effective_method("QUERY", &param), "POST");
+        assert_eq!(effective_method("PUT", &param), "POST");
+    }
+}
+
+#[test]
 fn effective_query_base_uses_form_action_for_body_locations() {
     let target = make_url("https://example.com/page");
     let mut param = Param {

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -234,14 +234,12 @@ pub fn parse_target(s: &str) -> Result<Target, Box<dyn std::error::Error>> {
 /// Returns (method, url, optional_body).
 /// If the string doesn't start with a known HTTP method, it returns ("GET", original_string, None).
 pub fn parse_method_url_body(s: &str) -> (String, String, Option<String>) {
-    const METHODS: [&str; 7] = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"];
-
     // Use splitn(3, ' ') to preserve spaces in the body portion (e.g., "POST url name=John Doe")
     let parts: Vec<&str> = s.splitn(3, ' ').collect();
 
     if parts.len() >= 2 {
         let potential_method = parts[0].to_uppercase();
-        if METHODS.iter().any(|m| m.eq(&potential_method)) {
+        if is_known_http_method(&potential_method) {
             let url = parts[1].to_string();
             let body = parts
                 .get(2)
@@ -253,6 +251,17 @@ pub fn parse_method_url_body(s: &str) -> (String, String, Option<String>) {
 
     // Not in METHOD URL [BODY] format, return as-is with GET method
     ("GET".to_string(), s.to_string(), None)
+}
+
+/// Methods recognized in `METHOD URL [BODY]` shorthand and raw-HTTP request lines.
+/// Includes RFC 10008 QUERY (safe/idempotent with a body).
+const KNOWN_HTTP_METHODS: [&str; 8] = [
+    "GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH", "QUERY",
+];
+
+#[inline]
+fn is_known_http_method(method: &str) -> bool {
+    KNOWN_HTTP_METHODS.iter().any(|m| m.eq(&method))
 }
 
 /// Parse a target string that may be in "METHOD URL [BODY]" format or a plain URL.
@@ -270,8 +279,7 @@ pub fn is_raw_http_request(s: &str) -> bool {
     let first = s.lines().next().unwrap_or("").trim_start();
     let mut it = first.split_whitespace();
     if let Some(method) = it.next() {
-        const METHODS: [&str; 7] = ["GET", "POST", "PUT", "DELETE", "HEAD", "OPTIONS", "PATCH"];
-        if METHODS.iter().any(|m| m.eq(&method)) && first.contains(" HTTP/") {
+        if is_known_http_method(method) && first.contains(" HTTP/") {
             return true;
         }
     }
@@ -704,6 +712,41 @@ mod tests {
         assert_eq!(method, "OPTIONS");
         assert_eq!(url, "https://example.com/api");
         assert_eq!(body, None);
+    }
+
+    #[test]
+    fn test_parse_method_url_body_query_with_json_body() {
+        // RFC 10008 QUERY — safe/idempotent method with a body.
+        let (method, url, body) =
+            parse_method_url_body("QUERY https://example.com/search {\"q\":\"test\"}");
+        assert_eq!(method, "QUERY");
+        assert_eq!(url, "https://example.com/search");
+        assert_eq!(body, Some("{\"q\":\"test\"}".to_string()));
+    }
+
+    #[test]
+    fn test_parse_method_url_body_query_lowercase() {
+        let (method, url, body) = parse_method_url_body("query https://example.com/search a=b");
+        assert_eq!(method, "QUERY");
+        assert_eq!(url, "https://example.com/search");
+        assert_eq!(body, Some("a=b".to_string()));
+    }
+
+    #[test]
+    fn test_is_raw_http_request_query() {
+        assert!(is_raw_http_request(
+            "QUERY /search HTTP/1.1\r\nHost: example.com\r\n\r\n{\"q\":\"test\"}"
+        ));
+        assert!(!is_raw_http_request("QUERY https://example.com/search"));
+    }
+
+    #[test]
+    fn test_parse_target_with_method_query() {
+        let target =
+            parse_target_with_method("QUERY https://example.com/search {\"q\":\"x\"}").unwrap();
+        assert_eq!(target.method, "QUERY");
+        assert_eq!(target.url.as_str(), "https://example.com/search");
+        assert_eq!(target.data, Some("{\"q\":\"x\"}".to_string()));
     }
 
     #[test]

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -278,10 +278,11 @@ pub fn parse_target_with_method(s: &str) -> Result<Target, Box<dyn std::error::E
 pub fn is_raw_http_request(s: &str) -> bool {
     let first = s.lines().next().unwrap_or("").trim_start();
     let mut it = first.split_whitespace();
-    if let Some(method) = it.next() {
-        if is_known_http_method(method) && first.contains(" HTTP/") {
-            return true;
-        }
+    if let Some(method) = it.next()
+        && is_known_http_method(method)
+        && first.contains(" HTTP/")
+    {
+        return true;
     }
     false
 }


### PR DESCRIPTION
## Summary

- Accept **QUERY** (RFC 10008) as a first-class HTTP method via `-X`/`--method`, `METHOD URL [BODY]` target shorthand, and raw-HTTP request lines.
- Introduce `body_location_method` so body/JSON/multipart injection preserves body-capable verbs (POST/PUT/PATCH/DELETE/**QUERY**/…) instead of always forcing POST. Body-less targets (GET/HEAD/OPTIONS/…) still force POST for form-discovery.
- Align finding metadata (`effective_method`), reflection/DOM/light-verify/mining probes, and PoC request rendering with the method actually sent.
- Document allowed methods in CLI/config reference and agent skill bundle.

Closes #1185

## Test plan

- [x] Unit: CLI parser accepts `query`/`QUERY`; rejects TRACE
- [x] Unit: `parse_method_url_body` / raw-HTTP / `parse_target_with_method` for QUERY + body
- [x] Unit: `body_location_method` / `effective_method` for QUERY vs GET body locations
- [x] Unit: `build_request_text` PoC line starts with `QUERY` for body injection
- [x] `cargo test` full suite
- [x] Manual: `dalfox scan -X QUERY -d 'q=1' … --dry-run` succeeds; `-X TRACE` rejected