### PR TITLE
fix(config): surface auto-creation of a missing explicit --config path

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -269,6 +269,26 @@ async fn main() {
         eprintln!("Warning: failed to load --config {}: {}", cfg_path, e);
     }
 
+    // A missing explicit `--config <path>` is scaffolded with a default template
+    // (see the create-if-missing branch above) and the scan proceeds on built-in
+    // defaults. That convenience is fine, but doing it *silently* reproduces the
+    // exact footgun the warning above guards against: a typo in the path (or a
+    // wrong directory) then runs with defaults while the operator believes their
+    // `encoders` / `method` / `format` settings applied — and writes an
+    // unsolicited file at the mistyped location. Surface it on stderr so the
+    // creation is visible; stdout stays clean for machine formats. Scoped to the
+    // explicit-`--config` path only — the implicit default-path init
+    // (`load_or_init`, `cli.config == None`) stays quiet on purpose so a
+    // first-time user isn't nagged about their bootstrapped config.
+    if let (Some(cfg_path), Ok(lr)) = (&cli.config, &config_load)
+        && lr.created
+    {
+        eprintln!(
+            "Notice: --config {} did not exist — created it with a default template and ran with built-in defaults (check the path if you meant to load an existing config)",
+            cfg_path
+        );
+    }
+
     // Config values are deserialized straight into `Config` and never pass
     // through clap's value-parsers, so an invalid `format`, a lowercase
     // `method`, or a `limit = 0` would be copied verbatim into `ScanArgs` and

--- a/tests/e2e/config_path_smoke_test.rs
+++ b/tests/e2e/config_path_smoke_test.rs
@@ -81,6 +81,56 @@ fn test_missing_toml_config_path_is_created() {
 }
 
 #[test]
+fn test_missing_config_path_creation_emits_notice_on_stderr() {
+    // The missing-path scaffold (asserted above) must not be silent: a typo'd
+    // `--config` path would otherwise run with built-in defaults while looking
+    // like a successful load. The creation is surfaced on stderr, and stdout
+    // stays clean so machine-format output is unaffected.
+    let dir = unique_temp_dir("cfg-create-notice");
+    let config_path = dir.join("config.toml");
+    assert!(!config_path.exists());
+
+    let output = run_payload_with_config(&config_path);
+    assert!(
+        output.status.success(),
+        "missing config path should succeed"
+    );
+    assert!(config_path.exists(), "config file should be created");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("Notice:") && stderr.contains("did not exist"),
+        "creation of a missing --config path must emit a stderr notice; stderr was:\n{stderr}"
+    );
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    assert!(
+        !stdout.contains("Notice:"),
+        "the creation notice must go to stderr, not stdout; stdout was:\n{stdout}"
+    );
+}
+
+#[test]
+fn test_existing_config_path_emits_no_creation_notice() {
+    // Control: an existing, valid config file is loaded, not created, so no
+    // creation notice fires — the notice is scoped to the scaffold case only.
+    let dir = unique_temp_dir("cfg-existing-no-notice");
+    let config_path = dir.join("config.toml");
+    std::fs::write(&config_path, "[scan]\nformat = \"plain\"\n").expect("write valid toml config");
+
+    let output = run_payload_with_config(&config_path);
+    assert!(
+        output.status.success(),
+        "existing config path should succeed"
+    );
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("Notice:"),
+        "loading an existing config must not emit a creation notice; stderr was:\n{stderr}"
+    );
+}
+
+#[test]
 fn test_existing_valid_json_config_path_is_parsed() {
     let dir = unique_temp_dir("cfg-existing-json");
     let config_path = dir.join("config.json");


### PR DESCRIPTION
## Problem

An explicit `--config <path>` pointing at a file that doesn't exist is silently scaffolded with a default template, and the scan then proceeds on **built-in defaults**. There's no output at all — exit 0, looks like a clean successful load.

This reproduces the exact footgun the adjacent malformed-config handling already guards against (`src/main.rs`, the `Warning: failed to load --config …` block):

- **Typo masks intent.** `--config ~/configs/prod-scan.toml` mistyped as `prod-scam.toml` doesn't error — dalfox fabricates a default file at the wrong path and runs with defaults, so the operator's `encoders` / `method` / `format` settings silently have no effect.
- **Unsolicited writes.** Pointing `--config` at a read location creates a file (and parent dirs) there.

Reproduce (before this change):
```
$ dalfox scan 'http://target/?q=1' --config /tmp/typo.toml
# ...runs, exit 0, no warning — and /tmp/typo.toml now exists with a default template
```

## Fix

Emit a stderr `Notice:` when a missing **explicit** `--config` path is auto-created, so the scaffolding is visible instead of masquerading as a successful load:

```
Notice: --config /tmp/typo.toml did not exist — created it with a default template and ran with built-in defaults (check the path if you meant to load an existing config)
```

- Goes to **stderr** — stdout stays clean, so machine-format (`json`/`jsonl`/`sarif`) output is unaffected (verified by the existing banner/format tests).
- Scoped to the **explicit-`--config`** path only. The implicit default-path init (`load_or_init`, `cli.config == None`) stays quiet on purpose so a first-time user isn't nagged about their bootstrapped `~/.config/dalfox/config.toml`.
- The scaffold behavior itself is **unchanged** — the file is still created and the run still succeeds; the existing `test_missing_{json,toml}_config_path_is_created` tests still pass.

## Tests

- `test_missing_config_path_creation_emits_notice_on_stderr` — notice appears on stderr, not stdout, file still created.
- `test_existing_config_path_emits_no_creation_notice` — control: loading an existing config emits no notice.
- Full `config_path_smoke_test` suite green (15/15); `cargo fmt --check` and `cargo clippy --all-targets` clean.

https://claude.ai/code/session_01USQAivAoSqGCbta2rPMTTQ