### PR TITLE
feat(dom): detect drag-drop, async-clipboard and FileReader DOM-XSS flows

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -461,6 +461,15 @@ const DOM_SOURCES: &[&str] = &[
     "event.clipboardData.getData",
     "e.clipboardData.getData",
     "navigator.clipboard.readText",
+    // Drag-and-drop `drop` handlers: `dataTransfer.getData(type)` returns the
+    // dragged payload, which the attacker controls end-to-end when the drag
+    // originates from a page they control (the classic drag-and-drop XSS: a
+    // crafted `text/html` flavour dropped into a widget that innerHTMLs it).
+    // Exactly the same trust model as the sibling `clipboardData.getData`
+    // reads above. The bare `dataTransfer` object is not listed: `.types` /
+    // `.files` / `.effectAllowed` are metadata, not attacker string content.
+    "event.dataTransfer.getData",
+    "e.dataTransfer.getData",
     // Keyboard / composition events – `key` / `code` carry user input
     // verbatim and are the natural source on autocompletion-style handlers.
     "event.key",
@@ -1673,6 +1682,31 @@ impl<'a> DomXssVisitor<'a> {
         }
     }
 
+    /// Recognise a call that returns a Promise resolving to attacker-controlled
+    /// data. Unlike `fetch(...)` — whose Promise resolves to a `Response` whose
+    /// `.text()`/`.json()` reads are the tainted part — these resolve *directly*
+    /// to the untrusted string, so the chain kind is `Tainted` at the root.
+    ///
+    /// Returns the source label to report.
+    ///
+    /// Kept as an explicit list rather than reusing the whole `DOM_SOURCES` set:
+    /// most sources are synchronous reads (`localStorage.getItem(...)` returns a
+    /// string, not a Promise), and treating those as Promise roots would attach
+    /// chain semantics to values that never have a `.then`.
+    fn async_tainted_source_call(&self, call: &CallExpression<'a>) -> Option<String> {
+        const ASYNC_TAINTED_SOURCE_CALLS: &[&str] = &[
+            // `navigator.clipboard.readText()` resolves to the clipboard text —
+            // the async counterpart of the `event.clipboardData.getData` read
+            // already modeled as a source.
+            "navigator.clipboard.readText",
+            "window.navigator.clipboard.readText",
+        ];
+        let callee = self.get_expr_string(&call.callee)?;
+        ASYNC_TAINTED_SOURCE_CALLS
+            .contains(&callee.as_str())
+            .then_some(callee)
+    }
+
     /// If `call` invokes a Promise combinator (`.then` / `.catch` / `.finally`),
     /// return the method name.
     fn promise_method_name(call: &CallExpression<'a>) -> Option<&'static str> {
@@ -1688,9 +1722,10 @@ impl<'a> DomXssVisitor<'a> {
     }
 
     /// True when this `.then`/`.catch`/`.finally` call sits on a Promise chain
-    /// whose root is a `fetch(...)` call. Walks the receiver chain down through
-    /// nested combinators.
-    fn promise_chain_roots_at_fetch(&self, call: &CallExpression<'a>) -> bool {
+    /// whose root produces untrusted data — a `fetch(...)` call, or an async
+    /// source call such as `navigator.clipboard.readText()`. Walks the receiver
+    /// chain down through nested combinators.
+    fn promise_chain_roots_at_untrusted_source(&self, call: &CallExpression<'a>) -> bool {
         let mut current: &Expression<'a> = match &call.callee {
             Expression::StaticMemberExpression(m) => &m.object,
             _ => return false,
@@ -1699,7 +1734,8 @@ impl<'a> DomXssVisitor<'a> {
             match current {
                 Expression::ParenthesizedExpression(p) => current = &p.expression,
                 Expression::CallExpression(inner) => {
-                    if self.is_fetch_call(inner) {
+                    if self.is_fetch_call(inner) || self.async_tainted_source_call(inner).is_some()
+                    {
                         return true;
                     }
                     if Self::promise_method_name(inner).is_some()
@@ -2271,6 +2307,30 @@ impl<'a> DomXssVisitor<'a> {
         }
     }
 
+    /// Source label when `member` reads the decoded bytes of a file the user
+    /// supplied (`reader.result`) on a variable known to hold a
+    /// `new FileReader()` instance. The file arrives by drag-and-drop or an
+    /// `<input type=file>` picker, so its contents are attacker-influenced in
+    /// exactly the same way as the `dataTransfer.getData` / `clipboardData`
+    /// reads above — the canonical shape is a "preview the dropped file"
+    /// widget that pushes `reader.result` straight into `innerHTML`.
+    ///
+    /// Only `result` is a source: `error` / `readyState` are status metadata.
+    fn file_reader_source_for_member(&self, member: &StaticMemberExpression<'a>) -> Option<String> {
+        let Expression::Identifier(id) = &member.object else {
+            return None;
+        };
+        if self
+            .instance_classes
+            .get(id.name.as_str())
+            .map(String::as_str)
+            != Some("FileReader")
+        {
+            return None;
+        }
+        (member.property.name.as_str() == "result").then(|| "FileReader.result".to_string())
+    }
+
     /// Check if expression is tainted.
     ///
     /// Hostile JavaScript can nest expressions arbitrarily deep (`a.b.c.d…`,
@@ -2296,6 +2356,9 @@ impl<'a> DomXssVisitor<'a> {
                     return true;
                 }
                 if self.xhr_response_source_for_member(member).is_some() {
+                    return true;
+                }
+                if self.file_reader_source_for_member(member).is_some() {
                     return true;
                 }
                 if let Some(full_path) = self.get_member_string(member) {
@@ -3139,6 +3202,9 @@ impl<'a> DomXssVisitor<'a> {
                 if let Some(source) = self.xhr_response_source_for_member(member) {
                     return Some(source);
                 }
+                if let Some(source) = self.file_reader_source_for_member(member) {
+                    return Some(source);
+                }
                 if let Some(full_path) = self.get_member_string(member) {
                     if matches!(
                         full_path.as_str(),
@@ -3432,6 +3498,17 @@ impl<'a> DomXssVisitor<'a> {
                 }
             }
             return PromiseValueKind::Response;
+        }
+
+        // An async source call (`navigator.clipboard.readText()`) resolves
+        // straight to the untrusted string, so the chain is tainted at its root.
+        if let Some(source) = self.async_tainted_source_call(call) {
+            for arg in &call.arguments {
+                if let Some(expr) = arg.as_expression() {
+                    self.walk_expression(expr);
+                }
+            }
+            return PromiseValueKind::Tainted(source);
         }
 
         let Some(method) = Self::promise_method_name(call) else {
@@ -4013,10 +4090,13 @@ impl<'a> DomXssVisitor<'a> {
             self.default_tt_policy = Some(info);
         }
 
-        // fetch().then(...) response-source chains (issue #1024). Drive the
-        // whole chain here so each callback body is walked with the resolved
-        // Response / tainted value bound to its parameter, then return.
-        if Self::promise_method_name(call).is_some() && self.promise_chain_roots_at_fetch(call) {
+        // fetch().then(...) response-source chains (issue #1024) and async
+        // source chains such as `navigator.clipboard.readText().then(...)`.
+        // Drive the whole chain here so each callback body is walked with the
+        // resolved Response / tainted value bound to its parameter, then return.
+        if Self::promise_method_name(call).is_some()
+            && self.promise_chain_roots_at_untrusted_source(call)
+        {
             self.promise_kind_of_call(call);
             return;
         }

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -3265,6 +3265,64 @@ document.addEventListener('paste', function(e) {
 }
 
 #[test]
+fn drag_drop_get_data_is_recognised_as_source() {
+    // Drop handler innerHTMLs the dragged `text/html` flavour — the classic
+    // drag-and-drop XSS. Same trust model as clipboardData.getData above.
+    let js = r#"
+z.addEventListener('drop', function (e) {
+    e.preventDefault();
+    document.getElementById('out').innerHTML = prefix + e.dataTransfer.getData('text/html');
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("dataTransfer")),
+        "drop-event dataTransfer.getData → innerHTML must surface; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn drag_drop_file_metadata_is_not_a_source() {
+    // `.files` / `.types` are metadata, not attacker-supplied string content,
+    // so only the `getData(...)` read is modeled as a source.
+    let js = r#"
+z.addEventListener('drop', function (e) {
+    document.getElementById('out').innerHTML = e.dataTransfer.files.length + e.dataTransfer.types[0];
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "dataTransfer metadata reads must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn drag_drop_get_data_into_textcontent_no_finding() {
+    // textContent is not an HTML sink, so the dragged payload is inert there.
+    let js = r#"
+z.addEventListener('drop', function (e) {
+    document.getElementById('out').textContent = e.dataTransfer.getData('text/html');
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "dataTransfer.getData into textContent must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn native_element_append_is_not_a_sink() {
     // `Element.prototype.append(string)` inserts the string as a Text node
     // — no HTML parsing — so a tainted argument is not exploitable. The
@@ -3616,6 +3674,62 @@ xhr.onload = function () { document.write(xhr.response); };
 }
 
 #[test]
+fn file_reader_result_to_innerhtml() {
+    // "Preview the dropped file" widget: the user-supplied file bytes land in
+    // innerHTML via `reader.result`.
+    let js = r#"
+var f = e.dataTransfer.files[0];
+var r = new FileReader();
+r.onload = function () { document.getElementById('out').innerHTML = prefix + r.result; };
+r.readAsText(f);
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("FileReader.result")),
+        "FileReader.result -> innerHTML must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn file_reader_status_metadata_is_not_a_source() {
+    // `readyState` / `error` are status metadata, not file content.
+    let js = r#"
+var r = new FileReader();
+r.onload = function () { document.getElementById('out').innerHTML = r.readyState + r.error; };
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "FileReader status metadata must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn non_file_reader_result_property_is_not_a_source() {
+    // `.result` is only a source on a real FileReader instance — an unrelated
+    // class with a `result` field must not taint.
+    let js = r#"
+var r = new ReportBuilder();
+document.getElementById('out').innerHTML = r.result;
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).unwrap();
+    assert!(
+        r.is_empty(),
+        "unrelated .result read must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn fetch_text_to_safe_textcontent_no_finding() {
     // textContent is not an HTML sink, so even tainted response text is safe.
     let js = r#"
@@ -3626,6 +3740,80 @@ fetch('/data.txt').then(function (r) { return r.text(); })
     assert!(
         r.is_empty(),
         "fetch response into textContent must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clipboard_read_text_promise_chain_to_innerhtml() {
+    // `navigator.clipboard.readText()` resolves directly to the untrusted
+    // string, so the `.then` parameter is tainted at the chain root — the
+    // async counterpart of the clipboardData.getData source.
+    let js = r#"
+document.getElementById('b').addEventListener('click', function () {
+    navigator.clipboard.readText().then(function (t) {
+        document.getElementById('out').innerHTML = prefix + t;
+    });
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("clipboard.readText")),
+        "clipboard.readText().then(t => innerHTML = t) must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clipboard_read_text_arrow_chain_to_document_write() {
+    let js = r#"
+navigator.clipboard.readText().then(t => document.write(t));
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.iter().any(|v| v.sink.contains("write")),
+        "clipboard.readText arrow chain into document.write must fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clipboard_read_text_to_safe_textcontent_no_finding() {
+    let js = r#"
+navigator.clipboard.readText().then(function (t) {
+    document.getElementById('o').textContent = t;
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "clipboard text into textContent must NOT fire; got {:?}",
+        r.iter()
+            .map(|v| (v.source.clone(), v.sink.clone()))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn clipboard_write_text_is_not_a_promise_source() {
+    // Only the *read* side is a source. `writeText` takes a value and resolves
+    // to undefined, so a chain rooted at it must stay untainted.
+    let js = r#"
+navigator.clipboard.writeText('x').then(function (t) {
+    document.getElementById('o').innerHTML = t;
+});
+"#;
+    let r = AstDomAnalyzer::new().analyze(js).expect("parses");
+    assert!(
+        r.is_empty(),
+        "clipboard.writeText chain must NOT fire; got {:?}",
         r.iter()
             .map(|v| (v.source.clone(), v.sink.clone()))
             .collect::<Vec<_>>()


### PR DESCRIPTION
## Why

Measuring DOM-XSS recall against [xssmaze](https://github.com/hahwul/xssmaze) surfaced a metric trap worth recording: scanning the 198 endpoints in the DOM-ish categories and counting *"dalfox reported something"* gives **192/198 (97%)** and looks saturated. Counting endpoints where dalfox identified the **DOM flow** (`detection_method == "ast"`) gives **85/198**. The difference is server-side reflected findings on the same page masking a missed DOM flow.

Re-deriving the test set from the *served JS* (rather than category names — `fragment` and `sink` are actually server-side HTML-context reflections) gives 93 genuine client-side source→sink flows, of which dalfox caught 80.

## What

Four of the 13 missed endpoints came down to three distinct root causes, all in `src/scanning/ast_dom_analysis.rs`:

1. **`dataTransfer.getData(type)` was not a source** — drag-and-drop XSS (a crafted `text/html` flavour dropped into a widget that `innerHTML`s it) was invisible. Added alongside the sibling `clipboardData.getData` reads, which have an identical trust model. The bare `dataTransfer` object stays out: `.types` / `.files` are metadata, not attacker string content.

2. **The promise-chain driver only engaged for `fetch`-rooted chains.** `navigator.clipboard.readText` was *already* in `DOM_SOURCES`, but `promise_chain_roots_at_fetch` gated the driver, so the `.then(t => …)` parameter never got tainted. Generalized to `promise_chain_roots_at_untrusted_source` + `async_tainted_source_call`, which resolves such a chain to `PromiseValueKind::Tainted` at its root. Kept as an explicit list rather than reusing all of `DOM_SOURCES`, since most sources are synchronous reads (`localStorage.getItem` returns a string, not a Promise). This is the reusable lever for any future async source.

3. **`FileReader.result` was not a source** — the "preview the dropped/picked file" shape never reached its `innerHTML` sink. `instance_classes` already tracks `new Foo()` generically, so this mirrors the existing `xhr_response_source_for_member` helper in ~15 LOC. Only `result` is a source; `readyState` / `error` are status metadata.

## Verification

- Full-corpus rescan: **85 → 89 DOM-detected**, exactly the four targeted endpoints, **zero losses**, and total findings unchanged at 192 — so no spurious findings were introduced anywhere in the corpus.
- 1952 lib tests + all integration bins pass; `cargo clippy --all-targets -- -D warnings` clean.
- 11 new tests, including FP controls for `dataTransfer` metadata reads, `clipboard.writeText` (write side is not a source), safe `textContent` sinks, and `.result` on a non-`FileReader` instance.

## Deliberately not addressed

`dataset.X` / `getAttribute()` as a source (`sink-level6`, `mobserver-level2` stay MISS). It is a real and common class — server-populated `data-*` read into `innerHTML` — but an unconditional source would fire on every benign `el.innerHTML = el.dataset.template` in component libraries, a far larger FP surface than `localStorage`. The sound version correlates the HTML pre-scan (precedent: `ast_integration::extract_script_element_ids`) to confirm the attribute value is reflected from a parameter, and deserves its own FP validation pass rather than a bolt-on.

The other 9 originally-flagged misses turned out to be prototype-pollution gadget chains, MutationObserver re-entry, and import-map injection — distinct feature classes, not recall gaps in this analyzer.