### PR TITLE
refactor: consolidate duplicated body-injection builders into url_inject

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -306,27 +306,8 @@ async fn send_probe_request_for_param(
             request_builder = client.request(req_method, url);
         }
         Location::Body => {
-            let body_string;
-            if let Some(d) = &data {
-                let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(d.as_bytes())
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                let mut found = false;
-                for (k, v) in &mut pairs {
-                    if *k == param_name {
-                        *v = payload.to_string();
-                        found = true;
-                    }
-                }
-                if !found {
-                    pairs.push((param_name.clone(), payload.to_string()));
-                }
-                body_string = url::form_urlencoded::Serializer::new(String::new())
-                    .extend_pairs(pairs)
-                    .finish();
-            } else {
-                body_string = format!("{}={}", param_name, payload);
-            }
+            let body_string =
+                crate::scanning::url_inject::urlencoded_body(data.as_deref(), &param_name, payload);
             request_builder = client
                 .request(req_method, action_resolved_url.clone())
                 .header("Content-Type", "application/x-www-form-urlencoded")
@@ -421,34 +402,8 @@ async fn send_probe_request_for_param(
                 .body(body_string);
         }
         Location::MultipartBody => {
-            let mut form = reqwest::multipart::Form::new();
-            let mut placed = false;
-            if let Some(d) = &data {
-                for pair in d.split('&') {
-                    if let Some((k, v)) = pair.split_once('=') {
-                        let k = urlencoding::decode(k)
-                            .unwrap_or(std::borrow::Cow::Borrowed(k))
-                            .to_string();
-                        let v = urlencoding::decode(v)
-                            .unwrap_or(std::borrow::Cow::Borrowed(v))
-                            .to_string();
-                        if k == param_name {
-                            form = form.text(k, payload.to_string());
-                            placed = true;
-                        } else {
-                            form = form.text(k, v);
-                        }
-                    }
-                }
-            }
-            // Append the param as a new field only when the exact-match loop
-            // didn't already inject it. The old `!data.contains(name)` substring
-            // guard skipped this whenever `name` was a substring of another key
-            // or value, sending the probe with no payload (so all specials
-            // classified invalid and the param's <,> payloads were pruned).
-            if !placed {
-                form = form.text(param_name.clone(), payload.to_string());
-            }
+            let form =
+                crate::scanning::url_inject::multipart_form(data.as_deref(), &param_name, payload);
             request_builder = client
                 .request(req_method, action_resolved_url.clone())
                 .multipart(form);

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -843,33 +843,11 @@ fn build_body_request(
     encoded_payload: &str,
 ) -> reqwest::RequestBuilder {
     let parsed_url = resolve_form_action_url(param, target);
-    let body = if let Some(ref data) = target.data {
-        let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(data.as_bytes())
-            .map(|(k, v)| (k.to_string(), v.to_string()))
-            .collect();
-        let mut found = false;
-        for pair in &mut pairs {
-            if pair.0 == param.name {
-                pair.1 = encoded_payload.to_string();
-                found = true;
-                break;
-            }
-        }
-        if !found {
-            pairs.push((param.name.clone(), encoded_payload.to_string()));
-        }
-        Some(
-            url::form_urlencoded::Serializer::new(String::new())
-                .extend_pairs(&pairs)
-                .finish(),
-        )
-    } else {
-        Some(format!(
-            "{}={}",
-            urlencoding::encode(&param.name),
-            urlencoding::encode(encoded_payload)
-        ))
-    };
+    let body = Some(crate::scanning::url_inject::urlencoded_body(
+        target.data.as_deref(),
+        &param.name,
+        encoded_payload,
+    ));
     let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
@@ -888,27 +866,12 @@ fn build_json_body_request(
     encoded_payload: &str,
 ) -> reqwest::RequestBuilder {
     let parsed_url = resolve_form_action_url(param, target);
-    let body = if let Some(ref data) = target.data {
-        if let Ok(mut json_val) = serde_json::from_str::<serde_json::Value>(data) {
-            if let Some(obj) = json_val.as_object_mut() {
-                obj.insert(
-                    param.name.clone(),
-                    serde_json::Value::String(encoded_payload.to_string()),
-                );
-            }
-            Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
-        } else if param.value.is_empty() {
-            // An empty `param.value` would make `str::replace` splice the payload
-            // between every byte of `data` (empty-pattern match), sending a
-            // garbled body. Re-serialize as `{name: payload}`, matching the
-            // no-data branch and the PoC builder in `scanning::mod`.
-            Some(serde_json::json!({ &param.name: encoded_payload }).to_string())
-        } else {
-            Some(data.replace(&param.value, encoded_payload))
-        }
-    } else {
-        Some(serde_json::json!({ &param.name: encoded_payload }).to_string())
-    };
+    let body = Some(crate::scanning::url_inject::json_body(
+        target.data.as_deref(),
+        &param.name,
+        &param.value,
+        encoded_payload,
+    ));
     let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     let base = crate::utils::build_request(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
@@ -924,34 +887,11 @@ fn build_multipart_request(
     encoded_payload: &str,
 ) -> reqwest::RequestBuilder {
     let parsed_url = resolve_form_action_url(param, target);
-    let mut form = reqwest::multipart::Form::new();
-    if let Some(ref data) = target.data {
-        let mut found = false;
-        for pair in data.split('&') {
-            if let Some((k, v)) = pair.split_once('=') {
-                let k = urlencoding::decode(k)
-                    .unwrap_or(std::borrow::Cow::Borrowed(k))
-                    .to_string();
-                let v = urlencoding::decode(v)
-                    .unwrap_or(std::borrow::Cow::Borrowed(v))
-                    .to_string();
-                if k == param.name {
-                    form = form.text(k, encoded_payload.to_string());
-                    found = true;
-                } else {
-                    form = form.text(k, v);
-                }
-            }
-        }
-        // A verified param absent from the captured body must still be injected,
-        // or the verification request carries no payload and can never confirm
-        // the finding. Mirrors the reflection/probe multipart builders.
-        if !found {
-            form = form.text(param.name.clone(), encoded_payload.to_string());
-        }
-    } else {
-        form = form.text(param.name.clone(), encoded_payload.to_string());
-    }
+    let form = crate::scanning::url_inject::multipart_form(
+        target.data.as_deref(),
+        &param.name,
+        encoded_payload,
+    );
     let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
     crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
 }

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1761,33 +1761,11 @@ async fn fetch_injection_response_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let body = if let Some(ref data) = target.data {
-                let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(data.as_bytes())
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                let mut found = false;
-                for pair in &mut pairs {
-                    if pair.0 == param.name {
-                        pair.1 = encoded_payload.to_string();
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    pairs.push((param.name.clone(), encoded_payload.to_string()));
-                }
-                Some(
-                    url::form_urlencoded::Serializer::new(String::new())
-                        .extend_pairs(&pairs)
-                        .finish(),
-                )
-            } else {
-                Some(format!(
-                    "{}={}",
-                    urlencoding::encode(&param.name),
-                    urlencoding::encode(&encoded_payload)
-                ))
-            };
+            let body = Some(crate::scanning::url_inject::urlencoded_body(
+                target.data.as_deref(),
+                &param.name,
+                &encoded_payload,
+            ));
             let rb = crate::utils::build_request(client, target, method, parsed_url, body);
             rb.header("Content-Type", "application/x-www-form-urlencoded")
         }
@@ -1801,30 +1779,12 @@ async fn fetch_injection_response_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let body = if let Some(ref data) = target.data {
-                // Attempt to parse as JSON and replace the param value
-                if let Ok(mut json_val) = serde_json::from_str::<serde_json::Value>(data) {
-                    if let Some(obj) = json_val.as_object_mut() {
-                        obj.insert(
-                            param.name.clone(),
-                            serde_json::Value::String(encoded_payload.to_string()),
-                        );
-                    }
-                    Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
-                } else if param.value.is_empty() {
-                    // An empty `param.value` makes `str::replace` splice the
-                    // payload between every byte of `data` (empty-pattern match),
-                    // sending a garbled body that never carries a clean injection.
-                    // Re-serialize as `{name: payload}`, matching the no-data
-                    // branch and the PoC builder in `scanning::mod`.
-                    Some(serde_json::json!({ &param.name: &*encoded_payload }).to_string())
-                } else {
-                    // Fallback: simple string replacement of the param's original value
-                    Some(data.replace(&param.value, &encoded_payload))
-                }
-            } else {
-                Some(serde_json::json!({ &param.name: &*encoded_payload }).to_string())
-            };
+            let body = Some(crate::scanning::url_inject::json_body(
+                target.data.as_deref(),
+                &param.name,
+                &param.value,
+                &encoded_payload,
+            ));
             let rb = crate::utils::build_request(client, target, method, parsed_url, body);
             rb.header("Content-Type", "application/json")
         }
@@ -1836,35 +1796,11 @@ async fn fetch_injection_response_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let mut form = reqwest::multipart::Form::new();
-            if let Some(ref data) = target.data {
-                let mut found = false;
-                for pair in data.split('&') {
-                    if let Some((k, v)) = pair.split_once('=') {
-                        let k = urlencoding::decode(k)
-                            .unwrap_or(std::borrow::Cow::Borrowed(k))
-                            .to_string();
-                        let v = urlencoding::decode(v)
-                            .unwrap_or(std::borrow::Cow::Borrowed(v))
-                            .to_string();
-                        if k == param.name {
-                            form = form.text(k, encoded_payload.to_string());
-                            found = true;
-                        } else {
-                            form = form.text(k, v);
-                        }
-                    }
-                }
-                // An injected param absent from the captured body must still be
-                // sent, or the request carries no payload and a real reflection
-                // is missed entirely. Mirrors the Body branch's `if !found` push
-                // and the same guard already in parameter_analysis mining/probe.
-                if !found {
-                    form = form.text(param.name.clone(), encoded_payload.to_string());
-                }
-            } else {
-                form = form.text(param.name.clone(), encoded_payload.to_string());
-            }
+            let form = crate::scanning::url_inject::multipart_form(
+                target.data.as_deref(),
+                &param.name,
+                &encoded_payload,
+            );
             crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
         }
         _ => {

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -46,33 +46,11 @@ pub async fn verify_dom_xss_light_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let body = if let Some(ref data) = target.data {
-                let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(data.as_bytes())
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                let mut found = false;
-                for pair in &mut pairs {
-                    if pair.0 == param.name {
-                        pair.1 = payload.to_string();
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    pairs.push((param.name.clone(), payload.to_string()));
-                }
-                Some(
-                    url::form_urlencoded::Serializer::new(String::new())
-                        .extend_pairs(&pairs)
-                        .finish(),
-                )
-            } else {
-                Some(format!(
-                    "{}={}",
-                    urlencoding::encode(&param.name),
-                    urlencoding::encode(payload)
-                ))
-            };
+            let body = Some(crate::scanning::url_inject::urlencoded_body(
+                target.data.as_deref(),
+                &param.name,
+                payload,
+            ));
             crate::utils::build_request(client, target, body_method, parsed_url, body)
         }
         Location::JsonBody => {
@@ -81,27 +59,12 @@ pub async fn verify_dom_xss_light_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let body = if let Some(ref data) = target.data {
-                if let Ok(mut json_val) = serde_json::from_str::<serde_json::Value>(data) {
-                    if let Some(obj) = json_val.as_object_mut() {
-                        obj.insert(
-                            param.name.clone(),
-                            serde_json::Value::String(payload.to_string()),
-                        );
-                    }
-                    Some(serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone()))
-                } else if param.value.is_empty() {
-                    // An empty `param.value` makes `str::replace` splice the
-                    // payload between every byte of `data`, sending a garbled
-                    // body. Re-serialize as `{name: payload}`, matching the
-                    // no-data branch and the PoC builder in `scanning::mod`.
-                    Some(serde_json::json!({ &param.name: payload }).to_string())
-                } else {
-                    Some(data.replace(&param.value, payload))
-                }
-            } else {
-                Some(serde_json::json!({ &param.name: payload }).to_string())
-            };
+            let body = Some(crate::scanning::url_inject::json_body(
+                target.data.as_deref(),
+                &param.name,
+                &param.value,
+                payload,
+            ));
             let rb = crate::utils::build_request(client, target, body_method, parsed_url, body);
             rb.header("Content-Type", "application/json")
         }
@@ -111,35 +74,11 @@ pub async fn verify_dom_xss_light_with_client(
                 .as_ref()
                 .and_then(|u| url::Url::parse(u).ok())
                 .unwrap_or_else(|| target.url.clone());
-            let mut form = reqwest::multipart::Form::new();
-            if let Some(ref data) = target.data {
-                let mut found = false;
-                for pair in data.split('&') {
-                    if let Some((k, v)) = pair.split_once('=') {
-                        let k = urlencoding::decode(k)
-                            .unwrap_or(std::borrow::Cow::Borrowed(k))
-                            .to_string();
-                        let v = urlencoding::decode(v)
-                            .unwrap_or(std::borrow::Cow::Borrowed(v))
-                            .to_string();
-                        if k == param.name {
-                            form = form.text(k, payload.to_string());
-                            found = true;
-                        } else {
-                            form = form.text(k, v);
-                        }
-                    }
-                }
-                // Mirror the `Body` branch: an injected param that isn't already
-                // in the captured body must still be sent, or the payload never
-                // reaches the server and verification silently fails (e.g. an
-                // explicit `--param` not present in the imported multipart body).
-                if !found {
-                    form = form.text(param.name.clone(), payload.to_string());
-                }
-            } else {
-                form = form.text(param.name.clone(), payload.to_string());
-            }
+            let form = crate::scanning::url_inject::multipart_form(
+                target.data.as_deref(),
+                &param.name,
+                payload,
+            );
             crate::utils::build_request(client, target, body_method, parsed_url, None)
                 .multipart(form)
         }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -911,56 +911,20 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
     // target has no original `data`, so the displayed PoC isn't an empty POST.
     let (body, content_type): (Option<String>, Option<&'static str>) = match param.location {
         Location::Body => {
-            let body = if let Some(data) = &target.data {
-                let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(data.as_bytes())
-                    .map(|(k, v)| (k.to_string(), v.to_string()))
-                    .collect();
-                let mut found = false;
-                for pair in &mut pairs {
-                    if pair.0 == param.name {
-                        pair.1 = payload.to_string();
-                        found = true;
-                        break;
-                    }
-                }
-                if !found {
-                    pairs.push((param.name.clone(), payload.to_string()));
-                }
-                url::form_urlencoded::Serializer::new(String::new())
-                    .extend_pairs(&pairs)
-                    .finish()
-            } else {
-                format!(
-                    "{}={}",
-                    urlencoding::encode(&param.name),
-                    urlencoding::encode(payload)
-                )
-            };
+            let body = crate::scanning::url_inject::urlencoded_body(
+                target.data.as_deref(),
+                &param.name,
+                payload,
+            );
             (Some(body), Some("application/x-www-form-urlencoded"))
         }
         Location::JsonBody => {
-            let body = if let Some(data) = &target.data {
-                if let Ok(mut json_val) = serde_json::from_str::<serde_json::Value>(data) {
-                    if let Some(obj) = json_val.as_object_mut() {
-                        obj.insert(
-                            param.name.clone(),
-                            serde_json::Value::String(payload.to_string()),
-                        );
-                    }
-                    serde_json::to_string(&json_val).unwrap_or_else(|_| data.clone())
-                } else if param.value.is_empty() {
-                    // An empty `param.value` would make `str::replace` splice the
-                    // payload between every byte of `data` (empty-pattern match),
-                    // producing a garbled PoC. Re-serialize as `{name: payload}`
-                    // instead — identical to the no-data branch below and to what
-                    // `inject_payload` actually sends for invalid-JSON bodies.
-                    serde_json::json!({ &param.name: payload }).to_string()
-                } else {
-                    data.replace(&param.value, payload)
-                }
-            } else {
-                serde_json::json!({ &param.name: payload }).to_string()
-            };
+            let body = crate::scanning::url_inject::json_body(
+                target.data.as_deref(),
+                &param.name,
+                &param.value,
+                payload,
+            );
             (Some(body), Some("application/json"))
         }
         Location::MultipartBody => (target.data.clone(), Some("multipart/form-data")),

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -505,5 +505,109 @@ pub fn build_hpp_urls(
         .collect()
 }
 
+/// Build an `application/x-www-form-urlencoded` body that carries `value` for
+/// `name`, replacing the existing value when the param is already present and
+/// appending it otherwise.
+///
+/// This is the single source of truth for form-body injection. It was
+/// previously copy-pasted (byte-identical) across the reflection check, light
+/// verify, DOM verify, and PoC builders; keeping one implementation prevents
+/// the drift those parallel copies were prone to.
+pub fn urlencoded_body(data: Option<&str>, name: &str, value: &str) -> String {
+    match data {
+        Some(data) => {
+            let mut pairs: Vec<(String, String)> = url::form_urlencoded::parse(data.as_bytes())
+                .map(|(k, v)| (k.to_string(), v.to_string()))
+                .collect();
+            let mut found = false;
+            for pair in &mut pairs {
+                if pair.0 == name {
+                    pair.1 = value.to_string();
+                    found = true;
+                    break;
+                }
+            }
+            if !found {
+                pairs.push((name.to_string(), value.to_string()));
+            }
+            url::form_urlencoded::Serializer::new(String::new())
+                .extend_pairs(&pairs)
+                .finish()
+        }
+        None => format!(
+            "{}={}",
+            urlencoding::encode(name),
+            urlencoding::encode(value)
+        ),
+    }
+}
+
+/// Build a JSON body that carries `value` for `name`.
+///
+/// - Valid JSON object body → insert/overwrite the `name` key.
+/// - Non-JSON body with an empty `param_value` → re-serialize as `{name: value}`
+///   (an empty `str::replace` pattern would splice the payload between every
+///   byte of the body).
+/// - Non-JSON body with a non-empty `param_value` → textual replace of the
+///   original value, preserving the surrounding (non-JSON) structure.
+/// - No captured body → `{name: value}`.
+///
+/// Single source of truth for the reflection / light-verify / DOM-verify / PoC
+/// JSON builders, which were byte-identical copies.
+pub fn json_body(data: Option<&str>, name: &str, param_value: &str, value: &str) -> String {
+    match data {
+        Some(data) => {
+            if let Ok(mut json_val) = serde_json::from_str::<serde_json::Value>(data) {
+                if let Some(obj) = json_val.as_object_mut() {
+                    obj.insert(
+                        name.to_string(),
+                        serde_json::Value::String(value.to_string()),
+                    );
+                }
+                serde_json::to_string(&json_val).unwrap_or_else(|_| data.to_string())
+            } else if param_value.is_empty() {
+                serde_json::json!({ name: value }).to_string()
+            } else {
+                data.replace(param_value, value)
+            }
+        }
+        None => serde_json::json!({ name: value }).to_string(),
+    }
+}
+
+/// Build a `multipart/form-data` form that carries `value` for `name`,
+/// replacing the matching field from the captured `data` and appending it when
+/// absent so an explicit `--param` not present in an imported body still ships
+/// its payload.
+///
+/// Single source of truth for the reflection / light-verify / DOM-verify /
+/// probe multipart builders.
+pub fn multipart_form(data: Option<&str>, name: &str, value: &str) -> reqwest::multipart::Form {
+    let mut form = reqwest::multipart::Form::new();
+    let mut found = false;
+    if let Some(data) = data {
+        for pair in data.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                let k = urlencoding::decode(k)
+                    .unwrap_or(Cow::Borrowed(k))
+                    .to_string();
+                let v = urlencoding::decode(v)
+                    .unwrap_or(Cow::Borrowed(v))
+                    .to_string();
+                if k == name {
+                    form = form.text(k, value.to_string());
+                    found = true;
+                } else {
+                    form = form.text(k, v);
+                }
+            }
+        }
+    }
+    if !found {
+        form = form.text(name.to_string(), value.to_string());
+    }
+    form
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -855,3 +855,64 @@ fn effective_query_base_falls_back_when_action_unparseable() {
         target.as_str()
     );
 }
+
+// --- Shared body-injection helpers -----------------------------------------
+// These consolidate logic that was previously copy-pasted across the
+// reflection / light-verify / DOM-verify / PoC / probe builders. Cover the
+// replace-vs-append and no-data branches so the single source of truth stays
+// honest.
+
+#[test]
+fn urlencoded_body_replaces_existing_value() {
+    let out = urlencoded_body(Some("a=1&b=2"), "a", "PAY");
+    assert_eq!(out, "a=PAY&b=2");
+}
+
+#[test]
+fn urlencoded_body_appends_when_absent() {
+    let out = urlencoded_body(Some("a=1"), "b", "PAY");
+    assert_eq!(out, "a=1&b=PAY");
+}
+
+#[test]
+fn urlencoded_body_no_data_encodes_pair() {
+    let out = urlencoded_body(None, "q", "a b&c");
+    assert_eq!(out, "q=a%20b%26c");
+}
+
+#[test]
+fn urlencoded_body_only_replaces_exact_name_not_substring() {
+    // `id` must not rewrite `userid`.
+    let out = urlencoded_body(Some("userid=9&id=1"), "id", "PAY");
+    assert_eq!(out, "userid=9&id=PAY");
+}
+
+#[test]
+fn json_body_inserts_into_object() {
+    let out = json_body(Some(r#"{"a":"1"}"#), "b", "", "PAY");
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["a"], "1");
+    assert_eq!(v["b"], "PAY");
+}
+
+#[test]
+fn json_body_empty_param_value_reserializes_not_splices() {
+    // A non-JSON body with an empty param value must NOT go through
+    // `str::replace("")`, which would splice the payload between every byte.
+    let out = json_body(Some("not json"), "q", "", "PAY");
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["q"], "PAY");
+}
+
+#[test]
+fn json_body_non_empty_param_value_textual_replace() {
+    let out = json_body(Some("prefix ORIG suffix"), "q", "ORIG", "PAY");
+    assert_eq!(out, "prefix PAY suffix");
+}
+
+#[test]
+fn json_body_no_data_builds_object() {
+    let out = json_body(None, "q", "", "PAY");
+    let v: serde_json::Value = serde_json::from_str(&out).unwrap();
+    assert_eq!(v["q"], "PAY");
+}


### PR DESCRIPTION
## Summary

The urlencoded / JSON / multipart body-injection logic was copy-pasted byte-for-byte across the reflection check, light verify, DOM verify, PoC builder, and probe paths. Those parallel copies are a documented source of drift — past fixes (multipart absent-param FN #1260/#1261, JSON empty-value `str::replace` garble #1263) had to be applied to each site separately and repeatedly missed some.

This extracts three pure helpers as the single source of truth in `scanning::url_inject`:

- `urlencoded_body(data, name, value)`
- `json_body(data, name, param_value, value)`
- `multipart_form(data, name, value)`

and routes every body-bearing builder through them.

## Sites consolidated

| Site | urlencoded | json | multipart |
|------|:---:|:---:|:---:|
| `scanning/check_reflection.rs` | ✓ | ✓ | ✓ |
| `scanning/light_verify.rs` | ✓ | ✓ | ✓ |
| `scanning/check_dom_verification.rs` | ✓ | ✓ | ✓ |
| `scanning/mod.rs` (PoC builder) | ✓ | ✓ | — (display-only) |
| `parameter_analysis/mod.rs` (probe) | ✓ | — (distinct semantics) | ✓ |

`parameter_analysis` JSON probing keeps its own always-rebuild-object semantics; `xss_blind` and `mining` seeding paths are intentionally left (different behavior). 

## Behavior notes

- The four scanning-path sites were byte-identical → pure no-op consolidation.
- `parameter_analysis` Body/Multipart **no-data fallback** now url-encodes its `name=value` pair to match the with-data `form_urlencoded::Serializer` (previously an inconsistent raw `format!`), and its Multipart path picks up the exact-match append guard.

## Verification

- `cargo build` / `cargo clippy --all-targets` clean
- `cargo test --lib` — 2103 + 8 new helper tests pass
- Net **-101 lines**; adds direct unit tests for replace / append / no-data / empty-param-value branches