### PR TITLE
test(har): stop naming temp fixtures with a clock that cannot tell them apart

### DIFF
--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -2190,19 +2190,55 @@ mod har_input {
           "postData":{"mimeType":"application/x-www-form-urlencoded","text":"body=hi"}}}
     ]}}"#;
 
-    fn write_temp_har(body: &str) -> std::path::PathBuf {
+    /// Per-call sequence number for [`write_temp_har`]. **Not decoration.**
+    ///
+    /// The name used to be `pid + SystemTime::now().as_nanos()`, which is not
+    /// unique: `as_nanos()` reports nanoseconds but the clock behind it is
+    /// quantised far more coarsely (1 µs on macOS — 200k back-to-back reads
+    /// yield ~8.5k distinct values, and 8 threads sampling at once produced 7).
+    /// Every test below writes *different* HAR content through this one
+    /// helper, and they run in parallel in a single process, so a collision
+    /// means one test reads another's fixture and asserts against the wrong
+    /// entry count. That is the intermittent
+    /// `explicit_har_resolves_get_and_post_targets` failure.
+    ///
+    /// A monotonic counter cannot collide, so the name no longer depends on
+    /// clock resolution.
+    static HAR_SEQ: std::sync::atomic::AtomicU64 = std::sync::atomic::AtomicU64::new(0);
+
+    fn temp_har_path() -> std::path::PathBuf {
         let mut path = std::env::temp_dir();
-        let nanos = std::time::SystemTime::now()
-            .duration_since(std::time::UNIX_EPOCH)
-            .expect("system time")
-            .as_nanos();
         path.push(format!(
             "dalfox-har-test-{}-{}.har",
             std::process::id(),
-            nanos
+            HAR_SEQ.fetch_add(1, std::sync::atomic::Ordering::Relaxed)
         ));
+        path
+    }
+
+    fn write_temp_har(body: &str) -> std::path::PathBuf {
+        let path = temp_har_path();
         std::fs::write(&path, body).expect("write temp HAR");
         path
+    }
+
+    // Guards the fix above: if the name generator ever goes back to a
+    // timestamp, this fails instead of the HAR tests flaking once a fortnight.
+    #[test]
+    fn temp_har_paths_are_unique_under_parallel_use() {
+        let handles: Vec<_> = (0..16)
+            .map(|_| std::thread::spawn(|| (0..64).map(|_| temp_har_path()).collect::<Vec<_>>()))
+            .collect();
+        let all: Vec<std::path::PathBuf> = handles
+            .into_iter()
+            .flat_map(|h| h.join().expect("thread"))
+            .collect();
+        let unique: std::collections::HashSet<_> = all.iter().collect();
+        assert_eq!(
+            unique.len(),
+            all.len(),
+            "temp HAR paths must be unique across threads; every test writes different content to this helper"
+        );
     }
 
     #[tokio::test]


### PR DESCRIPTION
Root-cause for the intermittent `har_input::explicit_har_resolves_get_and_post_targets` failure I hit during today's review. It is an entry-count assertion, and nothing in the HAR path is timing-dependent — so the timing had to be somewhere else.

## The name is the bug

`write_temp_har` built its path from `pid + SystemTime::now().as_nanos()`. `as_nanos()` reports a unit the clock does not resolve. Measured on this machine:

```
distinct values from 200k reads: 8582      # a 1 µs step, not 1 ns
smallest observed step: 1000 ns
8 concurrent threads -> 7 distinct timestamps   # collision on the first try
```

Eight tests write **different** HAR bodies through that one helper, with no per-caller tag in the name, and they run in parallel in a single process. A collision means one test reads another's fixture and asserts against the wrong entry count — exactly the observed failure.

## Fix

Name from a monotonic `AtomicU64` instead, which cannot collide regardless of clock resolution.

Added `temp_har_paths_are_unique_under_parallel_use` (16 threads × 64 names) so a future "simplification" back to a timestamp fails loudly instead of resurfacing as a fortnightly flake. **Verified in both directions**: the guard fails on the old naming, passes on the new.

## Scope

Other temp-path helpers in the tree (`input/tests.rs`, `utils/fs/tests.rs`, `xss_common`, `xss_blind`, `mining`, `scan_run_paths_test`, `session_loss_test`, `config_path_smoke_test`) use the same `SystemTime` trick, but every one of them embeds a per-caller tag or prefix — a collision there would need the same test racing itself. Left alone.

Test-only change; no production code touched.