### PR TITLE
fix(verify): inject absent multipart param in DOM light-verify

### DIFF
--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -107,6 +107,7 @@ pub async fn verify_dom_xss_light_with_client(
                 .unwrap_or_else(|| target.url.clone());
             let mut form = reqwest::multipart::Form::new();
             if let Some(ref data) = target.data {
+                let mut found = false;
                 for pair in data.split('&') {
                     if let Some((k, v)) = pair.split_once('=') {
                         let k = urlencoding::decode(k)
@@ -117,10 +118,18 @@ pub async fn verify_dom_xss_light_with_client(
                             .to_string();
                         if k == param.name {
                             form = form.text(k, payload.to_string());
+                            found = true;
                         } else {
                             form = form.text(k, v);
                         }
                     }
+                }
+                // Mirror the `Body` branch: an injected param that isn't already
+                // in the captured body must still be sent, or the payload never
+                // reaches the server and verification silently fails (e.g. an
+                // explicit `--param` not present in the imported multipart body).
+                if !found {
+                    form = form.text(param.name.clone(), payload.to_string());
                 }
             } else {
                 form = form.text(param.name.clone(), payload.to_string());

--- a/src/scanning/light_verify/tests.rs
+++ b/src/scanning/light_verify/tests.rs
@@ -405,3 +405,24 @@ async fn test_verify_dom_xss_light_location_multipart_body() {
     assert!(verified);
     assert!(response.expect("response").contains(&payload));
 }
+
+/// A multipart param that is NOT already present in the captured body (e.g. an
+/// explicit `--param`) must still be injected and sent, otherwise the payload
+/// never reaches the server and verification falsely fails. Regression for the
+/// missing `if !found` fallback that the `Body` branch already had.
+#[tokio::test]
+async fn test_verify_dom_xss_light_multipart_body_injects_absent_param() {
+    let marker = crate::scanning::markers::class_marker().to_string();
+    let addr = start_mock_server(&marker).await;
+    // Captured body carries a different field; the scanned param `q` is absent.
+    let target = make_target(addr, "/multipart", Some("POST"), Some("other=seed"));
+    let param = make_param(Location::MultipartBody, "q");
+    let payload = format!("<img class=\"{}\" src=x onerror=1>", marker);
+    let client = test_client();
+
+    let (verified, response, _note) =
+        verify_dom_xss_light_with_client(&client, &target, &param, &payload).await;
+
+    assert!(verified, "absent multipart param must still be injected");
+    assert!(response.expect("response").contains(&payload));
+}


### PR DESCRIPTION
## Summary

The `MultipartBody` branch of `verify_dom_xss_light_with_client` only injected the payload when `param.name` already matched a field in the captured body (`target.data`). When the scanned param was **not** present in the captured body — e.g. an explicit `--param` not in the imported multipart request — the payload was never added to the multipart form, so the verification request carried no injection and `verify_dom_xss_light` silently returned not-verified: a false negative.

The `Body` branch already guards this with an `if !found` fallback push; this mirrors it for multipart.

## Fix

Track whether the param matched an existing field; if not, append `param.name = payload` to the form before sending (matching the `Body`-branch behavior).

## Tests

`test_verify_dom_xss_light_multipart_body_injects_absent_param` — posts to a mock multipart endpoint whose captured body lacks the scanned param, and asserts the payload still lands and verifies. Confirmed to fail without the fix.

All 1963 lib tests pass; clippy clean.