### PR TITLE
docs: redesign the docs site with a moonlit-indigo theme

### DIFF
--- a/docs/config.toml
+++ b/docs/config.toml
@@ -306,8 +306,8 @@ emoji = false         # If true, convert emoji shortcodes (e.g. :smile:) to emoj
 [og.auto_image]
 enabled = true
 background = "#070811"                          # site dark navy — overlaid over the illustration
-text_color = "#e7e9f3"                          # site primary text
-accent_color = "#8b94e8"                        # site accent (periwinkle)
+text_color = "#e6edf7"                          # site primary text
+accent_color = "#7c87ea"                        # site accent (moonlit indigo)
 font_size = 52
 logo = "static/images/logo_solo.png"
 logo_position = "bottom-left"                   # bottom-left, bottom-right, top-left, top-right

--- a/docs/content/index.md
+++ b/docs/content/index.md
@@ -1,5 +1,5 @@
 +++
-title = "Dalfox — Powerful XSS Scanner"
+title = "Powerful XSS Scanner"
 description = "A powerful open-source XSS scanner and automation utility. Reflected, Stored, DOM-based with AST-level verification."
 template = "landing"
 +++
@@ -7,71 +7,23 @@ template = "landing"
 <section class="hero">
   <div class="hero-illustration" aria-hidden="true"></div>
   <div class="hero-inner">
-    <div class="hero-text">
-      <h1 class="hero-title">
-        Hunt <span class="strike">every</span> <span class="accent">XSS</span><br>
-        before it hunts you.
-      </h1>
-      <p class="hero-desc">
-        <strong>Dalfox</strong> is a powerful open-source XSS scanner and automation utility. Reflected, Stored, DOM-based: discovered, verified, and reported with AST-level precision across every parameter in your app.
-      </p>
-      <div class="hero-actions">
-        <a href="./getting-started/" class="btn btn-primary">
-          Get Started
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
-        </a>
-        <a href="https://github.com/hahwul/dalfox" class="btn btn-secondary" target="_blank" rel="noopener">
-          <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
-          Star on GitHub
-        </a>
-      </div>
-      <div class="hero-install" data-install>
-        <div class="hero-install-pm">
-          <button class="hero-install-pm-btn" type="button" aria-haspopup="listbox" aria-expanded="false" aria-label="Choose install method">
-            <span class="hero-install-pm-label">brew</span>
-            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
-          </button>
-          <ul class="hero-install-pm-menu" role="listbox" aria-label="Install method">
-            <li role="option" class="is-selected" aria-selected="true" data-label="brew" data-cmd="brew install dalfox">Homebrew</li>
-            <li role="option" aria-selected="false" data-label="snap" data-cmd="sudo snap install dalfox">Snap</li>
-            <li role="option" aria-selected="false" data-label="aur" data-cmd="yay -S dalfox">Arch (AUR)</li>
-            <li role="option" aria-selected="false" data-label="nix" data-cmd="nix profile install github:hahwul/dalfox">Nix</li>
-            <li role="option" aria-selected="false" data-label="cargo" data-cmd="cargo install dalfox">Cargo</li>
-          </ul>
-        </div>
-        <span class="hero-install-sep" aria-hidden="true"></span>
-        <span class="dollar">$</span>
-        <code>brew install dalfox</code>
-        <button class="hero-install-copy" type="button">copy</button>
-      </div>
-    </div>
-    <div class="hero-visual">
-      <div class="terminal">
-        <div class="terminal-bar">
-          <div class="terminal-dots">
-            <span class="terminal-dot red"></span>
-            <span class="terminal-dot amber"></span>
-            <span class="terminal-dot green"></span>
-          </div>
-          <div class="terminal-title">dalfox — scan</div>
-        </div>
-        <div class="terminal-body">
-          <div class="t-line"><span class="t-prompt">$</span><span class="t-cmd">dalfox scan https://xss-game.appspot.com/level1/frame</span></div>
-          <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> start scan to https://xss-game.appspot.com/level1/frame</div>
-          <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> found reflected 1 params</div>
-          <div class="t-line t-dim">└── query valid_specials="/\'{`<>"();=|}[.:]+,$-" invalid_specials=""</div>
-          <div class="t-line"></div>
-          <div class="t-line"></div>
-          <div class="t-line"><span class="t-ts">6:42PM</span> <span class="t-wrn">WRN</span> XSS found 1 XSS</div>
-          <div class="t-line"><span class="t-poc">[POC][V][GET][inHTML]</span> ...?query=%3Csvg%2Fonload%3Dalert%281%29%3E</div>
-          <div class="t-line t-dim">  ├── Issue: XSS payload DOM object identified</div>
-          <div class="t-line t-dim">  ├── Payload: &lt;svg/onload=alert(1)&gt;</div>
-          <div class="t-line t-dim">  └── L13: s were found for &#x3c;b&#x3e;&#x3c;svg/onload=alert(1)&#x3e;&#x3c;/b&#x3e;..</div>
-          <div class="t-line"></div>
-          <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> scan completed in 3.482 seconds</div>
-          <div class="t-line t-cursor"></div>
-        </div>
-      </div>
+    <p class="hero-eyebrow">xss scanner · rust</p>
+    <h1 class="hero-title">
+      Hunt <span class="strike">every</span> <span class="accent">XSS</span><br>
+      before it hunts you.
+    </h1>
+    <p class="hero-desc">
+      Reflected, Stored, and DOM-based flaws, discovered and verified with AST-level precision across every parameter.
+    </p>
+    <div class="hero-actions">
+      <a href="./getting-started/" class="btn btn-primary">
+        Get started
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="M5 12h14"/><path d="m12 5 7 7-7 7"/></svg>
+      </a>
+      <a href="https://github.com/hahwul/dalfox" class="btn btn-secondary" target="_blank" rel="noopener">
+        <svg width="16" height="16" viewBox="0 0 24 24" fill="currentColor"><path d="M12 0c-6.626 0-12 5.373-12 12 0 5.302 3.438 9.8 8.207 11.387.599.111.793-.261.793-.577v-2.234c-3.338.726-4.033-1.416-4.033-1.416-.546-1.387-1.333-1.756-1.333-1.756-1.089-.745.083-.729.083-.729 1.205.084 1.839 1.237 1.839 1.237 1.07 1.834 2.807 1.304 3.492.997.107-.775.418-1.305.762-1.604-2.665-.305-5.467-1.334-5.467-5.931 0-1.311.469-2.381 1.236-3.221-.124-.303-.535-1.524.117-3.176 0 0 1.008-.322 3.301 1.23.957-.266 1.983-.399 3.003-.404 1.02.005 2.047.138 3.006.404 2.291-1.552 3.297-1.23 3.297-1.23.653 1.653.242 2.874.118 3.176.77.84 1.235 1.911 1.235 3.221 0 4.609-2.807 5.624-5.479 5.921.43.372.823 1.102.823 2.222v3.293c0 .319.192.694.801.576 4.765-1.589 8.199-6.086 8.199-11.386 0-6.627-5.373-12-12-12z"/></svg>
+        Star on GitHub
+      </a>
     </div>
   </div>
 </section>
@@ -96,6 +48,61 @@ template = "landing"
     </div>
   </div>
 </div>
+
+<section class="section section--terminal">
+  <div class="section-inner">
+    <h2 class="section-title">One command, a verified finding</h2>
+    <p class="section-desc">Point Dalfox at a target and it discovers parameters, probes contexts, injects, and confirms the hit at the DOM level before it ever reaches your report.</p>
+    <div class="terminal-demo">
+      <div class="hero-visual">
+        <div class="terminal">
+          <div class="terminal-bar">
+            <div class="terminal-dots">
+              <span class="terminal-dot red"></span>
+              <span class="terminal-dot amber"></span>
+              <span class="terminal-dot green"></span>
+            </div>
+            <div class="terminal-title">dalfox · scan</div>
+          </div>
+          <div class="terminal-body">
+            <div class="t-line"><span class="t-prompt">$</span><span class="t-cmd">dalfox scan https://xss-game.appspot.com/level1/frame</span></div>
+            <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> start scan to https://xss-game.appspot.com/level1/frame</div>
+            <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> found reflected 1 params</div>
+            <div class="t-line t-dim">└── query valid_specials="/\'{`<>"();=|}[.:]+,$-" invalid_specials=""</div>
+            <div class="t-line"></div>
+            <div class="t-line"><span class="t-ts">6:42PM</span> <span class="t-wrn">WRN</span> XSS found 1 XSS</div>
+            <div class="t-line"><span class="t-poc">[POC][V][GET][inHTML]</span> ...?query=%3Csvg%2Fonload%3Dalert%281%29%3E</div>
+            <div class="t-line t-dim">  ├── Issue: XSS payload DOM object identified</div>
+            <div class="t-line t-dim">  ├── Payload: &lt;svg/onload=alert(1)&gt;</div>
+            <div class="t-line t-dim">  └── L13: matches for &#x3c;svg/onload=alert(1)&#x3e;</div>
+            <div class="t-line"></div>
+            <div class="t-line t-dim"><span class="t-ts">6:42PM</span> <span class="t-info">INF</span> scan completed in 3.482 seconds</div>
+            <div class="t-line t-cursor"></div>
+          </div>
+        </div>
+      </div>
+      <div class="hero-install" data-install>
+        <div class="hero-install-pm">
+          <button class="hero-install-pm-btn" type="button" aria-haspopup="listbox" aria-expanded="false" aria-label="Choose install method">
+            <span class="hero-install-pm-label">brew</span>
+            <svg width="11" height="11" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round"><path d="m6 9 6 6 6-6"/></svg>
+          </button>
+          <ul class="hero-install-pm-menu" role="listbox" aria-label="Install method">
+            <li role="option" class="is-selected" aria-selected="true" data-label="brew" data-cmd="brew install dalfox">Homebrew</li>
+            <li role="option" aria-selected="false" data-label="snap" data-cmd="sudo snap install dalfox">Snap</li>
+            <li role="option" aria-selected="false" data-label="aur" data-cmd="yay -S dalfox">Arch (AUR)</li>
+            <li role="option" aria-selected="false" data-label="nix" data-cmd="nix profile install github:hahwul/dalfox">Nix</li>
+            <li role="option" aria-selected="false" data-label="cargo" data-cmd="cargo install dalfox">Cargo</li>
+          </ul>
+        </div>
+        <span class="hero-install-sep" aria-hidden="true"></span>
+        <span class="dollar">$</span>
+        <code>brew install dalfox</code>
+        <button class="hero-install-copy" type="button">copy</button>
+      </div>
+    </div>
+  </div>
+</section>
 
 <section class="section">
   <div class="section-inner">
@@ -170,30 +177,46 @@ template = "landing"
     <p class="section-eyebrow">// Modes</p>
     <h2 class="section-title">Six ways to run Dalfox</h2>
     <p class="section-desc">Pick the shape that fits your target. Every mode shares the same discovery and verification engine.</p>
-    <div class="modes">
-      <div class="mode">
-        <div class="mode-name">URL</div>
-        <div class="mode-desc">Single target scan</div>
+    <div class="modes" data-modes>
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-url" checked>
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-file">
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-pipe">
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-sxss">
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-server">
+      <input class="mode-radio" type="radio" name="dalfox-mode" id="m-mcp">
+      <div class="mode-tabs" role="tablist" aria-label="Dalfox run modes">
+        <label class="mode-tab" for="m-url"><span class="mode-tab-name">URL</span><span class="mode-tab-sub">single target</span></label>
+        <label class="mode-tab" for="m-file"><span class="mode-tab-name">FILE</span><span class="mode-tab-sub">batch from a list</span></label>
+        <label class="mode-tab" for="m-pipe"><span class="mode-tab-name">PIPE</span><span class="mode-tab-sub">stdin pipeline</span></label>
+        <label class="mode-tab" for="m-sxss"><span class="mode-tab-name">SXSS</span><span class="mode-tab-sub">stored XSS</span></label>
+        <label class="mode-tab" for="m-server"><span class="mode-tab-name">SERVER</span><span class="mode-tab-sub">REST daemon</span></label>
+        <label class="mode-tab" for="m-mcp"><span class="mode-tab-name">MCP</span><span class="mode-tab-sub">agent-native</span></label>
       </div>
-      <div class="mode">
-        <div class="mode-name">FILE</div>
-        <div class="mode-desc">Batch from list</div>
-      </div>
-      <div class="mode">
-        <div class="mode-name">PIPE</div>
-        <div class="mode-desc">stdin pipeline</div>
-      </div>
-      <div class="mode">
-        <div class="mode-name">SXSS</div>
-        <div class="mode-desc">Stored XSS</div>
-      </div>
-      <div class="mode">
-        <div class="mode-name">SERVER</div>
-        <div class="mode-desc">REST + daemon</div>
-      </div>
-      <div class="mode">
-        <div class="mode-name">MCP</div>
-        <div class="mode-desc">Agent-native</div>
+      <div class="mode-panels">
+        <div class="mode-panel" data-mode="url">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>dalfox scan https://target.app</code></div>
+          <p>Point Dalfox at a single URL. It mines parameters, probes each context, and verifies every hit at the DOM level.</p>
+        </div>
+        <div class="mode-panel" data-mode="file">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>dalfox scan urls.txt</code></div>
+          <p>Sweep a whole list of targets from a file, one URL per line, with the same engine and one report.</p>
+        </div>
+        <div class="mode-panel" data-mode="pipe">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>cat urls.txt | dalfox scan</code></div>
+          <p>Read targets from stdin so Dalfox drops straight into your crawler or recon pipeline.</p>
+        </div>
+        <div class="mode-panel" data-mode="sxss">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>dalfox scan https://app/post --sxss-url https://app/feed</code></div>
+          <p>Inject on one endpoint, then confirm the payload fires on another. Stored XSS, actually verified.</p>
+        </div>
+        <div class="mode-panel" data-mode="server">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>dalfox server</code></div>
+          <p>Run Dalfox as a long-lived REST API for async scan jobs, integrations, and dashboards.</p>
+        </div>
+        <div class="mode-panel" data-mode="mcp">
+          <div class="mode-panel-cmd"><span class="dollar">$</span><code>dalfox mcp</code></div>
+          <p>Expose Dalfox as an MCP tool so agents and IDEs can scan on your behalf.</p>
+        </div>
       </div>
     </div>
   </div>
@@ -201,7 +224,6 @@ template = "landing"
 
 <section class="section">
   <div class="section-inner">
-    <p class="section-eyebrow">// Workflow</p>
     <h2 class="section-title">From install to verified finding in three steps</h2>
     <p class="section-desc">Dalfox is designed to drop into whatever you already have. No fancy setup, no heavy orchestration.</p>
     <div class="how-steps">
@@ -226,7 +248,6 @@ template = "landing"
 
 <section class="section section--community">
   <div class="section-inner">
-    <p class="section-eyebrow">// Community</p>
     <h2 class="section-title">Built in the open, by hunters everywhere</h2>
     <p class="section-desc">Dalfox is shaped by the people who run it. Open an issue, send a pull request, or trade payloads with the community. Every contribution sharpens the hunt.</p>
     <div class="community-links">
@@ -244,11 +265,10 @@ template = "landing"
   <div class="cta-illustration" aria-hidden="true"></div>
   <div class="cta-inner">
     <h2 class="cta-title">Ready to hunt?</h2>
-    <p class="cta-desc">Thousands of scans, zero fuss. Star the repo, read the docs, or drop Dalfox in your next recon loop.</p>
+    <p class="cta-desc">Thousands of scans, zero fuss. Read the docs, star the repo, or drop Dalfox in your next recon loop.</p>
     <div class="cta-buttons">
-      <a href="./getting-started/installation/" class="btn btn-primary">Install Dalfox</a>
-      <a href="./reference/cli/" class="btn btn-secondary">CLI Reference</a>
-      <a href="https://github.com/hahwul/dalfox" class="btn btn-ghost" target="_blank" rel="noopener">GitHub →</a>
+      <a href="./getting-started/" class="btn btn-primary">Get started</a>
+      <a href="./reference/cli/" class="btn btn-secondary">CLI reference</a>
     </div>
   </div>
 </section>

--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1,21 +1,22 @@
 /* ==========================================================================
-   Dalfox Documentation — Dark theme
-   Brand: #31365e (deep indigo)
-   Aesthetic: 東洋風 — ink lines (墨線), window lattice (窓), calm paper surfaces.
-   Refined lines & surfaces over a navy-ink dark base, referencing kami.tw93.fun.
+   Dalfox Documentation — Moonlit indigo dark theme
+   Accent: #7c87ea (moonlit indigo, brightened from the logo #30365e) on an
+   indigo-navy base. Aesthetic: 東洋風 — ink lines (墨線), window lattice (窓),
+   moon glow (月光). Dark-only; a redesigned take on the dalfox.hahwul.com identity.
    ========================================================================== */
 
 :root {
-    /* Brand */
-    --brand: #31365e;
-    --brand-2: #3d4477;
-    --brand-3: #5a63a8;
-    --accent: #8b94e8;
-    --accent-hover: #b4bbf0;
-    --accent-dim: rgba(139, 148, 232, 0.1);
-    --brand-glow: rgba(49, 54, 94, 0.45);
+    /* Brand — moonlit indigo, brightened from the logo #30365e */
+    --brand: #30365e;
+    --brand-2: #3b4272;
+    --brand-3: #565fa4;
+    --accent: #7c87ea;
+    --accent-hover: #9aa2f2;
+    --accent-dim: rgba(124, 135, 234, 0.1);
+    --accent-glow: #6e79e0;
+    --brand-glow: rgba(86, 95, 164, 0.4);
 
-    /* Backgrounds — navy-tinted dark */
+    /* Backgrounds — indigo-navy, toned toward the logo */
     --bg-body: #070811;
     --bg-sidebar: #0b0d18;
     --bg-content: #0a0c16;
@@ -25,32 +26,32 @@
     --bg-terminal: #060710;
 
     /* Text */
-    --text-primary: #e7e9f3;
-    --text-secondary: #9aa0bb;
-    --text-muted: #636980;
+    --text-primary: #e6edf7;
+    --text-secondary: #93a1bd;
+    --text-muted: #5d6b86;
 
     /* Borders */
     --border: #161a28;
     --border-light: #222741;
 
     /* ----- 東洋風 ornament tokens -----------------------------------------
-       Ink hairlines (墨線) derived from the periwinkle accent so every rule
+       Ink hairlines (墨線) derived from the moonlit-indigo accent so every rule
        reads as a single drawn line rather than a heavy box. The window-frame
        brackets (窓枠) and seal-mark accents reuse these. */
-    --ink-line: rgba(180, 187, 240, 0.12);
-    --ink-line-soft: rgba(180, 187, 240, 0.06);
-    --ink-line-strong: rgba(180, 187, 240, 0.28);
-    --bracket: rgba(139, 148, 232, 0.45);
-    --bracket-dim: rgba(139, 148, 232, 0.22);
+    --ink-line: rgba(124, 135, 234, 0.12);
+    --ink-line-soft: rgba(124, 135, 234, 0.06);
+    --ink-line-strong: rgba(124, 135, 234, 0.26);
+    --bracket: rgba(124, 135, 234, 0.42);
+    --bracket-dim: rgba(124, 135, 234, 0.22);
     /* faint paper grain + lattice motifs, applied at very low opacity */
     --paper-grain: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='120' height='120'%3E%3Cfilter id='n'%3E%3CfeTurbulence type='fractalNoise' baseFrequency='0.9' numOctaves='2' stitchTiles='stitch'/%3E%3C/filter%3E%3Crect width='100%25' height='100%25' filter='url(%23n)' opacity='0.5'/%3E%3C/svg%3E");
-    --asanoha: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='56' height='96' viewBox='0 0 56 96'%3E%3Cg fill='none' stroke='%238b94e8' stroke-width='0.8'%3E%3Cpath d='M28 0v24M28 24L7 36M28 24l21 12M28 24v24M28 48L7 36M28 48l21 12M28 48v24M28 72L7 60M28 72l21 12M28 96v-24M7 12v24M49 12v24M7 60v24M49 60v24M0 24l7 12M56 24l-7 12M0 72l7-12M56 72l-7-12'/%3E%3C/g%3E%3C/svg%3E");
+    --asanoha: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='56' height='96' viewBox='0 0 56 96'%3E%3Cg fill='none' stroke='%237c87ea' stroke-width='0.8'%3E%3Cpath d='M28 0v24M28 24L7 36M28 24l21 12M28 24v24M28 48L7 36M28 48l21 12M28 48v24M28 72L7 60M28 72l21 12M28 96v-24M7 12v24M49 12v24M7 60v24M49 60v24M0 24l7 12M56 24l-7 12M0 72l7-12M56 72l-7-12'/%3E%3C/g%3E%3C/svg%3E");
 
     /* Status */
-    --info-bg: rgba(96, 165, 250, 0.07);
-    --info-border: #60a5fa;
-    --warning-bg: rgba(245, 158, 11, 0.07);
-    --warning-border: #f59e0b;
+    --info-bg: rgba(124, 135, 234, 0.08);
+    --info-border: #7c87ea;
+    --warning-bg: rgba(245, 181, 68, 0.08);
+    --warning-border: #f5b544;
     --success: #34d399;
     --danger: #f87171;
 
@@ -90,7 +91,7 @@ body {
     background-color: var(--bg-body);
     background-image: radial-gradient(
         ellipse 80% 50% at 50% -10%,
-        rgba(49, 54, 94, 0.32),
+        rgba(110, 121, 224, 0.2),
         transparent 60%
     );
     background-attachment: fixed;
@@ -1482,18 +1483,19 @@ body:has(.docs-layout) .site-footer {
 .btn:active {
     transform: translateY(0);
 }
-/* Outline → fill: clean accent edge at rest, floods periwinkle on hover */
+/* Solid moonlight fill so the primary action carries the eye on the dark hero. */
 .btn-primary {
-    background: transparent;
-    color: var(--accent);
+    background: var(--accent);
+    color: #0a0e1a;
     border-color: var(--accent);
+    font-weight: 700;
 }
 .btn-primary:hover {
-    background: var(--accent);
-    color: var(--bg-content);
-    border-color: var(--accent);
+    background: var(--accent-hover);
+    color: #0a0e1a;
+    border-color: var(--accent-hover);
     transform: translateY(-1px);
-    box-shadow: 0 6px 18px rgba(139, 148, 232, 0.3);
+    box-shadow: 0 8px 24px rgba(124, 135, 234, 0.34);
 }
 .btn-secondary {
     background: var(--bg-surface);
@@ -1923,7 +1925,7 @@ body:has(.docs-layout) .site-footer {
     background: linear-gradient(
         135deg,
         var(--bg-hover),
-        rgba(48, 54, 94, 0.35)
+        rgba(124, 135, 234, 0.16)
     );
     border: 1px solid var(--border-light);
     color: var(--accent);
@@ -2613,4 +2615,280 @@ body:has(.docs-layout) .site-footer {
 .feature-cell:hover::before,
 .feature-cell:hover::after {
     opacity: 0.6;
+}
+
+/* ==========================================================================
+   Landing redesign — illustration-forward hero, moonlight glow (月光),
+   terminal demo, and a CSS-only mode switcher. Appended so it overrides the
+   split-hero base above without touching its (fragile) mask geometry.
+   ========================================================================== */
+
+/* ----- Hero: full-bleed fox-and-moon, headline centred over the art -------- */
+.hero {
+    min-height: min(86vh, 760px);
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    padding: calc(var(--header-h) + 3rem) 2rem 5rem;
+}
+/* Ambient moonlight wash — a soft cyan bloom high-centre, over the fox. */
+.hero::before {
+    top: -6%;
+    width: min(1000px, 130%);
+    height: 620px;
+    background: radial-gradient(
+        ellipse 68% 58% at 50% 4%,
+        rgba(110, 121, 224, 0.26),
+        rgba(86, 95, 164, 0.1) 42%,
+        transparent 72%
+    );
+    filter: blur(28px);
+}
+/* Reading scrim: darken the centre so the headline stays legible over the art
+   (the old asanoha lattice is repurposed here as a focus vignette). */
+.hero::after {
+    background-image: none;
+    background: radial-gradient(
+        ellipse 66% 62% at 50% 50%,
+        rgba(6, 10, 18, 0.66) 0%,
+        rgba(6, 10, 18, 0.42) 46%,
+        transparent 82%
+    );
+    mask-image: none;
+    -webkit-mask-image: none;
+    opacity: 1;
+}
+/* Illustration now leads: full-bleed cover, every edge dissolved into navy. */
+.hero-illustration {
+    background-position: center 30%;
+    background-size: cover;
+    opacity: 0.55;
+    filter: saturate(0.98) contrast(1.03);
+    mask-image: radial-gradient(
+        ellipse 94% 98% at 50% 38%,
+        black 26%,
+        rgba(0, 0, 0, 0.72) 56%,
+        rgba(0, 0, 0, 0.3) 80%,
+        transparent 99%
+    );
+    -webkit-mask-image: radial-gradient(
+        ellipse 94% 98% at 50% 38%,
+        black 26%,
+        rgba(0, 0, 0, 0.72) 56%,
+        rgba(0, 0, 0, 0.3) 80%,
+        transparent 99%
+    );
+    mask-composite: add;
+    -webkit-mask-composite: source-over;
+}
+.hero-inner {
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    max-width: 820px;
+    gap: 0;
+}
+/* Mono eyebrow, moonlight-tinted */
+.hero-eyebrow {
+    font-family: var(--font-mono);
+    font-size: 0.72rem;
+    letter-spacing: 0.2em;
+    text-transform: uppercase;
+    color: var(--accent);
+    background: var(--accent-dim);
+    border: 1px solid var(--bracket-dim);
+    border-radius: 100px;
+    padding: 0.32rem 0.85rem;
+    margin-bottom: 1.6rem;
+}
+.hero-title {
+    font-size: clamp(2.5rem, 6vw, 4.2rem);
+    margin-bottom: 1.4rem;
+    text-shadow: 0 2px 30px rgba(6, 10, 18, 0.6);
+}
+.hero-desc {
+    margin-left: auto;
+    margin-right: auto;
+    max-width: 560px;
+    text-shadow: 0 1px 16px rgba(6, 10, 18, 0.7);
+}
+.hero-actions {
+    justify-content: center;
+    margin-bottom: 0;
+}
+
+/* ----- Terminal demo section (moved out of the hero) ----------------------- */
+.terminal-demo {
+    max-width: 760px;
+    margin: 2.25rem 0 0;
+}
+/* A moonlit glow pooled under the terminal panel */
+.terminal-demo .hero-visual::before {
+    inset: -30px;
+    background: radial-gradient(
+        ellipse at center,
+        rgba(110, 121, 224, 0.16),
+        transparent 62%
+    );
+}
+.terminal-demo .hero-install {
+    margin: 1.5rem 0 0;
+}
+
+/* ----- Modes: CSS-only switcher (radio + :checked, no JS, CSP-proof) -------- */
+.modes {
+    display: grid;
+    grid-template-columns: 232px 1fr;
+    gap: 1.25rem;
+    margin-top: 1.75rem;
+    text-align: left;
+}
+.mode-radio {
+    position: absolute;
+    width: 1px;
+    height: 1px;
+    opacity: 0;
+    pointer-events: none;
+}
+.mode-tabs {
+    display: flex;
+    flex-direction: column;
+    gap: 0.45rem;
+}
+.mode-tab {
+    display: flex;
+    flex-direction: column;
+    gap: 0.1rem;
+    padding: 0.7rem 0.9rem;
+    border: 1px solid var(--border);
+    border-left: 2px solid var(--border);
+    border-radius: 8px;
+    background: linear-gradient(180deg, rgba(12, 19, 32, 0.85), rgba(8, 13, 23, 0.85));
+    backdrop-filter: blur(3px);
+    -webkit-backdrop-filter: blur(3px);
+    cursor: pointer;
+    transition: border-color 0.18s, background 0.18s, transform 0.18s;
+}
+.mode-tab:hover {
+    border-color: var(--bracket-dim);
+    transform: translateX(2px);
+}
+.mode-tab-name {
+    font-family: var(--font-mono);
+    font-size: 0.82rem;
+    font-weight: 700;
+    letter-spacing: 0.04em;
+    color: var(--text-secondary);
+    transition: color 0.18s;
+}
+.mode-tab-sub {
+    font-size: 0.7rem;
+    color: var(--text-muted);
+}
+.mode-panels {
+    position: relative;
+    min-height: 168px;
+}
+.mode-panel {
+    display: none;
+}
+.mode-panel-cmd {
+    display: flex;
+    align-items: center;
+    gap: 0.5rem;
+    font-family: var(--font-mono);
+    font-size: 0.86rem;
+    background: var(--bg-terminal);
+    border: 1px solid var(--border-light);
+    border-radius: 8px;
+    padding: 0.7rem 0.9rem;
+    margin-bottom: 1rem;
+    overflow-x: auto;
+}
+.mode-panel-cmd .dollar {
+    color: var(--accent);
+    user-select: none;
+}
+.mode-panel-cmd code {
+    color: var(--text-primary);
+    white-space: nowrap;
+}
+.mode-panel p {
+    color: var(--text-secondary);
+    font-size: 0.94rem;
+    line-height: 1.7;
+    max-width: 46ch;
+}
+/* active tab (border + fill + accent label) */
+#m-url:checked    ~ .mode-tabs label[for="m-url"],
+#m-file:checked   ~ .mode-tabs label[for="m-file"],
+#m-pipe:checked   ~ .mode-tabs label[for="m-pipe"],
+#m-sxss:checked   ~ .mode-tabs label[for="m-sxss"],
+#m-server:checked ~ .mode-tabs label[for="m-server"],
+#m-mcp:checked    ~ .mode-tabs label[for="m-mcp"] {
+    border-color: var(--bracket);
+    border-left-color: var(--accent);
+    background: var(--accent-dim);
+}
+#m-url:checked    ~ .mode-tabs label[for="m-url"]    .mode-tab-name,
+#m-file:checked   ~ .mode-tabs label[for="m-file"]   .mode-tab-name,
+#m-pipe:checked   ~ .mode-tabs label[for="m-pipe"]   .mode-tab-name,
+#m-sxss:checked   ~ .mode-tabs label[for="m-sxss"]   .mode-tab-name,
+#m-server:checked ~ .mode-tabs label[for="m-server"] .mode-tab-name,
+#m-mcp:checked    ~ .mode-tabs label[for="m-mcp"]    .mode-tab-name {
+    color: var(--accent);
+}
+/* reveal the matching panel */
+#m-url:checked    ~ .mode-panels .mode-panel[data-mode="url"],
+#m-file:checked   ~ .mode-panels .mode-panel[data-mode="file"],
+#m-pipe:checked   ~ .mode-panels .mode-panel[data-mode="pipe"],
+#m-sxss:checked   ~ .mode-panels .mode-panel[data-mode="sxss"],
+#m-server:checked ~ .mode-panels .mode-panel[data-mode="server"],
+#m-mcp:checked    ~ .mode-panels .mode-panel[data-mode="mcp"] {
+    display: block;
+}
+/* keyboard focus lands on the (visually-hidden) radio — surface it on the tab */
+.mode-radio:focus-visible ~ .mode-tabs label[for="m-url"] {
+    outline: 2px solid var(--accent);
+    outline-offset: 2px;
+}
+
+/* ----- Landing redesign responsive ----------------------------------------- */
+@media (max-width: 900px) {
+    .modes {
+        grid-template-columns: 1fr;
+    }
+    .mode-tabs {
+        flex-direction: row;
+        flex-wrap: wrap;
+    }
+    .mode-tab {
+        flex: 1 1 130px;
+    }
+    .mode-panels {
+        min-height: 0;
+    }
+}
+@media (max-width: 768px) {
+    .hero {
+        min-height: auto;
+        padding: calc(var(--header-h) + 2rem) 1.25rem 3.5rem;
+    }
+    .hero-illustration {
+        opacity: 0.42;
+    }
+}
+
+/* ----- Bento diversity — tint the two emphasis cells so the capability grid
+   isn't six identical flat cards (a moonlit wash on the lead + report cells). */
+.feature-cell.wide {
+    background: linear-gradient(150deg, rgba(124, 135, 234, 0.1), rgba(110, 121, 224, 0.02) 52%, var(--bg-content));
+}
+.feature-cell.full {
+    background: linear-gradient(120deg, var(--bg-content) 42%, rgba(124, 135, 234, 0.07));
+}
+.feature-cell.wide:hover,
+.feature-cell.full:hover {
+    background: linear-gradient(150deg, rgba(124, 135, 234, 0.15), rgba(110, 121, 224, 0.04) 52%, var(--bg-surface));
 }

--- a/docs/static/js/landing.js
+++ b/docs/static/js/landing.js
@@ -79,7 +79,7 @@
     '.hero-eyebrow', '.hero-title', '.hero-desc', '.hero-actions', '.hero-install', '.hero-visual',
     '.stat-item',
     '.section-eyebrow', '.section-title', '.section-desc',
-    '.feature-cell', '.mode', '.how-step',
+    '.feature-cell', '.mode-tab', '.how-step',
     '.community-links', '.contributors-label', '.contributors',
     '.cta-title', '.cta-desc', '.cta-buttons'
   ].join(', ');

--- a/docs/templates/header.html
+++ b/docs/templates/header.html
@@ -15,7 +15,7 @@
   {% endif %}
   <meta name="description" content="{{ page.description | e }}">
   <meta name="color-scheme" content="dark">
-  <meta name="theme-color" content="#31365e">
+  <meta name="theme-color" content="#0b0d18">
   <title>{{ page.title | e }} · {{ site.title | e }}</title>
   {{ og_all_tags }}
   {{ hreflang_tags }}


### PR DESCRIPTION
Reworks the docs site (`docs/`, hwaro) into a **moonlit-indigo** design — a bluer, more elegant take on the existing identity, toned to the logo `#30365e`.

## What changed
- **Palette**: accent `#8b94e8` (periwinkle) → **`#7c87ea`** (moonlit indigo), brand set to the logo `#30365e`, indigo-navy base. The whole chrome retints via `:root` tokens (窓枠 brackets, 墨線 hairlines, 印 seals), plus OG-image accent and `theme-color`.
- **Landing hero**: illustration-forward fox-and-moon with a moon-glow (月光) and a solid-fill primary CTA; hero copy trimmed, eyebrows rationed to 3, em-dashes removed from visible chrome.
- **Terminal demo**: moved out of the hero into its own left-aligned section.
- **Modes**: a CSS-only (JS-free, CSP-proof) switcher for the six run modes.
- **Capabilities bento**: tinted emphasis cells for visual variation.

## Scope / safety
- Only 5 files touched: `config.toml` (OG colors), `content/index.md` (landing), `static/css/style.css` (theme), `static/js/landing.js` (reveal selector), `templates/header.html` (theme-color).
- `base_url`, `static/CNAME`, and `AGENTS.md` are unchanged — no impact on hosting/SEO.
- Motion (scroll-reveal, hover) stays CSP-safe (`script-src 'self'`) and reduced-motion aware.

## Verification
- `hwaro build -i docs` clean (22 pages + 22 OG images), CSP `<meta>` present, no inline scripts.
- Headless-Chrome screenshots of the landing, docs pages, and 480px mobile confirm the redesign and readability.