### PR TITLE
docs(config): Key reference is missing an `Input` section (input_type, dedup_urls, state_file)

### DIFF
--- a/docs/content/reference/config.ko.md
+++ b/docs/content/reference/config.ko.md
@@ -128,6 +128,14 @@ debug = false
 
 ## 키 레퍼런스
 
+### 입력
+
+| 키 | 타입 | 기본값 | 설명 |
+|-----|------|---------|-------------|
+| `input_type` | string | `"auto"` | `auto`, `url`, `file`, `pipe`, `raw-http`, `har` |
+| `dedup_urls` | string | `"exact"` | `exact`, `signature`(파라미터 값만 다른 URL을 하나로 병합), `off` |
+| `state_file` | string | — | 완료된 대상을 기록해 재실행 시 건너뜁니다. **CLI 전용** — `dalfox server`/MCP는 무시합니다 |
+
 ### 출력
 
 | 키 | 타입 | 기본값 | 설명 |

--- a/docs/content/reference/config.md
+++ b/docs/content/reference/config.md
@@ -128,6 +128,14 @@ debug = false
 
 ## Key reference
 
+### Input
+
+| Key | Type | Default | Description |
+|-----|------|---------|-------------|
+| `input_type` | string | `"auto"` | `auto`, `url`, `file`, `pipe`, `raw-http`, `har` |
+| `dedup_urls` | string | `"exact"` | `exact`, `signature` (collapse URLs differing only in param values), `off` |
+| `state_file` | string | — | Record completed targets and skip them on re-run. **CLI only** — ignored by `dalfox server` / MCP |
+
 ### Output
 
 | Key | Type | Default | Description |


### PR DESCRIPTION
## Summary

The Key reference in `docs/content/reference/config.md` groups keys under
Output, Targets, Session, Scope, Discovery & mining, Network, Engine, XSS
scanning, WAF and Logging, but has no Input subsection. That leaves
`input_type`, `dedup_urls` and `state_file` with no entry, even though all
three appear in the annotated TOML template at the top of the same page and
in the CLI reference under an Input heading.

## Changes

- `docs/content/reference/config.md`: add an `### Input` subsection to the
  Key reference, before `### Output` to match the TOML template ordering,
  with a row for `input_type`, `dedup_urls` and `state_file`.
- `docs/content/reference/config.ko.md`: same subsection as `### 입력`,
  wording mirrored from the Korean TOML template and the existing
  `baseline` row's "CLI 전용" phrasing.

Defaults and value lists are taken from the config template in
`src/config.rs` and the Input table in `cli.md`, so the three surfaces stay
consistent.

## Testing

- `hwaro build -i docs` builds clean (46 content pages). Checked the
  rendered `reference/config/` and `ko/reference/config/` pages, both new
  tables render under the Key reference heading.
- `cargo test`: 2374 passed, 0 failed, 23 ignored.
- `cargo fmt --all -- --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` both clean.

No code changed, so the Rust results are unchanged from `main`.

Fixes #1306
