### PR TITLE
docs(skill): align agent recipes with bare -p seeding

### DIFF
--- a/docs/content/guide/parameters.md
+++ b/docs/content/guide/parameters.md
@@ -29,7 +29,14 @@ dalfox https://target.app/api \
   -p token:cookie
 ```
 
-Locations: `query`, `body`, `json`, `cookie`, `header`. Without a hint, Dalfox places the parameter wherever the target already exposes it.
+Locations: `query`, `body`, `json`, `multipart`, `cookie`, `header`. Prefer `name:location` when the injection point is not the query string.
+
+Without a location hint (`-p q` only):
+
+1. If discovery/mining already found a param with that name, it is kept (filter).
+2. Otherwise Dalfox **synthesizes** it: location is inferred from the request (URL query → body → cookies → headers), defaulting to `query`.
+
+That means recipes like `-p q --skip-discovery --skip-mining` still test `q` instead of silently scanning nothing.
 
 ## Mining with wordlists
 

--- a/skills/dalfox/SKILL.md
+++ b/skills/dalfox/SKILL.md
@@ -50,6 +50,7 @@ Use `preflight_dalfox`. Look at `estimated_total_requests` and `reachable`.
 **CLI**:
 ```bash
 dalfox scan https://target/?q=test --dry-run --skip-mining
+# Prefer --format json for machine parsing; check meta.warnings if you passed -p
 ```
 
 If the number is huge or `reachable == false`, report back to the user before sending real payloads.
@@ -58,8 +59,9 @@ If the number is huge or `reachable == false`, report back to the user before se
 
 1. Preflight (see above).
 2. Start the scan:
-   - MCP: `scan_with_dalfox` (store the `scan_id`).
-   - CLI: `dalfox scan https://target/?q=test -p q ...`
+   - MCP: `scan_with_dalfox` (store the `scan_id`). Prefer explicit `param` with location hints (`["q:query"]`) when you know the injection point.
+   - CLI: `dalfox scan https://target/?q=test -p q --skip-mining ...`  
+     Bare `-p name` is fine for query params (synthesized if discovery was skipped). Use `name:location` for body/header/cookie/json (`-p user:body`).
 3. Poll (MCP) or watch output (CLI).
 4. Present findings using the rules in `references/results.md` (lead with V, surface `type_description` and `inject_type`).
 5. Clean up: `delete_scan_dalfox` (MCP) or just let the process end (CLI). Terminal jobs auto-expire after 1 h.
@@ -123,7 +125,7 @@ Key points for agents:
 
 See `references/advanced.md` for the detailed recipes:
 
-- "Too many parameters / too slow" → preflight + `--skip-mining` + explicit `-p`
+- "Too many parameters / too slow" → preflight + `--skip-mining` + explicit `-p` (`name:location` when not query) + optional `--max-payloads-per-param`
 - "WAF present" → the matrix of `--waf-bypass`, `--force-waf`, `--waf-evasion`
 - "Need custom payloads or markers" → `--custom-payload`, `--inject-marker`, `--custom-alert-*`
 - "Captured request testing" → `-i raw-http` (single request) or `-i har` (whole proxy/DevTools export)
@@ -150,8 +152,8 @@ See `references/config.md`.
 - MCP tool schemas + gotchas (including why `cookie_from_raw` is absent) → `references/mcp.md`
 - Finding types, output formats, POC types, error codes, exit codes → `references/results.md`
 - Config precedence, paths, banner behavior → `references/config.md`
-- Server API + `dalfox payload` selectors → `references/server-and-payload.md`
-- WAF recipes, mining control, raw-http, HPP, custom payloads → `references/advanced.md`
+- Server API + `dalfox payload` selectors → `references/server-and-payload.md` (single file; not separate `server.md` / `payload.md`)
+- WAF recipes, mining control, bare vs `name:location` `-p`, raw-http, HPP, custom payloads → `references/advanced.md`
 
 ## 9. AGENTS.md Invariants (this skill must respect)
 

--- a/skills/dalfox/references/INDEX.md
+++ b/skills/dalfox/references/INDEX.md
@@ -10,9 +10,8 @@ This directory holds detailed, lookup-oriented reference material so the main `S
 | `mcp.md` | The 6 MCP tools (`scan_with_dalfox` etc.) with full parameter schemas, validation rules, and security notes | Working via MCP tools (preferred for long/async scans) |
 | `results.md` | Finding shape (V/A/R + `type_description`), `inject_type`, output formats, `--poc-type`, `include_request/response` contract | Interpreting scan output or choosing `--format` / POC style |
 | `config.md` | Config file search paths, precedence (`apply_to_scan_args_if_default`), example, banner/silence interaction | User has (or should have) a `config.toml`; or you see unexpected defaults |
-| `server.md` | When and how to use `dalfox server`, auth, CORS, JSONP, endpoint summary | User wants to expose an API or the MCP tools are not available |
-| `payload.md` | `dalfox payload <selector>` usage and what each selector actually emits | User asks to list payloads or you need event-handler / tag names |
-| `advanced.md` | WAF bypass strategies, mining/discovery controls, scope filters, custom payloads, HPP, concurrency caps, `raw-http` input, `--max-payloads-per-param` | You hit WAF, huge parameter surfaces, need custom payloads, or captured request testing |
+| `server-and-payload.md` | `dalfox server` API (auth, CORS, JSONP, endpoints) **and** `dalfox payload <selector>` output | User wants a persistent API, or to list/enumerate payloads |
+| `advanced.md` | WAF bypass, mining/discovery controls, scope filters, custom payloads, HPP, concurrency caps, `raw-http` / HAR, `--max-payloads-per-param`, bare vs `name:location` `-p` | WAF, huge param surfaces, custom payloads, captured-request testing, or agent fast-mode recipes |
 
 ## Design Principles for This Skill
 

--- a/skills/dalfox/references/advanced.md
+++ b/skills/dalfox/references/advanced.md
@@ -20,9 +20,9 @@
 
 Biggest lever for request count is usually `--skip-mining` (or the more granular `--skip-mining-dom` / `--skip-mining-dict`).
 
-Discovery (`--skip-discovery`) turns off HTML parsing for forms, links, and inline JS. Only parameters you pass with `-p` will be tested — never use this on a bare URL without `-p`.
+Discovery (`--skip-discovery`) turns off HTML form / link / inline-JS extraction. **Always pass `-p` when using it** — without `-p`, a bare URL has nothing to test. Bare `-p name` synthesizes a param when discovery/mining did not seed it (location inferred from the request, default `query`). Prefer `name:location` (`q:query`, `user:body`, `auth:header`, `sid:cookie`) when the location is not obvious.
 
-`--only-discovery` is excellent for a quick "how many parameters will this scan actually hit?" check before committing to a long run.
+`--only-discovery` / `--dry-run` are excellent for "how many parameters will this scan actually hit?" before a long run. Dry-run JSON surfaces `meta.warnings` if an explicit `-p` could not be seeded (e.g. `path` / `fragment`).
 
 Remote wordlists (`--remote-wordlists burp,assetnote`) are cached with OnceLock for the lifetime of the process.
 
@@ -79,15 +79,17 @@ Only when you have evidence that the first finding on a parameter is not the onl
 
 1. Preflight first (`--dry-run` or MCP `preflight_dalfox`).
 2. Add `--skip-mining`.
-3. Add explicit `-p` for the 5–10 parameters you actually care about.
-4. Cap with `--max-payloads-per-param 30`.
-5. If still too much: lower `--workers` and add `--delay`.
+3. Add explicit `-p` / `param` for the 5–10 parameters you care about (`name:location` when not query).
+4. Cap with `--max-payloads-per-param 30` (CLI; MCP parity tracked separately).
+5. If still too much: lower `--workers`, add `--delay` / `--rate-limit`, or `--scan-timeout`.
 
 ## MCP vs CLI for advanced scenarios
 
-Most of the flags above have direct equivalents in `scan_with_dalfox` parameters. The main absences on the MCP side are:
-- `--cookie-from-raw` (security)
-- `--remote-payloads` / `--remote-wordlists` (you can still pass custom lists via other means if needed)
+Most scan flags have direct equivalents in `scan_with_dalfox`. Notable absences / differences:
+- `--cookie-from-raw` — intentionally absent on MCP (host file-read class; supply `cookies` directly)
+- Managed `--blind-oob` lifecycle — CLI-only; MCP uses `blind_callback_url`
+- Multi-target / HAR / raw-http fan-out — CLI-only (call MCP once per URL)
+- `preflight_dalfox.param` is accepted but **not applied** (full discovery impact estimate); pass `param` on `scan_with_dalfox`
 - Some of the more exotic mining/scope filters (they exist in the engine but are not yet exposed on the MCP surface)
 
 When you need the full power, fall back to spawning the CLI with carefully constructed arguments (or extend the MCP tool surface in a future change).

--- a/skills/dalfox/references/cli.md
+++ b/skills/dalfox/references/cli.md
@@ -38,7 +38,7 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 |------|---------|
 | `-X, --method` | HTTP method override: `GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY` (RFC 10008; body-capable, safe/idempotent). Body params preserve the target method (e.g. `-X QUERY -d '…'`) |
 | `-d, --data` | Request body (form or JSON) |
-| `-p, --param` | Restrict to specific params (supports `name:location` hints) |
+| `-p, --param` | Restrict to specific params. Prefer `name:location` (`query`, `body`, `json`, `multipart`, `header`, `cookie`). Bare `-p name` still works: if discovery did not seed it, dalfox synthesizes it (infers location from the request, defaults to `query`) so `--skip-discovery -p q` is not a silent no-op |
 | `--include-url` | Regex whitelist (multiple) |
 | `--exclude-url` | Regex blacklist (multiple) |
 | `--ignore-param` | Skip these parameter names entirely |
@@ -57,7 +57,7 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 | `-W, --mining-dict-word` | Path to custom wordlist for dictionary mining |
 | `--remote-wordlists` | `burp,assetnote` (comma-separated) |
 
-**Common fast-mode combo**: `--skip-mining` (or `--skip-mining-dom`) + explicit `-p` params you care about.
+**Common fast-mode combo**: `--skip-mining` (or `--skip-mining-dom`) + explicit `-p` for the params you care about. With `--skip-discovery`, always pass `-p` (bare name is OK for query; use `name:location` for body/header/cookie/json).
 
 ## Network & Concurrency
 
@@ -125,7 +125,7 @@ See `references/advanced.md` for recommended WAF combinations.
 ## Other Useful / Diagnostic
 
 - `--cookie-from-raw request.txt` — lift cookies from a captured raw request file (CLI only)
-- `--dry-run` — preflight summary only (same as MCP `preflight_dalfox`)
+- `--dry-run` — preflight summary only (parameter discovery + request estimate; no attack payloads). JSON/JSONL include `meta.warnings` when `-p` specs could not be seeded (e.g. `path` / `fragment` only). MCP equivalent: `preflight_dalfox` (note: preflight intentionally ignores `param` filters for impact estimation)
 - `--debug` — show DBG lines
 - Global root flags: `--config`, `--debug`, `--no-color`, `--silence`
 
@@ -135,9 +135,12 @@ See `references/results.md`.
 
 ## Common High-Value Combinations
 
-**Fast smoke test on one param**:
+**Fast smoke test on one query param** (safe with skip-discovery — bare `-p` synthesizes as query if needed):
 ```bash
 dalfox scan https://target/?q=1 -p q --skip-mining --skip-discovery
+# Prefer location hints when not query:
+# dalfox scan https://target/search -p q:query --skip-mining --skip-discovery
+# dalfox scan https://target/api -X POST -d 'user=x' -p user:body --skip-mining --skip-discovery
 ```
 
 **Polite authenticated scan through Burp**:

--- a/skills/dalfox/references/results.md
+++ b/skills/dalfox/references/results.md
@@ -75,6 +75,17 @@ Never turn them on "just in case" during automated scans. Only enable when the u
 
 In MCP: `include_request` / `include_response` default to `false` and must be set explicitly.
 
+## Dry-run warnings (CLI)
+
+`--dry-run` with `--format json` / `jsonl` may include `meta.warnings` (string array). Codes agents should watch for:
+
+| Code prefix | Meaning |
+|-------------|---------|
+| `EXPLICIT_PARAM_NOT_SEEDED` | One or more `-p` specs could not be seeded (typically `path` / `fragment` / unknown type). Fix: use a synthesizable `name:location` such as `q:query`. |
+| `EXPLICIT_PARAM_EMPTY` | `-p` was set but zero scannable params remained after analysis. |
+
+Plain dry-run prints the same warnings under a `Warnings:` section.
+
 ## Streaming Findings
 
 `--stream-findings` emits each verified finding the moment it is confirmed instead of waiting for the final summary. Useful for very long scans where you want early signal. Off by default.


### PR DESCRIPTION
## Summary
- Align agent skill recipes with the bare `-p` synthesis fix (#1221): `--skip-discovery -p q` is intentional and safe.
- Prefer `name:location` in recipes when not query; document dry-run `meta.warnings`.
- Fix `references/INDEX.md` file map (`server-and-payload.md`).
- Update guide `parameters.md` for the same synthesis semantics.

## Test plan
- [x] Manual read-through of SKILL.md + cli/advanced/results/INDEX
- [ ] Docs site renders (no code change)

Depends on #1221 (already merged).