### PR TITLE
feat(payload): add 'all' selector to dump every static payload group (#1339)

### DIFF
--- a/docs/content/guide/payloads.ko.md
+++ b/docs/content/guide/payloads.ko.md
@@ -132,6 +132,7 @@ dalfox https://target.app --remote-payloads portswigger,payloadbox
 | `dom-clobbering` | DOM 클로버링 페이로드를 출력합니다 | `dalfox payload dom-clobbering` |
 | `mxss` | mutation-XSS / 새니타이저 우회 페이로드를 출력합니다 | `dalfox payload mxss` |
 | `blind` | blind-XSS 스켈레톤을 출력합니다 (`{}` = 콜백 URL) | `dalfox payload blind` |
+| `all` | 위의 모든 로컬 셀렉터를 한 번에, 각 그룹 앞에 `# name` 헤더를 붙여 출력합니다 (원격 셀렉터 제외 — 네트워크 요청 없음) | `dalfox payload all` |
 
 ```bash
 dalfox payload event-handlers  # onerror, onmouseover, ...
@@ -144,6 +145,7 @@ dalfox payload dom-clobbering  # DOM 클로버링 벡터
 dalfox payload mxss            # mutation-XSS / 새니타이저 우회 페이로드
 dalfox payload blind           # blind-XSS 스켈레톤 ({} = 콜백 URL)
 dalfox payload portswigger     # 원격 목록을 가져와 출력
+dalfox payload all             # 모든 로컬 셀렉터를 "# name" 헤더로 묶어 출력
 ```
 
 모든 셀렉터는 한 줄에 하나씩 출력하므로 일반적인 셸 도구와 조합할 수 있습니다:

--- a/docs/content/guide/payloads.md
+++ b/docs/content/guide/payloads.md
@@ -156,6 +156,7 @@ Print a payload family without running a scan:
 | `dom-clobbering` | Print DOM clobbering payloads | `dalfox payload dom-clobbering` |
 | `mxss` | Print mutation-XSS / sanitizer-bypass payloads | `dalfox payload mxss` |
 | `blind` | Print blind-XSS skeletons (`{}` = your OOB callback URL) | `dalfox payload blind` |
+| `all` | Print every local selector above in one pass, each under a `# name` header (remote selectors excluded — no network fetch) | `dalfox payload all` |
 
 ```bash
 dalfox payload event-handlers  # onerror, onmouseover, ...
@@ -168,6 +169,7 @@ dalfox payload dom-clobbering  # DOM clobbering vectors
 dalfox payload mxss            # mutation-XSS / sanitizer-bypass payloads
 dalfox payload blind           # blind-XSS skeletons ({} = your callback URL)
 dalfox payload portswigger     # fetch + print remote list
+dalfox payload all             # every local selector, grouped under "# name" headers
 ```
 
 Every selector prints one entry per line, so it composes with the usual shell tools:

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -249,6 +249,7 @@ dalfox payload <SELECTOR>
 | `blind` | Blind-XSS 스켈레톤(`{}` = OOB 콜백 URL) |
 | `portswigger` | 원격: PortSwigger XSS 치트시트 |
 | `payloadbox` | 원격: PayloadBox XSS 목록 |
+| `all` | 위의 모든 로컬 선택자를 한 번에, 각 그룹 앞에 `# name` 헤더를 붙여 출력 (네트워크 요청 없음) |
 
 ---
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -250,6 +250,7 @@ Selectors:
 | `blind` | Blind-XSS skeletons (`{}` = your OOB callback URL) |
 | `portswigger` | Remote: PortSwigger XSS cheatsheet |
 | `payloadbox` | Remote: PayloadBox XSS list |
+| `all` | Every local selector above in one pass, each under a `# name` header (no network fetch) |
 
 ---
 

--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -14,6 +14,7 @@ const KNOWN_SELECTORS: &[&str] = &[
     "dom-clobbering",
     "mxss",
     "blind",
+    "all",
 ];
 
 /// Manage or inspect payloads (no local flags).
@@ -25,13 +26,13 @@ const KNOWN_SELECTORS: &[&str] = &[
 #[derive(Args, Debug, Clone)]
 #[command(
     about = "Manage or inspect payloads",
-    long_about = "Selectors:\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)"
+    long_about = "Selectors:\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
 )]
 pub struct PayloadArgs {
     #[arg(
         value_name = "SELECTOR",
-        help = "Payload selector\nAvailable selectors:\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme\n  - special-chars\n  - functions\n  - awesome-alert\n  - dom-clobbering\n  - mxss\n  - blind",
-        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)"
+        help = "Payload selector\nAvailable selectors:\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme\n  - special-chars\n  - functions\n  - awesome-alert\n  - dom-clobbering\n  - mxss\n  - blind\n  - all",
+        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
     )]
     pub selector: Option<String>,
 }
@@ -140,30 +141,76 @@ fn print_lines<T: std::fmt::Display>(selector: &str, list: &[T]) {
     crate::dbg_log!("{}: {} items", selector, list.len());
 }
 
-/// Every static selector paired with the number of entries it prints. The
-/// remote selectors (`payloadbox`, `portswigger`) are absent: their size is
-/// only known after a fetch, and the summary must not touch the network.
-fn static_selector_counts() -> Vec<(&'static str, usize)> {
+/// The lines one selector prints: either a compile-time slice or a family
+/// built at call time. Keeping both shapes behind one type lets the summary
+/// and the `all` dump walk a single list of selectors.
+enum SelectorLines {
+    Static(&'static [&'static str]),
+    Owned(Vec<String>),
+}
+
+impl SelectorLines {
+    fn len(&self) -> usize {
+        match self {
+            SelectorLines::Static(list) => list.len(),
+            SelectorLines::Owned(list) => list.len(),
+        }
+    }
+
+    fn print(&self, selector: &str) {
+        match self {
+            SelectorLines::Static(list) => print_lines(selector, list),
+            SelectorLines::Owned(list) => print_lines(selector, list),
+        }
+    }
+}
+
+/// Every static selector paired with the lines it prints — the single source
+/// of truth behind both the summary counts and the `all` dump, so a selector
+/// added to one can never be missed by the other. The remote selectors
+/// (`payloadbox`, `portswigger`) are absent: their contents are only known
+/// after a fetch, and neither the summary nor `all` may touch the network.
+fn static_selector_groups() -> Vec<(&'static str, SelectorLines)> {
     vec![
         (
             "event-handlers",
-            crate::payload::xss_event::common_event_handler_names().len(),
+            SelectorLines::Static(crate::payload::xss_event::common_event_handler_names()),
         ),
         (
             "useful-tags",
-            crate::payload::xss_html::useful_html_tag_names().len(),
+            SelectorLines::Static(crate::payload::xss_html::useful_html_tag_names()),
         ),
-        ("uri-scheme", uri_scheme_payloads().len()),
-        ("special-chars", special_chars_payloads().len()),
-        ("functions", functions_payloads().len()),
-        ("awesome-alert", awesome_alert_payloads().len()),
+        ("uri-scheme", SelectorLines::Static(uri_scheme_payloads())),
+        (
+            "special-chars",
+            SelectorLines::Static(special_chars_payloads()),
+        ),
+        ("functions", SelectorLines::Static(functions_payloads())),
+        (
+            "awesome-alert",
+            SelectorLines::Static(awesome_alert_payloads()),
+        ),
         (
             "dom-clobbering",
-            crate::payload::get_dom_clobbering_payloads().len(),
+            SelectorLines::Owned(crate::payload::get_dom_clobbering_payloads()),
         ),
-        ("mxss", crate::payload::get_mxss_payloads().len()),
-        ("blind", crate::payload::XSS_BLIND_PAYLOADS.len()),
+        (
+            "mxss",
+            SelectorLines::Owned(crate::payload::get_mxss_payloads()),
+        ),
+        (
+            "blind",
+            SelectorLines::Static(crate::payload::XSS_BLIND_PAYLOADS),
+        ),
     ]
+}
+
+/// Every static selector paired with the number of entries it prints.
+fn static_selector_counts() -> Vec<(&'static str, usize)> {
+    static_selector_groups()
+        .into_iter()
+        .map(|(selector, lines)| (selector, lines.len()))
+        .collect()
 }
 
 /// The `Summary:` block, built as text so the rendered counts are assertable
@@ -194,7 +241,8 @@ fn print_summary() {
     println!("  dalfox payload awesome-alert");
     println!("  dalfox payload dom-clobbering");
     println!("  dalfox payload mxss");
-    println!("  dalfox payload blind\n");
+    println!("  dalfox payload blind");
+    println!("  dalfox payload all\n");
 
     print!("{}", summary_block());
 
@@ -253,6 +301,21 @@ fn fetch_and_print_remote(provider: &str) -> bool {
         return false;
     }
     ok.load(std::sync::atomic::Ordering::Relaxed)
+}
+
+/// Print every static selector's entries in one pass, with a `# name` header
+/// before each group. Network selectors (`payloadbox`, `portswigger`) are
+/// intentionally excluded — they require a remote fetch, so bundling them into
+/// `all` would make a "just show me everything local" command silently hit the
+/// network.
+fn print_all_payloads() {
+    for (index, (selector, lines)) in static_selector_groups().into_iter().enumerate() {
+        if index > 0 {
+            println!();
+        }
+        println!("# {}", selector);
+        lines.print(selector);
+    }
 }
 
 pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
@@ -318,6 +381,10 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
             // skeleton shows where the URL goes — users wire it up with
             // `-b https://your-callback`.
             print_lines("blind", crate::payload::XSS_BLIND_PAYLOADS);
+            ScanOutcome::Clean
+        }
+        Some("all") => {
+            print_all_payloads();
             ScanOutcome::Clean
         }
         Some(other) => {

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -1,11 +1,13 @@
 use super::{
     KNOWN_SELECTORS, PayloadArgs, awesome_alert_payloads, fetch_and_print_remote,
     functions_payloads, print_summary, run_payload, special_chars_payloads, static_selector_counts,
-    summary_block, uri_scheme_payloads,
+    static_selector_groups, summary_block, uri_scheme_payloads,
 };
 use crate::cmd::scan::ScanOutcome;
 
 const NETWORK_SELECTORS: [&str; 2] = ["payloadbox", "portswigger"];
+/// Selectors that print other selectors instead of a list of their own.
+const AGGREGATE_SELECTORS: [&str; 1] = ["all"];
 
 #[test]
 fn test_uri_scheme_payloads_shape() {
@@ -142,11 +144,20 @@ fn test_static_selector_counts_cover_every_local_selector() {
                 "{} needs a fetch and must not be counted",
                 selector
             );
+        } else if AGGREGATE_SELECTORS.contains(selector) {
+            assert!(
+                !named.contains(selector),
+                "{} prints other selectors and is not a list of its own",
+                selector
+            );
         } else {
             assert!(named.contains(selector), "{} is missing a count", selector);
         }
     }
-    assert_eq!(named.len(), KNOWN_SELECTORS.len() - NETWORK_SELECTORS.len());
+    assert_eq!(
+        named.len(),
+        KNOWN_SELECTORS.len() - NETWORK_SELECTORS.len() - AGGREGATE_SELECTORS.len()
+    );
 }
 
 #[test]
@@ -207,4 +218,35 @@ fn test_summary_block_renders_a_line_per_static_selector() {
             selector
         );
     }
+}
+
+#[test]
+fn test_run_payload_all_selector_returns_clean() {
+    let outcome = run_payload(PayloadArgs {
+        selector: Some("all".to_string()),
+    });
+    assert_eq!(outcome, ScanOutcome::Clean);
+}
+
+#[test]
+fn test_all_selector_included_in_known_selectors() {
+    assert!(KNOWN_SELECTORS.contains(&"all"));
+}
+
+#[test]
+fn test_all_selector_groups_cover_every_static_selector_in_order() {
+    let groups: Vec<&str> = static_selector_groups()
+        .iter()
+        .map(|(selector, _)| *selector)
+        .collect();
+    let counted: Vec<&str> = static_selector_counts().iter().map(|(s, _)| *s).collect();
+
+    // `all` dumps exactly what the summary counts — one list, one order.
+    assert_eq!(groups, counted);
+    assert!(
+        static_selector_groups()
+            .iter()
+            .all(|(_, lines)| lines.len() != 0),
+        "an empty group would print a header with nothing under it"
+    );
 }


### PR DESCRIPTION
Adds an `all` selector to `dalfox payload` that prints every static payload/list selector in one pass, with a `# name` header before each group.

- Reuses existing per-selector helpers (`uri_scheme_payloads()`, etc.) — no duplication
- Network selectors (`payloadbox`, `portswigger`) are excluded from `all` since they require a fetch
- Updated `long_about`/`help`/`long_help` and `print_summary()` to mention `all`
- Unit tests added: `test_run_payload_all_selector_returns_clean`, `test_all_selector_included_in_known_selectors`
- `cargo test --lib payload`: 344 passed, 0 failed

Closes #1339