### PR TITLE
perf(scanning): share one HTML parse in the AST DOM phase

### DIFF
--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -11,8 +11,17 @@ use super::selectors;
 /// JS file has no `document.createElement('script')` of its own. The
 /// caller threads the returned set into `AstDomAnalyzer::with_script_element_ids`.
 pub fn extract_script_element_ids(html: &str) -> HashSet<String> {
-    let mut ids = HashSet::new();
     let document = Html::parse_document(html);
+    script_element_ids_from_document(&document)
+}
+
+/// Collect the `id` attribute of every `<script>` element in an already-parsed
+/// document. Factored out of [`extract_script_element_ids`] so callers that
+/// also need the JS blocks can share a single `Html::parse_document` pass via
+/// [`extract_js_and_script_ids`] instead of parsing the (up to 16 MiB) body
+/// twice.
+fn script_element_ids_from_document(document: &Html) -> HashSet<String> {
+    let mut ids = HashSet::new();
     let selector = selectors::script();
     for element in document.select(selector) {
         if let Some(id) = element.value().attr("id") {
@@ -28,11 +37,31 @@ pub fn extract_script_element_ids(html: &str) -> HashSet<String> {
 /// Extract JavaScript code from HTML response
 /// Looks for <script> tags and inline event handlers
 pub fn extract_javascript_from_html(html: &str) -> Vec<String> {
+    let document = Html::parse_document(html);
+    js_blocks_from_document(&document)
+}
+
+/// Parse `html` once and return BOTH the JS blocks (see
+/// [`extract_javascript_from_html`]) and the `<script>` element ids (see
+/// [`extract_script_element_ids`]). The AST DOM-analysis entry points need
+/// both for the same response body; calling the two extractors separately
+/// parsed the full response through html5ever twice. Sharing one parse tree
+/// yields byte-identical results at half the HTML-parse cost.
+pub fn extract_js_and_script_ids(html: &str) -> (Vec<String>, HashSet<String>) {
+    let document = Html::parse_document(html);
+    let js_blocks = js_blocks_from_document(&document);
+    let script_ids = script_element_ids_from_document(&document);
+    (js_blocks, script_ids)
+}
+
+/// Extract JS blocks (inline `<script>` bodies, `on*` handler bodies, and
+/// `javascript:` href bodies) from an already-parsed document. Factored out of
+/// [`extract_javascript_from_html`] so [`extract_js_and_script_ids`] can reuse
+/// a single parse.
+fn js_blocks_from_document(document: &Html) -> Vec<String> {
     use std::collections::HashSet;
     let mut js_code = Vec::new();
     let mut seen = HashSet::new();
-
-    let document = Html::parse_document(html);
 
     // Extract from <script> tags
     {
@@ -1053,8 +1082,7 @@ pub fn run_initial_ast_dom_analysis(
     target_method: &str,
     posture: PageSecurityPosture,
 ) -> Vec<crate::scanning::result::Result> {
-    let js_blocks = extract_javascript_from_html(response_text);
-    let script_element_ids = extract_script_element_ids(response_text);
+    let (js_blocks, script_element_ids) = extract_js_and_script_ids(response_text);
     let mut out: Vec<crate::scanning::result::Result> = Vec::new();
     for js_code in js_blocks {
         let findings = analyze_javascript_for_dom_xss_with_html_context(

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -22,6 +22,36 @@ fn test_extract_javascript_from_html() {
     assert!(js_code[1].contains("location.search"));
 }
 
+/// The single-parse `extract_js_and_script_ids` must return byte-identical
+/// results to calling the two separate extractors — that equivalence is the
+/// entire safety argument for sharing one `Html::parse_document` pass.
+#[test]
+fn test_extract_js_and_script_ids_matches_separate_extractors() {
+    let html = r#"
+<html>
+<head>
+<script id="cfg" type="application/json">{"a":1}</script>
+<script id="app">
+    var y = location.hash;
+    document.getElementById('foo').innerHTML = y;
+</script>
+</head>
+<body onload="doStuff(location.search)">
+<a href="javascript:alert(1)">x</a>
+<script>console.log('no id here');</script>
+</body>
+</html>
+"#;
+    let (js_blocks, ids) = extract_js_and_script_ids(html);
+    assert_eq!(js_blocks, extract_javascript_from_html(html));
+    assert_eq!(ids, extract_script_element_ids(html));
+    // Sanity: both signals were actually populated.
+    assert!(ids.contains("app") && ids.contains("cfg"));
+    assert!(js_blocks.iter().any(|b| b.contains("location.hash")));
+    assert!(js_blocks.iter().any(|b| b.contains("doStuff")));
+    assert!(js_blocks.iter().any(|b| b.contains("alert(1)")));
+}
+
 #[test]
 fn test_analyze_javascript_for_dom_xss() {
     let js = r#"

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -535,9 +535,8 @@ async fn run_ast_dom_analysis(
     ast_seen: &mut HashSet<String>,
 ) -> Vec<crate::scanning::result::Result> {
     let mut results = Vec::new();
-    let js_blocks = crate::scanning::ast_integration::extract_javascript_from_html(response_text);
-    let script_element_ids =
-        crate::scanning::ast_integration::extract_script_element_ids(response_text);
+    let (js_blocks, script_element_ids) =
+        crate::scanning::ast_integration::extract_js_and_script_ids(response_text);
     let posture = crate::scanning::ast_integration::PageSecurityPosture::from_target(target);
     for js_code in js_blocks {
         let findings =


### PR DESCRIPTION
## What

The AST DOM-analysis entry points parsed the same response body (up to 16 MiB) through html5ever **twice** — once for the JS blocks (`extract_javascript_from_html`) and once for the `<script>` element ids (`extract_script_element_ids`):

- `run_ast_dom_analysis` — runs **once per reflecting param** per target
- `run_initial_ast_dom_analysis` — server/MCP preflight

This adds `extract_js_and_script_ids`, which parses once and derives both outputs from the shared parse tree. The two original extractors stay (other callers need only one of the two); their bodies are factored into `js_blocks_from_document` / `script_element_ids_from_document` so the combined path reuses identical logic.

## Why it's detection-neutral

Both outputs are pure functions of the same html5ever parse tree, the same cached selectors, and the same dedup logic — merging the two parses is byte-for-byte equivalent. A new test (`test_extract_js_and_script_ids_matches_separate_extractors`) asserts the combined helper equals calling the two extractors separately.

## Impact

Release microbench of the AST-phase HTML parse (temporary harness, not committed):

| page | body | old (2 parses) | new (1 parse) | speedup |
|------|------|----------------|---------------|---------|
| tiny, small JS | 1 KiB | 24.7 µs | 12.4 µs | 1.99x |
| small | 12 KiB | 151.8 µs | 82.1 µs | 1.85x |
| medium | 66 KiB | 1067 µs | 565 µs | 1.89x |
| large, big JS | 304 KiB | 5197 µs | 2733 µs | 1.90x |

Saved cost is paid once per reflecting param per target, so it scales with param count × page size. Pure CPU saving; no change to request behavior or findings.

## Tests

- `cargo test --lib` — 1942 passed (incl. new equivalence test)
- `cargo clippy --lib` — no warnings