### PR TITLE
fix(scan): guard empty param.value in JSON-body str::replace fallback

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -878,6 +878,12 @@ fn build_json_body_request(
                 );
             }
             Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
+        } else if param.value.is_empty() {
+            // An empty `param.value` would make `str::replace` splice the payload
+            // between every byte of `data` (empty-pattern match), sending a
+            // garbled body. Re-serialize as `{name: payload}`, matching the
+            // no-data branch and the PoC builder in `scanning::mod`.
+            Some(serde_json::json!({ &param.name: encoded_payload }).to_string())
         } else {
             Some(data.replace(&param.value, encoded_payload))
         }

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -348,6 +348,42 @@ async fn test_build_multipart_request_injects_absent_param() {
     assert!(body.contains("name=\"q\""), "form field q must be present");
 }
 
+/// `build_json_body_request` must not run `str::replace` with an empty
+/// `param.value`: an empty pattern splices the payload between every byte of the
+/// body, sending a garbled request. When the captured body isn't valid JSON and
+/// the value is empty, it must re-serialize as a clean `{name: payload}` object.
+#[tokio::test]
+async fn test_build_json_body_request_empty_value_not_garbled() {
+    let addr = start_mock_server("stored").await;
+    let mut target = make_target(addr, "/dom/multipart-echo");
+    target.method = "POST".to_string();
+    // Non-JSON captured body forces the fallback branch; empty param value would
+    // otherwise trigger `"abc".replace("", p)` == "papbpcp".
+    target.data = Some("abc".to_string());
+    let mut param = make_param();
+    param.location = Location::JsonBody;
+    param.value = String::new();
+
+    let client = target.build_client_or_default();
+    let rb = build_json_body_request(&client, &target, &param, "PAYMARK");
+    let body = rb
+        .send()
+        .await
+        .expect("send json")
+        .text()
+        .await
+        .expect("read echo body");
+    // Clean object, not the garbled empty-pattern splice ("aPAYMARKbPAYMARKc").
+    assert_eq!(
+        body, "{\"q\":\"PAYMARK\"}",
+        "empty-value JSON body must be a clean object, got: {body}"
+    );
+    assert!(
+        !body.contains("aPAYMARKb"),
+        "payload must not be spliced between body bytes, got: {body}"
+    );
+}
+
 // ── Issue #1156: DomVerifyOutcome threads reflected + status signals ───────
 
 #[tokio::test]

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1796,6 +1796,13 @@ async fn fetch_injection_response_with_client(
                         );
                     }
                     Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
+                } else if param.value.is_empty() {
+                    // An empty `param.value` makes `str::replace` splice the
+                    // payload between every byte of `data` (empty-pattern match),
+                    // sending a garbled body that never carries a clean injection.
+                    // Re-serialize as `{name: payload}`, matching the no-data
+                    // branch and the PoC builder in `scanning::mod`.
+                    Some(serde_json::json!({ &param.name: &*encoded_payload }).to_string())
                 } else {
                     // Fallback: simple string replacement of the param's original value
                     Some(data.replace(&param.value, &encoded_payload))

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -90,6 +90,12 @@ pub async fn verify_dom_xss_light_with_client(
                         );
                     }
                     Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
+                } else if param.value.is_empty() {
+                    // An empty `param.value` makes `str::replace` splice the
+                    // payload between every byte of `data`, sending a garbled
+                    // body. Re-serialize as `{name: payload}`, matching the
+                    // no-data branch and the PoC builder in `scanning::mod`.
+                    Some(serde_json::json!({ &param.name: payload }).to_string())
                 } else {
                     Some(data.replace(&param.value, payload))
                 }


### PR DESCRIPTION
## Summary

When a `JsonBody` target's captured body is not valid JSON, injection falls back to `data.replace(&param.value, payload)`. With an **empty** `param.value` (e.g. a JSON field whose value is `""`), `str::replace` matches the empty pattern **between every byte**, splicing the payload throughout and sending a garbled body that never carries a clean injection (`"abc".replace("", p)` → `"papbpcp"`).

`scanning::mod` (the PoC / request-string builder) already guards this with an `else if param.value.is_empty()` branch that re-serializes as `{name: payload}`. The three request-**sending** paths were missed:

- `check_reflection.rs` — main reflection scan
- `light_verify.rs` — DOM light-verify
- `check_dom_verification.rs::build_json_body_request` — DOM verify

## Fix

Apply the same `param.value.is_empty()` guard to all three so they emit a clean `{name: payload}` object instead of the garbled splice.

## Tests

`test_build_json_body_request_empty_value_not_garbled` — non-JSON captured body + empty param value, asserts the sent body is exactly `{"q":"PAYMARK"}` and not the spliced form. Confirmed to fail without the fix.

All 1967 lib tests pass; fmt + clippy clean.