### PR TITLE
test: cover the --hpp phase, probe request shapes, /preflight success, and mining collapse

### DIFF
--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1127,3 +1127,117 @@ fn test_has_knockout_html_clause_boundary_cases() {
     assert!(!has_knockout_html_clause("text: foo"));
     assert!(!has_knockout_html_clause(""));
 }
+
+/// A page with exactly 15 distinct field names that echoes *every* query
+/// parameter. 15 is deliberate: the sentinel pre-probe only runs above
+/// `SENTINEL_PROBE_COUNT * 5`, so this shape slips past it and forces the
+/// adaptive EWMA collapse instead — the branch that was never exercised.
+async fn reflect_everything_handler(Query(params): Query<HashMap<String, String>>) -> Html<String> {
+    let echoed: String = params.values().cloned().collect::<Vec<_>>().join(" ");
+    let mut form = String::from("<form>");
+    for i in 0..15 {
+        form.push_str(&format!("<input id=\"f{i}\" name=\"f{i}\" value=\"seed\">"));
+    }
+    form.push_str("</form>");
+    Html(format!("{form}<div>{echoed}</div>"))
+}
+
+async fn start_reflect_everything_server() -> SocketAddr {
+    let app = Router::new().route("/echo-all", get(reflect_everything_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+/// DOM mining against a reflect-everything page must collapse to the single
+/// synthetic `any` param instead of reporting one finding per field. This is an
+/// anti-amplification guard: without it the scan fans every payload out across
+/// every echoed name, which is where request counts explode on self-reflecting
+/// endpoints. The collapse block had no coverage at all.
+#[tokio::test]
+async fn test_probe_response_id_params_collapses_reflect_everything_page_to_any() {
+    let addr = start_reflect_everything_server().await;
+    let target = parse_target(&format!("http://{}:{}/echo-all", addr.ip(), addr.port()))
+        .expect("parse target");
+    let args = default_scan_args();
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(4));
+
+    probe_response_id_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    let query_params: Vec<_> = params
+        .iter()
+        .filter(|p| p.location == Location::Query)
+        .collect();
+    assert_eq!(
+        query_params.len(),
+        1,
+        "a reflect-everything page must collapse to exactly one Query param, got: {:?}",
+        params.iter().map(|p| &p.name).collect::<Vec<_>>()
+    );
+    assert_eq!(
+        query_params[0].name, "any",
+        "the collapsed param must be the synthetic `any`"
+    );
+    assert!(
+        query_params[0].injection_context.is_some(),
+        "the collapsed param must keep an injection context so payload selection still works"
+    );
+}
+
+/// The collapse rewrites the Query slice in place, so params discovered through
+/// other channels (a mined Body param, here) must survive it. Dropping them
+/// would silently un-scan every non-query surface on any self-reflecting page.
+#[tokio::test]
+async fn test_dom_mining_collapse_preserves_non_query_params() {
+    let addr = start_reflect_everything_server().await;
+    let target = parse_target(&format!("http://{}:{}/echo-all", addr.ip(), addr.port()))
+        .expect("parse target");
+    let args = default_scan_args();
+    let reflection_params = Arc::new(Mutex::new(vec![Param {
+        name: "body_field".to_string(),
+        value: "v".to_string(),
+        location: Location::Body,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    }]));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(4));
+
+    probe_response_id_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "body_field" && p.location == Location::Body),
+        "the pre-existing Body param must survive the Query collapse, got: {:?}",
+        params
+            .iter()
+            .map(|p| (&p.name, &p.location))
+            .collect::<Vec<_>>()
+    );
+    assert_eq!(
+        params
+            .iter()
+            .filter(|p| p.location == Location::Query)
+            .count(),
+        1,
+        "still exactly one collapsed Query param"
+    );
+}

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1412,3 +1412,202 @@ fn test_effective_wire_name() {
     };
     assert_eq!(plain.effective_wire_name(), "q");
 }
+
+// ─────────────────────────────────────────────────────────────────────────
+// `send_probe_request_for_param` — request-shape coverage for the body
+// locations that only had unreachable-endpoint (failure-path) tests.
+//
+// These arms decide what actually goes on the wire for the special-character
+// probe. When the probe request carries no payload, every special classifies
+// as invalid and the param's `<`/`>` payloads get pruned — a silent false
+// negative rather than an error (see the multipart absent-param fix, #1260 /
+// #1261). Asserting the response text is not enough for that class of bug;
+// these tests assert the request the server actually received.
+// ─────────────────────────────────────────────────────────────────────────
+
+/// Echoes the raw request body back inside an HTML shell so the probe's
+/// marker/special extraction sees exactly what was sent, and records each body
+/// for direct assertions on the request shape.
+async fn start_body_echo_server(
+    seen: std::sync::Arc<std::sync::Mutex<Vec<String>>>,
+) -> std::net::SocketAddr {
+    use axum::{Router, extract::State, response::Html};
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    async fn echo(
+        State(seen): State<std::sync::Arc<std::sync::Mutex<Vec<String>>>>,
+        body: String,
+    ) -> Html<String> {
+        seen.lock().expect("record body").push(body.clone());
+        Html(format!("<div>{}</div>", body))
+    }
+
+    let app = Router::new()
+        .route("/echo", axum::routing::post(echo))
+        .with_state(seen);
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+/// The scanned multipart param is absent from the captured body: the exact-match
+/// loop never places it, so the `!placed` fallback must append it. Without that
+/// fallback the probe carries no payload and the param's angle-bracket payloads
+/// are pruned as "invalid".
+#[tokio::test]
+async fn active_probe_multipart_appends_param_absent_from_captured_body() {
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let addr = start_body_echo_server(seen.clone()).await;
+    let mut target = parse_target(&format!("http://{addr}/echo")).unwrap();
+    target.method = "POST".to_string();
+    target.data = Some("other=seed".to_string());
+
+    let res = active_probe_param(
+        &target,
+        probe_param("q", Location::MultipartBody),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    let bodies = seen.lock().expect("bodies").clone();
+    assert!(!bodies.is_empty(), "the probe must have reached the server");
+    let first = &bodies[0];
+    assert!(
+        first.contains("name=\"q\""),
+        "the absent param must be appended as a multipart field, got: {first}"
+    );
+    assert!(
+        first.contains("name=\"other\""),
+        "the captured field must be preserved, got: {first}"
+    );
+    let valid = res.valid_specials.clone().unwrap_or_default();
+    assert!(
+        valid.contains(&'<') && valid.contains(&'>'),
+        "the echoed payload must classify angle brackets as valid; got {valid:?}"
+    );
+}
+
+/// The scanned param *is* in the captured body: it must be replaced with the
+/// payload (the `placed` arm) while every sibling field keeps its captured
+/// value (the `else` arm).
+#[tokio::test]
+async fn active_probe_multipart_replaces_present_param_and_keeps_siblings() {
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let addr = start_body_echo_server(seen.clone()).await;
+    let mut target = parse_target(&format!("http://{addr}/echo")).unwrap();
+    target.method = "POST".to_string();
+    target.data = Some("q=seed&other=keepme".to_string());
+
+    let _ = active_probe_param(
+        &target,
+        probe_param("q", Location::MultipartBody),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    let bodies = seen.lock().expect("bodies").clone();
+    let first = bodies.first().cloned().unwrap_or_default();
+    assert!(
+        first.contains("keepme"),
+        "sibling field values must be preserved verbatim, got: {first}"
+    );
+    assert!(
+        !first.contains("seed"),
+        "the scanned param's captured value must be replaced by the payload, got: {first}"
+    );
+    // Exactly one `q` field — the fallback must not double-append it.
+    assert_eq!(
+        first.matches("name=\"q\"").count(),
+        1,
+        "the replaced param must not also be appended, got: {first}"
+    );
+}
+
+/// A captured JSON body whose root is not an object (an array, here) must be
+/// replaced by a fresh single-key object rather than dropped — otherwise the
+/// probe body carries no payload at all.
+#[tokio::test]
+async fn active_probe_json_body_replaces_non_object_root_with_object() {
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let addr = start_body_echo_server(seen.clone()).await;
+    let mut target = parse_target(&format!("http://{addr}/echo")).unwrap();
+    target.method = "POST".to_string();
+    target.data = Some("[1,2,3]".to_string());
+
+    let res = active_probe_param(
+        &target,
+        probe_param("q", Location::JsonBody),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    let bodies = seen.lock().expect("bodies").clone();
+    let first = bodies.first().cloned().unwrap_or_default();
+    let parsed: serde_json::Value =
+        serde_json::from_str(&first).expect("probe body must still be valid JSON");
+    assert!(
+        parsed.get("q").and_then(|v| v.as_str()).is_some(),
+        "the array root must be replaced by an object keyed on the param, got: {first}"
+    );
+    let valid = res.valid_specials.clone().unwrap_or_default();
+    assert!(
+        !valid.is_empty(),
+        "the payload must have been echoed back for classification"
+    );
+}
+
+/// Fragment params are DOM-side: the fragment never travels to the server, so
+/// the probe must still send a well-formed request whose path and query are
+/// untouched. A fragment builder that leaked into the query would silently
+/// change which endpoint gets probed.
+#[tokio::test]
+async fn active_probe_fragment_leaves_path_and_query_intact() {
+    use axum::{Router, extract::State, http::Uri, response::Html, routing::get};
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    async fn record(
+        State(seen): State<std::sync::Arc<std::sync::Mutex<Vec<String>>>>,
+        uri: Uri,
+    ) -> Html<String> {
+        seen.lock().expect("record uri").push(uri.to_string());
+        Html("<div>ok</div>".to_string())
+    }
+
+    let seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/p", get(record))
+        .with_state(seen.clone());
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let target = parse_target(&format!("http://{addr}/p?a=1")).unwrap();
+    let _ = active_probe_param(
+        &target,
+        probe_param("f", Location::Fragment),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    let uris = seen.lock().expect("uris").clone();
+    assert!(!uris.is_empty(), "the fragment probe must still be sent");
+    for uri in &uris {
+        assert_eq!(
+            uri, "/p?a=1",
+            "the fragment must not leak into the request line"
+        );
+    }
+}

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -2163,3 +2163,175 @@ fn test_occurrence_inside_url_attr_value_handles_query_string() {
     let pos3 = h3.find("zzmarker").unwrap();
     assert!(!occurrence_inside_url_attr_value(h3.as_bytes(), pos3));
 }
+
+// ---------------------------------------------------------------------------
+// `check_reflection_with_hpp_url` — the request path behind `--hpp`.
+//
+// This function had no test at all: every one of its branches (the
+// skip/ignore-status early returns, the redirect-Location check, the capped
+// body read, the safe-context demotion) was exercised only by a live `--hpp`
+// scan. It is also the one reflection entry point that takes a pre-built URL
+// string instead of deriving it from the target, so a malformed URL from
+// `build_hpp_url` degrades here rather than at the call site.
+// ---------------------------------------------------------------------------
+
+/// Happy path: the duplicated-parameter URL is sent verbatim and the payload
+/// echoed by the server is classified as a reflection, with the body returned
+/// as evidence.
+#[tokio::test]
+async fn test_hpp_reflection_detects_echo_and_returns_body() {
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/reflect/raw");
+    let param = make_param();
+    let args = default_scan_args();
+    let client = target.build_client_or_default();
+    // What `build_hpp_url(.., HppPosition::Last)` produces for this target.
+    let hpp_url = format!(
+        "http://{}:{}/reflect/raw?q=seed&q=DALFOXHPP",
+        addr.ip(),
+        addr.port()
+    );
+
+    let (kind, body) =
+        check_reflection_with_hpp_url(&client, &target, &param, "DALFOXHPP", &hpp_url, &args).await;
+
+    assert!(
+        kind.is_some(),
+        "duplicated param echo must classify as a reflection"
+    );
+    assert!(
+        body.unwrap_or_default().contains("DALFOXHPP"),
+        "the response body must be returned as evidence"
+    );
+}
+
+/// `--skip-xss-scanning` must short-circuit before any request is made, or the
+/// analysis-only modes (preflight, REST/MCP preflight) would still attack.
+#[tokio::test]
+async fn test_hpp_reflection_respects_skip_xss_scanning() {
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/reflect/raw");
+    let param = make_param();
+    let mut args = default_scan_args();
+    args.skip_xss_scanning = true;
+    let client = target.build_client_or_default();
+    let hpp_url = format!(
+        "http://{}:{}/reflect/raw?q=seed&q=DALFOXHPP",
+        addr.ip(),
+        addr.port()
+    );
+
+    let (kind, body) =
+        check_reflection_with_hpp_url(&client, &target, &param, "DALFOXHPP", &hpp_url, &args).await;
+
+    assert!(kind.is_none() && body.is_none());
+}
+
+/// A status code in `--ignore-return` must suppress the finding even though the
+/// body reflects — this is how users mute WAF block pages that echo the input.
+#[tokio::test]
+async fn test_hpp_reflection_honors_ignore_return() {
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/reflect/raw");
+    let param = make_param();
+    let mut args = default_scan_args();
+    args.ignore_return = vec![200];
+    let client = target.build_client_or_default();
+    let hpp_url = format!(
+        "http://{}:{}/reflect/raw?q=seed&q=DALFOXHPP",
+        addr.ip(),
+        addr.port()
+    );
+
+    let (kind, body) =
+        check_reflection_with_hpp_url(&client, &target, &param, "DALFOXHPP", &hpp_url, &args).await;
+
+    assert!(
+        kind.is_none() && body.is_none(),
+        "an ignored status must not produce a finding or leak the body"
+    );
+}
+
+/// A redirect whose `Location` carries the payload is a reflection too: the
+/// body is empty, so only the header check can catch it.
+#[tokio::test]
+async fn test_hpp_reflection_detects_payload_in_redirect_location() {
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/redirect/decoded");
+    let param = make_param();
+    let args = default_scan_args();
+    let client = target.build_client_or_default();
+    let hpp_url = format!(
+        "http://{}:{}/redirect/decoded?q=seed&q=DALFOXHPP",
+        addr.ip(),
+        addr.port()
+    );
+
+    let (kind, evidence) =
+        check_reflection_with_hpp_url(&client, &target, &param, "DALFOXHPP", &hpp_url, &args).await;
+
+    assert!(
+        kind.is_some(),
+        "payload echoed into Location must be detected"
+    );
+    let evidence = evidence.unwrap_or_default();
+    assert!(
+        evidence.starts_with("/final?next=") && evidence.contains("DALFOXHPP"),
+        "the Location header must be returned as the evidence, got: {evidence}"
+    );
+}
+
+/// No echo -> no finding, but the body still comes back so callers can log it.
+#[tokio::test]
+async fn test_hpp_reflection_reports_no_kind_when_not_reflected() {
+    let addr = start_mock_server("stored").await;
+    let target = make_target(addr, "/reflect/none");
+    let param = make_param();
+    let args = default_scan_args();
+    let client = target.build_client_or_default();
+    let hpp_url = format!(
+        "http://{}:{}/reflect/none?q=seed&q=DALFOXHPP",
+        addr.ip(),
+        addr.port()
+    );
+
+    let (kind, body) =
+        check_reflection_with_hpp_url(&client, &target, &param, "DALFOXHPP", &hpp_url, &args).await;
+
+    assert!(kind.is_none());
+    assert!(body.unwrap_or_default().contains("not reflected"));
+}
+
+/// The HPP URL arrives as an already-serialized string. If it fails to parse,
+/// the scan must fall back to the target URL rather than panic or skip the
+/// param silently — `build_hpp_url` writes raw payload bytes into the query, so
+/// an unparseable result is reachable, not theoretical.
+#[tokio::test]
+async fn test_hpp_reflection_falls_back_to_target_url_when_hpp_url_is_unparseable() {
+    let addr = start_mock_server("stored").await;
+    // Target URL already carries `?q=seed`, so the fallback request reflects
+    // "seed" and not the payload.
+    let target = make_target(addr, "/reflect/raw");
+    let param = make_param();
+    let args = default_scan_args();
+    let client = target.build_client_or_default();
+
+    let (kind, body) = check_reflection_with_hpp_url(
+        &client,
+        &target,
+        &param,
+        "DALFOXHPP",
+        ":::not a url:::",
+        &args,
+    )
+    .await;
+
+    assert!(
+        kind.is_none(),
+        "the fallback request carries no payload, so nothing must be reported"
+    );
+    assert!(
+        body.unwrap_or_default().contains("seed"),
+        "the fallback must have hit the target URL"
+    );
+}

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2530,3 +2530,196 @@ fn test_extract_meta_csp_returns_report_only_when_no_enforcing() {
     assert_eq!(name, "Content-Security-Policy-Report-Only");
     assert!(content.contains("default-src 'self'"));
 }
+
+/// End-to-end coverage for the `--hpp` phase, which had none: `run_hpp_phase`
+/// and the `check_reflection_with_hpp_url` it drives were both fully untested,
+/// so an `inHTML-HPP` finding was never produced by any test.
+///
+/// The mock target models the shape HPP exists to defeat: the sanitizer runs on
+/// the *first* occurrence of `q`, while the reflection uses the *last* one. A
+/// single-parameter request (what the reflection phase sends) is therefore
+/// always sanitized and finds nothing — only the duplicated-parameter URL gets
+/// the payload through. That makes the assertion specific to the HPP phase
+/// rather than something the reflection phase could have produced.
+#[tokio::test]
+async fn test_run_scanning_hpp_phase_reports_duplicated_param_bypass() {
+    use axum::{Router, extract::RawQuery, response::Html, routing::get};
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::time::{Duration, sleep};
+
+    async fn hpp_handler(RawQuery(raw): RawQuery) -> Html<String> {
+        let raw = raw.unwrap_or_default();
+        let values: Vec<String> = raw
+            .split('&')
+            .filter_map(|pair| pair.strip_prefix("q="))
+            .map(|v| urlencoding::decode(v).unwrap_or_default().into_owned())
+            .collect();
+        if values.is_empty() {
+            return Html("<div>no q</div>".to_string());
+        }
+        // Sanitizer inspects the first occurrence...
+        let first = &values[0];
+        if first.contains('<') || first.contains('>') {
+            return Html("<div>blocked</div>".to_string());
+        }
+        // ...but the page renders the last one, raw.
+        Html(format!("<div>{}</div>", values[values.len() - 1]))
+    }
+
+    let app = Router::new().route("/", get(hpp_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let url = format!("http://{}/?q=safe", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.reflection_params.push(Param {
+        name: "q".to_string(),
+        value: "safe".to_string(),
+        location: Location::Query,
+        injection_context: Some(InjectionContext::Html(None)),
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    });
+
+    let mut args = integration_scan_args(false);
+    args.hpp = true;
+    let args = Arc::new(args);
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        args,
+        results.clone(),
+        None,
+        None,
+        Arc::new(AtomicUsize::new(0)),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let guard = results.lock().await;
+    let hpp: Vec<_> = guard
+        .iter()
+        .filter(|r| r.inject_type == "inHTML-HPP")
+        .collect();
+    assert!(
+        !hpp.is_empty(),
+        "the first-occurrence-sanitized / last-occurrence-rendered shape must \
+         yield an inHTML-HPP finding; got: {:?}",
+        guard
+            .iter()
+            .map(|r| (&r.result_type, r.inject_type.as_str()))
+            .collect::<Vec<_>>()
+    );
+    let finding = hpp[0];
+    // Pin the reporting contract for the HPP finding: these fields are what
+    // distinguishes it from a plain reflection in JSON/SARIF output.
+    assert_eq!(finding.param, "q");
+    assert_eq!(finding.message_id, 606);
+    assert_eq!(finding.severity, "Info");
+    assert_eq!(finding.location, "Query");
+    assert!(
+        finding.data.contains("q=") && finding.data.matches("q=").count() >= 2,
+        "the reported URL must be the duplicated-parameter one, got: {}",
+        finding.data
+    );
+    assert!(
+        finding.evidence.contains("HPP bypass") && finding.evidence.contains("position="),
+        "evidence must name the HPP position, got: {}",
+        finding.evidence
+    );
+    // Only one HPP finding per param — the phase breaks out after the first hit.
+    assert_eq!(
+        hpp.len(),
+        1,
+        "run_hpp_phase must report at most one finding per param"
+    );
+}
+
+/// The HPP phase is opt-in. Without `--hpp` the same target must produce no
+/// HPP finding, so the flag gate in `run_hpp_phase` (and the payload-cloning
+/// gate in `scan_param` that mirrors it) stays honest.
+#[tokio::test]
+async fn test_run_scanning_without_hpp_flag_reports_no_hpp_finding() {
+    use axum::{Router, extract::RawQuery, response::Html, routing::get};
+    use std::net::{Ipv4Addr, SocketAddr};
+    use tokio::time::{Duration, sleep};
+
+    async fn echo_last_q(RawQuery(raw): RawQuery) -> Html<String> {
+        let raw = raw.unwrap_or_default();
+        let last = raw
+            .split('&')
+            .filter_map(|pair| pair.strip_prefix("q="))
+            .next_back()
+            .unwrap_or("");
+        Html(format!(
+            "<div>{}</div>",
+            urlencoding::decode(last).unwrap_or_default()
+        ))
+    }
+
+    let app = Router::new().route("/", get(echo_last_q));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let url = format!("http://{}/?q=safe", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.reflection_params.push(Param {
+        name: "q".to_string(),
+        value: "safe".to_string(),
+        location: Location::Query,
+        injection_context: Some(InjectionContext::Html(None)),
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    });
+
+    let args = Arc::new(integration_scan_args(false));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        args,
+        results.clone(),
+        None,
+        None,
+        Arc::new(AtomicUsize::new(0)),
+        None,
+        None,
+        None,
+    )
+    .await;
+
+    let guard = results.lock().await;
+    assert!(
+        guard.iter().all(|r| r.inject_type != "inHTML-HPP"),
+        "HPP findings must require --hpp"
+    );
+}

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -123,6 +123,79 @@ fn test_path_injection_basic() {
     assert!(out.contains("/a/PAY%20LOAD/c"));
 }
 
+/// Only the space arm of the path-segment encoder was exercised. The rest of
+/// the table encodes the characters that would otherwise *truncate or reshape*
+/// the URL — `#` starts a fragment, `?` starts a query, `%` would corrupt the
+/// following bytes, and CR/LF/TAB are request-splitting material. If any arm
+/// regressed to a raw push the injected payload would silently land in a
+/// different URL component than the path segment under test.
+#[test]
+fn test_path_injection_encodes_url_structural_characters() {
+    let base = make_url("https://example.com/a/b/c");
+    let param = Param {
+        name: "path_segment_1".into(),
+        value: "b".into(),
+        location: Location::Path,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    let out = build_injected_url(&base, &param, "x#y?z%w\nq\tr\ns");
+    assert!(
+        out.contains("%23") && out.contains("%3F") && out.contains("%25"),
+        "#, ? and % must be percent-encoded, got: {out}"
+    );
+    assert!(
+        out.contains("%0A") && out.contains("%09"),
+        "LF and TAB must be percent-encoded, got: {out}"
+    );
+    // The payload must stay inside the path: no fragment, no query.
+    assert!(
+        !out.contains('#') && !out.contains('?'),
+        "structural characters leaked out of the path segment: {out}"
+    );
+    assert!(out.starts_with("https://example.com/a/"));
+    assert!(out.ends_with("/c"));
+}
+
+/// CR is on the encode table too, but a bare `\r` in a path is also something
+/// `Url::set_path` would reject or rewrite — pin that the encoder gets there
+/// first and the result stays a well-formed URL.
+#[test]
+fn test_path_injection_encodes_carriage_return() {
+    let base = make_url("https://example.com/a/b");
+    let param = Param {
+        name: "path_segment_1".into(),
+        value: "b".into(),
+        location: Location::Path,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    let out = build_injected_url(&base, &param, "a\rb");
+    assert!(
+        out.contains("%0D"),
+        "CR must be percent-encoded, got: {out}"
+    );
+    assert!(!out.contains('\r'), "raw CR must not survive: {out:?}");
+}
+
 #[test]
 fn test_path_injection_index_out_of_bounds() {
     let base = make_url("https://example.com/a");
@@ -404,6 +477,89 @@ fn test_hpp_absent_param_appended() {
     let out = build_hpp_url(&base, &param, "XSS", HppPosition::Last).unwrap();
     assert!(out.contains("other=1"));
     assert!(out.contains("q=&q=XSS"));
+}
+
+/// The append branch (param absent from the original query) has one arm per
+/// position, and only `Last` was covered. `First`/`Both` emit the *same*
+/// pair ordering as their replace-branch counterparts — a mismatch here would
+/// mean `--hpp` silently probes only one real ordering on mined/dictionary
+/// params, which are exactly the ones absent from the URL.
+#[test]
+fn test_hpp_absent_param_appended_first_position() {
+    let base = make_url("https://example.com/path?other=1");
+    let param = Param {
+        name: "q".into(),
+        value: "safe".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    let out = build_hpp_url(&base, &param, "XSS", HppPosition::First).unwrap();
+    assert_eq!(out, "https://example.com/path?other=1&q=XSS&q=safe");
+}
+
+#[test]
+fn test_hpp_absent_param_appended_both_position() {
+    let base = make_url("https://example.com/path?other=1");
+    let param = Param {
+        name: "q".into(),
+        value: "safe".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    let out = build_hpp_url(&base, &param, "XSS", HppPosition::Both).unwrap();
+    assert_eq!(out, "https://example.com/path?other=1&q=XSS&q=XSS");
+}
+
+/// Appending onto a URL with *no* existing query must not emit a leading `&`
+/// (`?&q=...`), which several servers parse as an empty first parameter and
+/// which would make the whole HPP probe malformed.
+#[test]
+fn test_hpp_absent_param_appended_on_bare_url_has_no_leading_amp() {
+    let base = make_url("https://example.com/path");
+    let param = Param {
+        name: "q".into(),
+        value: "safe".into(),
+        location: Location::Query,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    for (position, expected) in [
+        (HppPosition::Last, "https://example.com/path?q=safe&q=XSS"),
+        (HppPosition::First, "https://example.com/path?q=XSS&q=safe"),
+        (HppPosition::Both, "https://example.com/path?q=XSS&q=XSS"),
+    ] {
+        let out = build_hpp_url(&base, &param, "XSS", position).unwrap();
+        assert_eq!(out, expected, "position {:?}", position);
+    }
 }
 
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3706,3 +3706,118 @@ async fn test_suggested_poll_interval_is_monotonic_in_progress() {
         "a nearly-finished scan should be polled fastest"
     );
 }
+
+// ---- /preflight success path ----
+//
+// Only the rejection paths (bad URL, bad method, missing auth, unreachable
+// target) were covered. Everything after the reachability probe — building the
+// preflight ScanArgs, running discovery, and turning the discovered params into
+// the estimate the REST contract publishes — had no test, so the shape of a
+// successful response and the arithmetic behind `estimated_total_requests`
+// could drift silently.
+
+/// A reachable, reflecting target must come back `reachable: true` with one
+/// entry per discovered param and a total that is exactly the sum of the
+/// per-param estimates. Clients budget scan time off these numbers.
+#[tokio::test]
+async fn test_preflight_handler_success_reports_params_and_consistent_estimate() {
+    let addr = start_reflecting_target_server().await;
+    let state = make_state(None, None, false, false, "cb");
+    let resp = preflight_handler(
+        State(state),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            target: format!("http://{addr}/?q=1"),
+            options: Some(ScanOptions {
+                timeout: Some(5),
+                skip_mining: Some(true),
+                ..ScanOptions::default()
+            }),
+        })),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let parsed: serde_json::Value =
+        serde_json::from_str(&response_body_string(resp).await).expect("json");
+    let data = &parsed["data"];
+    assert_eq!(data["reachable"], true);
+    assert_eq!(data["method"], "GET");
+
+    let params = data["params"].as_array().expect("params array");
+    assert_eq!(
+        data["params_discovered"].as_u64().expect("count") as usize,
+        params.len(),
+        "params_discovered must match the params array length"
+    );
+    assert!(
+        !params.is_empty(),
+        "a reflecting target must yield at least one discovered param, got {data}"
+    );
+    for p in params {
+        assert!(p["name"].is_string(), "each param must carry a name: {p}");
+        assert!(
+            p["location"].is_string(),
+            "each param must carry a location: {p}"
+        );
+    }
+
+    let summed: u64 = params
+        .iter()
+        .map(|p| p["estimated_requests"].as_u64().unwrap_or(0))
+        .sum();
+    assert_eq!(
+        data["estimated_total_requests"].as_u64().expect("total"),
+        summed,
+        "the total must be the sum of the per-param estimates"
+    );
+    assert!(summed > 0, "a scannable param must bill a nonzero estimate");
+}
+
+/// `encoders: ["none"]` collapses the encoder fan-out factor to 1, so the
+/// estimate must come out strictly lower than the multi-encoder default. This
+/// is the one knob in the request that changes the arithmetic rather than the
+/// param set, and it is what callers reach for to preview a cheap scan.
+#[tokio::test]
+async fn test_preflight_handler_encoder_none_lowers_the_estimate() {
+    let addr = start_reflecting_target_server().await;
+
+    async fn estimate_for(addr: SocketAddr, encoders: Option<Vec<String>>) -> u64 {
+        let state = make_state(None, None, false, false, "cb");
+        let resp = preflight_handler(
+            State(state),
+            HeaderMap::new(),
+            Query(Map::new()),
+            Ok(Json(ScanRequest {
+                target: format!("http://{addr}/?q=1"),
+                options: Some(ScanOptions {
+                    timeout: Some(5),
+                    skip_mining: Some(true),
+                    encoders,
+                    ..ScanOptions::default()
+                }),
+            })),
+        )
+        .await
+        .into_response();
+        assert_eq!(resp.status(), StatusCode::OK);
+        let parsed: serde_json::Value =
+            serde_json::from_str(&response_body_string(resp).await).expect("json");
+        parsed["data"]["estimated_total_requests"]
+            .as_u64()
+            .expect("total")
+    }
+
+    let default_estimate = estimate_for(addr, None).await;
+    let none_estimate = estimate_for(addr, Some(vec!["none".to_string()])).await;
+    assert!(
+        default_estimate > 0 && none_estimate > 0,
+        "both runs must discover the reflecting param (default={default_estimate}, none={none_estimate})"
+    );
+    assert!(
+        none_estimate < default_estimate,
+        "`encoders: [none]` must shrink the estimate; got none={none_estimate} default={default_estimate}"
+    );
+}


### PR DESCRIPTION
Fills the lowest-value coverage gaps by targeting whole **features that had no runtime test at all**, rather than chasing file percentages. Tests only — no production code changed.

Measured with the same command CI uses (`cargo llvm-cov --all-features --workspace`), then mapped every uncovered line block back to its owning function.

## What was uncovered

| Cluster | Before | Why it mattered |
|---|---|---|
| **`--hpp` end-to-end** | 0% — `run_hpp_phase`, `check_reflection_with_hpp_url`, and the append arms of `build_hpp_url` | a shipped user-facing flag with no test whatsoever |
| **`send_probe_request_for_param`** | multipart / `Fragment` / non-object-JSON arms untested | where the #1260/#1261 multipart absent-param FN lived; a regression here is silent (specials misclassify → payloads pruned), not an error |
| **`/preflight` success path** | only rejection paths tested | the estimate is a published REST contract |
| **DOM-mining collapse-to-`any`** | 0% | anti-amplification guard against reflect-everything endpoints |

Note `scanning/url_inject.rs` sat at 89% while `--hpp` inside it was at 0% — the file percentage hid the untested feature.

## Notes on the tests

- The HPP end-to-end target sanitizes the **first** occurrence of a param and renders the **last**, so a single-param request (what the reflection phase sends) can never satisfy the assertion. Paired with an opt-in-gate counter-case that pins no HPP finding without `--hpp`.
- The probe tests assert **the request the server received**, not the response text — the multipart absent-param class of bug produces a well-formed request carrying no payload, which response-only assertions cannot catch.
- The mining collapse test uses exactly 15 candidate fields on purpose: the sentinel pre-probe only runs above `SENTINEL_PROBE_COUNT * 5`, so this shape slips past it and forces the adaptive EWMA collapse — the branch that was actually uncovered.

## Verification

- Mutation-checked rather than trusting a green run: disabling the multipart `!placed` fallback makes `active_probe_multipart_appends_param_absent_from_captured_body` fail.
- Confirmed via a targeted coverage run that the mining tests hit the EWMA collapse branch and **not** the sentinel pre-probe, which also collapses to `any` — they would have passed either way.
- `cargo fmt` + `cargo clippy --all-targets --all-features` clean; full suite green (2103 lib + all integration bins).

## Coverage

**86.76% → 87.67% lines** (regions 86.88% → 87.90%, functions 91.02% → 91.48%)

| File | Before | After | Uncovered lines |
|---|---|---|---|
| `scanning/url_inject.rs` | 89.1% | **97.3%** | 36 → 9 |
| `server/handlers.rs` | 80.7% | **88.7%** | 157 → 92 |
| `parameter_analysis/mod.rs` | 81.7% | **87.2%** | 163 → 114 |
| `scanning/check_reflection.rs` | 84.6% | **88.4%** | 195 → 147 |
| `scanning/mod.rs` | 85.8% | **88.6%** | 208 → 167 |
| `parameter_analysis/mining.rs` | 75.7% | **78.2%** | 341 → 306 |

The +0.91% total understates this — the percentage is dominated by large async orchestrators that can't be reached from unit tests.

## Deliberately not addressed

`cmd/scan/input.rs` (73.6%) is mostly stdin branches, and `resolve_targets` calls `std::io::stdin()` internally rather than taking a reader, so those need a subprocess e2e test. Same class: `cmd/scan/mod.rs` (58.2%), `analysis.rs` (61.7%), `scan_loop.rs` (66.1%) — each is one large async orchestrator. Closing those is a test-harness change, not more tests.

Still genuinely unit-testable and left open: `parameter_analysis/discovery.rs` (73%, the `check_form_discovery` inline-JSON and `JSON.stringify` body-discovery paths, ~130 lines) and the rest of `mining.rs`.