### PR TITLE
test(shimmer): cover smoothstep properties

### DIFF
--- a/src/utils/shimmer.rs
+++ b/src/utils/shimmer.rs
@@ -248,6 +248,25 @@ mod tests {
     use super::*;
 
     #[test]
+    fn smoothstep_clamps_and_hits_key_points() {
+        assert_eq!(smoothstep(0.0), 0.0);
+        assert_eq!(smoothstep(0.5), 0.5);
+        assert_eq!(smoothstep(1.0), 1.0);
+        assert_eq!(smoothstep(-1.0), 0.0);
+        assert_eq!(smoothstep(2.0), 1.0);
+    }
+
+    #[test]
+    fn smoothstep_is_monotonic() {
+        let mut previous = smoothstep(0.0);
+        for step in 1..=10 {
+            let current = smoothstep(step as f64 / 10.0);
+            assert!(current >= previous);
+            previous = current;
+        }
+    }
+
+    #[test]
     fn gray_code_spans_the_ramp() {
         assert_eq!(gray_code(0.0), GRAY_MIN);
         assert_eq!(gray_code(1.0), GRAY_MAX);


### PR DESCRIPTION
## Summary

- add direct coverage for `smoothstep` endpoints and midpoint
- verify out-of-range inputs clamp to the expected bounds
- verify the easing function is monotonic across a 0.1-step sweep

## Verification

- `cargo test --lib shimmer -q` (15 passed)
- `cargo test --lib -q` (2112 passed)
- `cargo fmt -- --check`
- `cargo clippy --lib -- -D warnings`

Closes #1305