### PR TITLE
ci(contributors): render CONTRIBUTORS.svg with contributor-mural (voronoi)

### DIFF
--- a/.github/contributor-mural.yml
+++ b/.github/contributor-mural.yml
@@ -1,0 +1,16 @@
+---
+# Config for crystal-actions/contributor-mural, rendered by
+# .github/workflows/ci-contributors.yml.
+style: voronoi
+output: docs/static/images/CONTRIBUTORS.svg
+
+contributors:
+  include_bots: true # matches the previous list; the excludes below do the filtering
+
+exclude:
+  - dependabot[bot]
+  - github-actions[bot]
+  - Copilot
+
+voronoi:
+  width: 900

--- a/.github/workflows/ci-contributors.yml
+++ b/.github/workflows/ci-contributors.yml
@@ -14,19 +14,18 @@ on:
 permissions:
   contents: write
   pull-requests: write
+concurrency:
+  group: contributor-mural
 jobs:
   contributors:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v7
-      - uses: wow-actions/contributors-list@v1.2.1
+      - uses: crystal-actions/contributor-mural@v1.1.2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          round: false
-          includeBots: true
-          excludeUsers: dependabot[bot],github-actions[bot],Copilot
-          svgPath: docs/static/images/CONTRIBUTORS.svg
-          noCommit: true
+          token: ${{ secrets.GITHUB_TOKEN }}
+          config: .github/contributor-mural.yml
+          no_commit: "true"
       - uses: peter-evans/create-pull-request@v8.1.1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
Swaps the contributor-wall generator from `wow-actions/contributors-list@v1.2.1` to [`crystal-actions/contributor-mural@v1.1.2`](https://github.com/crystal-actions/contributor-mural).

## Changes

- **New `.github/contributor-mural.yml`** — the action requires a config file and treats unknown keys as errors. `svgPath` / `includeBots` / `excludeUsers` all move here:
  ```yaml
  style: voronoi
  output: docs/static/images/CONTRIBUTORS.svg
  contributors:
    include_bots: true
  exclude: [dependabot[bot], github-actions[bot], Copilot]
  voronoi:
    width: 900
  ```
- **`.github/workflows/ci-contributors.yml`** — action swapped, `noCommit: true` → `no_commit: "true"`, plus a `concurrency` group as the action's docs recommend. Triggers and the existing `peter-evans/create-pull-request` step are unchanged, so the weekly auto-PR still works the same way.

## Notes

- `round: false` has no equivalent. Voronoi renders as stained glass — cells tile edge to edge — so the wall will look different from the old flat grid regardless of shape options.
- Pinned to `@v1.1.2` (latest release) rather than the floating `@v1`, matching how `actions/checkout` and `create-pull-request` are pinned in this repo.
- `docs/static/images/CONTRIBUTORS.svg` is **not** regenerated here; the next run on `main` replaces it via the usual auto-PR.