### PR TITLE
fix(csp): default-src unsafe-inline/eval must not override a present script-src

### DIFF
--- a/src/payload/xss_csp_bypass.rs
+++ b/src/payload/xss_csp_bypass.rs
@@ -109,6 +109,14 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
     let mut has_default_src = false;
     let mut has_base_uri = false;
     let mut has_object_src = false;
+    // `default-src` governs scripts ONLY when `script-src`/`script-src-elem` is
+    // absent — CSP spec: a present `script-src` fully overrides `default-src`
+    // for script resources. Stash default-src's script-relevant flags and fold
+    // them in after the loop, so `script-src 'nonce-x'; default-src
+    // 'unsafe-inline'` is not misread as inline-allowed (which flipped a
+    // nonce-hardened policy to "gadget-bypassable").
+    let mut default_src_unsafe_inline = false;
+    let mut default_src_unsafe_eval = false;
 
     for directive in &directives {
         let parts: Vec<&str> = directive.split_whitespace().collect();
@@ -163,10 +171,10 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
                 for v in &values {
                     let lower = v.to_ascii_lowercase();
                     if lower == "'unsafe-inline'" {
-                        analysis.has_unsafe_inline = true;
+                        default_src_unsafe_inline = true;
                     }
                     if lower == "'unsafe-eval'" {
-                        analysis.has_unsafe_eval = true;
+                        default_src_unsafe_eval = true;
                     }
                 }
             }
@@ -196,6 +204,16 @@ pub fn analyze_csp(csp_value: &str) -> CspAnalysis {
                 analysis.trusted_types = Some(collected);
             }
             _ => {}
+        }
+    }
+
+    // Fold in default-src's script flags only when no script-src overrode it.
+    if !has_script_src {
+        if default_src_unsafe_inline {
+            analysis.has_unsafe_inline = true;
+        }
+        if default_src_unsafe_eval {
+            analysis.has_unsafe_eval = true;
         }
     }
 

--- a/src/payload/xss_csp_bypass/tests.rs
+++ b/src/payload/xss_csp_bypass/tests.rs
@@ -132,6 +132,31 @@ fn test_analyze_csp_default_src_unsafe_inline_and_eval() {
     assert!(!analysis.missing_script_src);
 }
 
+/// A present `script-src` fully overrides `default-src` for scripts (CSP
+/// spec), so `default-src 'unsafe-inline'` must NOT mark scripts as
+/// inline-allowed when `script-src` hardens them with a nonce — otherwise a
+/// hardened policy is misread as gadget-bypassable and inline payloads that
+/// can't execute are emitted.
+#[test]
+fn test_analyze_csp_default_src_unsafe_inline_ignored_when_script_src_present() {
+    let analysis =
+        analyze_csp("script-src 'nonce-abc123'; default-src 'unsafe-inline' 'unsafe-eval'");
+    assert!(
+        !analysis.has_unsafe_inline,
+        "default-src unsafe-inline must not apply to scripts when script-src is present"
+    );
+    assert!(
+        !analysis.has_unsafe_eval,
+        "default-src unsafe-eval must not apply to scripts when script-src is present"
+    );
+    assert!(analysis.is_nonce_or_hash_based());
+    assert!(
+        analysis.is_hardened(),
+        "nonce script-src with no real escape hatch is hardened"
+    );
+    assert!(!analysis.is_gadget_bypassable());
+}
+
 #[test]
 fn test_analyze_csp_wildcard_and_keywords_not_whitelisted() {
     let analysis = analyze_csp("script-src 'self' 'none' * data: blob:");


### PR DESCRIPTION
## Summary

`analyze_csp` set `has_unsafe_inline` / `has_unsafe_eval` from `default-src` **unconditionally**. Per the CSP spec, a present `script-src` (or `script-src-elem`) fully governs script resources and `default-src` is not consulted for them.

So a policy like `script-src 'nonce-abc'; default-src 'unsafe-inline'` hardens scripts with a nonce — yet `analyze_csp` reported `has_unsafe_inline=true`. That flipped:
- `is_gadget_bypassable()` → `true`
- `is_hardened()` → `false`

so the generator emitted inline-script bypass payloads that can't execute (nonce required), and telemetry mislabeled a hardened CSP as bypassable.

## Fix

Stash `default-src`'s script-relevant flags during the parse and fold them into the analysis only when no `script-src`/`script-src-elem` is present. Default-src-only policies are unaffected.

## Tests

`test_analyze_csp_default_src_unsafe_inline_ignored_when_script_src_present` — nonce `script-src` + `unsafe-inline` `default-src`, asserts scripts are not marked inline-allowed and the policy reads as hardened. Confirmed to fail without the fix.

All 1970 lib tests pass; fmt + clippy clean.