### PR TITLE
test: cover payload encoder helpers

### DIFF
--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -91,15 +91,49 @@ mod encoder_policy_tests {
 
     #[test]
     fn test_apply_encoders_order_and_dedup() {
-        let bases = vec!["<x>".to_string()];
-        let encs = vec!["url".to_string(), "html".to_string()];
+        let bases = vec!["<x>".to_string(), "<x>".to_string()];
+        let encs = vec![
+            "base64".to_string(),
+            "html".to_string(),
+            "url".to_string(),
+            "url".to_string(),
+        ];
         let out = apply_encoders_to_payloads(&bases, &encs);
-        assert!(out.contains(&"<x>".to_string()));
-        assert!(out.contains(&url_encode("<x>")));
-        assert!(out.contains(&html_entity_encode("<x>")));
-        // No duplicates
-        let mut set = std::collections::HashSet::new();
-        assert!(out.iter().all(|p| set.insert(p)));
+        assert_eq!(
+            out,
+            vec![
+                "<x>".to_string(),
+                url_encode("<x>"),
+                html_entity_encode("<x>"),
+                base64_encode("<x>"),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_each_payload_encoder_known_output() {
+        type Encoder = fn(&str) -> String;
+
+        let cases: [(&str, &str, Encoder, &str); 9] = [
+            ("url", "<", url_encode, "%3C"),
+            ("html", "<", html_entity_encode, "&#x003c;"),
+            (
+                "htmlpad",
+                "<",
+                html_entity_zero_padded_encode,
+                "&#x000003c;",
+            ),
+            ("2url", "<", double_url_encode, "%253C"),
+            ("3url", "<", triple_url_encode, "%25253C"),
+            ("4url", "<", quadruple_url_encode, "%2525253C"),
+            ("base64", "<svg>", base64_encode, "PHN2Zz4="),
+            ("unicode", "<", unicode_fullwidth_encode, "＜"),
+            ("zwsp", "<", zero_width_encode, "<\u{200B}"),
+        ];
+
+        for (name, input, encoder, expected) in cases {
+            assert_eq!(encoder(input), expected, "encoder {name}");
+        }
     }
 
     #[test]


### PR DESCRIPTION
## Summary

- add table-driven exact-output coverage for all nine payload encoder helpers
- strengthen encoder-policy coverage for `none`, fixed ordering, and duplicate payload/encoder inputs
- keep production behavior unchanged

## Validation

- `cargo test encoder_policy_tests` (4 passed)
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo build --release`
- `just fix` (no diff change)
- `cargo fmt --all -- --check`
- `git diff --check`

I also ran `cargo test -- --include-ignored`. Its 225 runnable tests passed; the four existing detection-corpus threshold benchmarks documented as excluded from CI failed on their current baselines (`test_query_reflection_category_baselines_v2`, `test_query_reflection_v2`, `test_realworld_xss_by_category`, and `test_realworld_xss_scenarios`).

Closes #1330

I used Codex as a coding assistant and reviewed and tested the resulting test patch.