### PR TITLE
test(tech_detect): cover the `has_interpolation_brackets` template heuristic

### DIFF
--- a/src/scanning/tech_detect.rs
+++ b/src/scanning/tech_detect.rs
@@ -416,7 +416,10 @@ pub fn detect_technologies(headers: &HeaderMap, body: Option<&str>) -> TechDetec
 /// interpolation. Conservative: requires an identifier-shaped token
 /// (`a-zA-Z_$` start, optionally followed by `\w` / `.` / `[…]` chain)
 /// between the braces so we don't trip on prose like `{{ }}` or
-/// `{{ TODO }}` placeholders rendered as plain text.
+/// `{{ 1 + 2 }}`. An identifier-shaped placeholder such as `{{ TODO }}`
+/// does match, deliberately: that is the shape a real interpolation
+/// takes, so it is cheaper to send the template payloads than to miss a
+/// sink on a minified SPA.
 fn has_interpolation_brackets(body: &str) -> bool {
     static RE: std::sync::OnceLock<regex::Regex> = std::sync::OnceLock::new();
     let re = RE.get_or_init(|| {

--- a/src/scanning/tech_detect/tests.rs
+++ b/src/scanning/tech_detect/tests.rs
@@ -161,6 +161,39 @@ fn test_interpolation_brackets_skipped_when_vue_detected() {
 }
 
 #[test]
+fn test_has_interpolation_brackets_matches_identifier_shaped_expressions() {
+    for body in [
+        "{{ user.name }}",
+        "{{count}}",
+        "{{ items[0] }}",
+        "{{ $scope.value }}",
+        "{{ TODO }}",
+        "<p>prefix {{x}} suffix</p>",
+    ] {
+        assert!(has_interpolation_brackets(body), "should match {:?}", body);
+    }
+}
+
+#[test]
+fn test_has_interpolation_brackets_rejects_non_identifier_contents() {
+    for body in [
+        "{{ }}",
+        "{{}}",
+        "{{ 1 + 2 }}",
+        "{{ user name }}",
+        "{ single brace }",
+        "{{ user.name",
+        "plain text with no braces",
+    ] {
+        assert!(
+            !has_interpolation_brackets(body),
+            "should not match {:?}",
+            body
+        );
+    }
+}
+
+#[test]
 fn test_multiple_techs_detected() {
     let headers = make_headers(&[]);
     let body = "<div ng-app></div><script src='jquery.min.js'></script>";


### PR DESCRIPTION
## Summary

Two direct tests for `has_interpolation_brackets`, plus a correction to
its doc comment.

## What was already covered

Six tests at `src/scanning/tech_detect/tests.rs:75-160` already exercise
this heuristic through `detect_technologies`, including the empty-braces
case, the `{{ TODO }}` case and dotted/indexed identifiers. What they do
not reach is the regex's own boundaries, so the genuinely new coverage
here is a `$`-prefixed identifier, digit-leading contents, a space inside
the braces, a lone brace pair, and an unclosed `{{`.

## Changes

- Two table-driven tests, one per direction, asserting the behaviour I
  confirmed against the regex rather than the values suggested in the
  issue. Notably `{{ TODO }}` matches, as the issue's own correction
  notes, and `{{ 1 + 2 }}` does not.
- The doc comment said the identifier guard exists so the heuristic does
  not trip on `{{ }}` or `{{ TODO }}` placeholders. `{{ TODO }}` does
  trip it, and `test_interpolation_brackets_promote_even_when_identifier_is_a_word`
  already asserts exactly that. Corrected to describe the real behaviour,
  using `{{ 1 + 2 }}` as an example that genuinely does not match. Split
  into its own commit. Happy to drop it if you would rather keep this PR
  to tests.

## Testing

- `cargo test`: 2385 passed, 0 failed, 23 ignored. Baseline on `main` is
  2383, so the delta is exactly these two tests.
- Mutation-checked both directions. Widening the class to `[^}]*` fails
  the reject test on `{{ }}`; narrowing it to `[a-zA-Z_][\w.]*` fails the
  match test on `{{ items[0] }}`.
- `cargo fmt --all -- --check` and
  `cargo clippy --all-targets --all-features -- -D warnings` both clean.

Fixes #1303
