### PR TITLE
feat(payload): expand 'dalfox payload' selectors (special-chars, functions, awesome-alert, ...)

### DIFF
--- a/docs/content/guide/payloads.ko.md
+++ b/docs/content/guide/payloads.ko.md
@@ -123,8 +123,26 @@ dalfox https://target.app --remote-payloads portswigger,payloadbox
 dalfox payload event-handlers  # onerror, onmouseover, ...
 dalfox payload useful-tags     # svg, img, script, ...
 dalfox payload uri-scheme      # javascript:, data:
+dalfox payload special-chars   # < > " ' ` ( ) ... 및 인코딩된 변형
+dalfox payload functions       # 확인 가능한 싱크: alert(1), window['alert'](1), ...
+dalfox payload awesome-alert   # PoC alert: alert(document.domain), alert(document.cookie)
+dalfox payload dom-clobbering  # DOM 클로버링 벡터
+dalfox payload mxss            # mutation-XSS / 새니타이저 우회 페이로드
+dalfox payload blind           # blind-XSS 스켈레톤 ({} = 콜백 URL)
 dalfox payload portswigger     # 원격 목록을 가져와 출력
 ```
+
+모든 셀렉터는 한 줄에 하나씩 출력하므로 일반적인 셸 도구와 조합할 수 있습니다:
+
+```bash
+dalfox payload functions | grep -i prompt
+dalfox payload special-chars | wc -l
+```
+
+`special-chars` 그룹은 수동 반사 테스트에 유용합니다. 각 바이트를 하나씩 주입해 어떤 문자가
+그대로 반사되는지, 어떤 문자가 HTML/URL 인코딩되어 돌아오는지, 어떤 문자가 제거되는지 확인할 수
+있습니다. `functions` 와 `awesome-alert` 는 *눈으로* 실행을 확인하고 호스트/오리진을 표시하도록
+선별되어 있어, 스크린샷 한 장으로 영향을 증명할 수 있습니다.
 
 ## "alert" 커스터마이징
 

--- a/docs/content/guide/payloads.md
+++ b/docs/content/guide/payloads.md
@@ -147,8 +147,26 @@ Print a payload family without running a scan:
 dalfox payload event-handlers  # onerror, onmouseover, ...
 dalfox payload useful-tags     # svg, img, script, ...
 dalfox payload uri-scheme      # javascript:, data:
+dalfox payload special-chars   # < > " ' ` ( ) ... and encoded variants
+dalfox payload functions       # confirmable sinks: alert(1), window['alert'](1), ...
+dalfox payload awesome-alert   # PoC alerts: alert(document.domain), alert(document.cookie)
+dalfox payload dom-clobbering  # DOM clobbering vectors
+dalfox payload mxss            # mutation-XSS / sanitizer-bypass payloads
+dalfox payload blind           # blind-XSS skeletons ({} = your callback URL)
 dalfox payload portswigger     # fetch + print remote list
 ```
+
+Every selector prints one entry per line, so it composes with the usual shell tools:
+
+```bash
+dalfox payload functions | grep -i prompt
+dalfox payload special-chars | wc -l
+```
+
+The `special-chars` group is handy for manual reflection testing — inject each byte on
+its own to see which characters survive verbatim, which come back HTML/URL-encoded, and
+which are stripped. `functions` and `awesome-alert` are curated to *visibly* fire (and to
+render the host/origin), so a single screenshot proves impact.
 
 ## Customising the "alert"
 

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -218,6 +218,12 @@ dalfox payload <SELECTOR>
 | `event-handlers` | DOM 이벤트 핸들러 속성 이름 |
 | `useful-tags` | 유용한 HTML 태그 |
 | `uri-scheme` | `javascript:`/`data:` URL 페이로드 |
+| `special-chars` | 컨텍스트 프로빙용 특수 문자(및 인코딩된 변형) |
+| `functions` | 필터를 우회하는 변형이 포함된 확인 가능한 싱크(`alert`, `prompt`, ...) |
+| `awesome-alert` | 스크린샷용으로 다듬어진 alert PoC(`alert(document.domain)`, ...) |
+| `dom-clobbering` | DOM 클로버링 벡터 |
+| `mxss` | Mutation-XSS / 새니타이저 우회 페이로드 |
+| `blind` | Blind-XSS 스켈레톤(`{}` = OOB 콜백 URL) |
 | `portswigger` | 원격: PortSwigger XSS 치트시트 |
 | `payloadbox` | 원격: PayloadBox XSS 목록 |
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -218,6 +218,12 @@ Selectors:
 | `event-handlers` | DOM event handler attribute names |
 | `useful-tags` | Useful HTML tags |
 | `uri-scheme` | `javascript:`/`data:` URL payloads |
+| `special-chars` | Special characters (and encoded variants) for context probing |
+| `functions` | Confirmable sinks with filter-surviving variants (`alert`, `prompt`, ...) |
+| `awesome-alert` | Polished alert PoCs for screenshots (`alert(document.domain)`, ...) |
+| `dom-clobbering` | DOM clobbering vectors |
+| `mxss` | Mutation-XSS / sanitizer-bypass payloads |
+| `blind` | Blind-XSS skeletons (`{}` = your OOB callback URL) |
 | `portswigger` | Remote: PortSwigger XSS cheatsheet |
 | `payloadbox` | Remote: PayloadBox XSS list |
 

--- a/skills/dalfox/references/server-and-payload.md
+++ b/skills/dalfox/references/server-and-payload.md
@@ -57,6 +57,12 @@ Supported selectors:
 | (no arg) | Prints short help + summary of built-in JS payload count |
 | `event-handlers` | All common DOM event handler attribute names (`onclick`, `onload`, `onerror`, ...) |
 | `useful-tags` | HTML tags frequently useful for XSS (`script`, `img`, `svg`, `iframe`, `object`, ...) |
+| `special-chars` | Special characters + encoded variants for context probing / breakout (`<`, `>`, `"`, `&lt;`, `%3C`, ...) |
+| `functions` | Confirmable sinks with filter-surviving variants (`alert(1)`, `window['alert'](1)`, `setTimeout('alert(1)')`, ...) |
+| `awesome-alert` | Polished alert PoCs for clean screenshots (`alert(document.domain)`, `alert(document.cookie)`, ...) |
+| `dom-clobbering` | DOM clobbering vectors |
+| `mxss` | Mutation-XSS / sanitizer-bypass payloads |
+| `blind` | Blind-XSS skeletons (`{}` = your OOB callback URL) |
 | `payloadbox` | Fetches current remote XSS payloads from PayloadBox provider (requires network) |
 | `portswigger` | Fetches current remote XSS payloads from PortSwigger cheat sheet |
 | `uri-scheme` | Scheme-based payloads (`javascript:`, `data:text/html,...`, base64 variants, etc.) |

--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -8,6 +8,12 @@ const KNOWN_SELECTORS: &[&str] = &[
     "payloadbox",
     "portswigger",
     "uri-scheme",
+    "special-chars",
+    "functions",
+    "awesome-alert",
+    "dom-clobbering",
+    "mxss",
+    "blind",
 ];
 
 /// Manage or inspect payloads (no local flags).
@@ -19,13 +25,13 @@ const KNOWN_SELECTORS: &[&str] = &[
 #[derive(Args, Debug, Clone)]
 #[command(
     about = "Manage or inspect payloads",
-    long_about = "Selectors:\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)"
+    long_about = "Selectors:\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)"
 )]
 pub struct PayloadArgs {
     #[arg(
         value_name = "SELECTOR",
-        help = "Payload selector\nAvailable selectors:\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme",
-        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)"
+        help = "Payload selector\nAvailable selectors:\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme\n  - special-chars\n  - functions\n  - awesome-alert\n  - dom-clobbering\n  - mxss\n  - blind",
+        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)"
     )]
     pub selector: Option<String>,
 }
@@ -40,6 +46,83 @@ fn uri_scheme_payloads() -> &'static [&'static str] {
     ]
 }
 
+/// Special characters (and a few encoded variants) for context probing and
+/// breakout. Injecting these one at a time reveals how a sink reflects input:
+/// which bytes survive verbatim, which are HTML/URL-encoded, and which are
+/// stripped — the same signal the engine uses to pick a context-aware payload.
+fn special_chars_payloads() -> &'static [&'static str] {
+    &[
+        // Raw breakout characters
+        "<", ">", "\"", "'", "`", "(", ")", "{", "}", "[", "]", ";", "/", "=", "+", "%", "\\", "-",
+        "!", "&", // HTML entity variants
+        "&lt;", "&gt;", "&quot;", "&#39;", "&#x27;", "&apos;", "&#96;",
+        // URL-encoded variants
+        "%3C", "%3E", "%22", "%27", "%60", "%28", "%29", // Double URL-encoded
+        "%253C", "%253E", // Unicode escapes (JS string context)
+        "\\u003c", "\\u003e", "\\x3c", "\\x3e",
+    ]
+}
+
+/// Sinks that produce a **visibly confirmable** result, plus variants that
+/// survive common filters. If one of these fires you can *see* it, so impact is
+/// proven rather than inferred. Prefer these for manual verification.
+fn functions_payloads() -> &'static [&'static str] {
+    &[
+        // Canonical sinks
+        "alert(1)",
+        "prompt(1)",
+        "confirm(1)",
+        "print()",
+        // Grouping / property-access forms that dodge naive keyword filters
+        "(alert)(1)",
+        "(alert)`1`",
+        "window['alert'](1)",
+        "window[/**/'alert'](1)",
+        "self['alert'](1)",
+        "globalThis['alert'](1)",
+        "top.alert(1)",
+        "parent.alert(1)",
+        "this['alert'](1)",
+        // Tagged-template invocation (no parentheses)
+        "alert`1`",
+        // String-to-code sinks
+        "setTimeout('alert(1)')",
+        "setInterval('alert(1)')",
+        "Function('alert(1)')()",
+        "[].constructor.constructor('alert(1)')()",
+        "eval('alert(1)')",
+        // Reconstruct the keyword from fragments
+        "window['al'+'ert'](1)",
+        "top[8680439..toString(30)](1)",
+    ]
+}
+
+/// Polished, self-explanatory alert PoCs for clean screenshots, reports, and
+/// talks. Each renders the host/origin/cookie so the popup proves *where* it
+/// fired without any extra explanation.
+fn awesome_alert_payloads() -> &'static [&'static str] {
+    &[
+        "alert(document.domain)",
+        "alert(document.cookie)",
+        "alert(window.origin)",
+        "alert(location.href)",
+        "alert(document.location)",
+        "alert(`XSS on ${document.domain}`)",
+        "prompt(document.domain)",
+        "confirm(document.domain)",
+        "alert(navigator.userAgent)",
+        "alert(document.baseURI)",
+    ]
+}
+
+/// Print a list of owned strings one per line and log the count.
+fn print_lines(selector: &str, list: &[String]) {
+    for p in list.iter() {
+        println!("{}", p);
+    }
+    crate::dbg_log!("{}: {} items", selector, list.len());
+}
+
 fn print_summary() {
     let js_count = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len();
 
@@ -50,7 +133,13 @@ fn print_summary() {
     println!("  dalfox payload useful-tags");
     println!("  dalfox payload payloadbox");
     println!("  dalfox payload portswigger");
-    println!("  dalfox payload uri-scheme\n");
+    println!("  dalfox payload uri-scheme");
+    println!("  dalfox payload special-chars");
+    println!("  dalfox payload functions");
+    println!("  dalfox payload awesome-alert");
+    println!("  dalfox payload dom-clobbering");
+    println!("  dalfox payload mxss");
+    println!("  dalfox payload blind\n");
 
     println!("Summary:");
     println!("- Canonical JavaScript payloads: {}", js_count);
@@ -150,6 +239,52 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
                 println!("{}", payload);
             }
             crate::dbg_log!("uri-scheme: {} payloads", list.len());
+            ScanOutcome::Clean
+        }
+        Some("special-chars") => {
+            let list = special_chars_payloads();
+            for payload in list {
+                println!("{}", payload);
+            }
+            crate::dbg_log!("special-chars: {} items", list.len());
+            ScanOutcome::Clean
+        }
+        Some("functions") => {
+            let list = functions_payloads();
+            for payload in list {
+                println!("{}", payload);
+            }
+            crate::dbg_log!("functions: {} items", list.len());
+            ScanOutcome::Clean
+        }
+        Some("awesome-alert") => {
+            let list = awesome_alert_payloads();
+            for payload in list {
+                println!("{}", payload);
+            }
+            crate::dbg_log!("awesome-alert: {} items", list.len());
+            ScanOutcome::Clean
+        }
+        Some("dom-clobbering") => {
+            print_lines(
+                "dom-clobbering",
+                &crate::payload::get_dom_clobbering_payloads(),
+            );
+            ScanOutcome::Clean
+        }
+        Some("mxss") => {
+            print_lines("mxss", &crate::payload::get_mxss_payloads());
+            ScanOutcome::Clean
+        }
+        Some("blind") => {
+            // XSS_BLIND_PAYLOADS carries a `{}` placeholder for the OOB callback
+            // URL; keep it verbatim so the printed skeleton shows where the URL
+            // goes (users wire it up with `-b https://your-callback`).
+            let list: Vec<String> = crate::payload::XSS_BLIND_PAYLOADS
+                .iter()
+                .map(|s| s.to_string())
+                .collect();
+            print_lines("blind", &list);
             ScanOutcome::Clean
         }
         Some(other) => {

--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -115,10 +115,13 @@ fn awesome_alert_payloads() -> &'static [&'static str] {
     ]
 }
 
-/// Print a list of owned strings one per line and log the count.
-fn print_lines(selector: &str, list: &[String]) {
-    for p in list.iter() {
-        println!("{}", p);
+/// Print a list one entry per line and log the count. Generic over the element
+/// type so every listing selector — static `&[&str]` slices and owned
+/// `Vec<String>` families alike — emits through the same path with identical
+/// formatting and log wording.
+fn print_lines<T: std::fmt::Display>(selector: &str, list: &[T]) {
+    for entry in list.iter() {
+        println!("{}", entry);
     }
     crate::dbg_log!("{}: {} items", selector, list.len());
 }
@@ -204,19 +207,17 @@ fn fetch_and_print_remote(provider: &str) -> bool {
 pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
     match args.selector.as_deref() {
         Some("event-handlers") => {
-            let list = crate::payload::xss_event::common_event_handler_names();
-            for ev in list.iter() {
-                println!("{}", ev);
-            }
-            crate::dbg_log!("event-handlers: {} items", list.len());
+            print_lines(
+                "event-handlers",
+                crate::payload::xss_event::common_event_handler_names(),
+            );
             ScanOutcome::Clean
         }
         Some("useful-tags") => {
-            let list = crate::payload::xss_html::useful_html_tag_names();
-            for t in list.iter() {
-                println!("{}", t);
-            }
-            crate::dbg_log!("useful-tags: {} items", list.len());
+            print_lines(
+                "useful-tags",
+                crate::payload::xss_html::useful_html_tag_names(),
+            );
             ScanOutcome::Clean
         }
         Some("payloadbox") => {
@@ -234,35 +235,19 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
             }
         }
         Some("uri-scheme") => {
-            let list = uri_scheme_payloads();
-            for payload in list {
-                println!("{}", payload);
-            }
-            crate::dbg_log!("uri-scheme: {} payloads", list.len());
+            print_lines("uri-scheme", uri_scheme_payloads());
             ScanOutcome::Clean
         }
         Some("special-chars") => {
-            let list = special_chars_payloads();
-            for payload in list {
-                println!("{}", payload);
-            }
-            crate::dbg_log!("special-chars: {} items", list.len());
+            print_lines("special-chars", special_chars_payloads());
             ScanOutcome::Clean
         }
         Some("functions") => {
-            let list = functions_payloads();
-            for payload in list {
-                println!("{}", payload);
-            }
-            crate::dbg_log!("functions: {} items", list.len());
+            print_lines("functions", functions_payloads());
             ScanOutcome::Clean
         }
         Some("awesome-alert") => {
-            let list = awesome_alert_payloads();
-            for payload in list {
-                println!("{}", payload);
-            }
-            crate::dbg_log!("awesome-alert: {} items", list.len());
+            print_lines("awesome-alert", awesome_alert_payloads());
             ScanOutcome::Clean
         }
         Some("dom-clobbering") => {
@@ -278,13 +263,10 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
         }
         Some("blind") => {
             // XSS_BLIND_PAYLOADS carries a `{}` placeholder for the OOB callback
-            // URL; keep it verbatim so the printed skeleton shows where the URL
-            // goes (users wire it up with `-b https://your-callback`).
-            let list: Vec<String> = crate::payload::XSS_BLIND_PAYLOADS
-                .iter()
-                .map(|s| s.to_string())
-                .collect();
-            print_lines("blind", &list);
+            // URL; printed verbatim (as a value, never a format string) so the
+            // skeleton shows where the URL goes — users wire it up with
+            // `-b https://your-callback`.
+            print_lines("blind", crate::payload::XSS_BLIND_PAYLOADS);
             ScanOutcome::Clean
         }
         Some(other) => {

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -1,4 +1,7 @@
-use super::{PayloadArgs, fetch_and_print_remote, print_summary, run_payload, uri_scheme_payloads};
+use super::{
+    PayloadArgs, awesome_alert_payloads, fetch_and_print_remote, functions_payloads, print_summary,
+    run_payload, special_chars_payloads, uri_scheme_payloads,
+};
 use crate::cmd::scan::ScanOutcome;
 
 #[test]
@@ -10,8 +13,37 @@ fn test_uri_scheme_payloads_shape() {
 }
 
 #[test]
+fn test_curated_selector_lists_are_nonempty_and_clean() {
+    for list in [
+        special_chars_payloads(),
+        functions_payloads(),
+        awesome_alert_payloads(),
+    ] {
+        assert!(!list.is_empty());
+        assert!(list.iter().all(|p| !p.is_empty()));
+        // One entry per line: no embedded newlines.
+        assert!(list.iter().all(|p| !p.contains('\n')));
+    }
+    // Sanity: the confirmable-sink list surfaces the canonical alert sink and a
+    // filter-surviving variant; the PoC list renders the host.
+    assert!(functions_payloads().contains(&"alert(1)"));
+    assert!(functions_payloads().contains(&"window['alert'](1)"));
+    assert!(awesome_alert_payloads().contains(&"alert(document.domain)"));
+}
+
+#[test]
 fn test_run_payload_known_selectors_return_clean() {
-    for selector in ["event-handlers", "useful-tags", "uri-scheme"] {
+    for selector in [
+        "event-handlers",
+        "useful-tags",
+        "uri-scheme",
+        "special-chars",
+        "functions",
+        "awesome-alert",
+        "dom-clobbering",
+        "mxss",
+        "blind",
+    ] {
         let outcome = run_payload(PayloadArgs {
             selector: Some(selector.to_string()),
         });


### PR DESCRIPTION
Closes #1058

## Summary

Expands the selectors exposed by `dalfox payload <selector>` so users can inspect and reuse more payload groups directly from the CLI. Previously only `event-handlers`, `useful-tags`, `payloadbox`, `portswigger`, and `uri-scheme` were available.

## New selectors

| Selector | What it prints |
|----------|----------------|
| `special-chars` | Special characters + encoded variants for context probing / breakout (`<`, `>`, `"`, `&lt;`, `%3C`, `<`, ...) |
| `functions` | Confirmable sinks with filter-surviving variants (`alert(1)`, `(alert)(1)`, `window['alert'](1)`, `setTimeout('alert(1)')`, `Function('alert(1)')()`, ...) |
| `awesome-alert` | Polished alert PoCs for screenshots/demos (`alert(document.domain)`, `alert(document.cookie)`, `alert(window.origin)`, ...) |
| `dom-clobbering` | DOM clobbering vectors (exposes `get_dom_clobbering_payloads`) |
| `mxss` | Mutation-XSS / sanitizer-bypass payloads (exposes `get_mxss_payloads`) |
| `blind` | Blind-XSS skeletons (`{}` = your OOB callback URL) |

Each selector prints **one entry per line**, so it composes with the usual shell tools (`| grep`, `| wc -l`, `> file`). The three curated lists (`special-chars`, `functions`, `awesome-alert`) are deduplicated and prefer payloads that visibly fire / render the host.

## Acceptance criteria

- [x] New selectors added to `KNOWN_SELECTORS`, the `--help` / `long_about` text, and the no-arg summary in `src/cmd/payload.rs`.
- [x] `special-chars`, `functions`, `awesome-alert` each print one entry per line.
- [x] Docs updated: `docs/content/guide/payloads.md` "Inspecting payloads" section (+ KO, + `reference/cli.md`, + agent-skills reference).
- [x] Selector names kept consistent (kebab-case) with existing ones.

## Tests

- Added `test_curated_selector_lists_are_nonempty_and_clean` (non-empty, no blanks, one-per-line / no embedded newlines, canonical entries present).
- Extended `test_run_payload_known_selectors_return_clean` to cover all six new selectors.
- `cargo test --lib cmd::payload`, `cargo fmt`, `cargo clippy --lib` all clean.

## Notes

The issue also floated `csp-bypass` under "other useful groups" — deliberately left out because `get_csp_bypass_payloads` is context-dependent (requires a parsed `CspAnalysis`) and doesn't map cleanly to a static print. Happy to add a permissive-CSP synthesized view in a follow-up if wanted.