### PR TITLE
fix(csp): prefer enforcing over report-only meta CSP

### DIFF
--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1020,23 +1020,44 @@ fn compute_waf_strategy(
 /// policy than the CLI does for the same page.
 pub(crate) fn extract_meta_csp(html: &str) -> Option<(String, String)> {
     let doc = scraper::Html::parse_document(html);
+    // Prefer an ENFORCING `Content-Security-Policy` meta over a report-only one,
+    // mirroring the header path's enforcing-over-report-only `.or_else`. A page
+    // may carry both (report-only for telemetry, enforcing for protection), and
+    // their document order is arbitrary — returning whichever appears first
+    // could hand back the report-only policy, which downstream marks
+    // `report_only = true` and zeroes `require_trusted_types_for`. That drops
+    // the real enforcing policy: a TT-hardened enforcing meta would then be
+    // ignored and its (neutralised) DOM findings surface as false positives.
+    let mut report_only: Option<(String, String)> = None;
     for el in doc.select(crate::scanning::selectors::meta_csp()) {
         let http_equiv = el
             .value()
             .attr("http-equiv")
             .unwrap_or("")
             .to_ascii_lowercase();
-        let name = match http_equiv.as_str() {
-            "content-security-policy" => "Content-Security-Policy",
-            "content-security-policy-report-only" => "Content-Security-Policy-Report-Only",
-            _ => continue,
-        };
         let content = el.value().attr("content").unwrap_or("");
-        if !content.is_empty() {
-            return Some((name.to_string(), content.to_string()));
+        if content.is_empty() {
+            continue;
+        }
+        match http_equiv.as_str() {
+            "content-security-policy" => {
+                // Enforcing policy wins outright.
+                return Some(("Content-Security-Policy".to_string(), content.to_string()));
+            }
+            "content-security-policy-report-only" => {
+                // Remember the first report-only, but keep scanning for an
+                // enforcing policy which takes precedence.
+                report_only.get_or_insert_with(|| {
+                    (
+                        "Content-Security-Policy-Report-Only".to_string(),
+                        content.to_string(),
+                    )
+                });
+            }
+            _ => continue,
         }
     }
-    None
+    report_only
 }
 
 /// Whether the response headers carry an **enforcing** CSP with

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2943,3 +2943,30 @@ fn generate_param_jobs_shared_payloads_appended_after_cap() {
     assert!(dom.iter().any(|p| p == "zz-angle-free-shared"));
     assert!(!dom.iter().any(|p| p == "<svg/onload=alert(1)>"));
 }
+
+/// `extract_meta_csp` must prefer an enforcing `Content-Security-Policy` meta
+/// over a report-only one even when the report-only tag appears first —
+/// otherwise downstream marks the policy report-only (zeroing Trusted Types
+/// enforcement) and the real enforcing policy is dropped.
+#[test]
+fn test_extract_meta_csp_prefers_enforcing_over_report_only() {
+    let html = r#"<html><head>
+        <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'none'">
+        <meta http-equiv="Content-Security-Policy" content="require-trusted-types-for 'script'">
+    </head><body></body></html>"#;
+    let (name, content) = extract_meta_csp(html).expect("a meta CSP is present");
+    assert_eq!(name, "Content-Security-Policy");
+    assert!(content.contains("require-trusted-types-for"));
+}
+
+/// With only a report-only meta present, it is still returned (nothing else to
+/// fall back to).
+#[test]
+fn test_extract_meta_csp_returns_report_only_when_no_enforcing() {
+    let html = r#"<html><head>
+        <meta http-equiv="Content-Security-Policy-Report-Only" content="default-src 'self'">
+    </head><body></body></html>"#;
+    let (name, content) = extract_meta_csp(html).expect("a report-only meta is present");
+    assert_eq!(name, "Content-Security-Policy-Report-Only");
+    assert!(content.contains("default-src 'self'"));
+}


### PR DESCRIPTION
## Summary

`extract_meta_csp` returned the **first** recognized meta CSP in document order, whether enforcing or report-only. The header path already prefers an enforcing `Content-Security-Policy` over the report-only variant (via `.or_else`), but the meta path did not: a page carrying a `Content-Security-Policy-Report-Only` meta **before** an enforcing `Content-Security-Policy` meta handed back the report-only policy.

Downstream (`analysis.rs`) then sets `report_only = true` and zeroes `require_trusted_types_for`, so the real enforcing policy is dropped:
- a TT-hardened enforcing meta is ignored → its browser-neutralised DOM-sink findings surface as **false positives**;
- a script-restricting enforcing meta is ignored → wrong bypass-payload selection.

## Fix

Scan all meta CSP tags, return the first **enforcing** policy outright, and fall back to the first report-only only when no enforcing policy exists — mirroring the header semantics.

## Tests

- `test_extract_meta_csp_prefers_enforcing_over_report_only` (report-only tag first, enforcing second) — fails without the fix.
- `test_extract_meta_csp_returns_report_only_when_no_enforcing` — fallback still works.

All 1973 lib tests pass; fmt + clippy clean.