### PR TITLE
fix(scan): inject absent multipart param in reflection + DOM-verify

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -901,6 +901,7 @@ fn build_multipart_request(
     let parsed_url = resolve_form_action_url(param, target);
     let mut form = reqwest::multipart::Form::new();
     if let Some(ref data) = target.data {
+        let mut found = false;
         for pair in data.split('&') {
             if let Some((k, v)) = pair.split_once('=') {
                 let k = urlencoding::decode(k)
@@ -911,10 +912,17 @@ fn build_multipart_request(
                     .to_string();
                 if k == param.name {
                     form = form.text(k, encoded_payload.to_string());
+                    found = true;
                 } else {
                     form = form.text(k, v);
                 }
             }
+        }
+        // A verified param absent from the captured body must still be injected,
+        // or the verification request carries no payload and can never confirm
+        // the finding. Mirrors the reflection/probe multipart builders.
+        if !found {
+            form = form.text(param.name.clone(), encoded_payload.to_string());
         }
     } else {
         form = form.text(param.name.clone(), encoded_payload.to_string());

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -239,6 +239,12 @@ async fn sxss_html_handler(State(state): State<TestState>) -> Html<String> {
     Html(format!("<div>{}</div>", state.stored_payload))
 }
 
+/// Echo the raw request body so tests can assert what fields a multipart
+/// request actually carried.
+async fn multipart_echo_handler(body: String) -> impl IntoResponse {
+    (StatusCode::OK, body)
+}
+
 async fn sxss_json_handler(State(state): State<TestState>) -> impl IntoResponse {
     (
         StatusCode::OK,
@@ -268,6 +274,10 @@ async fn start_mock_server(stored_payload: &str) -> SocketAddr {
         .route("/dom/server-error", get(server_error_handler))
         .route("/sxss/html", get(sxss_html_handler))
         .route("/sxss/json", get(sxss_json_handler))
+        .route(
+            "/dom/multipart-echo",
+            axum::routing::post(multipart_echo_handler),
+        )
         .with_state(TestState {
             stored_payload: stored_payload.to_string(),
         });
@@ -307,6 +317,35 @@ async fn test_check_dom_verification_detects_html_reflection() {
     let (found, body) = check_dom_verification(&target, &param, &payload, &args).await;
     assert!(found, "text/html responses with payload should be detected");
     assert!(body.unwrap_or_default().contains(&payload));
+}
+
+/// `build_multipart_request` must inject the scanned param even when it is
+/// absent from the captured body — otherwise the verification request carries
+/// no payload and the finding can never be confirmed (false negative).
+#[tokio::test]
+async fn test_build_multipart_request_injects_absent_param() {
+    let addr = start_mock_server("stored").await;
+    // Captured body carries a different field; the scanned param `q` is absent.
+    let mut target = make_target(addr, "/dom/multipart-echo");
+    target.method = "POST".to_string();
+    target.data = Some("other=seed".to_string());
+    let mut param = make_param();
+    param.location = Location::MultipartBody;
+
+    let client = target.build_client_or_default();
+    let rb = build_multipart_request(&client, &target, &param, "PAYLOAD_MARKER");
+    let body = rb
+        .send()
+        .await
+        .expect("send multipart")
+        .text()
+        .await
+        .expect("read echo body");
+    assert!(
+        body.contains("PAYLOAD_MARKER"),
+        "absent multipart param must still be injected, got body: {body}"
+    );
+    assert!(body.contains("name=\"q\""), "form field q must be present");
 }
 
 // ── Issue #1156: DomVerifyOutcome threads reflected + status signals ───────

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1816,6 +1816,7 @@ async fn fetch_injection_response_with_client(
                 .unwrap_or_else(|| target.url.clone());
             let mut form = reqwest::multipart::Form::new();
             if let Some(ref data) = target.data {
+                let mut found = false;
                 for pair in data.split('&') {
                     if let Some((k, v)) = pair.split_once('=') {
                         let k = urlencoding::decode(k)
@@ -1826,10 +1827,18 @@ async fn fetch_injection_response_with_client(
                             .to_string();
                         if k == param.name {
                             form = form.text(k, encoded_payload.to_string());
+                            found = true;
                         } else {
                             form = form.text(k, v);
                         }
                     }
+                }
+                // An injected param absent from the captured body must still be
+                // sent, or the request carries no payload and a real reflection
+                // is missed entirely. Mirrors the Body branch's `if !found` push
+                // and the same guard already in parameter_analysis mining/probe.
+                if !found {
+                    form = form.text(param.name.clone(), encoded_payload.to_string());
                 }
             } else {
                 form = form.text(param.name.clone(), encoded_payload.to_string());

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -215,6 +215,12 @@ async fn redirect_json_ct_handler(
     )
 }
 
+/// Echo the raw request body back inside an HTML shell so a reflection check
+/// can see whatever multipart fields the request actually carried.
+async fn multipart_echo_handler(body: String) -> Html<String> {
+    Html(format!("<div>{}</div>", body))
+}
+
 async fn start_mock_server(stored_payload: &str) -> SocketAddr {
     let app = Router::new()
         .route("/reflect/raw", get(raw_handler))
@@ -227,6 +233,10 @@ async fn start_mock_server(stored_payload: &str) -> SocketAddr {
         .route("/sxss/stored", get(sxss_handler))
         .route("/redirect/decoded", get(redirect_decoded_handler))
         .route("/redirect/json-ct", get(redirect_json_ct_handler))
+        .route(
+            "/reflect/multipart-echo",
+            axum::routing::post(multipart_echo_handler),
+        )
         .with_state(TestState {
             stored_payload: stored_payload.to_string(),
         });
@@ -240,6 +250,34 @@ async fn start_mock_server(stored_payload: &str) -> SocketAddr {
     });
     sleep(Duration::from_millis(20)).await;
     addr
+}
+
+/// The reflection-scan multipart injection must send the payload even when the
+/// scanned param is absent from the captured body, or the request carries no
+/// injection and a real reflection is missed. Exercises the `if !found`
+/// fallback in `fetch_injection_response_with_client`'s MultipartBody arm.
+#[tokio::test]
+async fn test_fetch_injection_multipart_injects_absent_param() {
+    let addr = start_mock_server("stored").await;
+    let mut target = make_target(addr, "/reflect/multipart-echo");
+    target.method = "POST".to_string();
+    // Captured body carries a different field; the scanned param `q` is absent.
+    target.data = Some("other=seed".to_string());
+    let mut param = make_param();
+    param.location = Location::MultipartBody;
+    let args = default_scan_args();
+    let streak = std::sync::atomic::AtomicU32::new(0);
+    let client = target.build_client_or_default();
+
+    let body =
+        fetch_injection_response_with_client(&client, &target, &param, "PAYMARK", &args, &streak)
+            .await
+            .expect("injection response");
+    let text = body.renderable_text().unwrap_or_default();
+    assert!(
+        text.contains("PAYMARK"),
+        "absent multipart param must still be injected, got: {text}"
+    );
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Summary

Follow-up to #1260. Two more multipart request builders dropped the injected payload when the scanned param was **not** already a field in the captured body (`target.data`):

- **`check_reflection.rs`** — the *main reflection-scan* injection. The request went out with no payload at all, so a real reflected XSS was never triggered and the finding was **missed entirely** (not just unconfirmed).
- **`check_dom_verification.rs::build_multipart_request`** — the DOM-verification request carried no payload, so a candidate could never be confirmed.

`parameter_analysis` mining/probe and (via #1260) the light-verify path already guard this with an `if !found` / `!placed` fallback; these two sites were overlooked.

## Fix

Track whether the param matched an existing multipart field; if not, append `param.name = payload` before sending — mirroring the `Body` branch and the other multipart builders.

## Tests

`test_build_multipart_request_injects_absent_param` drives `build_multipart_request` against a multipart echo endpoint whose captured body lacks the scanned param, asserting the payload and the `q` field land. Confirmed to fail without the fix.

All 1964 lib tests pass; clippy clean.