### PR TITLE
test: cover explicit_param_names, parse_waf_type_from_rule, effective_wire_name (#1202, #1203, #1204)

### DIFF
--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -945,3 +945,43 @@ fn test_dedupe_keeps_canonical_metadata_over_duplicate() {
     assert_eq!(merged.framework_sink.as_deref(), Some("ng-bind-html"));
     assert_eq!(merged.form_origin_url.as_deref(), Some("https://base/form"));
 }
+
+// Exercises the pure `-p name:<type>` spec parser directly. In production it is
+// only reached from async, network-bound discovery/mining call sites (issue
+// #1202), so its four match-arm behaviors are asserted here in isolation.
+#[test]
+fn test_explicit_param_names() {
+    // Matching type returns the name.
+    assert_eq!(
+        explicit_param_names(&["sid:cookie".to_string()], "cookie"),
+        vec!["sid".to_string()],
+    );
+
+    // Mismatched type returns nothing.
+    assert!(explicit_param_names(&["sid:cookie".to_string()], "header").is_empty());
+
+    // Empty-name spec is rejected (guard `!name.is_empty()`).
+    assert!(explicit_param_names(&[":header".to_string()], "header").is_empty());
+
+    // A spec with no colon is rejected: the single-element slice fails the
+    // `[name, ty, ..]` arity.
+    assert!(explicit_param_names(&["foo".to_string()], "header").is_empty());
+
+    // A trailing third field (`name:type:extra`) is tolerated by the `..` rest
+    // pattern and still matches on the type.
+    assert_eq!(
+        explicit_param_names(&["file:multipart:extra".to_string()], "multipart"),
+        vec!["file".to_string()],
+    );
+
+    // Multiple specs: only the matching-type entries are collected, in order.
+    let specs = vec![
+        "a:header".to_string(),
+        "b:cookie".to_string(),
+        "c:header".to_string(),
+    ];
+    assert_eq!(
+        explicit_param_names(&specs, "header"),
+        vec!["a".to_string(), "c".to_string()],
+    );
+}

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1682,3 +1682,37 @@ fn test_encoded_variants_maps_every_known_special() {
     assert!(encoded_variants('a').is_empty());
     assert!(encoded_variants('0').is_empty());
 }
+
+// `effective_wire_name` selects which parameter key gets fuzzed: the parent
+// HTTP param when this is a nested-field virtual param (`wire_name: Some(..)`),
+// otherwise the param's own `name`. Both branches are asserted here (issue
+// #1204) since production fixtures only ever build the `None` branch.
+#[test]
+fn test_effective_wire_name() {
+    // wire_name set: returns the parent HTTP param key, not `name`.
+    let nested = Param {
+        name: "child".to_string(),
+        value: String::new(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: Some("parent".to_string()),
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    assert_eq!(nested.effective_wire_name(), "parent");
+
+    // wire_name None: falls back to the param's own `name`.
+    let plain = Param {
+        name: "q".to_string(),
+        wire_name: None,
+        ..nested.clone()
+    };
+    assert_eq!(plain.effective_wire_name(), "q");
+}

--- a/src/waf/tests.rs
+++ b/src/waf/tests.rs
@@ -594,3 +594,27 @@ fn test_multivalued_set_cookie_all_checked() {
         "second Set-Cookie (incap_ses) must be detected via get_all"
     );
 }
+
+#[test]
+fn test_parse_waf_type_from_rule_named_and_fallback() {
+    // A sample of the named arms map to their dedicated variant.
+    assert_eq!(parse_waf_type_from_rule("Cloudflare"), WafType::Cloudflare);
+    assert_eq!(
+        parse_waf_type_from_rule("ModSecurity"),
+        WafType::ModSecurity
+    );
+    assert_eq!(parse_waf_type_from_rule("Citrix"), WafType::Citrix);
+
+    // The wildcard fallback (never reached via the production `rules.toml`
+    // path, issue #1203): an unrecognized name lands as `Unknown`, preserving
+    // the original string as the bypass-strategy hint rather than crashing.
+    assert_eq!(
+        parse_waf_type_from_rule("BrandNewWaf"),
+        WafType::Unknown("BrandNewWaf".to_string()),
+    );
+    // Empty string is also just an unrecognized name, not a special case.
+    assert_eq!(
+        parse_waf_type_from_rule(""),
+        WafType::Unknown(String::new()),
+    );
+}


### PR DESCRIPTION
## Summary

Adds unit tests for three pure functions that were untested (or only exercised indirectly), closing three `good first issue` coverage tickets. **Test-only — no production code changes.**

| Issue | Function | File | Branches covered |
|-------|----------|------|------------------|
| #1202 | `explicit_param_names` (`-p name:<type>` spec parser) | `src/parameter_analysis/discovery/tests.rs` | type match→name, type mismatch→empty, empty-name reject, no-colon reject (+ `name:type:extra` rest-pattern, multi-spec order) |
| #1203 | `parse_waf_type_from_rule` | `src/waf/tests.rs` | named arms + the `Unknown(other)` fallback no `rules.toml` value reaches (+ empty string) |
| #1204 | `Param::effective_wire_name` | `src/parameter_analysis/tests.rs` | `wire_name: Some(..)`→parent key, `None`→`name` fallback |

Each test covers the minimal cases requested in the issue plus a few regression-guarding edge cases.

## Verification

- `cargo test --lib waf::` → 105 passed
- `cargo test --lib parameter_analysis` → 124 passed
- `cargo fmt --check` → clean

Closes #1202
Closes #1203
Closes #1204