### PR TITLE
fix(waf): apply blocking-status confidence boost even with no body

### DIFF
--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -228,13 +228,16 @@ pub fn fingerprint_from_response(
                 );
             }
         }
+    }
 
-        // Status code hints (boost confidence for known WAF block codes)
-        if status_code == 403 || status_code == 406 || status_code == 429 || status_code == 503 {
-            // Boost all existing detections slightly if we see a blocking status
-            for fp in &mut result.detected {
-                fp.confidence = (fp.confidence + 0.05).min(1.0);
-            }
+    // Status code hints (boost confidence for known WAF block codes). This is
+    // independent of the body: a HEAD preflight or a failed body read passes
+    // `body: None`, but the blocking status is still a signal, and header-based
+    // detections must still get the boost. Previously this lived inside the
+    // `if let Some(body)` block, so a `None` body silently dropped the boost.
+    if status_code == 403 || status_code == 406 || status_code == 429 || status_code == 503 {
+        for fp in &mut result.detected {
+            fp.confidence = (fp.confidence + 0.05).min(1.0);
         }
     }
 

--- a/src/waf/tests.rs
+++ b/src/waf/tests.rs
@@ -253,6 +253,34 @@ fn test_gfe_header_is_weak_signal_filtered_by_default() {
     );
 }
 
+/// The blocking-status confidence boost must apply even when no response body
+/// was fetched (HEAD preflight, or a failed body read that yields `None`). It
+/// used to be nested inside the `if let Some(body)` block, so a `None` body
+/// silently dropped the boost for header-detected WAFs.
+#[test]
+fn test_status_code_boost_applies_without_body() {
+    let headers = make_headers(&[("server", "Google Frontend")]);
+    let confidence_at = |status: u16| {
+        fingerprint_from_response(&headers, None, status)
+            .detected
+            .iter()
+            .find(|fp| fp.waf_type == WafType::CloudArmor)
+            .expect("CloudArmor rule fires from the GFE header")
+            .confidence
+    };
+    let base = confidence_at(200);
+    let boosted = confidence_at(403);
+    assert!(
+        boosted > base,
+        "a 403 blocking status must boost confidence even with no body \
+         (base={base}, boosted={boosted})"
+    );
+    assert!(
+        (boosted - base - 0.05).abs() < 1e-6,
+        "boost should be +0.05 (base={base}, boosted={boosted})"
+    );
+}
+
 #[test]
 fn test_cloud_armor_body_marker_survives_default_floor() {
     // Real Cloud Armor block pages contain the literal string. This is a


### PR DESCRIPTION
## Summary

`fingerprint_from_response` nested the `403/406/429/503` confidence boost **inside** the `if let Some(body_text) = body` block, so it only fired when a response body was present.

But a HEAD preflight or a failed body read passes `body: None` — `fingerprint_with_probe` sets `body_text = read_body(...).await.ok()`, which is `None` on read failure. The blocking status is still a WAF signal, and header-based detections should still get the boost. With a `None` body, a header-detected WAF returning 403 got **no** confidence boost, so it could fall below `--waf-min-confidence` and be dropped.

## Fix

Hoist the status-code boost out of the body block so it applies whenever the status is a known block code, independent of body presence. Body-**pattern** matching stays gated on the body as before.

## Tests

`test_status_code_boost_applies_without_body` — asserts the +0.05 boost applies to a header-detected WAF with a `None` body when status is 403. Confirmed to fail without the fix.

All 1969 lib tests pass; fmt + clippy clean.