### PR TITLE
test: cover gadget db host component

### DIFF
--- a/src/payload/gadget_db/tests.rs
+++ b/src/payload/gadget_db/tests.rs
@@ -39,6 +39,24 @@ fn test_host_patterns_are_lowercase() {
 }
 
 #[test]
+fn test_host_component_extracts_host() {
+    let cases = [
+        (
+            "https://ajax.googleapis.com/ajax/libs/jquery.js",
+            "ajax.googleapis.com",
+        ),
+        ("http://localhost:8080/x", "localhost"),
+        ("//cdn.example.com/lib.js", "cdn.example.com"),
+        ("example.com", "example.com"),
+        ("https://a.com/p?x=1#frag", "a.com"),
+    ];
+
+    for (origin, expected) in cases {
+        assert_eq!(host_component(origin), expected, "origin: {origin}");
+    }
+}
+
+#[test]
 fn test_gadgets_for_host_matches_cdnjs() {
     let hits: Vec<_> = gadgets_for_host("https://cdnjs.cloudflare.com").collect();
     assert!(hits.iter().any(|g| g.template.contains("angular")));


### PR DESCRIPTION
## Summary

- add table-driven coverage for the five host_component inputs from #1298
- keep the production implementation unchanged

## Validation

- cargo fmt --all -- --check
- cargo clippy --all-targets --all-features -- -D warnings
- cargo build --verbose
- cargo test --verbose
- cargo +1.93.0 build --locked --all-targets (CARGO_BUILD_JOBS=1)
- cargo +1.93.0 test --locked --all-targets (CARGO_BUILD_JOBS=1)

Closes #1298