### PR TITLE
fix(scanning): honest redirect evidence + working --sxss discovery

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -1100,6 +1100,23 @@ pub async fn analyze_parameters(
         // `-p name:type` targets; synthesize those so a named injection point
         // is always tested regardless of `--skip-*` flags.
         ensure_explicit_params(&mut params, &args.param, target);
+    } else if args.sxss {
+        // Stored-XSS candidate seeding.
+        //
+        // Every discovery/mining probe keeps a param only when the marker
+        // comes back in the *immediate* response. For a stored sink that is
+        // precisely the wrong test: the defining property of `--sxss` is that
+        // the write endpoint does not echo — the payload surfaces later, on
+        // the retrieval URL. So the documented flow (inject at A, verify at
+        // `--sxss-url` B) discovered zero params and reported a clean scan
+        // without ever requesting B, even though the SXSS-aware reflection and
+        // DOM stages downstream do fetch B correctly.
+        //
+        // Seed the inputs the request actually carries so those stages get a
+        // chance to run. Anything discovery already found keeps its richer
+        // probe metadata; these fills are the same shape `-p name:type`
+        // synthesizes, which is the path that already worked.
+        ensure_sxss_candidate_params(&mut params, target, args);
     }
     target.reflection_params = params;
 
@@ -1263,6 +1280,55 @@ fn ensure_explicit_params(params: &mut Vec<Param>, param_specs: &[String], targe
             let location = infer_location_for_bare_param(name, target);
             push_synthesized_param(params, name, location);
         }
+    }
+}
+
+/// Seed stored-XSS candidates from the inputs the request actually carries.
+///
+/// Only called under `--sxss` with no explicit `-p`. Discovery gates on
+/// immediate-response reflection, which a stored sink by definition fails, so
+/// without this the scan has nothing to test and silently reports clean. See
+/// the call site for the full rationale.
+///
+/// Deliberately limited to inputs already present on the wire (URL query pairs
+/// and `--data` body fields) rather than the mining wordlists: those are the
+/// operator's own declared inputs, so seeding them cannot invent traffic the
+/// user did not ask for. `--ignore-param` is still honoured.
+fn ensure_sxss_candidate_params(params: &mut Vec<Param>, target: &Target, args: &ScanArgs) {
+    let mut candidates: Vec<(String, Location)> = Vec::new();
+
+    for (name, _) in target.url.query_pairs() {
+        candidates.push((name.to_string(), Location::Query));
+    }
+
+    if let Some(data) = args.data.as_deref() {
+        let trimmed = data.trim_start();
+        if trimmed.starts_with('{') {
+            if let Ok(Value::Object(map)) = serde_json::from_str::<Value>(trimmed) {
+                for key in map.keys() {
+                    candidates.push((key.clone(), Location::JsonBody));
+                }
+            }
+        } else {
+            for (name, _) in url::form_urlencoded::parse(data.as_bytes()) {
+                candidates.push((name.to_string(), Location::Body));
+            }
+        }
+    }
+
+    for (name, location) in candidates {
+        if name.is_empty() || args.ignore_param.iter().any(|ignored| ignored == &name) {
+            continue;
+        }
+        // Keep whatever discovery produced for this slot — it carries probed
+        // specials / injection context that a bare synthesis does not.
+        if params
+            .iter()
+            .any(|p| p.name == name && p.location == location)
+        {
+            continue;
+        }
+        push_synthesized_param(params, &name, location);
     }
 }
 

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -959,6 +959,103 @@ fn test_unresolved_explicit_param_specs_reports_path_fragment() {
     assert!(missing.iter().any(|s| s == "q"));
 }
 
+#[test]
+fn test_ensure_sxss_candidate_params_seeds_query_and_body_inputs() {
+    // Regression: under --sxss the write endpoint does not echo, so every
+    // discovery probe (which gates on immediate-response reflection) kept zero
+    // params and the scan reported clean without ever fetching --sxss-url.
+    // The request's own declared inputs must be seeded as candidates.
+    let mut target = parse_target("https://example.com/store?msg=1&other=2").unwrap();
+    target.data = Some("comment=hi&author=bob".to_string());
+    let mut args = default_scan_args();
+    args.sxss = true;
+    args.data = Some("comment=hi&author=bob".to_string());
+
+    let mut params: Vec<Param> = vec![];
+    ensure_sxss_candidate_params(&mut params, &target, &args);
+
+    for (name, loc) in [
+        ("msg", Location::Query),
+        ("other", Location::Query),
+        ("comment", Location::Body),
+        ("author", Location::Body),
+    ] {
+        assert!(
+            params.iter().any(|p| p.name == name && p.location == loc),
+            "stored-XSS candidate {name} ({loc:?}) must be seeded, got {:?}",
+            params
+                .iter()
+                .map(|p| (&p.name, &p.location))
+                .collect::<Vec<_>>()
+        );
+    }
+}
+
+#[test]
+fn test_ensure_sxss_candidate_params_preserves_discovered_metadata() {
+    // A param discovery *did* find (inline-echoing stored sink) carries probed
+    // specials / injection context. Seeding must not shadow it with a bare
+    // duplicate, which would both double the scan cost and lose the metadata.
+    let target = parse_target("https://example.com/store?msg=1").unwrap();
+    let mut args = default_scan_args();
+    args.sxss = true;
+
+    let mut discovered = bare_param("msg", Location::Query);
+    discovered.valid_specials = Some(vec!['<', '>']);
+    let mut params = vec![discovered];
+    ensure_sxss_candidate_params(&mut params, &target, &args);
+
+    assert_eq!(
+        params.iter().filter(|p| p.name == "msg").count(),
+        1,
+        "discovered param must not be duplicated by seeding"
+    );
+    assert_eq!(
+        params[0].valid_specials.as_deref(),
+        Some(['<', '>'].as_slice()),
+        "probe metadata must survive seeding"
+    );
+}
+
+#[test]
+fn test_ensure_sxss_candidate_params_honours_ignore_param() {
+    let target = parse_target("https://example.com/store?msg=1&csrf=abc").unwrap();
+    let mut args = default_scan_args();
+    args.sxss = true;
+    args.ignore_param = vec!["csrf".to_string()];
+
+    let mut params: Vec<Param> = vec![];
+    ensure_sxss_candidate_params(&mut params, &target, &args);
+
+    assert!(params.iter().any(|p| p.name == "msg"));
+    assert!(
+        !params.iter().any(|p| p.name == "csrf"),
+        "--ignore-param must still exclude a seeded stored-XSS candidate"
+    );
+}
+
+#[test]
+fn test_ensure_sxss_candidate_params_seeds_json_body_keys() {
+    let target = parse_target("https://example.com/api/comment").unwrap();
+    let mut args = default_scan_args();
+    args.sxss = true;
+    args.data = Some(r#"{"body":"hi","author":"bob"}"#.to_string());
+
+    let mut params: Vec<Param> = vec![];
+    ensure_sxss_candidate_params(&mut params, &target, &args);
+
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "body" && p.location == Location::JsonBody)
+    );
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "author" && p.location == Location::JsonBody)
+    );
+}
+
 fn default_scan_args() -> ScanArgs {
     ScanArgs {
         insecure: Some(true),

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1632,13 +1632,66 @@ pub(crate) fn resolve_sxss_check_urls(
     urls
 }
 
+/// Text handed back by the reflection check, tagged with whether a browser
+/// would ever have rendered it as a document.
+///
+/// Nearly every reflection body is the server's real response, and consumers
+/// may freely infer execution from it. The 3xx `Location:` vector is the
+/// exception: browsers never render a redirect's body — only the `Location:`
+/// header drives navigation — so that path returns a *stand-in* string that
+/// merely contains the payload, purely so `classify_reflection` can still
+/// record the R finding.
+///
+/// The distinction is a type-level invariant rather than a convention because
+/// getting it wrong is silent and severe: a stand-in that happens to parse as
+/// HTML will match the DOM-marker selector and mint a "Verified / High"
+/// finding whose evidence no browser ever executed. Any consumer that infers
+/// execution — DOM-marker evidence, AST sink analysis, user-facing PoC
+/// evidence — must gate on [`ReflectionBody::renderable`].
+#[derive(Debug, Clone)]
+pub struct ReflectionBody {
+    /// The text to match the payload against when classifying reflection.
+    pub text: String,
+    /// Whether `text` is the response body a browser would actually parse and
+    /// render as a document. `false` for the 3xx `Location:` stand-in.
+    pub renderable: bool,
+}
+
+impl ReflectionBody {
+    /// A real response body: safe for execution-inferring consumers.
+    fn rendered(text: String) -> Self {
+        Self {
+            text,
+            renderable: true,
+        }
+    }
+
+    /// A stand-in for a 3xx `Location:` header value.
+    ///
+    /// Rendered as a plain status/header line rather than synthetic markup:
+    /// the payload still appears verbatim (so `classify_reflection` records
+    /// R), but the text is an honest description of what was observed instead
+    /// of a fabricated document that never existed on the wire.
+    fn redirect_location(status_code: u16, location: &str) -> Self {
+        Self {
+            text: format!("HTTP {} Location: {}", status_code, location),
+            renderable: false,
+        }
+    }
+
+    /// Borrow the text only when a browser would have rendered it.
+    pub fn renderable_text(&self) -> Option<&str> {
+        self.renderable.then_some(self.text.as_str())
+    }
+}
+
 async fn fetch_injection_response(
     target: &Target,
     param: &Param,
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
     streak: &std::sync::atomic::AtomicU32,
-) -> Option<String> {
+) -> Option<ReflectionBody> {
     if args.skip_xss_scanning {
         return None;
     }
@@ -1653,7 +1706,7 @@ async fn fetch_injection_response_with_client(
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
     streak: &std::sync::atomic::AtomicU32,
-) -> Option<String> {
+) -> Option<ReflectionBody> {
     if args.skip_xss_scanning {
         return None;
     }
@@ -1880,7 +1933,7 @@ async fn fetch_injection_response_with_client(
                     && !text.is_empty()
                 {
                     if classify_reflection(&text, payload).is_some() {
-                        return Some(text);
+                        return Some(ReflectionBody::rendered(text));
                     }
                     if fallback_body.is_none() {
                         fallback_body = Some(text);
@@ -1895,9 +1948,9 @@ async fn fetch_injection_response_with_client(
         if let Some(body) = inject_body.as_ref()
             && classify_reflection(body, payload).is_some()
         {
-            return inject_body;
+            return inject_body.map(ReflectionBody::rendered);
         }
-        fallback_body.or(inject_body)
+        fallback_body.or(inject_body).map(ReflectionBody::rendered)
     } else {
         // Normal reflection check
         if let Ok(resp) = inject_resp {
@@ -1990,19 +2043,22 @@ async fn fetch_injection_response_with_client(
                 && let Some(location) = resp.headers().get("location").and_then(|v| v.to_str().ok())
                 && (location.contains(&*encoded_payload) || location.contains(payload))
             {
-                // Wrap the Location value in a minimal HTML container so the
-                // downstream reflection check still finds the payload via
-                // substring match, but the JS-context AST verifier cannot
-                // parse the synthesized text as JavaScript and wrongly
-                // upgrade the finding to V. Without the wrapper, a literal
-                // `Location: javascript:alert(1)` becomes a freestanding
-                // expression statement that the oxc parser accepts, which
-                // triggered V on redirects that no browser ever follows
-                // (browsers refuse `javascript:` / `data:` schemes in 3xx
-                // `Location:` headers). The wrapper starts with `<html>`,
-                // which fails JS parsing cleanly, so reflection-finding
-                // R is preserved while the false V upgrade is blocked.
-                return Some(format!("<html><body>{}</body></html>", location));
+                // Report the Location value as a non-renderable stand-in.
+                // Browsers never render a redirect's body — only `Location:`
+                // drives navigation — so nothing here is executable, and no
+                // consumer may infer execution from it. `renderable: false`
+                // enforces that at the type level, keeping both the JS-context
+                // AST verifier and the DOM-marker classifier off this text
+                // while the substring match below still records R.
+                //
+                // Prior revisions instead returned a synthetic
+                // `<html><body>{location}</body></html>` wrapper to defeat the
+                // AST verifier. That merely swapped one false-V source for
+                // another: the wrapper parses as valid HTML, so a payload
+                // carrying a `dlx` marker matched the DOM-marker selector and
+                // minted a Verified/High finding whose "response" evidence the
+                // server never sent.
+                return Some(ReflectionBody::redirect_location(status_code, location));
             }
             match crate::utils::http::read_body(resp).await {
                 Ok(body) => {
@@ -2025,7 +2081,7 @@ async fn fetch_injection_response_with_client(
                         );
                         return None;
                     }
-                    Some(body)
+                    Some(ReflectionBody::rendered(body))
                 }
                 Err(e) => {
                     crate::dbg_log!(
@@ -2054,7 +2110,9 @@ pub async fn check_reflection_with_response(
     args: &crate::cmd::scan::ScanArgs,
 ) -> (Option<ReflectionKind>, Option<String>) {
     let streak = std::sync::atomic::AtomicU32::new(0);
-    check_reflection_with_response_tracked(client, target, param, payload, args, &streak).await
+    let (kind, body) =
+        check_reflection_with_response_tracked(client, target, param, payload, args, &streak).await;
+    (kind, body.map(|b| b.text))
 }
 
 /// Inject `payload`, then classify reflection in the response.
@@ -2075,20 +2133,20 @@ pub async fn check_reflection_with_response_tracked(
     payload: &str,
     args: &crate::cmd::scan::ScanArgs,
     streak: &std::sync::atomic::AtomicU32,
-) -> (Option<ReflectionKind>, Option<String>) {
-    let text = match client {
+) -> (Option<ReflectionKind>, Option<ReflectionBody>) {
+    let body = match client {
         Some(client) => {
             fetch_injection_response_with_client(client, target, param, payload, args, streak).await
         }
         None => fetch_injection_response(target, param, payload, args, streak).await,
     };
-    if let Some(text) = text {
-        let kind = classify_reflection(&text, payload);
+    if let Some(body) = body {
+        let kind = classify_reflection(&body.text, payload);
         let kind = match kind {
-            Some(_) if is_in_safe_context_decoded(&text, payload) => None,
+            Some(_) if is_in_safe_context_decoded(&body.text, payload) => None,
             other => other,
         };
-        (kind, Some(text))
+        (kind, Some(body))
     } else {
         (None, None)
     }

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -998,6 +998,81 @@ async fn test_check_reflection_catches_decoded_payload_in_redirect_location() {
 }
 
 #[tokio::test]
+async fn test_redirect_location_body_is_not_renderable_and_carries_no_markup() {
+    // Regression: a marker-bearing payload echoed into a 3xx `Location:` used
+    // to come back wrapped as `<html><body>{location}</body></html>`. That
+    // stand-in parses as valid HTML, so the static V upgrade's DOM-marker
+    // selector matched it and minted a Verified/High finding whose "response"
+    // evidence the server never sent — browsers don't render redirect bodies
+    // at all. The body must now be flagged non-renderable (keeping every
+    // execution-inferring consumer off it) and must not fabricate markup.
+    let payload = "<svg/onload=alert(1) class=dalfox>";
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/redirect/decoded");
+    let param = make_param();
+    let args = default_scan_args();
+    let streak = std::sync::atomic::AtomicU32::new(0);
+
+    let (kind, body) = crate::scanning::check_reflection::check_reflection_with_response_tracked(
+        None, &target, &param, payload, &args, &streak,
+    )
+    .await;
+
+    assert!(
+        kind.is_some(),
+        "Location-header reflection must still be reported as R"
+    );
+    let body = body.expect("redirect reflection must return a body");
+    assert!(
+        !body.renderable,
+        "a 3xx Location stand-in is not a browser-rendered document"
+    );
+    assert_eq!(
+        body.renderable_text(),
+        None,
+        "execution-inferring consumers must not be handed the stand-in"
+    );
+    assert!(
+        !body.text.contains("<html>") && !body.text.contains("<body>"),
+        "stand-in must not fabricate markup that never came off the wire: {}",
+        body.text
+    );
+    assert!(
+        body.text.contains(payload),
+        "stand-in must still contain the payload so R classification works: {}",
+        body.text
+    );
+}
+
+#[tokio::test]
+async fn test_redirect_location_stand_in_yields_no_dom_marker_evidence() {
+    // The precise false-positive mechanism: `classify_dom_evidence` finds the
+    // `dalfox` marker in the old synthetic wrapper. Pin that the text now
+    // handed to that classifier (i.e. the renderable text) is absent, so no
+    // V upgrade is reachable from a redirect.
+    let payload = "<svg/onload=alert(1) class=dalfox>";
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/redirect/decoded");
+    let param = make_param();
+    let args = default_scan_args();
+    let streak = std::sync::atomic::AtomicU32::new(0);
+
+    let (_, body) = crate::scanning::check_reflection::check_reflection_with_response_tracked(
+        None, &target, &param, payload, &args, &streak,
+    )
+    .await;
+    let body = body.expect("redirect reflection must return a body");
+
+    let evidence = body.renderable_text().and_then(|text| {
+        crate::scanning::check_dom_verification::classify_dom_evidence(payload, text)
+    });
+    assert!(
+        evidence.is_none(),
+        "a redirect must never produce DOM-marker evidence (no browser renders it)"
+    );
+}
+
+#[tokio::test]
 async fn test_inert_data_gate_does_not_swallow_redirect_location_reflection() {
     // A 302 whose body is declared `application/json` still echoes the payload
     // in its `Location` header. The inert-data content-type gate must skip

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1724,6 +1724,9 @@ impl ScanWorkerCtx {
                 &state.waf_streak,
             )
             .await;
+            // Only a browser-rendered body may seed AST analysis / probe
+            // classification; the 3xx `Location:` stand-in is not a document.
+            let response_text = response_text.and_then(|b| b.renderable.then_some(b.text));
             if kind.is_some() {
                 probe_reflected = true;
                 probe_response_text = response_text;
@@ -1845,12 +1848,21 @@ impl ScanWorkerCtx {
                 }
             };
             let reflected_kind = reflection_tuple.0;
-            let reflection_response_text = reflection_tuple.1;
+            let reflection_body = reflection_tuple.1;
+            // Everything downstream of here infers execution from the body
+            // (AST sinks, the static V upgrade), so it may only ever see a
+            // body a browser would actually render. The 3xx `Location:`
+            // stand-in is withheld: it contains the payload for R
+            // classification but was never a document. Borrowed rather than
+            // cloned — a response body runs up to 16 MiB and this is the
+            // per-payload hot loop.
+            let renderable_text: Option<&str> =
+                reflection_body.as_ref().and_then(|b| b.renderable_text());
 
             // AST-based DOM XSS analysis (enabled by default unless skipped)
             if !self.args.skip_ast_analysis
                 && !state.ast_analysis_done
-                && let Some(ref response_text) = reflection_response_text
+                && let Some(response_text) = renderable_text
             {
                 state.ast_analysis_done = true;
                 let ast_findings = run_ast_dom_analysis(
@@ -1928,7 +1940,7 @@ impl ScanWorkerCtx {
                     // when angles are reported "invalid" at one of the
                     // reflection sites, and the prior `has_js_context_evidence`
                     // check only covered the `<script>`-block case.
-                    let dom_evidence_kind = reflection_response_text.as_deref().and_then(|body| {
+                    let dom_evidence_kind = renderable_text.and_then(|body| {
                         crate::scanning::check_dom_verification::classify_dom_evidence(
                             &reflection_payload,
                             body,
@@ -1999,7 +2011,12 @@ impl ScanWorkerCtx {
                     result.location = format!("{:?}", param.location);
                     result.request =
                         Some(build_request_text(&self.target, param, &reflection_payload));
-                    result.response = reflection_response_text;
+                    // Report the observed text even when it isn't renderable:
+                    // the redirect stand-in is an honest `HTTP 302 Location: …`
+                    // line, which is the real evidence for that vector. Only
+                    // execution-inferring consumers above are gated on
+                    // `renderable`.
+                    result.response = reflection_body.map(|b| b.text);
 
                     self.stream_finding(&result);
                     // Defer pushing to shared results (batched)


### PR DESCRIPTION
Two bugs found by building the CLI and driving it against a local vulnerable server. Both silently produced wrong scan results — the worst failure mode for a scanner.

Neither overlaps #1239 (stdin hang), which is already in progress and deliberately untouched here.

## 1. Redirect reflections minted a fabricated Verified/High finding

A payload echoed into a 3xx `Location:` came back wrapped as `<html><body>{location}</body></html>`. That wrapper existed to stop the JS-context AST verifier from parsing a bare `Location: javascript:alert(1)` as executable JS — but it only swapped one false-V source for another: the wrapper parses as valid HTML, so a marker-bearing payload matched the DOM-marker selector in the static V upgrade.

Observed before the fix, against a server whose redirect body is empty:

```json
{
  "type": "V",
  "severity": "High",
  "evidence": "DOM verification successful for param url (DOM marker)",
  "response": "<html><body>><svg onload=alert(1) class=dlx...></body></html>"
}
```

The `response` field is markup the server never sent. Browsers never render a redirect body at all — `check_dom_verification::check_redirect_location` already documents this and declines the V upgrade — but the sibling static path in `run_reflection_phase` bypassed that guard.

**Fix:** the reflection check now returns `ReflectionBody`, which records whether a browser would have rendered the text. The redirect path reports an honest `HTTP 302 Location: …` line with `renderable: false`, keeping every execution-inferring consumer (DOM-marker evidence, AST sinks) off it at the type level while the substring match still records R — the tier `check_dom_verification` documents as correct for this vector.

After:

```json
{
  "type": "R",
  "severity": "Info",
  "response": "HTTP 302 Location: ><svg onload=alert(1) class=dlx...>"
}
```

## 2. `--sxss` never requested `--sxss-url`, silently reporting clean

Discovery keeps a param only when the marker returns in the *immediate* response. That is exactly the wrong test for a stored sink, whose defining property is that the write endpoint does not echo.

So the flow in `docs/content/guide/stored-xss.md` — inject at A, verify at B — discovered zero params and sent **zero requests to B**, reporting `0 XSS` with no error or warning:

```
$ dalfox scan --sxss --sxss-url http://host/view http://host/store?q=1
INF found reflected 0 params
WRN XSS found 0 XSS          # 169 requests sent, 0 to /view
```

The SXSS-aware reflection and DOM stages downstream fetch B correctly — they were simply unreachable. Passing `-p q:query` made it work, which is what isolated the gate.

**Fix:** under `--sxss` with no explicit `-p`, seed the inputs the request already carries (query pairs, `--data` body/JSON fields) as candidates, reusing the same synthesis `-p` uses. Params discovery did find keep their richer probe metadata, and `--ignore-param` is still honoured. Non-storing params stay cheap — the existing Stage-0 probe is already SXSS-aware, so they exit before the heavy payload loop.

After: `1 V/High [sxss-inHTML] param=q`, with the retrieval URL actually fetched.

## Verification

End to end against a local vulnerable server:

| Endpoint | Before | After |
|---|---|---|
| `/redirect?url=` | V/High + fabricated evidence | **R/Info + honest evidence** |
| `/store` + `--sxss` | 0 findings, 0 retrieval reqs | **V/High [sxss-inHTML]**, retrieval fetched |
| `/reflect`, `/attr`, `/attr-single`, `/script`, `/partial` | V/High | V/High (unchanged) |
| `/multi` (3 params) | 3x V/High | 3x V/High (unchanged) |
| `/dom.html` | A/Medium | A/Medium (unchanged) |
| `/encoded`, `/json`, `/header-reflect` | clean | clean (unchanged) |

- `cargo test --lib`: 1901 passed, 0 failed
- `cargo clippy --all-targets`: 0 warnings; `cargo fmt --check`: clean
- Integration binaries (`unit_tests`, `scan_run_paths_test`, `observed_js_breakout_test`, `escaped_quote_probe_test`): all pass
- 7 new regression tests pinning both behaviours

## Note

On one full-suite run `har_input::explicit_har_parses_when_markers_past_prefix` failed, then passed in isolation and on two consecutive full runs. HAR parsing is untouched by this change; it looks like a pre-existing parallel-execution flake from shared global state, worth a separate look.