### PR TITLE
fix(server,mcp): terminal-webhook client, honest error progress, JSONP hardening

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -561,11 +561,20 @@ impl DalfoxMcp {
         // (the client would compute estimated_completion_pct = 100 even
         // though the scan stopped at, say, 10/50 params).
         let was_cancelled = cancel_flag.load(std::sync::atomic::Ordering::Relaxed);
+        // A worker-task panic means a parameter's findings are incomplete;
+        // surface it as `error` (partial results still attached) so a poller
+        // can't mistake a crashed scan for a clean finish. Cancellation wins.
+        let panicked = !was_cancelled && scan_report.worker_panics > 0;
 
-        if !was_cancelled {
-            // After natural completion, all discovered params have been
-            // processed by `run_scanning`. No per-param counter is wired
-            // today, so the most honest post-scan value is `params_total`.
+        if !was_cancelled && !panicked {
+            // Only a clean, complete run pins `params_tested` to `params_total`
+            // (exactly 100%). Skip on cancellation AND on a worker panic: both
+            // stop short of finishing every discovered parameter — a panicked
+            // worker never bumps the live per-param counter fed to
+            // `run_scanning` at line ~540 — so promoting to params_total would
+            // make get_results_dalfox report estimated_completion_pct = 100 for
+            // a job whose status is cancelled/error, a partial scan reading as a
+            // clean finish.
             progress.params_tested.store(
                 progress
                     .params_total
@@ -585,11 +594,7 @@ impl DalfoxMcp {
                 .collect::<Vec<_>>()
         };
 
-        // A worker-task panic means a parameter's findings are incomplete;
-        // surface it as `error` (partial results still attached) so a poller
-        // can't mistake a crashed scan for a clean finish. Cancellation wins.
-        let panicked = !was_cancelled && scan_report.worker_panics > 0;
-        {
+        let final_status = {
             let mut jobs = self.lock_jobs();
             if let Some(j) = jobs.get_mut(&scan_id) {
                 // Store partial or complete results
@@ -624,15 +629,21 @@ impl DalfoxMcp {
                 if j.finished_at_ms.is_none() {
                     j.finished_at_ms = Some(now_ms());
                 }
+                Some(j.status.clone())
+            } else {
+                None
             }
-        }
+        };
 
-        let status_label = if was_cancelled {
-            "cancelled"
-        } else if panicked {
-            "error"
-        } else {
-            "finished"
+        // Derive the log label from the status actually stored, not the pre-lock
+        // was_cancelled/panicked snapshot — a cancel_scan_dalfox landing between
+        // those reads and this lock flips the job to `cancelled`, and the log
+        // line must agree with what get_results_dalfox now reports rather than
+        // announcing `finished` for a job stored as cancelled.
+        let status_label = match final_status {
+            Some(JobStatus::Cancelled) => "cancelled",
+            Some(JobStatus::Error) => "error",
+            _ => "finished",
         };
         Self::log(
             "JOB",

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -859,6 +859,37 @@ async fn test_get_results_done_shows_100_pct_and_zero_poll_interval() {
 }
 
 #[tokio::test]
+async fn test_get_results_error_with_partial_params_reports_honest_pct() {
+    // Regression for L1: a scan that settled `error` (e.g. worker panics) left
+    // some parameters unfinished, so `run_job` must NOT promote params_tested to
+    // params_total. get_results_dalfox then reports the honest partial percentage
+    // instead of a misleading 100% that reads as a clean finish. This guards the
+    // reporting contract the run_job promotion-gating fix upholds.
+    let mcp = DalfoxMcp::new();
+    {
+        let mut jobs = mcp.jobs.lock().expect("jobs mutex poisoned");
+        let job = test_job(JobStatus::Error, Some(vec![]));
+        job.progress
+            .params_total
+            .store(10, std::sync::atomic::Ordering::Relaxed);
+        job.progress
+            .params_tested
+            .store(7, std::sync::atomic::Ordering::Relaxed);
+        jobs.insert("error-partial".to_string(), job);
+    }
+
+    let resp = mcp
+        .get_results_dalfox(Parameters(get_params("error-partial")))
+        .await
+        .expect("get_results should succeed");
+    let payload = parse_result_json(&resp);
+    assert_eq!(
+        payload["progress"]["estimated_completion_pct"], 70,
+        "an error scan with 7/10 params tested must report 70%, not 100%"
+    );
+}
+
+#[tokio::test]
 async fn test_get_results_includes_timestamps() {
     let mcp = DalfoxMcp::new();
     {

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -71,6 +71,9 @@ pub(crate) fn spawn_scan_task(
                     &job_id_for_recovery,
                     &url_for_recovery,
                     msg,
+                    // Panic recovery: no scan target was built, so fall back to
+                    // the default client for the terminal webhook.
+                    None,
                 )
                 .await;
             });
@@ -119,7 +122,7 @@ fn fail_job_via_fresh_runtime(state: &AppState, job_id: &str, url: &str, msg: St
     let job_id = job_id.to_string();
     let url = url.to_string();
     rt.block_on(async move {
-        mark_job_error(&state, &job_id, &url, msg).await;
+        mark_job_error(&state, &job_id, &url, msg, None).await;
     });
 }
 
@@ -131,11 +134,20 @@ fn fail_job_via_fresh_runtime(state: &AppState, job_id: &str, url: &str, msg: St
 /// don't receive duplicate notifications.
 ///
 /// The webhook is dispatched after the jobs lock is released so a slow
-/// callback URL can't block concurrent job updates. We use the default
-/// reqwest client because the panic / parse-error paths may not have a
-/// fully-built target available; this still mirrors the contract that
-/// every terminal state fires the webhook (see commit aeb8cdb).
-pub(crate) async fn mark_job_error(state: &AppState, job_id: &str, url: &str, msg: String) {
+/// callback URL can't block concurrent job updates. `client` lets a caller
+/// that already built the scan's target hand in a proxy/TLS/redirect-aware
+/// reqwest client so the webhook honors the same network boundary as the scan
+/// (see the unreachable path in `run_scan_job`); the panic / parse-error paths
+/// have no usable target and pass `None`, falling back to a default client.
+/// Either way this mirrors the contract that every terminal state fires the
+/// webhook (see commit aeb8cdb).
+pub(crate) async fn mark_job_error(
+    state: &AppState,
+    job_id: &str,
+    url: &str,
+    msg: String,
+    client: Option<reqwest::Client>,
+) {
     let (transitioned, callback_url) = {
         let mut jobs = state.jobs.lock().await;
         if let Some(job) = jobs.get_mut(job_id)
@@ -152,7 +164,7 @@ pub(crate) async fn mark_job_error(state: &AppState, job_id: &str, url: &str, ms
         }
     };
     if transitioned {
-        send_terminal_webhook(state, callback_url, job_id, url, "error", &[], None).await;
+        send_terminal_webhook(state, callback_url, job_id, url, "error", &[], client).await;
     }
 }
 
@@ -438,7 +450,7 @@ pub(crate) async fn run_scan_job(
             // subscriber waiting indefinitely. mark_job_error now handles
             // both the status update and the webhook dispatch.
             let msg = format!("parse_target failed: {}", e);
-            mark_job_error(&state, &job_id, &url, msg).await;
+            mark_job_error(&state, &job_id, &url, msg, None).await;
             return;
         }
     };
@@ -466,7 +478,20 @@ pub(crate) async fn run_scan_job(
     // returns reachable:false; mirror that here so /scan clients can tell the
     // two apart. Any HTTP response (including 4xx/5xx) counts as reachable.
     if !send_reachability_probe(&target).await {
-        mark_job_error(&state, &job_id, &url, unreachable_error_message()).await;
+        // The target is fully hydrated here, so deliver the terminal webhook
+        // through its proxy/TLS/redirect-aware client — matching the done /
+        // cancelled paths. Without this, the unreachable/error webhook went out
+        // on a bare default client and silently failed whenever the callback
+        // host was only reachable via the scan's configured proxy.
+        let cb_client = target.build_client_or_default();
+        mark_job_error(
+            &state,
+            &job_id,
+            &url,
+            unreachable_error_message(),
+            Some(cb_client),
+        )
+        .await;
         return;
     }
 
@@ -648,13 +673,20 @@ pub(crate) async fn run_scan_job(
     drop(findings_updater);
 
     let was_cancelled = cancel_flag.load(std::sync::atomic::Ordering::Relaxed);
+    // A worker-task panic means at least one parameter's findings are
+    // incomplete. Surface that as `error` (with the partial results still
+    // attached) so a poller can't mistake a crashed scan for a clean `done`.
+    // Cancellation takes precedence (it's already a partial-by-design state).
+    let panicked = !was_cancelled && scan_report.worker_panics > 0;
 
-    if !was_cancelled {
-        // After natural completion, every discovered parameter has been
-        // processed by `run_scanning`, so reflect that in `params_tested`.
-        // Skip this on cancellation: the scan stopped early and promoting
-        // params_tested to params_total would falsely report 100%
-        // completion to API pollers computing estimated_completion_pct.
+    if !was_cancelled && !panicked {
+        // After a clean, complete run every discovered parameter was processed
+        // by `run_scanning`, so pin `params_tested` to `params_total` (exactly
+        // 100%). Skip this on cancellation AND on a worker panic: both stop
+        // short of finishing every parameter — a panicked worker never bumps
+        // the live counter — so promoting to params_total would report
+        // estimated_completion_pct = 100 for a job whose status is
+        // cancelled/error, making a partial scan read as a clean finish.
         progress.params_tested.store(
             progress
                 .params_total
@@ -674,13 +706,8 @@ pub(crate) async fn run_scan_job(
             .collect::<Vec<_>>()
     };
 
-    // A worker-task panic means at least one parameter's findings are
-    // incomplete. Surface that as `error` (with the partial results still
-    // attached) so a poller can't mistake a crashed scan for a clean `done`.
-    // Cancellation takes precedence (it's already a partial-by-design state).
-    let panicked = !was_cancelled && scan_report.worker_panics > 0;
     let final_results_arc = Arc::new(final_results);
-    let callback_url = {
+    let (callback_url, final_status) = {
         let mut jobs = state.jobs.lock().await;
 
         if let Some(job) = jobs.get_mut(&job_id) {
@@ -714,17 +741,21 @@ pub(crate) async fn run_scan_job(
             if job.finished_at_ms.is_none() {
                 job.finished_at_ms = Some(now_ms());
             }
-            job.callback_url.clone()
+            (job.callback_url.clone(), Some(job.status.clone()))
         } else {
-            None
+            (None, None)
         }
     };
-    let status_label = if was_cancelled {
-        "cancelled"
-    } else if panicked {
-        "error"
-    } else {
-        "done"
+    // Derive the webhook/log label from the status actually stored, not from the
+    // pre-lock `was_cancelled`/`panicked` snapshot: a DELETE cancel landing in
+    // the window between those reads and this lock flips the job to `cancelled`,
+    // and the webhook payload (which subscribers branch on) and the JOB log must
+    // agree with what GET /scan/{id} now reports rather than announcing `done`
+    // for a job stored as cancelled.
+    let status_label = match final_status {
+        Some(JobStatus::Cancelled) => "cancelled",
+        Some(JobStatus::Error) => "error",
+        _ => "done",
     };
     log(
         &state,

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -50,10 +50,23 @@ pub(crate) fn build_response_body<T: Serialize>(
 ) -> (Option<&'static str>, String) {
     let json = serde_json::to_string(resp).expect("serializable response");
     match jsonp_cb {
-        Some(cb) => (
-            Some("application/javascript; charset=utf-8"),
-            format!("{}({});", cb, json),
-        ),
+        Some(cb) => {
+            // serde_json leaves U+2028 (LINE SEPARATOR) and U+2029 (PARAGRAPH
+            // SEPARATOR) as raw bytes. They're valid inside JSON strings, but in
+            // a JSONP body served as application/javascript they are string-
+            // literal line terminators on pre-ES2019 engines — an attacker-
+            // influenced finding field (target URL, payload, evidence) carrying
+            // one would break the wrapped `callback(...)` into a syntax error or
+            // split its string literal. Escape them so the JS stays valid
+            // regardless of finding content.
+            let safe = json
+                .replace('\u{2028}', "\\u2028")
+                .replace('\u{2029}', "\\u2029");
+            (
+                Some("application/javascript; charset=utf-8"),
+                format!("{}({});", cb, safe),
+            )
+        }
         None => (None, json),
     }
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -231,6 +231,33 @@ fn test_validate_jsonp_callback_accepts_and_rejects() {
 }
 
 #[test]
+fn test_jsonp_body_escapes_line_and_paragraph_separators() {
+    // F4: U+2028 (LINE SEPARATOR) / U+2029 (PARAGRAPH SEPARATOR) in an
+    // attacker-influenced finding field must be escaped in the JSONP body, or
+    // the wrapped `callback(...)` becomes a syntax error / split string literal
+    // on engines that treat them as string-literal line terminators.
+    let resp = ApiResponse::<serde_json::Value> {
+        code: 200,
+        msg: "ok".to_string(),
+        data: Some(serde_json::json!({ "evidence": "a\u{2028}b\u{2029}c" })),
+    };
+    let (ct, body) = build_response_body(&resp, Some("cb"));
+    assert_eq!(ct, Some("application/javascript; charset=utf-8"));
+    assert!(body.starts_with("cb(") && body.ends_with(");"));
+    assert!(
+        !body.contains('\u{2028}') && !body.contains('\u{2029}'),
+        "raw separators must not survive into the JS body: {body}"
+    );
+    assert!(body.contains("\\u2028") && body.contains("\\u2029"));
+
+    // The non-JSONP path is unchanged: plain JSON is a superset and modern
+    // parsers accept the raw separators, so they pass through untouched.
+    let (ct2, body2) = build_response_body(&resp, None);
+    assert_eq!(ct2, None);
+    assert!(body2.contains('\u{2028}') && body2.contains('\u{2029}'));
+}
+
+#[test]
 fn test_build_cors_headers_none_all_exact_regex_and_fallbacks() {
     let req_headers = HeaderMap::new();
     let state_none = make_state(None, None, false, false, "callback");
@@ -1407,6 +1434,117 @@ async fn test_run_scan_job_webhook_reports_done_status() {
 }
 
 #[tokio::test]
+async fn test_run_scan_job_unreachable_target_fires_error_webhook() {
+    // Regression for F1: an unreachable (but parseable) target must still fire a
+    // terminal webhook, and that webhook is now dispatched through the scan
+    // target's own proxy/TLS/redirect-aware client (previously a bare default
+    // client, which silently failed to deliver whenever the callback host was
+    // only reachable via the scan's configured proxy). We can't wire a proxy in
+    // a unit test, but we lock in the observable contract subscribers depend on:
+    // unreachable → a webhook with status="error", and the job settles Error.
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use tokio::sync::oneshot;
+
+    // Webhook capture server (bound first so it can't collide with the port we
+    // free below).
+    let captured: Arc<Mutex<Option<serde_json::Value>>> = Arc::new(Mutex::new(None));
+    let fired = Arc::new(AtomicBool::new(false));
+    let (tx, rx) = oneshot::channel::<()>();
+    let tx_shared = Arc::new(Mutex::new(Some(tx)));
+    let captured_clone = captured.clone();
+    let fired_clone = fired.clone();
+    let tx_clone = tx_shared.clone();
+    let webhook_app = Router::new().route(
+        "/hook",
+        any(move |body: axum::body::Bytes| {
+            let captured = captured_clone.clone();
+            let fired = fired_clone.clone();
+            let tx_shared = tx_clone.clone();
+            async move {
+                let parsed: serde_json::Value =
+                    serde_json::from_slice(&body).unwrap_or(serde_json::Value::Null);
+                *captured.lock().await = Some(parsed);
+                if !fired.swap(true, Ordering::SeqCst)
+                    && let Some(tx) = tx_shared.lock().await.take()
+                {
+                    let _ = tx.send(());
+                }
+                StatusCode::OK
+            }
+        }),
+    );
+    let webhook_listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind webhook listener");
+    let webhook_addr = webhook_listener.local_addr().expect("webhook local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(webhook_listener, webhook_app).await;
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    // Reserve then immediately drop a port so a connection there is refused —
+    // a reliably unreachable but well-formed http target.
+    let dead_addr = {
+        let l = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+            .await
+            .expect("bind throwaway listener");
+        l.local_addr().expect("throwaway local addr")
+    };
+
+    let state = make_state(None, None, false, false, "callback");
+    let id = "unreachable-webhook-test".to_string();
+    let mut job = test_job(JobStatus::Queued, None, "");
+    job.callback_url = Some(format!("http://{}/hook", webhook_addr));
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), job);
+    }
+
+    let opts = ScanOptions {
+        // Short request timeout; connection-refused returns well within it.
+        timeout: Some(5),
+        callback_url: Some(format!("http://{}/hook", webhook_addr)),
+        ..ScanOptions::default()
+    };
+
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(30),
+        run_scan_job(
+            state.clone(),
+            id.clone(),
+            format!("http://{}/", dead_addr),
+            opts,
+            false,
+            false,
+        ),
+    )
+    .await;
+    assert!(
+        run.is_ok(),
+        "run_scan_job should return promptly for an unreachable target"
+    );
+
+    let _ = tokio::time::timeout(std::time::Duration::from_secs(2), rx).await;
+    let payload = captured
+        .lock()
+        .await
+        .clone()
+        .expect("unreachable scan must still fire a terminal webhook");
+    assert_eq!(
+        payload["status"], "error",
+        "unreachable target must emit status=error (got payload: {})",
+        payload
+    );
+    assert_eq!(payload["scan_id"], serde_json::Value::String(id.clone()));
+
+    let jobs = state.jobs.lock().await;
+    assert_eq!(
+        jobs.get(&id).expect("job still present").status,
+        JobStatus::Error
+    );
+}
+
+#[tokio::test]
 async fn test_get_result_handler_jsonp_done_branch() {
     let state = make_state(None, None, false, true, "cb");
     let id = "done-jsonp".to_string();
@@ -2365,7 +2503,7 @@ async fn test_mark_job_error_transitions_non_terminal() {
         jobs.insert(id.clone(), test_job(JobStatus::Running, None, "http://x"));
     }
 
-    mark_job_error(&state, &id, "http://x", "synthetic panic".to_string()).await;
+    mark_job_error(&state, &id, "http://x", "synthetic panic".to_string(), None).await;
 
     let jobs = state.jobs.lock().await;
     let job = jobs.get(&id).expect("job present");
@@ -2391,7 +2529,14 @@ async fn test_mark_job_error_does_not_clobber_terminal_state() {
             let mut jobs = state.jobs.lock().await;
             jobs.insert(id.to_string(), test_job(status.clone(), None, "http://x"));
         }
-        mark_job_error(&state, id, "http://x", "should-not-overwrite".to_string()).await;
+        mark_job_error(
+            &state,
+            id,
+            "http://x",
+            "should-not-overwrite".to_string(),
+            None,
+        )
+        .await;
         let jobs = state.jobs.lock().await;
         let job = jobs.get(id).expect("job present");
         assert_eq!(
@@ -2447,6 +2592,7 @@ async fn test_mark_job_error_fires_webhook_with_error_status() {
         &id,
         target_url,
         "parse_target failed: bad url".to_string(),
+        None,
     )
     .await;
 
@@ -2498,7 +2644,7 @@ async fn test_mark_job_error_does_not_double_fire_webhook_on_terminal_job() {
         jobs.insert(id.clone(), job);
     }
 
-    mark_job_error(&state, &id, "http://x", "late panic".to_string()).await;
+    mark_job_error(&state, &id, "http://x", "late panic".to_string(), None).await;
     // Give the webhook a beat in case it was sent anyway (it shouldn't be).
     tokio::time::sleep(std::time::Duration::from_millis(50)).await;
     assert_eq!(

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -10,7 +10,10 @@ Rationale:
 Notes:
 - If target.headers already contains a Cookie header (case-insensitive), we do NOT auto-attach cookies.
 - If a custom cookie header is provided to build_request_with_cookie, it takes precedence over auto-attach.
-- If both a header "User-Agent" is present and target.user_agent is Some, target.user_agent overwrites it.
+- reqwest's `RequestBuilder::header()` *appends*, so if `target.headers` already carries a
+  "User-Agent" entry AND `target.user_agent` is `Some`, the request sends BOTH (two User-Agent
+  headers). The scan/MCP/REST paths do exactly this on purpose — the header entry lets the
+  header-reflection probe exercise the UA while `target.user_agent` drives the common sweep.
 
 Usage examples:
   let rb = http::build_request(&client, &target, Method::GET, target.url.clone(), None);
@@ -77,7 +80,9 @@ pub fn has_header(headers: &[(String, String)], name: &str) -> bool {
     headers.iter().any(|(k, _)| k.eq_ignore_ascii_case(name))
 }
 
-/// Apply provided headers (verbatim), then apply User-Agent if present (overrides any existing).
+/// Apply provided headers (verbatim), then append `target.user_agent` as a
+/// User-Agent header when non-empty. reqwest appends rather than overrides, so a
+/// caller that also placed a User-Agent in `target.headers` ends up sending both.
 /// If `cookie_header` is Some, attach it. Otherwise, if no Cookie header exists in headers,
 /// auto-attach from target.cookies (when non-empty).
 pub fn apply_headers_ua_cookies(


### PR DESCRIPTION
## Summary

An audit of the two async scan front-ends — the REST **server** and the **MCP** runtime, which share nearly identical job-lifecycle code — surfaced a handful of correctness/robustness bugs. This PR fixes them with regression tests.

## Fixes

### Server-only
- **Terminal webhook ignored the scan's proxy/TLS on the unreachable/error path.** The `done`/`cancelled` paths build the callback client from the hydrated target (proxy/TLS/redirect-aware), but the unreachable path routed through `mark_job_error`, which always used a bare default `reqwest::Client`. So the webhook for exactly the unreachable/error outcome silently failed to deliver whenever the callback host was only reachable via the scan's configured proxy — while a successful scan's webhook to the same host went through. `mark_job_error` now takes an optional `client`; the panic / parse-error paths (no usable target) still pass `None`.
- **JSONP bodies did not escape U+2028 / U+2029.** `serde_json` leaves them raw; inside a `callback(...)` body served as `application/javascript` they are string-literal line terminators on pre-ES2019 engines, so an attacker-influenced finding field (target URL, payload, evidence) could break the wrapped JS. Now escaped in the JSONP branch only; plain-JSON output is unchanged.

### Shared (server + MCP)
- **`estimated_completion_pct` reported 100% for a crashed (`error`) scan.** A worker-panic exit left some parameters unfinished (a panicked worker never bumps the live per-param counter), yet the code still promoted `params_tested → params_total`, so a poller keying off the percentage read a crashed scan as a clean finish. The promotion is now gated on a clean, complete run.
- **Terminal webhook/log label could disagree with the stored status on a cancel race.** The label was computed from a pre-lock `was_cancelled`/`panicked` snapshot; a cancel landing in the window before the final lock flipped the job to `cancelled` while the webhook/log still announced `done`/`finished`. The label is now derived from the status actually stored under the lock, so it matches what a poll returns.

### Docs
- Corrected the `utils/http.rs` User-Agent comment: reqwest **appends** headers (the UA header entry + `target.user_agent` intentionally send two UA headers), it does not overwrite. Dropped a stale "no per-param counter is wired" comment.

## Tests
- `test_run_scan_job_unreachable_target_fires_error_webhook` — unreachable target still fires a terminal `error` webhook (exercises the new client path).
- `test_jsonp_body_escapes_line_and_paragraph_separators` — U+2028/U+2029 escaped in JSONP, untouched in plain JSON.
- `test_get_results_error_with_partial_params_reports_honest_pct` — an `error` scan with 7/10 params reports 70%, not 100%.

Full lib suite green (1881 passed), `cargo clippy --lib` clean.

## Not changed (verified, intentional)
- Concurrency cap + scan-id reservation, purge CAS throttle, webhook coverage of every terminal path, job-scope propagation into spawned workers, pagination bounds — all audited and correct.
- Pre-scan work (remote-resource fetch, reachability probe) runs before the `scan_timeout` budget wrap; left as a documented, lower-risk follow-up rather than reworking timeout semantics on the hot path.