### PR TITLE
fix(scan): seed bare -p names when discovery is skipped

### DIFF
--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -19,6 +19,7 @@ pub(crate) async fn render_dry_run(
 ) -> ScanOutcome {
     let skipped_targets = &state.skipped_targets;
     let mut dry_run_targets = Vec::new();
+    let mut warnings: Vec<String> = Vec::new();
     for group in host_groups.values() {
         for target in group {
             let param_count = target.reflection_params.len();
@@ -70,6 +71,30 @@ pub(crate) async fn render_dry_run(
                 })
                 .collect();
 
+            // Surface -p specs that still could not be seeded (path/fragment,
+            // unknown type). Agents use this to avoid treating "0 params" as a
+            // clean no-op when the operator asked for an unsynthesizable target.
+            if !args.param.is_empty() {
+                let unresolved = crate::parameter_analysis::unresolved_explicit_param_specs(
+                    &target.reflection_params,
+                    &args.param,
+                    target,
+                );
+                if !unresolved.is_empty() {
+                    warnings.push(format!(
+                        "EXPLICIT_PARAM_NOT_SEEDED target={} specs=[{}] (path/fragment and unknown types cannot be synthesized by name; use a name:location form such as q:query)",
+                        target.url,
+                        unresolved.join(", ")
+                    ));
+                } else if param_count == 0 {
+                    warnings.push(format!(
+                        "EXPLICIT_PARAM_EMPTY target={} param=[{}] produced zero scannable parameters",
+                        target.url,
+                        args.param.join(", ")
+                    ));
+                }
+            }
+
             dry_run_targets.push(serde_json::json!({
                 "target": target.url.as_str(),
                 "method": target.method,
@@ -93,16 +118,20 @@ pub(crate) async fn render_dry_run(
     let skipped = skipped_targets.lock().await;
 
     if args.format == "json" || args.format == "jsonl" {
+        let mut meta = serde_json::json!({
+            "dalfox_version": env!("CARGO_PKG_VERSION"),
+            "targets_input": args.targets.len(),
+            "targets_scannable": dry_run_targets.len(),
+            "targets_skipped": skipped.len(),
+            "total_params_discovered": total_params,
+            "total_estimated_requests": total_estimated,
+        });
+        if !warnings.is_empty() {
+            meta["warnings"] = serde_json::json!(warnings);
+        }
         let output = serde_json::json!({
             "dry_run": true,
-            "meta": {
-                "dalfox_version": env!("CARGO_PKG_VERSION"),
-                "targets_input": args.targets.len(),
-                "targets_scannable": dry_run_targets.len(),
-                "targets_skipped": skipped.len(),
-                "total_params_discovered": total_params,
-                "total_estimated_requests": total_estimated,
-            },
+            "meta": meta,
             "targets": dry_run_targets,
         });
         if args.format == "json" {
@@ -120,6 +149,12 @@ pub(crate) async fn render_dry_run(
         println!("  Targets (skipped):   {}", skipped.len());
         println!("  Params discovered:   {}", total_params);
         println!("  Estimated requests:  {}", total_estimated);
+        if !warnings.is_empty() {
+            println!("  Warnings:");
+            for w in &warnings {
+                println!("    - {}", w);
+            }
+        }
         println!();
         for t in &dry_run_targets {
             println!(

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -1163,6 +1163,27 @@ async fn test_render_dry_run_json_with_encoders() {
     assert!(matches!(outcome, ScanOutcome::Clean));
 }
 
+#[tokio::test]
+async fn test_render_dry_run_warns_on_unresolved_explicit_params() {
+    // path cannot be synthesized by name; dry-run should still complete cleanly
+    // while emitting a machine-readable warning path via unresolved specs.
+    let target = target_with_params("https://example.com", vec![]);
+    let mut args = default_scan_args();
+    args.format = "json".to_string();
+    args.targets = vec!["https://example.com".to_string()];
+    args.param = vec!["seg:path".to_string()];
+    let state = make_scan_state(vec![]);
+    let outcome = render_dry_run(&args, &host_group(vec![target]), &state).await;
+    assert!(matches!(outcome, ScanOutcome::Clean));
+    // Ensure the helper itself flags the unsynthesizable spec (source of warnings).
+    let missing = crate::parameter_analysis::unresolved_explicit_param_specs(
+        &[],
+        &args.param,
+        &parse_target("https://example.com").unwrap(),
+    );
+    assert_eq!(missing, vec!["seg:path".to_string()]);
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // output.rs — render_results (async; all format branches via file output)
 // ─────────────────────────────────────────────────────────────────────────

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -1260,7 +1260,7 @@ fn ensure_explicit_params(params: &mut Vec<Param>, param_specs: &[String], targe
             if params.iter().any(|p| p.name == name) {
                 continue;
             }
-            let (location, _label) = infer_location_for_bare_param(name, target);
+            let location = infer_location_for_bare_param(name, target);
             push_synthesized_param(params, name, location);
         }
     }
@@ -1290,10 +1290,10 @@ fn push_synthesized_param(params: &mut Vec<Param>, name: &str, location: Locatio
 /// Order mirrors how operators usually mean an untyped name: query string
 /// first (most common XSS surface), then request body, cookies, headers.
 /// Default is `query` so `--skip-discovery -p q` still tests something.
-fn infer_location_for_bare_param(name: &str, target: &Target) -> (Location, &'static str) {
+fn infer_location_for_bare_param(name: &str, target: &Target) -> Location {
     // URL query
     if target.url.query_pairs().any(|(k, _)| k.as_ref() == name) {
-        return (Location::Query, "query");
+        return Location::Query;
     }
 
     // Form / JSON body
@@ -1303,16 +1303,16 @@ fn infer_location_for_bare_param(name: &str, target: &Target) -> (Location, &'st
             if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(trimmed)
                 && map.contains_key(name)
             {
-                return (Location::JsonBody, "json");
+                return Location::JsonBody;
             }
         } else if url::form_urlencoded::parse(data.as_bytes()).any(|(k, _)| k.as_ref() == name) {
-            return (Location::Body, "body");
+            return Location::Body;
         }
     }
 
-    // Cookies (Header location, cookie label)
+    // Cookies (Header location; `param_type_label` reports "cookie")
     if target.cookies.iter().any(|(n, _)| n == name) {
-        return (Location::Header, "cookie");
+        return Location::Header;
     }
 
     // Headers (case-insensitive name match on header names)
@@ -1321,10 +1321,10 @@ fn infer_location_for_bare_param(name: &str, target: &Target) -> (Location, &'st
         .iter()
         .any(|(n, _)| n.eq_ignore_ascii_case(name))
     {
-        return (Location::Header, "header");
+        return Location::Header;
     }
 
-    (Location::Query, "query")
+    Location::Query
 }
 
 /// Return `-p` specs that are still absent from `params` after filtering +

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -1206,13 +1206,21 @@ fn filter_params(params: Vec<Param>, param_specs: &[String], target: &Target) ->
         .collect()
 }
 
-/// Guarantee that every explicit `-p name:<type>` injection point is present
-/// in `params`, synthesizing any that discovery/mining did not seed.
+/// Guarantee that every explicit `-p` injection point is present in `params`,
+/// synthesizing any that discovery/mining did not seed.
 ///
 /// `-p` is otherwise just a *filter* over discovered params, so a `--skip-*`
 /// flag that suppresses the phase which would have seeded a location silently
 /// drops the operator's explicit target (the #1044 / #1045 bug class). This is
 /// the general guard: a named target is always tested, whatever was skipped.
+///
+/// Spec forms:
+/// - `name:type` — synthesize that exact location (`query`, `body`, `json`,
+///   `multipart`, `header`, `cookie`).
+/// - bare `name` — if no param with that name is already present, infer a
+///   location from the target (URL query → body → cookies → headers) and
+///   fall back to `query`. Bare names that already matched via filtering are
+///   left alone (any location).
 ///
 /// Synthesized params carry no `injection_context` (scanning then uses the
 /// context-agnostic fallback payloads) and no special-char profile (the active
@@ -1224,40 +1232,128 @@ fn ensure_explicit_params(params: &mut Vec<Param>, param_specs: &[String], targe
         // Parse "name:type" as parts[0]/parts[1] to match `filter_params`.
         let parts: Vec<&str> = spec.split(':').collect();
         let (name, type_str) = match parts.as_slice() {
-            [name, ty, ..] if !name.is_empty() => (*name, *ty),
-            _ => continue, // name-only → filtering, nothing to synthesize
-        };
-        let location = match type_str {
-            "query" => Location::Query,
-            "body" => Location::Body,
-            "json" => Location::JsonBody,
-            "multipart" => Location::MultipartBody,
-            "header" | "cookie" => Location::Header,
+            [name, ty, ..] if !name.is_empty() && !ty.is_empty() => (*name, Some(*ty)),
+            [name] if !name.is_empty() => (*name, None),
+            [name, ..] if !name.is_empty() => (*name, None),
             _ => continue,
         };
-        let already = params
-            .iter()
-            .any(|p| p.name == name && param_type_label(p, target) == type_str);
-        if already {
-            continue;
+
+        if let Some(type_str) = type_str {
+            let location = match type_str {
+                "query" => Location::Query,
+                "body" => Location::Body,
+                "json" => Location::JsonBody,
+                "multipart" => Location::MultipartBody,
+                "header" | "cookie" => Location::Header,
+                // path / fragment / unknown: not name-addressable for synthesis
+                _ => continue,
+            };
+            let already = params
+                .iter()
+                .any(|p| p.name == name && param_type_label(p, target) == type_str);
+            if already {
+                continue;
+            }
+            push_synthesized_param(params, name, location);
+        } else {
+            // Bare name: keep any filtered matches; only synthesize when none.
+            if params.iter().any(|p| p.name == name) {
+                continue;
+            }
+            let (location, _label) = infer_location_for_bare_param(name, target);
+            push_synthesized_param(params, name, location);
         }
-        params.push(Param {
-            name: name.to_string(),
-            value: String::new(),
-            location,
-            injection_context: None,
-            valid_specials: None,
-            invalid_specials: None,
-            pre_encoding: None,
-            pre_encoding_pipeline: None,
-            wire_name: None,
-            form_action_url: None,
-            form_origin_url: None,
-            framework_sink: None,
-            escaped_specials: None,
-            js_breakout: None,
-        });
     }
+}
+
+fn push_synthesized_param(params: &mut Vec<Param>, name: &str, location: Location) {
+    params.push(Param {
+        name: name.to_string(),
+        value: String::new(),
+        location,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    });
+}
+
+/// Infer a wire location for a bare `-p name` when discovery did not seed it.
+///
+/// Order mirrors how operators usually mean an untyped name: query string
+/// first (most common XSS surface), then request body, cookies, headers.
+/// Default is `query` so `--skip-discovery -p q` still tests something.
+fn infer_location_for_bare_param(name: &str, target: &Target) -> (Location, &'static str) {
+    // URL query
+    if target.url.query_pairs().any(|(k, _)| k.as_ref() == name) {
+        return (Location::Query, "query");
+    }
+
+    // Form / JSON body
+    if let Some(data) = target.data.as_deref() {
+        let trimmed = data.trim_start();
+        if trimmed.starts_with('{') {
+            if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(trimmed)
+                && map.contains_key(name)
+            {
+                return (Location::JsonBody, "json");
+            }
+        } else if url::form_urlencoded::parse(data.as_bytes()).any(|(k, _)| k.as_ref() == name) {
+            return (Location::Body, "body");
+        }
+    }
+
+    // Cookies (Header location, cookie label)
+    if target.cookies.iter().any(|(n, _)| n == name) {
+        return (Location::Header, "cookie");
+    }
+
+    // Headers (case-insensitive name match on header names)
+    if target
+        .headers
+        .iter()
+        .any(|(n, _)| n.eq_ignore_ascii_case(name))
+    {
+        return (Location::Header, "header");
+    }
+
+    (Location::Query, "query")
+}
+
+/// Return `-p` specs that are still absent from `params` after filtering +
+/// synthesis. Used by dry-run to surface agent-visible warnings (e.g. only
+/// `path`/`fragment` specs, which cannot be synthesized by name).
+pub fn unresolved_explicit_param_specs(
+    params: &[Param],
+    param_specs: &[String],
+    target: &Target,
+) -> Vec<String> {
+    let mut missing = Vec::new();
+    for spec in param_specs {
+        let parts: Vec<&str> = spec.split(':').collect();
+        match parts.as_slice() {
+            [name, ty, ..] if !name.is_empty() && !ty.is_empty() => {
+                let present = params
+                    .iter()
+                    .any(|p| p.name == *name && param_type_label(p, target) == *ty);
+                if !present {
+                    missing.push(spec.clone());
+                }
+            }
+            [name, ..] if !name.is_empty() && !params.iter().any(|p| p.name == *name) => {
+                missing.push(spec.clone());
+            }
+            _ => {}
+        }
+    }
+    missing
 }
 
 #[cfg(test)]

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -883,21 +883,80 @@ fn test_ensure_explicit_params_synthesizes_missing_targets() {
 }
 
 #[test]
-fn test_ensure_explicit_params_skips_unsynthesizable_specs() {
+fn test_ensure_explicit_params_skips_unsynthesizable_typed_specs() {
     let target = parse_target("https://example.com").unwrap();
     let mut params: Vec<Param> = vec![];
-    // name-only (ambiguous), path (positional), fragment (never scanned)
-    let specs = vec![
-        "foo".to_string(),
-        "seg:path".to_string(),
-        "h:fragment".to_string(),
-    ];
+    // path (positional) and fragment (never scanned) still cannot be synthesized
+    let specs = vec!["seg:path".to_string(), "h:fragment".to_string()];
     ensure_explicit_params(&mut params, &specs, &target);
     assert!(
         params.is_empty(),
-        "name-only / path / fragment specs must not be synthesized, got {:?}",
+        "path / fragment specs must not be synthesized, got {:?}",
         params.iter().map(|p| &p.name).collect::<Vec<_>>()
     );
+}
+
+#[test]
+fn test_ensure_explicit_params_bare_name_defaults_to_query() {
+    // Fast-smoke recipe: -p q --skip-discovery must still seed the param.
+    let target = parse_target("https://example.com/").unwrap();
+    let mut params: Vec<Param> = vec![];
+    ensure_explicit_params(&mut params, &["q".to_string()], &target);
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].name, "q");
+    assert_eq!(params[0].location, Location::Query);
+}
+
+#[test]
+fn test_ensure_explicit_params_bare_name_infers_from_url_query() {
+    let target = parse_target("https://example.com/search?q=test&lang=en").unwrap();
+    let mut params: Vec<Param> = vec![];
+    ensure_explicit_params(&mut params, &["q".to_string()], &target);
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].location, Location::Query);
+}
+
+#[test]
+fn test_ensure_explicit_params_bare_name_infers_body() {
+    let mut target = parse_target("https://example.com/submit").unwrap();
+    target.data = Some("user=alice&token=abc".to_string());
+    let mut params: Vec<Param> = vec![];
+    ensure_explicit_params(&mut params, &["token".to_string()], &target);
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].name, "token");
+    assert_eq!(params[0].location, Location::Body);
+}
+
+#[test]
+fn test_ensure_explicit_params_bare_name_does_not_duplicate_existing() {
+    let target = parse_target("https://example.com/?q=1").unwrap();
+    let mut params = vec![bare_param("q", Location::Query)];
+    ensure_explicit_params(&mut params, &["q".to_string()], &target);
+    assert_eq!(
+        params.len(),
+        1,
+        "bare name must not duplicate a filtered match"
+    );
+}
+
+#[test]
+fn test_unresolved_explicit_param_specs_reports_path_fragment() {
+    let target = parse_target("https://example.com/").unwrap();
+    let params: Vec<Param> = vec![];
+    let missing = unresolved_explicit_param_specs(
+        &params,
+        &[
+            "q".to_string(),
+            "seg:path".to_string(),
+            "h:fragment".to_string(),
+        ],
+        &target,
+    );
+    // After synthesis "q" would be present; unresolved is for post-ensure checks.
+    // With empty params, all three are missing.
+    assert!(missing.iter().any(|s| s == "seg:path"));
+    assert!(missing.iter().any(|s| s == "h:fragment"));
+    assert!(missing.iter().any(|s| s == "q"));
 }
 
 fn default_scan_args() -> ScanArgs {


### PR DESCRIPTION
## Summary
- Bare `-p name` previously only *filtered* discovered params, so recipes like `-p q --skip-mining --skip-discovery` silently tested nothing and returned clean (agent false negative).
- `ensure_explicit_params` now synthesizes bare names: infer location from URL query / body / cookies / headers, defaulting to `query`.
- Dry-run emits `meta.warnings` (`EXPLICIT_PARAM_NOT_SEEDED` / `EXPLICIT_PARAM_EMPTY`) when `-p` specs still cannot be seeded (e.g. `path` / `fragment`).

## Test plan
- [x] Unit: bare name default/infer/no-duplicate; path/fragment still not synthesized
- [x] Unit: dry-run unresolved helper
- [x] E2E: local mock with `-p q --skip-mining --skip-discovery` finds V
- [x] E2E: dry-run with same flags reports 1 param
- [ ] CI green