### PR TITLE
test(csp): cover `dedup_preserve_order` first-occurrence dedup

### DIFF
--- a/src/payload/xss_csp_bypass/tests.rs
+++ b/src/payload/xss_csp_bypass/tests.rs
@@ -463,3 +463,21 @@ fn test_report_only_and_full_csp_parse_identically() {
     assert_eq!(analysis.nonce_values, vec!["abc".to_string()]);
     assert!(analysis.require_trusted_types_for);
 }
+
+#[test]
+fn test_dedup_preserve_order_keeps_first_occurrence() {
+    let payloads = ["a", "b", "a", "c", "b"].map(str::to_string).to_vec();
+    assert_eq!(dedup_preserve_order(payloads), ["a", "b", "c"]);
+}
+
+#[test]
+fn test_dedup_preserve_order_keeps_unique_input_unchanged() {
+    // Unsorted on purpose: the order that survives is the input's, not a sorted one.
+    let payloads = ["c", "a", "b"].map(str::to_string).to_vec();
+    assert_eq!(dedup_preserve_order(payloads.clone()), payloads);
+}
+
+#[test]
+fn test_dedup_preserve_order_on_empty_input() {
+    assert!(dedup_preserve_order(Vec::new()).is_empty());
+}


### PR DESCRIPTION
## Summary

`dedup_preserve_order` in `src/payload/xss_csp_bypass.rs` had no direct
test. It collapses repeated gadget templates so the per-parameter request
count does not grow when one host matches several gadget patterns.

## Changes

Three tests in the existing `src/payload/xss_csp_bypass/tests.rs` module:

- `test_dedup_preserve_order_keeps_first_occurrence` — `["a","b","a","c","b"]`
  becomes `["a","b","c"]`.
- `test_dedup_preserve_order_keeps_unique_input_unchanged` — already-unique
  input is returned in its original order.
- `test_dedup_preserve_order_on_empty_input` — empty in, empty out.

The second test uses deliberately unsorted input, `["c","a","b"]`. The
example in the issue has an expected output that is already in sorted
order, so it passes against a `sort` + `dedup` implementation and pins the
dedup property but not the ordering one. I confirmed this by temporarily
swapping the body of `dedup_preserve_order` for `sort` + `dedup`, which
leaves the first and third tests green and fails only the second. The
existing `test_payloads_are_deduped` has the same blind spot, since it
sorts a copy before comparing lengths.

## Testing

- `cargo test`: 2377 passed, 0 failed, 23 ignored. Baseline on `main` is
  2374, so the delta is exactly these three tests.
- `cargo fmt --all -- --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` both clean.

Fixes #1304
