### PR TITLE
docs(cli): clarify --skip-mining-dom scope vs --skip-ast-analysis (#1238)

### DIFF
--- a/docs/content/guide/parameters.ko.md
+++ b/docs/content/guide/parameters.ko.md
@@ -108,10 +108,12 @@ dalfox https://target.app --only-discovery
 | `--skip-discovery` | 탐색 단계 전체 |
 | `--skip-mining` | 모든 워드리스트/DOM 마이닝 |
 | `--skip-mining-dict` | 사전 마이닝만 |
-| `--skip-mining-dom` | DOM 마이닝만 |
+| `--skip-mining-dom` | HTML `id`/`name` 속성에서 파라미터 이름을 수확하는 마이닝만 |
 | `--skip-reflection-header` | 헤더 반사 확인 |
 | `--skip-reflection-cookie` | 쿠키 반사 확인 |
 | `--skip-reflection-path` | 경로 반사 확인 |
+
+> `--skip-mining-dom`은 응답 HTML에서 파라미터 *이름*을 수확하는 동작만 멈춥니다. DOM-XSS 탐지 자체를 끄지는 **않습니다**: 인라인 `<script>` 블록을 정적 분석해 `location.hash` → `innerHTML` 같은 source→sink 흐름을 찾아 `[A]`(AST 탐지) 결과를 내는 패스는 [`--skip-ast-analysis`](../payloads/)가 제어하는 별개의 단계입니다. 결과에서 해당 항목만 걸러내려면 `--only-poc v,r`을 사용하세요.
 
 ## 주입 마커(Injection markers)
 

--- a/docs/content/guide/parameters.md
+++ b/docs/content/guide/parameters.md
@@ -108,10 +108,12 @@ To move faster or work around a fragile target, skip parts of the pipeline:
 | `--skip-discovery` | Entire discovery stage |
 | `--skip-mining` | All wordlist/DOM mining |
 | `--skip-mining-dict` | Dictionary mining only |
-| `--skip-mining-dom` | DOM mining only |
+| `--skip-mining-dom` | Mining parameter names from HTML `id`/`name` attributes only |
 | `--skip-reflection-header` | Header reflection checks |
 | `--skip-reflection-cookie` | Cookie reflection checks |
 | `--skip-reflection-path` | Path reflection checks |
+
+> `--skip-mining-dom` only stops dalfox from harvesting parameter *names* out of the response HTML. It does **not** disable DOM-XSS detection: the static analysis of inline `<script>` blocks (which emits the `[A]` AST-detected findings, source→sink flows such as `location.hash` → `innerHTML`) is a separate pass controlled by [`--skip-ast-analysis`](../payloads/). To filter those findings out of the output instead, use `--only-poc v,r`.
 
 ## Injection markers
 

--- a/docs/content/guide/payloads.ko.md
+++ b/docs/content/guide/payloads.ko.md
@@ -179,7 +179,9 @@ dalfox https://target.app --deep-scan
 | 플래그 | 효과 |
 |------|--------|
 | `--skip-xss-scanning` | 탐색과 프로빙만 수행; 페이로드 주입 없음 |
-| `--skip-ast-analysis` | AST 기반 DOM-XSS 탐지 건너뛰기 |
+| `--skip-ast-analysis` | 인라인 스크립트의 AST 기반 DOM-XSS 탐지 건너뛰기 (`[A]` 결과) |
+
+`--skip-ast-analysis`는 `source → sink` 흐름(예: `location.hash` → `innerHTML`)을 `[A]`(AST 탐지) 결과로 보고하는 정적 DOM-XSS 패스를 제어하며, 파라미터 마이닝과는 독립적입니다. `--skip-mining-dom`은 이 패스에 영향을 주지 **않습니다**. 패스는 그대로 두고 결과에서만 숨기려면 `--only-poc v,r`을 사용하세요.
 
 ## 다음 단계
 

--- a/docs/content/guide/payloads.md
+++ b/docs/content/guide/payloads.md
@@ -203,7 +203,9 @@ Useful for research; slower for production pipelines.
 | Flag | Effect |
 |------|--------|
 | `--skip-xss-scanning` | Discover and probe only; no payload injection |
-| `--skip-ast-analysis` | Skip AST-based DOM-XSS detection |
+| `--skip-ast-analysis` | Skip AST-based DOM-XSS detection of inline scripts (the `[A]` findings) |
+
+`--skip-ast-analysis` is the control for the static DOM-XSS pass that reports `source → sink` flows (e.g. `location.hash` → `innerHTML`) as `[A]` (AST-detected) findings — independent of parameter mining. `--skip-mining-dom` does **not** affect it. To keep the pass running but hide those findings from the output, use `--only-poc v,r`.
 
 ## Next
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -110,7 +110,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--remote-wordlists` | — | — | 원격 소스: `burp`, `assetnote` |
 | `--skip-mining` | — | false | 모든 마이닝을 건너뜁니다 |
 | `--skip-mining-dict` | — | false | 사전 마이닝을 건너뜁니다 |
-| `--skip-mining-dom` | — | false | DOM 마이닝을 건너뜁니다 |
+| `--skip-mining-dom` | — | false | HTML `id`/`name` 속성에서 파라미터 이름 수확을 건너뜁니다 (DOM-XSS 탐지가 아님 — `--skip-ast-analysis` 참고) |
 
 ### 네트워크
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -110,7 +110,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--remote-wordlists` | — | — | Remote sources: `burp`, `assetnote` |
 | `--skip-mining` | — | false | Skip all mining |
 | `--skip-mining-dict` | — | false | Skip dictionary mining |
-| `--skip-mining-dom` | — | false | Skip DOM mining |
+| `--skip-mining-dom` | — | false | Skip mining parameter names from HTML `id`/`name` attributes (not DOM-XSS detection — see `--skip-ast-analysis`) |
 
 ### Network
 

--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -172,7 +172,7 @@ debug = false
 | `remote_wordlists` | array | `[]` | `burp`, `assetnote` |
 | `skip_mining` | bool | `false` | 모든 마이닝 건너뜀 |
 | `skip_mining_dict` | bool | `false` | 사전 기반 마이닝 건너뜀 |
-| `skip_mining_dom` | bool | `false` | DOM 마이닝 건너뜀 |
+| `skip_mining_dom` | bool | `false` | HTML `id`/`name` 속성에서 파라미터 이름 수확 건너뜀 (DOM-XSS 탐지가 아님 — `skip_ast_analysis` 참고) |
 
 ### 네트워크
 

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -172,7 +172,7 @@ debug = false
 | `remote_wordlists` | array | `[]` | `burp`, `assetnote` |
 | `skip_mining` | bool | `false` | Skip all mining |
 | `skip_mining_dict` | bool | `false` | Skip dictionary mining |
-| `skip_mining_dom` | bool | `false` | Skip DOM mining |
+| `skip_mining_dom` | bool | `false` | Skip mining parameter names from HTML `id`/`name` attributes (not DOM-XSS detection — see `skip_ast_analysis`) |
 
 ### Network
 

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -353,7 +353,7 @@ pub struct ScanArgs {
     pub skip_mining_dict: bool,
 
     #[clap(help_heading = "PARAMETER MINING")]
-    /// Skip DOM-based mining
+    /// Skip mining parameter names from HTML input id/name attributes. Does NOT disable DOM-XSS static analysis of inline scripts (the `[A]` findings) — use --skip-ast-analysis for that.
     #[arg(long)]
     pub skip_mining_dom: bool,
 


### PR DESCRIPTION
## Summary

Fixes #1238 — a docs/help clarification, no behavior change.

`--skip-mining-dom`'s help text ("Skip DOM-based mining") led a user to expect it would suppress DOM-XSS detection. It doesn't: the flag only gates **mining parameter names from HTML `id`/`name` attributes** (`probe_response_id_params`). The DOM-XSS findings they saw (`[POC][A]`, source→sink flows in inline scripts such as `location.hash` → `innerHTML`) come from the **AST static-analysis pass**, which is a separate stage controlled by `--skip-ast-analysis`.

I reproduced the report locally and confirmed via request logging that `--skip-mining-dom` works correctly and that the `[A]` findings involve no parameter discovery/mining at all (`param: "-"`, `type: "A"`). So this is a naming/scope confusion, not a bug in the flag.

## Changes

- `src/cmd/scan/args.rs` — reword the clap help for `--skip-mining-dom` to state its true scope and point to `--skip-ast-analysis`.
- Docs (EN + KO):
  - `guide/parameters.*` — table wording + a note explaining the DOM-XSS static pass is separate, with a cross-reference to `--skip-ast-analysis` and the `--only-poc v,r` output filter.
  - `guide/payloads.*` — reverse cross-reference: `--skip-ast-analysis` controls the `[A]` findings, independent of `--skip-mining-dom`.
  - `reference/cli.*`, `reference/config.*` — table row descriptions.

## Verification

- `cargo build --release` passes; `--help` renders the new text.
- `hwaro build` — clean 44-page build; the new `../payloads/` cross-reference resolves.
- Mining lib tests pass (no logic touched).

## Follow-up

While investigating I found an unrelated bug — `dalfox scan <URL>` hangs on an idle open stdin pipe even with an explicit target. Filed separately as #1239.
