### PR TITLE
fix(waf): match sink keywords only at identifier boundaries

### DIFF
--- a/src/waf/bypass.rs
+++ b/src/waf/bypass.rs
@@ -557,11 +557,29 @@ const CALL_SINK_NAMES: &[&str] = &["alert", "confirm", "prompt", "print", "eval"
 /// matching from the opening `(` so nested parens in the argument
 /// (`alert((1))`, `alert(String(1))`) close correctly. Returns `None`
 /// when no known sink call is present or its parens are unbalanced.
+///
+/// The sink keyword must sit at an identifier boundary: a bare
+/// `payload.find("eval(")` also matches the *tail* of a longer identifier
+/// (`retrieval(`, `myeval(`, `fingerprint(` contains `print(`), and the
+/// callers rewrite the call by slicing at `name_start`, so a substring match
+/// splices the wrapper into the middle of an unrelated identifier and emits
+/// broken JS. Reachable with user `--custom-payload` values. Every match of a
+/// keyword is scanned so a rejected substring hit does not hide a later valid
+/// call.
 fn find_sink_call(payload: &str) -> Option<(usize, usize, usize)> {
     let bytes = payload.as_bytes();
     for name in CALL_SINK_NAMES {
         let needle = format!("{}(", name);
-        if let Some(pos) = payload.find(&needle) {
+        for (pos, _) in payload.match_indices(&needle) {
+            // Reject a match whose left edge is glued to a JS
+            // identifier-continuation byte — it is the tail of a longer name,
+            // not a call to this sink.
+            if pos > 0 {
+                let prev = bytes[pos - 1];
+                if prev.is_ascii_alphanumeric() || prev == b'_' || prev == b'$' {
+                    continue;
+                }
+            }
             let open = pos + name.len(); // index of '('
             let mut depth = 0usize;
             let mut k = open;

--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -507,6 +507,35 @@ fn test_find_sink_call_balances_nested_parens() {
     assert_eq!(&"alert(String(1))"[open..=close], "(String(1))");
 }
 
+/// A sink keyword that is only the *tail* of a longer identifier is not a
+/// call to that sink. Matching it as a substring makes the call-rewriting
+/// mutations splice their wrapper into the middle of an unrelated identifier
+/// and emit broken JS. Reachable through user `--custom-payload` values.
+#[test]
+fn test_find_sink_call_requires_identifier_boundary() {
+    // `myeval(1)` / `retrieval(x)` / `fingerprint(x)` are NOT sink calls: the
+    // keyword is glued to a preceding identifier byte.
+    assert_eq!(find_sink_call("myeval(1)"), None);
+    assert_eq!(find_sink_call("retrieval(x)"), None);
+    assert_eq!(find_sink_call("fingerprint(x)"), None);
+    // A genuine call preceded by a non-identifier byte still resolves, even
+    // when an earlier substring hit for the same keyword was rejected.
+    let (start, ..) = find_sink_call("myeval;alert(1)").unwrap();
+    assert_eq!(&"myeval;alert(1)"[start..start + 5], "alert");
+    // A boundary later in the string is found when the first hit is a tail.
+    let (start, ..) = find_sink_call("fingerprint(a);print(1)").unwrap();
+    assert_eq!(&"fingerprint(a);print(1)"[start..start + 5], "print");
+}
+
+/// The call-rewriting mutations must leave a payload whose only sink-looking
+/// token is a substring of a larger identifier untouched, instead of
+/// corrupting it into invalid JS.
+#[test]
+fn test_call_mutations_ignore_substring_sinks() {
+    assert_eq!(backtick_parens("myeval(1)"), "myeval(1)");
+    assert_eq!(constructor_chain("retrieval(x)"), "retrieval(x)");
+}
+
 #[test]
 fn test_citrix_netscaler_strategy() {
     let strategy = get_bypass_strategy(&WafType::Citrix);


### PR DESCRIPTION
## Summary

`find_sink_call` in the WAF-bypass mutation layer located a sink call with a bare `payload.find("eval(")`, which also matches the **tail of a longer identifier**:

- `myeval(1)` / `retrieval(x)` → match `eval(`
- `fingerprint(x)` → matches `print(`

The call-rewriting mutations (`backtick_parens`, `constructor_chain`, `keyword_entity_encode`) then slice the payload at that mislocated `name_start` and splice their wrapper into the middle of the unrelated identifier, emitting broken JS. For example `constructor_chain("myeval(1)")` produced `my[].constructor.constructor('eval(1)')()` — a syntax error instead of a valid bypass variant. Reachable in practice through user-supplied `--custom-payload` values.

## Fix

- Require the sink keyword's left edge to not be a JS identifier-continuation byte (ASCII alphanumeric / `_` / `$`).
- Scan **every** match of a keyword so a rejected substring hit doesn't hide a later valid call in the same payload.

Strictly additive: only previously-corrupting matches are rejected, so no existing bypass behavior regresses.

## Tests

- `test_find_sink_call_requires_identifier_boundary` — substring hits rejected; genuine calls still resolve, including reject-tail-then-find-later-boundary.
- `test_call_mutations_ignore_substring_sinks` — `backtick_parens` / `constructor_chain` leave substring-only payloads untouched.

All 1962 lib tests pass; clippy clean.