### PR TITLE
fix(server): deterministic scan_id tiebreak in REST+MCP scan listing

### DIFF
--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1639,7 +1639,16 @@ status, and result_count."
                 .iter()
                 .filter(|(_, job)| filter_status.as_ref().is_none_or(|f| &job.status == f))
                 .collect();
-            matching.sort_by_key(|(_, job)| std::cmp::Reverse(job.queued_at_ms));
+            // Newest first, then scan_id ascending as a deterministic tiebreak
+            // (matches the REST `/scans` contract). Without the tiebreak, jobs
+            // sharing a queued_at_ms millisecond fall back to nondeterministic
+            // HashMap order, so an entry could appear on two pages or be skipped
+            // across paginated calls.
+            matching.sort_by(|a, b| {
+                b.1.queued_at_ms
+                    .cmp(&a.1.queued_at_ms)
+                    .then_with(|| a.0.cmp(b.0))
+            });
             let total = matching.len();
             let start = offset.min(total);
             let end = if limit == 0 {

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -705,7 +705,16 @@ pub(crate) async fn list_scans_handler(
             .iter()
             .filter(|(_, job)| filter_status.as_ref().is_none_or(|f| &job.status == f))
             .collect();
-        matching.sort_by_key(|(_, job)| std::cmp::Reverse(job.queued_at_ms));
+        // Total, deterministic order: newest first, then scan_id ascending as a
+        // tiebreak. Without the tiebreak, jobs sharing a queued_at_ms
+        // millisecond fall back to nondeterministic HashMap iteration order, so
+        // an entry could appear on two pages or be skipped across paginated
+        // calls (offset/limit over an unstable ordering).
+        matching.sort_by(|a, b| {
+            b.1.queued_at_ms
+                .cmp(&a.1.queued_at_ms)
+                .then_with(|| a.0.cmp(b.0))
+        });
 
         let total = matching.len();
         let start = offset.min(total);

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1760,6 +1760,43 @@ async fn test_list_scans_handler_returns_all_jobs() {
     assert_eq!(parsed["data"]["scans"].as_array().unwrap().len(), 2);
 }
 
+/// Jobs sharing a `queued_at_ms` millisecond must list in a deterministic
+/// order (scan_id ascending as the tiebreak), not the nondeterministic HashMap
+/// iteration order — otherwise offset/limit pagination over the unstable order
+/// could skip or duplicate an entry across pages.
+#[tokio::test]
+async fn test_list_scans_handler_deterministic_tiebreak_on_equal_queued_at() {
+    let state = make_state(None, None, false, false, "cb");
+    {
+        let mut jobs = state.jobs.lock().await;
+        // Insert in a deliberately non-sorted id order, all with the SAME
+        // queued_at_ms so only the tiebreak decides ordering.
+        for id in ["m", "a", "z", "c", "b"] {
+            let mut job = test_job(JobStatus::Done, None, "");
+            job.queued_at_ms = 1_700_000_000_000;
+            jobs.insert(id.to_string(), job);
+        }
+    }
+
+    let resp = list_scans_handler(State(state), HeaderMap::new(), Query(Map::new()))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let body = response_body_string(resp).await;
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("json");
+    let ids: Vec<&str> = parsed["data"]["scans"]
+        .as_array()
+        .unwrap()
+        .iter()
+        .map(|s| s["scan_id"].as_str().unwrap())
+        .collect();
+    assert_eq!(
+        ids,
+        vec!["a", "b", "c", "m", "z"],
+        "equal-timestamp jobs must be ordered by scan_id ascending"
+    );
+}
+
 #[tokio::test]
 async fn test_list_scans_handler_filters_by_status() {
     let state = make_state(None, None, false, false, "cb");


### PR DESCRIPTION
## Summary

`list_scans` (REST `GET /scans`) and the MCP `list_scans` tool sorted jobs by `queued_at_ms` **descending only**. Jobs sharing a millisecond then fell back to nondeterministic `HashMap` iteration order, so `offset`/`limit` pagination over that unstable order could return an entry on **two pages** or **skip** it entirely across paginated calls.

(Noted as a deferred follow-up in the earlier server/MCP bug hunt.)

## Fix

Add `scan_id` ascending as a total-order tiebreak in both handlers (`queued_at_ms` desc, then id asc), so the paged listing is stable and deterministic. Applied identically to the REST and MCP siblings.

## Tests

`test_list_scans_handler_deterministic_tiebreak_on_equal_queued_at` inserts equal-`queued_at_ms` jobs in non-sorted id order and asserts scan_id-ascending output. Confirmed to fail without the tiebreak.

All 1968 lib tests pass; fmt + clippy clean.