### PR TITLE
fix(scanning): stop reporting HTML-tag echoes in application/javascript as verified XSS

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -631,6 +631,25 @@ impl DomEvidenceKind {
             DomEvidenceKind::InlineHandlerBreakout => "inline handler JS breakout",
         }
     }
+
+    /// True when this evidence is derived from HTML-parsing the response body
+    /// (a DOM marker, a `javascript:` URL in an attribute, an injected element
+    /// carrying a sink handler, or a breakout of an existing `on*` handler).
+    ///
+    /// Such evidence only confirms exploitability when a browser actually parses
+    /// the body as markup. A response served as executable JavaScript
+    /// (`application/javascript`, JSONP) is run as script and never HTML-parsed,
+    /// so an HTML tag reflected into it is inert — only [`Self::JsContext`]
+    /// evidence (the payload runs as JavaScript) confirms XSS there.
+    pub(crate) fn requires_html_rendering(&self) -> bool {
+        match self {
+            DomEvidenceKind::Marker
+            | DomEvidenceKind::ExecutableUrl
+            | DomEvidenceKind::HtmlStructural
+            | DomEvidenceKind::InlineHandlerBreakout => true,
+            DomEvidenceKind::JsContext => false,
+        }
+    }
 }
 
 /// Returns the evidence kind that confirms the payload is exploitable, or
@@ -1055,15 +1074,31 @@ async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> DomVerifyO
         };
     }
 
+    // A response served as executable JavaScript (JSONP) is run as script and
+    // never HTML-parsed, so HTML-parse-derived evidence (a DOM marker, a
+    // `javascript:` attribute, an injected element/handler) found inside it is
+    // inert. Only JS-context evidence — the payload runs as JavaScript, the
+    // genuine JSONP-callback case — confirms XSS there. `text/plain` and empty
+    // content-types stay eligible for HTML-parse evidence (browsers sniff them).
+    let js_body_inert_to_markup = crate::utils::is_javascript_content_type(
+        headers
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok())
+            .unwrap_or(""),
+    );
+
     // Both HTML and non-HTML (JSONP, JSON with HTML) content types are accepted
-    // as long as there is reflection + marker/executable-URL evidence in the
-    // response. `reflected` is computed independently of `has_dom_evidence` so
-    // an inert echo (payload present, but not executable) is still reported as
-    // reflected for the DOM-phase early-exit signal.
+    // as long as there is reflection + qualifying DOM evidence in the response.
+    // `reflected` is computed independently of the evidence check so an inert
+    // echo (payload present, but not executable) is still reported as reflected
+    // for the DOM-phase early-exit signal.
     if let Ok(text) = crate::utils::http::read_body(resp).await {
         let reflected =
             crate::scanning::check_reflection::classify_reflection(&text, payload).is_some();
-        if reflected && has_dom_evidence(payload, &text) {
+        let verified = reflected
+            && classify_dom_evidence(payload, &text)
+                .is_some_and(|kind| !(js_body_inert_to_markup && kind.requires_html_rendering()));
+        if verified {
             return DomVerifyOutcome {
                 verified: true,
                 response_text: Some(text),

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -893,6 +893,36 @@ fn test_has_marker_evidence_entity_encoded_sink() {
     );
 }
 
+/// The evidence kinds derived from HTML-parsing the response body require the
+/// browser to actually render it as markup; JS-context evidence does not. This
+/// mapping gates the JSONP content-type false positive — HTML-parse evidence
+/// found in a `application/javascript` body is inert (the body runs as script).
+#[test]
+fn test_dom_evidence_kind_requires_html_rendering() {
+    use super::DomEvidenceKind::*;
+    assert!(Marker.requires_html_rendering());
+    assert!(ExecutableUrl.requires_html_rendering());
+    assert!(HtmlStructural.requires_html_rendering());
+    assert!(InlineHandlerBreakout.requires_html_rendering());
+    // JS-context evidence is valid on a JS body (the payload runs as script).
+    assert!(!JsContext.requires_html_rendering());
+}
+
+/// A JSONP-callback payload reflected as the callable identifier of a JS body
+/// (`callback=…` → `…({"data":1})`) must classify as JS-context evidence — the
+/// genuine JSONP XSS — and NOT rely on an HTML marker.
+#[test]
+fn test_jsonp_callback_payload_yields_js_context_evidence() {
+    for payload in crate::scanning::get_jsonp_callback_payloads() {
+        let body = format!("{payload}({{\"data\":1}})");
+        assert_eq!(
+            classify_dom_evidence(&payload, &body),
+            Some(super::DomEvidenceKind::JsContext),
+            "JSONP payload {payload:?} should verify via JS-context AST in body {body:?}"
+        );
+    }
+}
+
 /// Issue #1118: the public entry point used by the scan worker
 /// (`classify_dom_evidence`) must return `None` for a truncated-handler
 /// reflection — no fallback evidence path (HTML-structural, JS-context, inline

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1655,6 +1655,13 @@ pub struct ReflectionBody {
     /// Whether `text` is the response body a browser would actually parse and
     /// render as a document. `false` for the 3xx `Location:` stand-in.
     pub renderable: bool,
+    /// Whether the response was served as executable JavaScript
+    /// (`application/javascript`, JSONP). Such a body runs as script and is
+    /// never HTML-parsed, so HTML-parse-derived DOM evidence (markers,
+    /// `javascript:` attributes, injected elements) found inside it is inert —
+    /// only JS-context evidence confirms XSS. R→V upgraders that reuse this body
+    /// must consult it (see the static V-upgrade in `scanning::mod`).
+    pub js_content_type: bool,
 }
 
 impl ReflectionBody {
@@ -1663,7 +1670,14 @@ impl ReflectionBody {
         Self {
             text,
             renderable: true,
+            js_content_type: false,
         }
+    }
+
+    /// Mark the body as served with an executable-JavaScript content-type.
+    fn with_js_content_type(mut self, is_js: bool) -> Self {
+        self.js_content_type = is_js;
+        self
     }
 
     /// A stand-in for a 3xx `Location:` header value.
@@ -1676,6 +1690,7 @@ impl ReflectionBody {
         Self {
             text: format!("HTTP {} Location: {}", status_code, location),
             renderable: false,
+            js_content_type: false,
         }
     }
 
@@ -1972,6 +1987,16 @@ async fn fetch_injection_response_with_client(
         if let Ok(resp) = inject_resp {
             let status_code = resp.status().as_u16();
 
+            // Capture whether the body is served as executable JavaScript before
+            // `read_body` consumes the response, so the returned `ReflectionBody`
+            // can tell R→V upgraders that HTML-parse evidence is inert here.
+            let is_js_content_type = crate::utils::is_javascript_content_type(
+                resp.headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or(""),
+            );
+
             // Adaptive WAF accounting (per-worker streak + cooldown + telemetry).
             apply_injection_waf_accounting(status_code, target, args, streak).await;
 
@@ -2097,7 +2122,7 @@ async fn fetch_injection_response_with_client(
                         );
                         return None;
                     }
-                    Some(ReflectionBody::rendered(body))
+                    Some(ReflectionBody::rendered(body).with_js_content_type(is_js_content_type))
                 }
                 Err(e) => {
                     crate::dbg_log!(

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -398,6 +398,23 @@ fn get_js_breakout_payloads() -> Vec<String> {
     payloads
 }
 
+/// JSONP-callback payloads: reflected as the *callable identifier* of a
+/// `application/javascript` (JSONP) response — `callback=…` echoed into
+/// `…({"data":1})`. Each is executable JavaScript that calls a visible sink and
+/// comments-out / neutralises the trailing `({…})`, so `has_js_context_evidence`
+/// confirms a real `CallExpression` covered by the payload (the genuine JSONP
+/// XSS the `content_type_is_inert_data` carve-out keeps `application/javascript`
+/// scannable for). On an HTML body these parse-fail as whole-document
+/// JavaScript, so they add no false positives — only the DOM phase's
+/// content-type-aware JS-context check upgrades them to V.
+pub(crate) fn get_jsonp_callback_payloads() -> Vec<String> {
+    vec![
+        "alert(document.domain)//".to_string(),
+        ";alert(1)//".to_string(),
+        "-alert(1)-".to_string(),
+    ]
+}
+
 /// Round-robin interleave several payload families into one list so that any
 /// prefix samples *every* family proportionally (issue #1156). Used for the
 /// unknown-context DOM catalog so the recall-preserving DOM-phase early exit
@@ -444,6 +461,28 @@ pub(crate) fn effective_payload_cap(max_payloads: usize, deep_scan: bool) -> usi
 }
 
 pub(crate) fn get_dom_payloads(
+    param: &Param,
+    args: &ScanArgs,
+) -> Result<Vec<String>, Box<dyn std::error::Error>> {
+    let mut payloads = get_dom_payloads_for_context(param, args)?;
+
+    // Prepend JSONP-callback verifiers (raw, un-encoded) so a
+    // `application/javascript` endpoint that reflects the callable identifier is
+    // DOM-verified via JS-context evidence — the genuine JSONP XSS — instead of
+    // the false-positive HTML-marker echo the content-type gate now suppresses.
+    // Placed first so they land inside the DOM phase's inert-echo early-exit
+    // window; on an HTML body they parse-fail as whole-document JS and add no
+    // findings. Skipped only when the user restricts to custom payloads.
+    if !args.only_custom_payload {
+        let jsonp = get_jsonp_callback_payloads();
+        if !jsonp.is_empty() {
+            payloads.splice(0..0, jsonp);
+        }
+    }
+    Ok(payloads)
+}
+
+fn get_dom_payloads_for_context(
     param: &Param,
     args: &ScanArgs,
 ) -> Result<Vec<String>, Box<dyn std::error::Error>> {
@@ -1936,6 +1975,11 @@ impl ScanWorkerCtx {
             // per-payload hot loop.
             let renderable_text: Option<&str> =
                 reflection_body.as_ref().and_then(|b| b.renderable_text());
+            // A body served as executable JavaScript (JSONP) is run as script,
+            // never HTML-parsed, so HTML-parse-derived DOM evidence found in it
+            // is inert — an `<svg onload=…>` echo is a JS syntax error, not a
+            // rendered element. Only JS-context evidence upgrades R→V there.
+            let body_is_javascript = reflection_body.as_ref().is_some_and(|b| b.js_content_type);
 
             // AST-based DOM XSS analysis (enabled by default unless skipped)
             if !self.args.skip_ast_analysis
@@ -1964,6 +2008,43 @@ impl ScanWorkerCtx {
                 opb.inc(1);
             }
             if let Some(kind) = reflected_kind {
+                // Static V upgrade: reuse the reflection response body to look
+                // for browser-executable DOM evidence (marker, executable URL in
+                // a dangerous attribute, HTML element with a sink handler,
+                // JS-context sink call). Computed *before* the reflection lock so
+                // an inert JS-body echo can be handled without emitting a bogus
+                // finding.
+                //
+                // On a body served as executable JavaScript (JSONP), drop
+                // HTML-parse-derived evidence: the browser runs the body as
+                // script and never HTML-parses it, so a `<svg onload=…>` echo is
+                // a JS syntax error, not a rendered element. Only JS-context
+                // evidence (the payload runs as JavaScript) confirms XSS there;
+                // the dedicated DOM phase supplies JSONP-callable payloads that
+                // can prove that genuine V.
+                let dom_evidence_kind = renderable_text
+                    .and_then(|body| {
+                        crate::scanning::check_dom_verification::classify_dom_evidence(
+                            &reflection_payload,
+                            body,
+                        )
+                    })
+                    .filter(|kind| !(body_is_javascript && kind.requires_html_rendering()));
+
+                // An inert HTML echo into a JS body is not a finding. Lock the
+                // param's reflection slot (so the reflection phase stops here
+                // instead of hammering an endpoint that echoes every payload)
+                // but emit nothing, and leave `found.dom` unset so the DOM phase
+                // still runs — a JSONP-callable payload there can prove V.
+                if body_is_javascript && dom_evidence_kind.is_none() {
+                    if !self.args.deep_scan {
+                        let mut found = self.found_params.write().await;
+                        found.reflection.insert(param.name.clone());
+                        state.reflection_found_locally = true;
+                    }
+                    continue;
+                }
+
                 let should_add = if self.args.deep_scan {
                     true
                 } else {
@@ -2018,12 +2099,8 @@ impl ScanWorkerCtx {
                     // when angles are reported "invalid" at one of the
                     // reflection sites, and the prior `has_js_context_evidence`
                     // check only covered the `<script>`-block case.
-                    let dom_evidence_kind = renderable_text.and_then(|body| {
-                        crate::scanning::check_dom_verification::classify_dom_evidence(
-                            &reflection_payload,
-                            body,
-                        )
-                    });
+                    // (`dom_evidence_kind` is computed above, before the lock,
+                    // so a JS-body echo can be filtered without emitting an R.)
 
                     // Both arms come from the reflection phase, so the tier-derived
                     // default (`dom-verification` for V) would misattribute the

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -236,6 +236,31 @@ pub fn is_htmlish_content_type(ct: &str) -> bool {
     )
 }
 
+/// True when a response Content-Type declares an executable-JavaScript body
+/// (`application/javascript`, `text/javascript`, ECMAScript aliases). A browser
+/// runs these as script — it never parses the body as an HTML document — so an
+/// HTML tag reflected into such a response is inert as markup: `<svg onload=…>`
+/// echoed into a JS body is a syntax error, not a rendered element. Only a
+/// payload that executes *as JavaScript* (e.g. a JSONP callback name) is
+/// exploitable there.
+///
+/// Deliberately excludes `text/plain` and empty/missing types, which browsers
+/// content-sniff into HTML when `X-Content-Type-Options: nosniff` is absent.
+#[inline]
+pub fn is_javascript_content_type(ct: &str) -> bool {
+    let Some(primary) = content_type_primary(ct) else {
+        return false;
+    };
+    matches!(
+        primary.as_str(),
+        "application/javascript"
+            | "text/javascript"
+            | "application/ecmascript"
+            | "text/ecmascript"
+            | "application/x-javascript"
+    )
+}
+
 /// Allow-list check for content types that are still worth scanning for XSS,
 /// even when they are not directly HTML documents.
 ///

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -113,6 +113,23 @@ fn test_is_htmlish_content_type_deny_list() {
 }
 
 #[test]
+fn test_is_javascript_content_type() {
+    // Executable-JavaScript bodies: run as script, never HTML-parsed.
+    assert!(is_javascript_content_type("application/javascript"));
+    assert!(is_javascript_content_type("text/javascript; charset=utf-8"));
+    assert!(is_javascript_content_type("application/ecmascript"));
+    assert!(is_javascript_content_type("text/ecmascript"));
+    assert!(is_javascript_content_type("application/x-javascript"));
+    // Not JS: HTML, structured data, and the sniffable grey-zone types that
+    // browsers CAN render as HTML — these must stay eligible for HTML evidence.
+    assert!(!is_javascript_content_type("text/html"));
+    assert!(!is_javascript_content_type("application/json"));
+    assert!(!is_javascript_content_type("text/plain"));
+    assert!(!is_javascript_content_type("image/svg+xml"));
+    assert!(!is_javascript_content_type(""));
+}
+
+#[test]
 fn test_is_xss_scannable_content_type_allow_list() {
     assert!(is_xss_scannable_content_type("text/html"));
     assert!(is_xss_scannable_content_type("application/json"));

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -22,7 +22,8 @@ pub use scan_id::{make_scan_id, make_unique_scan_id, short_scan_id};
 pub use http::{
     apply_header_overrides, apply_headers_ua_cookies, build_preflight_request, build_request,
     build_request_with_cookie, compose_cookie_header_excluding, content_type_is_inert_data,
-    content_type_primary, is_htmlish_content_type, is_xss_scannable_content_type, send_with_retry,
+    content_type_primary, is_htmlish_content_type, is_javascript_content_type,
+    is_xss_scannable_content_type, send_with_retry,
 };
 
 // Re-export remote payload/wordlist getters at `crate::utils::*`

--- a/tests/integration/scan_verification.rs
+++ b/tests/integration/scan_verification.rs
@@ -196,6 +196,24 @@ async fn vuln_jsonp_callback(Query(p): Query<HashMap<String, String>>) -> impl I
     )
 }
 
+/// Inert-JSONP fixture: reflects the param into a *string literal* of a
+/// `application/javascript` body, with quotes escaped, so neither an HTML tag
+/// nor a callback-name injection executes. A browser runs the body as script
+/// (never HTML-parses it), so an `<svg onload=…>` echo here is inert. dalfox
+/// must NOT report a marker-based V — regression guard for the JSONP
+/// content-type false positive.
+async fn safe_js_string_literal_appjs(
+    Query(p): Query<HashMap<String, String>>,
+) -> impl IntoResponse {
+    let q = p.get("q").cloned().unwrap_or_default();
+    let escaped = q.replace('\\', "\\\\").replace('"', "\\\"");
+    (
+        axum::http::StatusCode::OK,
+        [(axum::http::header::CONTENT_TYPE, "application/javascript")],
+        format!("var config = \"{escaped}\";"),
+    )
+}
+
 /// Mirrors brutelogic c1 / c5: HTML-entity-encodes `'` and `<` of the param
 /// and reflects inside a single-quoted JS string. Not exploitable: entities
 /// don't decode inside `<script>`. Used to verify R suppression.
@@ -491,6 +509,7 @@ async fn start_test_server() -> SocketAddr {
         .route("/js/raw", get(vuln_js_raw))
         .route("/js/inline-event", get(vuln_inline_event))
         .route("/safe/js-apos-encoded", get(safe_js_apos_encoded))
+        .route("/safe/js-string-appjs", get(safe_js_string_literal_appjs))
         .route("/jsonp", get(vuln_jsonp_callback))
         // Reflected: CSS
         .route("/css/style", get(vuln_css_style))
@@ -849,6 +868,45 @@ async fn test_jsonp_callback_endpoint_yields_verified() {
         &findings,
         "V",
         "JSONP callback reflection should produce V via JS-context fallback",
+    );
+    // The V must come from the JS-context AST evidence (the payload executes as
+    // JavaScript when the JSONP is loaded via <script src>), NOT from
+    // HTML-parsing the application/javascript body for a DOM marker — a browser
+    // never HTML-parses a JS response, so a marker-based V there is a false
+    // positive. Pin the mechanism so a regression can't silently reinstate it.
+    let v_evidence: Vec<&str> = findings
+        .iter()
+        .filter(|f| f["type"].as_str() == Some("V"))
+        .filter_map(|f| f["evidence"].as_str())
+        .collect();
+    assert!(
+        v_evidence.iter().any(|e| e.contains("JS-context")),
+        "JSONP V must be JS-context AST evidence, not an HTML DOM marker; got: {v_evidence:?}"
+    );
+    assert!(
+        !v_evidence.iter().any(|e| e.contains("DOM marker")),
+        "JSONP must not be verified via an HTML DOM marker on a application/javascript body; got: {v_evidence:?}"
+    );
+}
+
+/// Regression guard for the JSONP content-type false positive: an HTML-tag
+/// payload echoed into a `application/javascript` string literal is inert (the
+/// body runs as script, never HTML-parsed; the string is quote-escaped so no
+/// callback injection executes). It must not be reported as a verified (V)
+/// finding via the DOM-marker path.
+#[tokio::test]
+async fn test_appjs_string_literal_no_false_v() {
+    let addr = start_test_server().await;
+    let mut args = base_scan_args();
+    args.targets = vec![format!("http://{addr}/safe/js-string-appjs?q=test")];
+    let findings = run_scan_and_collect(args).await;
+    assert!(
+        !findings.iter().any(|f| f["type"].as_str() == Some("V")),
+        "inert application/javascript string-literal echo must not yield a false V, got: {:?}",
+        findings
+            .iter()
+            .map(|f| (f["type"].as_str(), f["evidence"].as_str()))
+            .collect::<Vec<_>>()
     );
 }
 


### PR DESCRIPTION
## Problem

A parameter reflected into an `application/javascript` (JSONP) response was reported as **`V` / High / verified**:

```
evidence: DOM verification successful for param q (DOM marker)
payload:  <svg onload=alert(1) class=dlx…>
```

This is a **false positive**. A browser runs a JS response as script and never HTML-parses it, so `<svg onload=…>` echoed into a JS body is a syntax error, not a rendered element. It also contradicts dalfox's own `content_type_is_inert_data` rationale — `application/javascript` is kept scannable because a reflected **callback name** is executable via `<script src>`, and an HTML tag is not a callback name.

Root cause: two R→V upgrade paths (the reflection-phase static upgrade in `scanning/mod.rs` and `verify_normal_dom`) ran the HTML-parse marker check on the JS body with **no content-type gate**. The existing `test_jsonp_callback_endpoint_yields_verified` was passing via this FP path — not the "JS-context AST fallback" its comment claimed.

## Fix

1. **Gate HTML-parse evidence** — `DomEvidenceKind::requires_html_rendering()` (marker / `javascript:`-URL attribute / injected element / inline-handler breakout) is dropped on JavaScript content-types; only `JsContext` (payload runs *as JS*) confirms XSS there. Added `utils::is_javascript_content_type()` (excludes `text/plain`/empty — those content-sniff to HTML). Threaded via a new `ReflectionBody.js_content_type` captured before the body is consumed.
2. **Preserve genuine JSONP detection** — added JSONP-callable DOM payloads (`alert(document.domain)//`, `;alert(1)//`, `-alert(1)-`) so the DOM phase verifies real callback injection via JS-context AST. On a JS body the reflection phase now locks the param's reflection slot **without emitting** the inert HTML echo (bounds request volume) and lets the DOM phase prove the V.

## Results

| Case | Before | After |
|---|---|---|
| JSONP callable (`cb → cb({...})`) | V via DOM marker (wrong mechanism) | **V via JS-context AST** ✅ |
| Inert JS-string echo in `application/javascript` | **false V** | no V ✅ |
| HTML endpoint | V via marker (168 reqs) | unchanged (168 reqs) ✅ |
| Escaped/safe | none | none ✅ |

## Tests

- Unit: `is_javascript_content_type`, `requires_html_rendering`, JSONP payload → JS-context evidence.
- Integration: JSONP V mechanism pinned to JS-context (not DOM marker); inert `application/javascript` echo yields no V.
- Full suite green (2069 lib + 208 integration/functional), clippy clean.

> ⚠️ Touches the tuned precision/recall core; validated locally + against the mock/functional suite but **not** against xssmaze. Worth a benchmark pass to confirm recall.