### PR TITLE
feat(dom): detect setAttributeNS, indirect eval and DOMParser HTML sinks

### DIFF
--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -524,6 +524,17 @@ const DOM_SINKS: &[&str] = &[
     "prepend",
     "after",
     "before",
+    // Namespaced sibling of `setAttribute`. Same danger, different arity:
+    // `setAttributeNS(ns, name, value)` puts the attribute name at index 1 and
+    // the value at index 2, so it gets its own arity-aware branch below.
+    "setAttributeNS",
+    // `new DOMParser().parseFromString(html, 'text/html')` parses attacker HTML
+    // into a document with no browsing context. Nothing executes *there*, but
+    // the resulting nodes are routinely moved into the live document with
+    // `adoptNode` / `importNode` / `appendChild`, at which point they do — the
+    // same "inert until inserted" shape as the `createContextualFragment` sink
+    // already modeled. Gated on an HTML-ish MIME type below.
+    "parseFromString",
     "execCommand",
     // Modern Sanitizer-API methods. `setHTML` accepts a Sanitizer config and
     // strips known XSS vectors, so on its own it is not an exploitable sink —
@@ -1680,6 +1691,30 @@ impl<'a> DomXssVisitor<'a> {
                 _ => return false,
             }
         }
+    }
+
+    /// Resolve the indirect-eval idiom `(0, eval)(code)` to its sink name.
+    ///
+    /// Wrapping a bare `eval` reference in a comma expression detaches it from
+    /// the *direct* eval reference, so the code runs in global scope instead of
+    /// the caller's. Only the last element of the sequence is the callee;
+    /// earlier operands are evaluated and discarded. `get_expr_string` sees a
+    /// parenthesized `SequenceExpression` and yields nothing, so without this
+    /// the sink lookup misses the call entirely.
+    ///
+    /// Returns a name only when it resolves to an already-known sink — this
+    /// never invents one.
+    fn indirect_call_sink_name(&self, call: &CallExpression<'a>) -> Option<String> {
+        let mut current = &call.callee;
+        loop {
+            match current {
+                Expression::ParenthesizedExpression(p) => current = &p.expression,
+                Expression::SequenceExpression(seq) => current = seq.expressions.last()?,
+                _ => break,
+            }
+        }
+        let name = self.get_expr_string(current)?;
+        self.sinks.contains(name.as_str()).then_some(name)
     }
 
     /// Recognise a call that returns a Promise resolving to attacker-controlled
@@ -4606,7 +4641,10 @@ impl<'a> DomXssVisitor<'a> {
         } else {
             None
         };
-        if let Some(func_name) = direct_sink_name.or(bound_sink_name) {
+        if let Some(func_name) = direct_sink_name
+            .or(bound_sink_name)
+            .or_else(|| self.indirect_call_sink_name(call))
+        {
             if let Some(bound_alias) = alias_owned.as_ref()
                 && self.sinks.contains(bound_alias.target.as_str())
             {
@@ -4688,6 +4726,62 @@ impl<'a> DomXssVisitor<'a> {
                             );
                             return;
                         }
+                    }
+                }
+            // `setAttributeNS(ns, name, value)` — same dangerous-attribute
+            // filter as `setAttribute`, shifted one index for the namespace.
+            } else if method_name == "setAttributeNS" && call.arguments.len() >= 3 {
+                let attr_name_lc = call
+                    .arguments
+                    .get(1)
+                    .and_then(|arg1| self.eval_static_string_arg(arg1))
+                    .map(|name| name.to_ascii_lowercase());
+                if let Some(name) = attr_name_lc {
+                    // Namespaced attribute names arrive as `xlink:href` or a
+                    // bare local name depending on the call, so match both.
+                    let local = name.rsplit(':').next().unwrap_or(&name);
+                    let dangerous = local.starts_with("on")
+                        || local == "href"
+                        || local == "srcdoc"
+                        || name == "xlink:href";
+                    if dangerous && let Some(arg2) = call.arguments.get(2) {
+                        let (tainted, source_hint) = self.argument_taint_and_source(arg2);
+                        if tainted {
+                            self.report_vulnerability_with_source(
+                                call.span(),
+                                &format!("setAttributeNS:{}", name),
+                                "Tainted data assigned to dangerous namespaced attribute",
+                                source_hint,
+                            );
+                            return;
+                        }
+                    }
+                }
+            // `parseFromString(str, mime)` only builds a DOM that can carry
+            // script for HTML/XHTML/SVG MIME types. A `text/xml` /
+            // `application/json`-style parse cannot produce executable nodes,
+            // so restrict to the HTML-ish types; an unknown (non-literal) MIME
+            // still fires, to fail toward reporting.
+            } else if method_name == "parseFromString" {
+                let mime = call
+                    .arguments
+                    .get(1)
+                    .and_then(|arg1| self.eval_static_string_arg(arg1))
+                    .map(|m| m.trim().to_ascii_lowercase());
+                let html_ish = match mime.as_deref() {
+                    None => true,
+                    Some(m) => matches!(m, "text/html" | "application/xhtml+xml" | "image/svg+xml"),
+                };
+                if html_ish && let Some(arg0) = call.arguments.first() {
+                    let (tainted, source_hint) = self.argument_taint_and_source(arg0);
+                    if tainted {
+                        self.report_vulnerability_with_source(
+                            call.span(),
+                            "parseFromString",
+                            "Tainted data parsed as HTML (executes once the nodes are adopted into the live document)",
+                            source_hint,
+                        );
+                        return;
                     }
                 }
             // Special-case execCommand - only insertHTML is dangerous, and the third arg is the value

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -346,6 +346,128 @@ setAttribute('onclick', data);
 }
 
 #[test]
+fn set_attribute_ns_dangerous_attribute_is_a_sink() {
+    // setAttributeNS(ns, name, value): the attribute name is at index 1 and the
+    // value at index 2, one further along than setAttribute.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query');
+document.getElementById('go').setAttributeNS(null, 'onclick', q);
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "setAttributeNS:onclick"),
+        "setAttributeNS onclick must fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn set_attribute_ns_xlink_href_is_a_sink() {
+    let code = r#"
+var q = location.search;
+el.setAttributeNS('http://www.w3.org/1999/xlink', 'xlink:href', q);
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink.starts_with("setAttributeNS:")),
+        "setAttributeNS xlink:href must fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn set_attribute_ns_inert_attribute_no_finding() {
+    // Same dangerous-attribute filter as setAttribute: `class` cannot execute.
+    let code = r#"
+var q = location.search;
+document.getElementById('go').setAttributeNS(null, 'class', q);
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.is_empty(),
+        "setAttributeNS of an inert attribute must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn indirect_eval_comma_sequence_is_a_sink() {
+    // `(0, eval)(x)` detaches the eval reference so the code runs in global
+    // scope; the callee is a parenthesized SequenceExpression, which the plain
+    // callee-name lookup cannot resolve.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query');
+if (q) { (0, eval)(q); }
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "eval"),
+        "indirect eval must fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn indirect_call_to_non_sink_no_finding() {
+    // The sequence-unwrap must only resolve names that are already sinks — it
+    // must not turn an arbitrary comma-expression call into a finding.
+    let code = r#"
+var q = location.search;
+(0, renderPlainText)(q);
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.is_empty(),
+        "indirect call to a non-sink must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dom_parser_parse_from_string_html_is_a_sink() {
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query');
+var parsed = new DOMParser().parseFromString(q, 'text/html');
+out.appendChild(document.adoptNode(parsed.body.firstChild));
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.iter().any(|v| v.sink == "parseFromString"),
+        "parseFromString with text/html must fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dom_parser_parse_from_string_xml_no_finding() {
+    // A text/xml parse cannot produce script-bearing nodes, so it is not an
+    // XSS sink even with tainted input.
+    let code = r#"
+var q = location.search;
+var doc = new DOMParser().parseFromString(q, 'text/xml');
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.is_empty(),
+        "parseFromString with text/xml must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn dom_parser_parse_from_string_untainted_no_finding() {
+    let code = r#"
+var doc = new DOMParser().parseFromString('<p>static</p>', 'text/html');
+"#;
+    let r = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        r.is_empty(),
+        "untainted parseFromString must NOT fire; got {:?}",
+        r.iter().map(|v| v.sink.clone()).collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn test_jquery_html_sink() {
     // Simplified: direct call to html() function
     let code = r#"


### PR DESCRIPTION
Round two of the [xssmaze](https://github.com/hahwul/xssmaze) DOM benchmark, following #1257.

xssmaze [#36](https://github.com/hahwul/xssmaze/pull/36) added 23 levels each built to isolate exactly one source, sink, or propagation shape. dalfox found **10/23**, and because each level varies one thing, attributing the misses was straightforward. Three are missing *sink coverage* rather than missing analysis:

## `setAttributeNS`

Not modeled at all, even though `setAttribute` was. `setAttributeNS(ns, name, value)` carries the attribute name at index 1 and the value at index 2, so it needs its own arity-aware branch — a plain table entry would mistake the namespace argument for the attribute name and never check the value. Reuses the same dangerous-attribute filter (`on*` / `href` / `srcdoc` / `xlink:href`), matching the local name so both `xlink:href` and a bare `href` resolve.

## Indirect eval `(0, eval)(code)`

Invisible before. Wrapping a bare `eval` reference in a comma expression detaches it from the *direct*-eval reference, so the code runs in global scope — a real and deliberate idiom. The callee is then a parenthesized `SequenceExpression`, which the callee-name lookup cannot resolve, so the sink lookup missed the call entirely.

`indirect_call_sink_name` unwraps parentheses and takes the last element of the sequence (earlier operands are evaluated and discarded). It returns a name **only** when that resolves to an already-known sink, so it can never invent one — covered by an FP control test.

## `DOMParser.parseFromString`

Not a sink before. Nothing executes in the resulting document — it has no browsing context — but the nodes are routinely moved into the live document via `adoptNode` / `importNode` / `appendChild`, at which point they do. That is precisely the "inert until inserted" shape as the `createContextualFragment` sink dalfox already models, so treating it as a sink is consistent rather than new policy.

Gated on an HTML-ish MIME type (`text/html`, `application/xhtml+xml`, `image/svg+xml`) so a `text/xml` parse does not fire. An unknown (non-literal) MIME **does** fire, to fail toward reporting.

## Verification

- New levels: **10 → 13** detected.
- Existing 198-endpoint corpus: unchanged at **89** DOM-detected and **192** total findings — no regressions, and no spurious findings introduced.
- 1960 lib tests + all integration bins pass; `cargo fmt --check` and `cargo clippy --all-targets -- -D warnings` clean.
- 8 new tests, half of them FP controls: inert `setAttributeNS(null,'class')`, an indirect call to a non-sink, a `text/xml` parse, and an untainted parse.

## Not addressed, with reasons

- **`form.action = x` + `submit()`** — sink matching is by property name, and `action` is far too common a property name in ordinary JS (redux-style action objects) to add unconditionally. Needs element-type knowledge to be safe.
- **`Object.assign(location, {href: x})`** — needs Object.assign target modeling.
- **`Array.prototype.map(eval)`** — needs exec-sink-passed-as-callback modeling.
- **The five `taintflow` propagation gaps** — Proxy `get` trap, class getter, `Promise.all` by index, tagged template, and `String.replace` with a replacer function (the value is the callback's *return*, never an argument). These are genuine dataflow work, not table entries, and are the natural next round.
- **`img.src`** is still reported as a sink although no browser executes a `javascript:` or JS `data:` URL from an image src — xssmaze now marks that endpoint an explicit control. Element-type gating would fix it, but it is 1 endpoint in 198 and would thread a tag map through the HTML-parse path that #1256 just optimized. Deliberately parked.