### PR TITLE
docs: correct stale CLI, WAF, env and config-template reference values

### DIFF
--- a/docs/content/guide/waf-bypass.ko.md
+++ b/docs/content/guide/waf-bypass.ko.md
@@ -32,6 +32,7 @@ toc = true
 - Google Cloud Armor
 - Fastly
 - Wordfence
+- Citrix NetScaler
 
 인식되지 않는 WAF는 일반 폴백 전략을 발동시킵니다.
 
@@ -139,8 +140,8 @@ WAF마다 각기 다른 수법에 무너집니다. 작은 샘플을 소개합니
 
 ```bash
 dalfox https://target.app -e url,base64
-# Cloudflare detected → extra encoders: unicode, zwsp
-# Effective: url, base64, unicode, zwsp
+# Cloudflare detected → extra encoders: unicode, 4url, zwsp
+# Effective: url, base64, unicode, 4url, zwsp
 ```
 
 중복을 자동으로 제거하고 순서를 보존합니다.

--- a/docs/content/guide/waf-bypass.md
+++ b/docs/content/guide/waf-bypass.md
@@ -32,6 +32,7 @@ This is all on by default. You only touch flags if you want to disable or steer 
 - Google Cloud Armor
 - Fastly
 - Wordfence
+- Citrix NetScaler
 
 Unrecognised WAFs trigger a generic fallback strategy.
 
@@ -139,8 +140,8 @@ Your `--encoders` list and the WAF's extra encoders are merged. So this:
 
 ```bash
 dalfox https://target.app -e url,base64
-# Cloudflare detected → extra encoders: unicode, zwsp
-# Effective: url, base64, unicode, zwsp
+# Cloudflare detected → extra encoders: unicode, 4url, zwsp
+# Effective: url, base64, unicode, 4url, zwsp
 ```
 
 De-duplicates automatically, preserves order.

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -157,7 +157,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--sxss-url` | — | — | SXSS용 조회 URL |
 | `--sxss-method` | — | `GET` | 조회 메서드 |
 | `--sxss-retries` | — | `3` | 저장된 출력을 가져올 때 조회 URL에 대한 재시도 횟수 |
-| `--max-payloads-per-param` | — | `0` | 파라미터별로 테스트하는 페이로드 수 제한 (`0` = 제한 없음) |
+| `--max-payloads-per-param` | — | `0` | 파라미터별로 테스트하는 페이로드 수 제한 (`0`은 `--deep-scan`이 없으면 세트당 3000개의 내장 안전 상한을 적용) |
 | `--skip-ast-analysis` | — | false | AST DOM-XSS를 건너뜁니다 |
 | `--analyze-external-js` | — | false | 동일 출처의 `<script src>` 번들을 가져와 AST DOM-XSS 분석을 수행합니다 (프리플라이트, 대상별 1회; 최대 16개 파일, 각 512 KiB; `--include-url`/`--exclude-url`을 준수) |
 | `--hpp` | — | false | HTTP 파라미터 오염 |
@@ -194,10 +194,10 @@ dalfox server [FLAGS]
 | `--callback-param-name` | — | `callback` | JSONP 콜백 파라미터 |
 | `--cors-allow-methods` | — | `GET,POST,OPTIONS,PUT,PATCH,DELETE` | CORS 메서드 |
 | `--cors-allow-headers` | — | `Content-Type,X-API-KEY,Authorization` | CORS 헤더 |
-| `--rate-limit` | `-r`, `--rl` | `0` | 전역 아웃바운드 요청 속도를 제한합니다 (초당 요청 수, `0` = 무제한) |
+| `--rate-limit` | — | `0` | 전역 아웃바운드 요청 속도를 제한합니다 (초당 요청 수, `0` = 무제한) |
 | `--scan-timeout` | — | `0` | 스캔 단계에 대한 대상별 하드 실제 시간 상한(초) |
-| `--max-concurrent-scans` | — | `0` | 동시 스캔 수 제한 (`0` = 무제한) |
-| `--max-body-bytes` | — | `0` | 분석용 응답 본문 바이트 제한 (`0` = 무제한) |
+| `--max-concurrent-scans` | — | `100` | 동시 스캔 수 제한 (`0` = 무제한) |
+| `--max-body-bytes` | — | `1048576` | `POST /scan` 및 `/preflight`가 허용하는 최대 요청 본문 크기(바이트). 초과 시 `413` 응답 |
 
 엔드포인트는 [REST API Server](../../integrations/server/)를 참조하세요.
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -157,7 +157,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--sxss-url` | — | — | Retrieval URL for SXSS |
 | `--sxss-method` | — | `GET` | Retrieval method |
 | `--sxss-retries` | — | `3` | Retries on the retrieval URL when fetching stored output |
-| `--max-payloads-per-param` | — | `0` | Cap payloads tested per parameter (`0` = no cap) |
+| `--max-payloads-per-param` | — | `0` | Cap payloads tested per parameter (`0` applies a built-in safety cap of 3000 per set unless `--deep-scan` is set) |
 | `--skip-ast-analysis` | — | false | Skip AST DOM-XSS |
 | `--analyze-external-js` | — | false | Fetch same-origin `<script src>` bundles and run AST DOM-XSS analysis on them (preflight, once per target; up to 16 files, 512 KiB each; respects `--include-url`/`--exclude-url`) |
 | `--hpp` | — | false | HTTP Parameter Pollution |
@@ -194,10 +194,10 @@ dalfox server [FLAGS]
 | `--callback-param-name` | — | `callback` | JSONP callback param |
 | `--cors-allow-methods` | — | `GET,POST,OPTIONS,PUT,PATCH,DELETE` | CORS methods |
 | `--cors-allow-headers` | — | `Content-Type,X-API-KEY,Authorization` | CORS headers |
-| `--rate-limit` | `-r`, `--rl` | `0` | Cap the global outbound request rate (requests/sec, `0` = unlimited) |
+| `--rate-limit` | — | `0` | Cap the global outbound request rate (requests/sec, `0` = unlimited) |
 | `--scan-timeout` | — | `0` | Hard wall-clock cap per target for the scan stage, in seconds |
-| `--max-concurrent-scans` | — | `0` | Limit on simultaneous scans (`0` = unlimited) |
-| `--max-body-bytes` | — | `0` | Limit response body bytes for analysis (`0` = unlimited) |
+| `--max-concurrent-scans` | — | `100` | Limit on simultaneous scans (`0` = unlimited) |
+| `--max-body-bytes` | — | `1048576` | Maximum accepted request body size (bytes) for `POST /scan` and `/preflight`; oversized bodies get `413` |
 
 See [REST API Server](../../integrations/server/) for endpoints.
 

--- a/docs/content/reference/environment.ko.md
+++ b/docs/content/reference/environment.ko.md
@@ -14,6 +14,7 @@ Dalfox는 파일이나 명령줄에 두기 적합하지 않은 설정을 위해 
 | `NO_COLOR` | 모든 모드 | 비어 있지 않은 값으로 설정되면 ANSI 색상 출력을 비활성화. [NO_COLOR](https://no-color.org) 관례를 따름. |
 | `XDG_CONFIG_HOME` | 설정 로더 | 설정 파일의 기준 디렉터리 (`$XDG_CONFIG_HOME/dalfox/config.toml`). `$HOME/.config`로 폴백. |
 | `HOME` | 설정 로더 | `XDG_CONFIG_HOME`이 설정되지 않았을 때 사용. |
+| `USERPROFILE` | 설정 로더 | `XDG_CONFIG_HOME`과 `HOME`이 모두 없을 때 사용하는 Windows 폴백 기준 디렉터리. |
 
 ## 예시
 

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -14,6 +14,7 @@ Dalfox respects a small set of environment variables for configuration that does
 | `NO_COLOR` | all modes | Disables ANSI colour output when set to any non-empty value. Follows the [NO_COLOR](https://no-color.org) convention. |
 | `XDG_CONFIG_HOME` | config loader | Base directory for the config file (`$XDG_CONFIG_HOME/dalfox/config.toml`). Falls back to `$HOME/.config`. |
 | `HOME` | config loader | Used when `XDG_CONFIG_HOME` is unset. |
+| `USERPROFILE` | config loader | Windows fallback base directory, used when both `XDG_CONFIG_HOME` and `HOME` are unset. |
 
 ## Examples
 

--- a/src/config.rs
+++ b/src/config.rs
@@ -1295,7 +1295,7 @@ pub fn default_toml_template() -> String {
 # max_targets_per_host = 100
 
 # XSS SCANNING
-# encoders = ["url", "html"]  # none, url, 2url, 3url, 4url, html, base64
+# encoders = ["url", "html"]  # none, url, 2url, 3url, 4url, html, htmlpad, base64, unicode, zwsp
 # remote_payloads = ["payloadbox", "portswigger"]
 # custom_blind_xss_payload = "blind.txt"
 # blind_callback_url = "https://your-bxss-callback.com"
@@ -1305,7 +1305,7 @@ pub fn default_toml_template() -> String {
 # custom_payload = "payloads.txt"
 # only_custom_payload = false
 # skip_xss_scanning = false
-# max_payloads_per_param = 0  # cap payloads per param (0 = unlimited)
+# max_payloads_per_param = 0  # cap payloads per param (0 = built-in safety cap of 3000 per set, unless deep_scan)
 # deep_scan = false
 # sxss = false
 # sxss_url = "https://target/echo"


### PR DESCRIPTION
Resolves all seven open `good first issue` items. Every one is a docs-accuracy fix verified against the current code; there is no behavioral change.

## Fixes

| Issue | Fix | Source of truth |
|---|---|---|
| #1193 | `--max-concurrent-scans` default `0` → `100`; `--max-body-bytes` default `0` → `1048576`, reworded from "response body bytes for analysis" to the inbound **request**-body cap it actually is | `src/server/types.rs:47,53`; `DefaultBodyLimit::max(...)` in `src/server/mod.rs` |
| #1194 | server `--rate-limit` Short cell `-r`, `--rl` → `—` | `ServerArgs` declares no short; those aliases belong to `scan` (`src/cmd/scan/args.rs:362`) |
| #1195 | Added a `USERPROFILE` row to the environment reference | `resolve_config_dir()` in `src/config.rs` |
| #1196 | `--max-payloads-per-param 0` applies a built-in 3000-per-set safety cap unless `--deep-scan`, not "no cap" | `effective_payload_cap()`; `DEFAULT_PAYLOAD_SAFETY_CAP = 3000` |
| #1197 | Added `- Citrix NetScaler` to Supported WAFs | `WafType::Citrix` Display (`src/waf/mod.rs:60`) |
| #1198 | Cloudflare encoder-merge example now includes `4url` | `src/waf/bypass.rs:173` (test-pinned) |
| #1199 | Config-template `encoders` comment now lists `htmlpad`, `unicode`, `zwsp` | `src/encoding/mod.rs` prio array / `ENCODER_VALUES` |

## Two things beyond the literal issue text

- **Korean docs.** The issues cite only the EN pages, but `cli.ko.md`, `environment.ko.md` and `waf-bypass.ko.md` carried the identical wrong values — fixing only EN would leave the same inaccuracy live on `/ko`. All six doc fixes are applied to both languages. In `cli.ko.md` only line 197 (the *server* `--rate-limit` row) changed; line 122 is the *scan* row, where `-r`/`--rl` are correct.
- **#1196's optional follow-on.** The `max_payloads_per_param` comment in the generated config template repeated the same "0 = unlimited" error, so it is corrected here too.

## Verification

- `cargo fmt --check` clean
- `cargo test --lib config::` — 25/25 pass (no test pins the template comment text)
- `hwaro build` — 44 pages render clean

The only non-docs edit is two comment strings inside `default_toml_template()`.

Closes #1193
Closes #1194
Closes #1195
Closes #1196
Closes #1197
Closes #1198
Closes #1199