### PR TITLE
fix(csp): wildcard script-src origin matches deeper-subdomain gadget hosts

### DIFF
--- a/src/payload/gadget_db.rs
+++ b/src/payload/gadget_db.rs
@@ -131,24 +131,39 @@ pub fn all() -> &'static [ScriptGadget] {
 /// whitelisted host genuinely permits loading a `<script src>` from it.
 pub fn gadgets_for_host(allowed_origin: &str) -> impl Iterator<Item = &'static ScriptGadget> {
     let lowered = allowed_origin.to_ascii_lowercase();
-    let host = extract_host(&lowered).to_string();
+    let component = host_component(&lowered);
+    // A `*.D` (or `https://*.D`) origin allows ANY subdomain of D, so a gadget
+    // whose host is a *deeper* subdomain than the wildcard base — e.g.
+    // `cdnjs.cloudflare.com` under `*.cloudflare.com`, where the gadget's only
+    // matching pattern is the full subdomain, not a bare `cloudflare.com` — is
+    // still reachable even though the base collapses to `D`. Without this the
+    // wildcard silently missed those gadgets.
+    let is_wildcard = component.starts_with("*.");
+    let host = component
+        .strip_prefix("*.")
+        .unwrap_or(component)
+        .to_string();
+    let subdomain_suffix = format!(".{host}");
     GADGETS.iter().filter(move |g| {
-        !g.host_patterns.is_empty() && g.host_patterns.iter().any(|p| host_matches(&host, p))
+        !g.host_patterns.is_empty()
+            && g.host_patterns.iter().any(|p| {
+                host_matches(&host, p)
+                    || (is_wildcard && p.contains('.') && p.ends_with(&subdomain_suffix))
+            })
     })
 }
 
-/// Extract the bare host from a CSP `script-src` source value: strips the
-/// scheme (`https://` or a leading `//`), any path/query/fragment, the port,
-/// and a leading `*.` wildcard label. Input is expected already lowercased.
-fn extract_host(origin: &str) -> &str {
+/// The host authority of a CSP `script-src` source value: strips the scheme
+/// (`https://` or a leading `//`), any path/query/fragment, and the port, but
+/// keeps a leading `*.` wildcard label. Input is expected already lowercased.
+fn host_component(origin: &str) -> &str {
     let s = origin
         .split_once("://")
         .map(|(_, rest)| rest)
         .unwrap_or(origin);
     let s = s.strip_prefix("//").unwrap_or(s);
     let s = s.split(['/', '?', '#']).next().unwrap_or(s);
-    let s = s.split(':').next().unwrap_or(s);
-    s.strip_prefix("*.").unwrap_or(s)
+    s.split(':').next().unwrap_or(s)
 }
 
 /// Match an allowlisted `host` against a gadget host pattern. A dotted pattern

--- a/src/payload/gadget_db/tests.rs
+++ b/src/payload/gadget_db/tests.rs
@@ -118,6 +118,24 @@ fn test_gadgets_for_host_handles_wildcard_and_schemeless() {
     assert!(gadgets_for_host("//cdn.jsdelivr.net").next().is_some());
 }
 
+/// A `*.D` wildcard allows any subdomain of `D`, so a gadget whose ONLY
+/// matching pattern is a deeper subdomain (`cdnjs.cloudflare.com`, with no bare
+/// `cloudflare.com` parent pattern) must still be found — the base collapsing
+/// to `cloudflare.com` previously missed it.
+#[test]
+fn test_gadgets_for_host_wildcard_matches_deeper_subdomain_gadget() {
+    let hits: Vec<_> = gadgets_for_host("https://*.cloudflare.com").collect();
+    assert!(
+        hits.iter().any(|g| g.template.contains("angular")),
+        "*.cloudflare.com allows cdnjs.cloudflare.com, so the AngularJS gadget must match"
+    );
+    // But a wildcard over an unrelated domain must not pull in those gadgets.
+    assert!(
+        gadgets_for_host("https://*.attacker.test").next().is_none(),
+        "a wildcard over an unrelated domain must not over-match gadget hosts"
+    );
+}
+
 #[test]
 fn test_gadgets_for_host_is_case_insensitive() {
     let hits: Vec<_> = gadgets_for_host("HTTPS://CODE.JQUERY.COM").collect();


### PR DESCRIPTION
## Summary

`gadgets_for_host` collapsed a `*.D` origin to the bare base `D` (via `extract_host`), then `host_matches` only matched a gadget pattern equal to or a *parent* of `D`. But a `*.D` wildcard allows **any subdomain of D**.

So a gadget whose only matching pattern is a *deeper* subdomain — e.g. `cdnjs.cloudflare.com` under `script-src *.cloudflare.com` (the AngularJS gadget's patterns are `angularjs.org` / `angular` / `cdnjs.cloudflare.com`, with no bare `cloudflare.com`) — was silently missed, under-reporting a gadget-bypassable CSP as safe.

## Fix

Track wildcard-ness (`host_component` keeps the `*.` label; `extract_host`'s strip is inlined) and, for a wildcard origin, additionally match gadget patterns that are subdomains of the base (dotted pattern ending in `.D`). Non-wildcard origins and wildcards over unrelated domains are unchanged — no over-match.

## Tests

`test_gadgets_for_host_wildcard_matches_deeper_subdomain_gadget` — `*.cloudflare.com` matches the cdnjs-only AngularJS gadget, and `*.attacker.test` matches nothing. Confirmed to fail without the fix.

All 1971 lib tests pass; fmt + clippy clean.