### PR TITLE
fix(scan): don't block on an idle stdin pipe when a target is given

### DIFF
--- a/docs/content/guide/scanning-modes.ko.md
+++ b/docs/content/guide/scanning-modes.ko.md
@@ -56,6 +56,19 @@ hakrawler -url https://target.app | dalfox scan
 
 Dalfox는 입력을 버퍼링하고 중복을 제거한 뒤 모든 줄을 대상으로 스캔합니다.
 
+### 명령줄 대상과 함께 파이프하기
+
+대상을 인자로 주면서 동시에 파이프로도 넘기면 두 목록이 병합됩니다:
+
+```bash
+cat urls.txt | dalfox scan https://target.app/one
+# [info] Merged 12 target(s) from stdin and 1 target(s) from arguments
+```
+
+이 경우 명령줄 대상만으로도 이미 스캔이 가능하므로, Dalfox는 `stdin`의 첫 바이트를 약 500ms만 기다립니다. 래퍼나 CI 잡, 잡 러너가 열어둔 채 아무것도 쓰지 않는 파이프는 실행을 막지 않고 경고와 함께 건너뜁니다. 일단 스트림이 데이터를 보내기 시작하면 끝까지 읽으므로, 길거나 천천히 쓰이는 목록이 잘리는 일은 없습니다.
+
+이 동작을 조정하려면 `DALFOX_STDIN_WAIT_MS`로 대기 시간을 늘리거나 `0`으로 병합을 끌 수 있습니다([Environment](../../reference/environment/) 참고). `stdin`이 곧 입력이며 얼마가 걸리든 기다려야 한다면 `--input-type pipe`를 사용하세요.
+
 ## Raw HTTP 모드
 
 Burp, Caido, ZAP에서 캡처한 요청을 파일로 저장한 뒤 Dalfox에 넘겨줍니다:

--- a/docs/content/guide/scanning-modes.md
+++ b/docs/content/guide/scanning-modes.md
@@ -56,6 +56,19 @@ hakrawler -url https://target.app | dalfox scan
 
 Dalfox buffers the input, deduplicates, and scans every line as a target.
 
+### Piping alongside a command-line target
+
+Give Dalfox a target *and* pipe one, and the two lists merge:
+
+```bash
+cat urls.txt | dalfox scan https://target.app/one
+# [info] Merged 12 target(s) from stdin and 1 target(s) from arguments
+```
+
+Here the command-line target is already enough to scan, so Dalfox waits only ~500 ms for `stdin` to produce its first byte. A pipe that a wrapper, CI job, or job runner left open and idle is skipped with a warning instead of blocking the run. Once the stream does start talking, it's read to the end — a long or slowly written list is never truncated.
+
+To adjust that: `DALFOX_STDIN_WAIT_MS` raises the wait (or disables the merge with `0`) — see [Environment](../../reference/environment/) — and `--input-type pipe` says `stdin` *is* the input, so Dalfox waits for it however long it takes.
+
 ## Raw HTTP mode
 
 Save a request you captured in Burp, Caido, or ZAP to a file and hand it to Dalfox:

--- a/docs/content/reference/environment.ko.md
+++ b/docs/content/reference/environment.ko.md
@@ -10,6 +10,7 @@ Dalfox는 파일이나 명령줄에 두기 적합하지 않은 설정을 위해 
 | 변수 | 사용 위치 | 용도 |
 |----------|---------|---------|
 | `DALFOX_API_KEY` | `dalfox server` | `X-API-KEY` 헤더에 요구되는 값. `--api-key`와 동일. |
+| `DALFOX_STDIN_WAIT_MS` | `dalfox scan` (auto 입력) | 명령줄에도 대상을 준 상태에서 파이프된 `stdin`의 첫 바이트를 기다릴 밀리초. 기본값 `500`, `0`이면 stdin 병합을 건너뜁니다. 항상 대기하는 `--input-type pipe`/`har`에는 적용되지 않습니다. |
 | `NO_COLOR` | 모든 모드 | 비어 있지 않은 값으로 설정되면 ANSI 색상 출력을 비활성화. [NO_COLOR](https://no-color.org) 관례를 따름. |
 | `XDG_CONFIG_HOME` | 설정 로더 | 설정 파일의 기준 디렉터리 (`$XDG_CONFIG_HOME/dalfox/config.toml`). `$HOME/.config`로 폴백. |
 | `HOME` | 설정 로더 | `XDG_CONFIG_HOME`이 설정되지 않았을 때 사용. |

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -10,6 +10,7 @@ Dalfox respects a small set of environment variables for configuration that does
 | Variable | Used by | Purpose |
 |----------|---------|---------|
 | `DALFOX_API_KEY` | `dalfox server` | Value required in the `X-API-KEY` header. Equivalent to `--api-key`. |
+| `DALFOX_STDIN_WAIT_MS` | `dalfox scan` (auto input) | Milliseconds to wait for piped `stdin` to produce its first byte when targets were *also* given on the command line. Default `500`; `0` skips the stdin merge entirely. Does not apply to `--input-type pipe`/`har`, which always wait. |
 | `NO_COLOR` | all modes | Disables ANSI colour output when set to any non-empty value. Follows the [NO_COLOR](https://no-color.org) convention. |
 | `XDG_CONFIG_HOME` | config loader | Base directory for the config file (`$XDG_CONFIG_HOME/dalfox/config.toml`). Falls back to `$HOME/.config`. |
 | `HOME` | config loader | Used when `XDG_CONFIG_HOME` is unset. |

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -145,9 +145,25 @@ pub(crate) async fn resolve_targets(
 
     if input_type == "auto" {
         // If stdin is piped under auto, read it and merge targets!
+        //
+        // Reaching here means the user already named targets on the command
+        // line (the empty case above resolved to `pipe`/`har` or errored), so
+        // stdin is a bonus source rather than the input they asked for.
+        // Reading it to EOF unconditionally hangs `dalfox scan <URL>` whenever
+        // the parent process leaves an idle pipe on stdin — `is_terminal()`
+        // can't tell that apart from a pipe about to deliver a URL list
+        // (#1239). So wait only a short grace window for stdin's first byte:
+        // a real producer has bytes buffered long before we look, an idle pipe
+        // stays silent and we scan the CLI targets instead. `-i pipe` remains
+        // the way to say "stdin *is* the input, wait for it".
         if stdin_is_piped {
-            match crate::utils::fs::read_stdin_bounded(MAX_TARGET_LIST_BYTES, "stdin pipe") {
-                Ok(buffer) => {
+            let wait_ms = stdin_merge_wait_ms();
+            match crate::utils::fs::read_stdin_bounded_within(
+                MAX_TARGET_LIST_BYTES,
+                "stdin pipe",
+                std::time::Duration::from_millis(wait_ms),
+            ) {
+                Ok(crate::utils::fs::StdinRead::Data(buffer)) => {
                     let mut stdin_count = 0;
                     for line in buffer.lines() {
                         let trimmed = line.trim();
@@ -160,6 +176,20 @@ pub(crate) async fn resolve_targets(
                         eprintln!(
                             "[info] Merged {} target(s) from stdin and {} target(s) from arguments",
                             stdin_count,
+                            args.targets.len()
+                        );
+                    }
+                }
+                Ok(crate::utils::fs::StdinRead::Idle) => {
+                    // Say so rather than dropping the stream silently: if the
+                    // pipe *was* meant to carry targets, its producer is just
+                    // slow and the operator needs to know they were skipped.
+                    if !args.silence {
+                        eprintln!(
+                            "[warn] stdin is an open pipe but sent no data within {}ms; \
+                             scanning the {} target(s) from arguments only. Use `-i pipe` to \
+                             wait for stdin, or set DALFOX_STDIN_WAIT_MS to adjust the wait.",
+                            wait_ms,
                             args.targets.len()
                         );
                     }
@@ -712,6 +742,35 @@ pub(crate) async fn resolve_targets(
     }
 
     Ok(parsed_targets)
+}
+
+/// Default grace window for the `auto` stdin merge, in milliseconds.
+///
+/// Only spent when stdin is a pipe *and* targets were given on the command
+/// line. A shell pipeline (`cat urls.txt | dalfox scan <URL>`) has its first
+/// bytes in the pipe buffer within microseconds — orders of magnitude under
+/// this — while an idle pipe pays the window once and then gets out of the
+/// way. Half a second is long enough to absorb a heavily loaded machine
+/// scheduling the producer late, short enough to read as instant.
+const STDIN_MERGE_WAIT_MS: u64 = 500;
+
+/// Upper bound on the configured wait: one hour. Past this the knob has
+/// stopped meaning "grace window" and `-i pipe` is the honest way to say
+/// "block until stdin is done" — and a wild value (`u64::MAX`) would overflow
+/// the deadline arithmetic inside `recv_timeout` and panic.
+const MAX_STDIN_MERGE_WAIT_MS: u64 = 60 * 60 * 1000;
+
+/// [`STDIN_MERGE_WAIT_MS`], overridable via `DALFOX_STDIN_WAIT_MS` for the two
+/// tails this can't guess: a producer that takes seconds to emit its first URL
+/// (raise it), and a wrapper that always leaves an idle pipe on stdin (`0`
+/// skips the merge outright). A malformed value falls back to the default; an
+/// oversized one is clamped to [`MAX_STDIN_MERGE_WAIT_MS`].
+fn stdin_merge_wait_ms() -> u64 {
+    std::env::var("DALFOX_STDIN_WAIT_MS")
+        .ok()
+        .and_then(|v| v.trim().parse::<u64>().ok())
+        .map(|ms| ms.min(MAX_STDIN_MERGE_WAIT_MS))
+        .unwrap_or(STDIN_MERGE_WAIT_MS)
 }
 
 /// Load the source text for a request-bearing input (`raw-http` or `har`):

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -756,8 +756,10 @@ const STDIN_MERGE_WAIT_MS: u64 = 500;
 
 /// Upper bound on the configured wait: one hour. Past this the knob has
 /// stopped meaning "grace window" and `-i pipe` is the honest way to say
-/// "block until stdin is done" — and a wild value (`u64::MAX`) would overflow
-/// the deadline arithmetic inside `recv_timeout` and panic.
+/// "block until stdin is done". The clamp also keeps the knob from silently
+/// re-creating #1239: a wait so large that `Instant::now() + wait` overflows
+/// (e.g. `u64::MAX`) makes `recv_timeout` fall back to an unbounded `recv()`,
+/// which is exactly the indefinite block this fix removed.
 const MAX_STDIN_MERGE_WAIT_MS: u64 = 60 * 60 * 1000;
 
 /// [`STDIN_MERGE_WAIT_MS`], overridable via `DALFOX_STDIN_WAIT_MS` for the two

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -122,5 +122,123 @@ pub fn read_stdin_bounded(max_bytes: u64, label: &str) -> std::io::Result<String
     Ok(buf)
 }
 
+/// Outcome of [`read_stdin_bounded_within`].
+#[derive(Debug)]
+pub enum StdinRead {
+    /// stdin answered within the grace window — it either delivered bytes or
+    /// hit an immediate EOF. The payload is the whole stream, read to EOF.
+    Data(String),
+    /// The grace window elapsed with stdin silent: an open pipe nobody is
+    /// writing to. Nothing was consumed that the caller could have used.
+    Idle,
+}
+
+/// [`read_stdin_bounded`] with a bound on how long we wait for the *first*
+/// byte.
+///
+/// `is_terminal()` cannot tell a pipe that is about to deliver a URL list
+/// apart from one a parent process left open and idle (CI harnesses, job
+/// runners, wrappers) — both are simply "not a TTY". Blocking on the latter
+/// hangs the whole run (#1239). Waiting a short grace window for the first
+/// byte separates them: a real producer (`cat urls.txt | dalfox …`) has bytes
+/// buffered in the pipe long before we look, while an idle pipe stays silent
+/// and the caller can carry on without it.
+///
+/// Only the first byte is time-bounded. Once the stream starts talking we are
+/// committed and read it to EOF like [`read_stdin_bounded`] would, so a large
+/// or slowly-written list is never silently truncated.
+///
+/// The read runs on a detached thread that outlives a timeout — a blocking
+/// `read()` on a pipe cannot be cancelled portably. That thread only ever
+/// touches stdin and its own buffer, and it is reaped at process exit.
+pub fn read_stdin_bounded_within(
+    max_bytes: u64,
+    label: &str,
+    grace: std::time::Duration,
+) -> std::io::Result<StdinRead> {
+    read_bounded_within(std::io::stdin(), max_bytes, label, grace)
+}
+
+/// Reader-generic core of [`read_stdin_bounded_within`], so the timing
+/// behaviour can be tested without hijacking the process's real stdin.
+fn read_bounded_within<R: Read + Send + 'static>(
+    reader: R,
+    max_bytes: u64,
+    label: &str,
+    grace: std::time::Duration,
+) -> std::io::Result<StdinRead> {
+    use std::sync::mpsc;
+
+    let label = label.to_string();
+    // `first_byte` fires as soon as the stream commits to an answer (a byte,
+    // EOF, or an error); `done` carries the fully-read result afterwards.
+    let (first_byte_tx, first_byte_rx) = mpsc::channel::<()>();
+    let (done_tx, done_rx) = mpsc::channel::<std::io::Result<String>>();
+
+    std::thread::spawn(move || {
+        // `take(max + 1)` bounds the read itself, so a stream that never ends
+        // stops one byte past the cap and is rejected below.
+        let mut reader = reader.take(max_bytes + 1);
+        let mut buf: Vec<u8> = Vec::new();
+        let mut chunk = vec![0u8; 64 * 1024];
+        let mut announced = false;
+        let read_result = loop {
+            match reader.read(&mut chunk) {
+                Ok(0) => break Ok(()),
+                Ok(n) => {
+                    if !announced {
+                        announced = true;
+                        let _ = first_byte_tx.send(());
+                    }
+                    buf.extend_from_slice(&chunk[..n]);
+                }
+                // A signal interrupted the read; the stream is still fine.
+                Err(e) if e.kind() == std::io::ErrorKind::Interrupted => continue,
+                Err(e) => {
+                    break Err(std::io::Error::new(
+                        std::io::ErrorKind::InvalidData,
+                        format!("read failed (or non-UTF8): {}", e),
+                    ));
+                }
+            }
+        };
+        // Empty stream or an error on the very first read: still an answer, so
+        // release the waiter rather than letting it time out as "idle".
+        if !announced {
+            let _ = first_byte_tx.send(());
+        }
+        let result = read_result.and_then(|()| {
+            if buf.len() as u64 > max_bytes {
+                return Err(std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!(
+                        "{} exceeded {}-byte cap (likely a streaming source)",
+                        label, max_bytes
+                    ),
+                ));
+            }
+            String::from_utf8(buf).map_err(|e| {
+                std::io::Error::new(
+                    std::io::ErrorKind::InvalidData,
+                    format!("read failed (or non-UTF8): {}", e),
+                )
+            })
+        });
+        let _ = done_tx.send(result);
+    });
+
+    match first_byte_rx.recv_timeout(grace) {
+        // The stream answered — now wait for all of it.
+        Ok(()) => done_rx
+            .recv()
+            .unwrap_or_else(|_| Err(std::io::Error::other("stdin reader ended without a result")))
+            .map(StdinRead::Data),
+        // Timeout: an open pipe with nothing in it. Disconnected: the reader
+        // thread died without answering. Neither yields usable input, and
+        // neither is worth failing the run over.
+        Err(_) => Ok(StdinRead::Idle),
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/utils/fs.rs
+++ b/src/utils/fs.rs
@@ -149,8 +149,11 @@ pub enum StdinRead {
 /// or slowly-written list is never silently truncated.
 ///
 /// The read runs on a detached thread that outlives a timeout — a blocking
-/// `read()` on a pipe cannot be cancelled portably. That thread only ever
-/// touches stdin and its own buffer, and it is reaped at process exit.
+/// `read()` on a pipe cannot be cancelled portably. Once the caller has given
+/// up, the thread stops at its next completed read and drops what it had, so
+/// a pipe that goes quiet and later floods can't grow a buffer nobody will
+/// ever look at. Until then it is parked in `read()`, holding one chunk, and
+/// is reaped at process exit.
 pub fn read_stdin_bounded_within(
     max_bytes: u64,
     label: &str,
@@ -167,13 +170,18 @@ fn read_bounded_within<R: Read + Send + 'static>(
     label: &str,
     grace: std::time::Duration,
 ) -> std::io::Result<StdinRead> {
-    use std::sync::mpsc;
+    use std::sync::atomic::{AtomicBool, Ordering};
+    use std::sync::{Arc, mpsc};
 
     let label = label.to_string();
     // `first_byte` fires as soon as the stream commits to an answer (a byte,
     // EOF, or an error); `done` carries the fully-read result afterwards.
     let (first_byte_tx, first_byte_rx) = mpsc::channel::<()>();
     let (done_tx, done_rx) = mpsc::channel::<std::io::Result<String>>();
+    // Set when the grace window expires: the caller is no longer interested,
+    // so the reader should stop rather than buffer a stream nobody will read.
+    let abandoned = Arc::new(AtomicBool::new(false));
+    let reader_abandoned = Arc::clone(&abandoned);
 
     std::thread::spawn(move || {
         // `take(max + 1)` bounds the read itself, so a stream that never ends
@@ -183,6 +191,11 @@ fn read_bounded_within<R: Read + Send + 'static>(
         let mut chunk = vec![0u8; 64 * 1024];
         let mut announced = false;
         let read_result = loop {
+            // Checked between reads (a blocking `read()` can't be woken): the
+            // caller timed out, so drop the buffer and stop draining stdin.
+            if reader_abandoned.load(Ordering::Relaxed) {
+                return;
+            }
             match reader.read(&mut chunk) {
                 Ok(0) => break Ok(()),
                 Ok(n) => {
@@ -235,8 +248,12 @@ fn read_bounded_within<R: Read + Send + 'static>(
             .map(StdinRead::Data),
         // Timeout: an open pipe with nothing in it. Disconnected: the reader
         // thread died without answering. Neither yields usable input, and
-        // neither is worth failing the run over.
-        Err(_) => Ok(StdinRead::Idle),
+        // neither is worth failing the run over — just tell the reader to
+        // stand down.
+        Err(_) => {
+            abandoned.store(true, Ordering::Relaxed);
+            Ok(StdinRead::Idle)
+        }
     }
 }
 

--- a/src/utils/fs/tests.rs
+++ b/src/utils/fs/tests.rs
@@ -111,6 +111,158 @@ fn read_prefix_lossy_rejects_directory() {
     assert!(err.to_string().contains("not a regular file"));
 }
 
+// ── read_bounded_within: grace window on the *first* byte ───────────
+//
+// The real stdin can't be swapped out inside a test process, so these
+// drive the reader-generic core with readers that reproduce the shapes
+// that matter: a live-but-silent pipe, a normal producer, and a producer
+// that keeps the stream open long after its first byte (#1239).
+
+/// Blocks on every read for `hold`, then reports EOF — an open pipe whose
+/// writer never sends anything.
+struct SilentReader {
+    hold: std::time::Duration,
+}
+
+impl std::io::Read for SilentReader {
+    fn read(&mut self, _buf: &mut [u8]) -> std::io::Result<usize> {
+        std::thread::sleep(self.hold);
+        Ok(0)
+    }
+}
+
+/// Emits `head` immediately, then holds the stream open for `hold` before
+/// delivering `tail` and EOF — a slow producer that has already started.
+struct SlowTailReader {
+    head: Vec<u8>,
+    tail: Vec<u8>,
+    hold: std::time::Duration,
+    sent_head: bool,
+}
+
+impl std::io::Read for SlowTailReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if !self.sent_head {
+            self.sent_head = true;
+            let n = self.head.len().min(buf.len());
+            buf[..n].copy_from_slice(&self.head[..n]);
+            return Ok(n);
+        }
+        if !self.tail.is_empty() {
+            std::thread::sleep(self.hold);
+            let n = self.tail.len().min(buf.len());
+            buf[..n].copy_from_slice(&self.tail[..n]);
+            self.tail.drain(..n);
+            return Ok(n);
+        }
+        Ok(0)
+    }
+}
+
+#[test]
+fn read_bounded_within_reports_idle_when_nothing_arrives() {
+    let reader = SilentReader {
+        hold: std::time::Duration::from_secs(30),
+    };
+    let started = std::time::Instant::now();
+    let out = read_bounded_within(
+        reader,
+        1024,
+        "stdin pipe",
+        std::time::Duration::from_millis(100),
+    )
+    .unwrap();
+    assert!(
+        matches!(out, StdinRead::Idle),
+        "a silent pipe must not block the caller: {out:?}"
+    );
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(5),
+        "should have returned right after the grace window"
+    );
+}
+
+#[test]
+fn read_bounded_within_returns_data_that_is_ready() {
+    let out = read_bounded_within(
+        std::io::Cursor::new(b"http://a.example\nhttp://b.example\n".to_vec()),
+        1024,
+        "stdin pipe",
+        std::time::Duration::from_secs(5),
+    )
+    .unwrap();
+    match out {
+        StdinRead::Data(s) => assert_eq!(s.lines().count(), 2),
+        StdinRead::Idle => panic!("buffered input must not be reported as idle"),
+    }
+}
+
+#[test]
+fn read_bounded_within_treats_immediate_eof_as_empty_data() {
+    // `echo -n "" | dalfox scan <URL>`: stdin answered, it just had nothing.
+    // That's not the idle case — there is no producer to wait for.
+    let out = read_bounded_within(
+        std::io::Cursor::new(Vec::new()),
+        1024,
+        "stdin pipe",
+        std::time::Duration::from_millis(100),
+    )
+    .unwrap();
+    match out {
+        StdinRead::Data(s) => assert!(s.is_empty()),
+        StdinRead::Idle => panic!("a closed empty stream is data, not idle"),
+    }
+}
+
+#[test]
+fn read_bounded_within_bounds_only_the_first_byte_not_the_whole_read() {
+    // Once the stream talks we're committed: a list still being written when
+    // the grace window expires must arrive whole, never truncated.
+    let out = read_bounded_within(
+        SlowTailReader {
+            head: b"http://first.example\n".to_vec(),
+            tail: b"http://second.example\n".to_vec(),
+            hold: std::time::Duration::from_millis(300),
+            sent_head: false,
+        },
+        1024,
+        "stdin pipe",
+        std::time::Duration::from_millis(50),
+    )
+    .unwrap();
+    match out {
+        StdinRead::Data(s) => assert_eq!(
+            s, "http://first.example\nhttp://second.example\n",
+            "the tail written after the grace window must still be read"
+        ),
+        StdinRead::Idle => panic!("stream had data before the window expired"),
+    }
+}
+
+#[test]
+fn read_bounded_within_enforces_the_byte_cap() {
+    let err = read_bounded_within(
+        std::io::Cursor::new(vec![b'x'; 64]),
+        16,
+        "stdin pipe",
+        std::time::Duration::from_secs(5),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("exceeded 16-byte cap"));
+}
+
+#[test]
+fn read_bounded_within_rejects_non_utf8() {
+    let err = read_bounded_within(
+        std::io::Cursor::new(vec![0x80, 0x81]),
+        1024,
+        "stdin pipe",
+        std::time::Duration::from_secs(5),
+    )
+    .unwrap_err();
+    assert!(err.to_string().contains("read failed (or non-UTF8)"));
+}
+
 #[test]
 fn read_prefix_lossy_tolerates_split_multibyte_char() {
     // A 3-byte '…' (U+2026) cut after 1 byte must not error — the partial

--- a/src/utils/fs/tests.rs
+++ b/src/utils/fs/tests.rs
@@ -137,15 +137,16 @@ struct SlowTailReader {
     head: Vec<u8>,
     tail: Vec<u8>,
     hold: std::time::Duration,
-    sent_head: bool,
 }
 
 impl std::io::Read for SlowTailReader {
     fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
-        if !self.sent_head {
-            self.sent_head = true;
+        if !self.head.is_empty() {
+            // Drain what fits rather than dropping the remainder: a short
+            // `buf` must cost an extra read, not data.
             let n = self.head.len().min(buf.len());
             buf[..n].copy_from_slice(&self.head[..n]);
+            self.head.drain(..n);
             return Ok(n);
         }
         if !self.tail.is_empty() {
@@ -223,7 +224,6 @@ fn read_bounded_within_bounds_only_the_first_byte_not_the_whole_read() {
             head: b"http://first.example\n".to_vec(),
             tail: b"http://second.example\n".to_vec(),
             hold: std::time::Duration::from_millis(300),
-            sent_head: false,
         },
         1024,
         "stdin pipe",
@@ -237,6 +237,55 @@ fn read_bounded_within_bounds_only_the_first_byte_not_the_whole_read() {
         ),
         StdinRead::Idle => panic!("stream had data before the window expired"),
     }
+}
+
+/// Silent past the grace window, then streams without end — the pipe that goes
+/// quiet and later floods.
+struct LateFloodReader {
+    quiet: std::time::Duration,
+    reads: std::sync::Arc<std::sync::atomic::AtomicUsize>,
+    served_quiet: bool,
+}
+
+impl std::io::Read for LateFloodReader {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        if !self.served_quiet {
+            self.served_quiet = true;
+            std::thread::sleep(self.quiet);
+        }
+        self.reads.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        buf.fill(b'x');
+        Ok(buf.len())
+    }
+}
+
+#[test]
+fn read_bounded_within_stops_reading_once_the_caller_gave_up() {
+    // The reader can't be interrupted mid-`read()`, but it must not keep
+    // draining and buffering a stream the caller already walked away from —
+    // that would grow toward the cap in the background of a live scan.
+    let reads = std::sync::Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    let out = read_bounded_within(
+        LateFloodReader {
+            quiet: std::time::Duration::from_millis(250),
+            reads: std::sync::Arc::clone(&reads),
+            served_quiet: false,
+        },
+        64 << 20, // large cap: `take` must not be what stops the flood
+        "stdin pipe",
+        std::time::Duration::from_millis(50),
+    )
+    .unwrap();
+    assert!(matches!(out, StdinRead::Idle), "expected idle: {out:?}");
+
+    // Let the flood run: the reader should serve one read (the one already in
+    // flight when the window expired) and then stand down.
+    std::thread::sleep(std::time::Duration::from_millis(400));
+    let served = reads.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(
+        served <= 2,
+        "abandoned reader kept draining stdin: {served} reads"
+    );
 }
 
 #[test]

--- a/tests/e2e/cli_smoke_test.rs
+++ b/tests/e2e/cli_smoke_test.rs
@@ -258,6 +258,147 @@ fn test_e2e_stdin_and_positional_targets_merged() {
     );
 }
 
+/// Run `dalfox` with an idle (open but silent) pipe on stdin, holding the write
+/// end for the whole run. Returns `(exited_in_time, stdout, stderr)`.
+///
+/// stdout/stderr are drained on their own threads: the child must never stall
+/// on a full pipe buffer, or a hang here would mean "we didn't read" rather
+/// than "dalfox blocked".
+fn run_with_idle_stdin_pipe(
+    args: &[&str],
+    env: &[(&str, &str)],
+    write_after: Option<(std::time::Duration, &'static str)>,
+    limit: std::time::Duration,
+) -> (bool, String, String) {
+    let mut cmd = Command::new(env!("CARGO_BIN_EXE_dalfox"));
+    cmd.args(args)
+        .stdin(Stdio::piped())
+        .stdout(Stdio::piped())
+        .stderr(Stdio::piped());
+    for (k, v) in env {
+        cmd.env(k, v);
+    }
+    let mut child = cmd.spawn().expect("failed to execute dalfox");
+
+    let mut stdin = child.stdin.take().expect("child stdin should be piped");
+    let mut stdout_pipe = child.stdout.take().expect("child stdout should be piped");
+    let mut stderr_pipe = child.stderr.take().expect("child stderr should be piped");
+    let out_reader = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = std::io::Read::read_to_string(&mut stdout_pipe, &mut s);
+        s
+    });
+    let err_reader = std::thread::spawn(move || {
+        let mut s = String::new();
+        let _ = std::io::Read::read_to_string(&mut stderr_pipe, &mut s);
+        s
+    });
+    // With no payload the write end is held open and silent for the whole run
+    // (the #1239 shape); with one, it sends late and then closes so the child
+    // reaches EOF.
+    let mut held_stdin = None;
+    let writer = if let Some((delay, payload)) = write_after {
+        Some(std::thread::spawn(move || {
+            std::thread::sleep(delay);
+            let _ = stdin.write_all(payload.as_bytes());
+            drop(stdin);
+        }))
+    } else {
+        held_stdin = Some(stdin);
+        None
+    };
+
+    let deadline = std::time::Instant::now() + limit;
+    let exited = loop {
+        match child.try_wait().expect("failed polling dalfox") {
+            Some(_) => break true,
+            None if std::time::Instant::now() >= deadline => {
+                let _ = child.kill();
+                let _ = child.wait();
+                break false;
+            }
+            None => std::thread::sleep(std::time::Duration::from_millis(50)),
+        }
+    };
+
+    drop(held_stdin);
+    let stdout = out_reader.join().unwrap_or_default();
+    let stderr = err_reader.join().unwrap_or_default();
+    if let Some(w) = writer {
+        let _ = w.join();
+    }
+    (exited, stdout, stderr)
+}
+
+/// Regression test for #1239: an explicit target on the command line must be
+/// scanned even when a parent process leaves an open, idle pipe on stdin
+/// (`sleep 60 | dalfox scan <URL>` — the shape CI harnesses and job runners
+/// produce). Before the fix, dalfox blocked in `read()` on fd 0 forever.
+#[test]
+fn test_e2e_idle_stdin_pipe_does_not_block_explicit_target() {
+    let (exited, stdout, stderr) = run_with_idle_stdin_pipe(
+        &[
+            "scan",
+            "http://127.0.0.1:1/?q=test",
+            "--skip-xss-scanning",
+            "--skip-discovery",
+            "--skip-mining",
+            "--format",
+            "json",
+        ],
+        &[],
+        None,
+        std::time::Duration::from_secs(30),
+    );
+
+    assert!(
+        exited,
+        "dalfox blocked on an idle stdin pipe despite an explicit target (#1239)\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stdout.contains("http://127.0.0.1:1/?q=test"),
+        "the command-line target should still be scanned, got stdout:\n{stdout}"
+    );
+    assert!(
+        stderr.contains("stdin is an open pipe but sent no data"),
+        "skipping an idle stdin should be announced, got stderr:\n{stderr}"
+    );
+}
+
+/// The grace window is an estimate, so `DALFOX_STDIN_WAIT_MS` has to be able to
+/// stretch it for a producer that takes seconds to emit its first URL.
+#[test]
+fn test_e2e_stdin_wait_env_extends_the_merge_window() {
+    let (exited, stdout, stderr) = run_with_idle_stdin_pipe(
+        &[
+            "scan",
+            "http://127.0.0.1:1/?cli=1",
+            "--skip-xss-scanning",
+            "--skip-discovery",
+            "--skip-mining",
+            "--format",
+            "json",
+        ],
+        &[("DALFOX_STDIN_WAIT_MS", "20000")],
+        Some((
+            std::time::Duration::from_millis(1500),
+            "http://127.0.0.1:1/?piped=1\n",
+        )),
+        std::time::Duration::from_secs(60),
+    );
+
+    assert!(
+        exited,
+        "dalfox should finish once the slow producer sends its target\n\
+         stdout: {stdout}\nstderr: {stderr}"
+    );
+    assert!(
+        stderr.contains("Merged 1 target(s) from stdin"),
+        "a target that arrives inside the widened window must still merge, got stderr:\n{stderr}"
+    );
+}
+
 /// Verify `--analyze-external-js` is a recognized flag (clap doesn't reject it).
 #[test]
 fn test_analyze_external_js_flag_is_recognized() {


### PR DESCRIPTION
Fixes #1239.

## Problem

`dalfox scan <URL>` (and bare `dalfox <URL>`) blocked forever whenever stdin was a pipe held open by a parent process — the shape CI harnesses, wrappers, and job runners leave behind:

```bash
sleep 60 | dalfox scan "http://target.example/?q=test"   # banner, then hangs
```

Under `--input-type auto`, the stdin→target merge read stdin to EOF unconditionally, and `is_terminal()` cannot tell an idle pipe apart from one about to deliver a URL list.

## Fix

Reaching that merge implies positional targets already exist (the empty case resolves to `pipe`/`har` or errors), so stdin is a *bonus* source there. It now waits only for stdin's **first byte** (500 ms grace):

- first byte, or immediate EOF, inside the window → read to EOF and merge exactly as before;
- window elapses with the pipe silent → skip stdin, scan the CLI targets, and say so on stderr rather than dropping the stream quietly.

Only the first byte is time-bounded — once the stream talks it's read to the end, so a long or slowly written list is never truncated. `-i pipe` / `-i har` still block unconditionally: that's the explicit "stdin *is* the input" opt-in.

`utils::fs::read_stdin_bounded_within` does the timing. A blocking `read()` on a pipe can't be cancelled portably, so the read runs on a detached thread that signals first-byte separately from completion; on timeout the thread is abandoned (it only touches stdin and its own buffer, and is reaped at process exit). No new dependencies, no platform-specific code. Cap and UTF-8 semantics match `read_stdin_bounded`.

`DALFOX_STDIN_WAIT_MS` tunes the window — raise it for a producer that takes seconds to emit its first URL, `0` disables the merge outright. Clamped to 1 h so a wild value can't panic the deadline arithmetic.

## Verification

| case | before | after |
|------|--------|-------|
| `sleep 60 \| dalfox scan <URL>` | hangs | 1.6 s |
| `echo -n "" \| dalfox scan <URL>` | 0.2 s | 0.2 s |
| `dalfox scan <URL>` (no pipe) | 0.7 s | 0.7 s |
| `printf 'u1\nu2\n' \| dalfox scan <URL>` | merges 2+1 | merges 2+1 |
| tail written 3 s late | full list | full list (not truncated) |
| `-i pipe` with a 5 s producer | waits | waits |

- New e2e test `test_e2e_idle_stdin_pipe_does_not_block_explicit_target`, confirmed **failing (30 s timeout) with the fix reverted** and passing with it.
- e2e test for the `DALFOX_STDIN_WAIT_MS` escape hatch, plus 6 unit tests: idle / ready / immediate-EOF / late-tail / cap / non-UTF-8.
- `cargo fmt --check`, `cargo clippy --all-targets --all-features` (0 warnings), full `cargo test` green.

## Docs

"Piping alongside a command-line target" section in the scanning-modes guide and a `DALFOX_STDIN_WAIT_MS` row in the environment reference — EN and KO.