### PR TITLE
Document the --no-color flag and NO_COLOR env var in the docs

### DIFF
--- a/docs/content/reference/environment.ko.md
+++ b/docs/content/reference/environment.ko.md
@@ -11,7 +11,7 @@ Dalfox는 설정 파일이나 명령줄에 두기 적합하지 않은 설정을 
 |----------|---------|---------|
 | `DALFOX_API_KEY` | `dalfox server` | `X-API-KEY` 헤더에 요구되는 값. `--api-key`와 동일. |
 | `DALFOX_STDIN_WAIT_MS` | `dalfox scan` (auto 입력) | 명령줄에도 대상을 준 상태에서 파이프된 `stdin`의 첫 바이트를 기다릴 밀리초. 기본값 `500`, `0`이면 stdin 병합을 건너뜁니다. 항상 대기하는 `--input-type pipe`/`har`에는 적용되지 않습니다. |
-| `NO_COLOR` | 모든 모드 | 비어 있지 않은 값으로 설정되면 ANSI 색상 출력을 비활성화. [NO_COLOR](https://no-color.org) 관례를 따름. |
+| `NO_COLOR` | 모든 모드 | 빈 문자열을 포함해 어떤 값으로든 설정되면 ANSI 색상 출력을 비활성화. `--no-color` 및 설정 파일의 `no_color = true`와 동일. [NO_COLOR](https://no-color.org) 관례 참고. |
 | `XDG_CONFIG_HOME` | 설정 로더 | 설정 파일의 기준 디렉터리 (`$XDG_CONFIG_HOME/dalfox/config.toml`). `$HOME/.config`로 폴백. |
 | `HOME` | 설정 로더 | `XDG_CONFIG_HOME`이 설정되지 않았을 때 사용. |
 | `USERPROFILE` | 설정 로더 | `XDG_CONFIG_HOME`과 `HOME`이 모두 없을 때 사용하는 Windows 폴백 기준 디렉터리. |
@@ -30,6 +30,15 @@ dalfox server --port 6664
 ```bash
 export NO_COLOR=1
 ```
+
+`--no-color`는 한 번의 실행에, 설정 파일의 `no_color = true`는 모든 실행에 같은 효과를 냅니다. 또한 stdout이 TTY가 아니면 색상이 자동으로 비활성화되므로, 파이프하거나 리다이렉트한 스캔은 아무 설정 없이도 일반 텍스트로 출력됩니다.
+
+```bash
+dalfox scan https://target.app --no-color
+dalfox scan https://target.app > scan.log   # 이미 일반 텍스트
+```
+
+출력 가이드의 [색상 및 TTY 동작](../../guide/output/#색상-및-tty-동작)을 참고하세요.
 
 ### 프로젝트 로컬 설정 사용
 

--- a/docs/content/reference/environment.md
+++ b/docs/content/reference/environment.md
@@ -11,7 +11,7 @@ Dalfox respects a small set of environment variables for configuration that does
 |----------|---------|---------|
 | `DALFOX_API_KEY` | `dalfox server` | Value required in the `X-API-KEY` header. Equivalent to `--api-key`. |
 | `DALFOX_STDIN_WAIT_MS` | `dalfox scan` (auto input) | Milliseconds to wait for piped `stdin` to produce its first byte when targets were *also* given on the command line. Default `500`; `0` skips the stdin merge entirely. Does not apply to `--input-type pipe`/`har`, which always wait. |
-| `NO_COLOR` | all modes | Disables ANSI colour output when set to any non-empty value. Follows the [NO_COLOR](https://no-color.org) convention. |
+| `NO_COLOR` | all modes | Disables ANSI colour output when set to any value, an empty string included. Equivalent to `--no-color`, and to `no_color = true` in the config file. See the [NO_COLOR](https://no-color.org) convention. |
 | `XDG_CONFIG_HOME` | config loader | Base directory for the config file (`$XDG_CONFIG_HOME/dalfox/config.toml`). Falls back to `$HOME/.config`. |
 | `HOME` | config loader | Used when `XDG_CONFIG_HOME` is unset. |
 | `USERPROFILE` | config loader | Windows fallback base directory, used when both `XDG_CONFIG_HOME` and `HOME` are unset. |
@@ -30,6 +30,15 @@ dalfox server --port 6664
 ```bash
 export NO_COLOR=1
 ```
+
+`--no-color` does the same for a single run, and `no_color = true` in the config file does it for every run. Colour is also suppressed automatically whenever stdout is not a TTY, so a piped or redirected scan is plain text without setting anything.
+
+```bash
+dalfox scan https://target.app --no-color
+dalfox scan https://target.app > scan.log   # already plain text
+```
+
+See [Colour & TTY behaviour](../../guide/output/#colour-tty-behaviour) in the output guide.
 
 ### Use a project-local config
 


### PR DESCRIPTION
## Summary

The environment reference documented `NO_COLOR` but not the `--no-color` flag, the `no_color` config option, or the automatic suppression when stdout is not a TTY. This adds them, EN and KO.

## Context

Fixes #1331.

One correction to the issue's framing. The behaviour was already documented in `guide/output.md`, which has a `Colour & TTY behaviour` section covering all three points in both languages. The gap was on the reference page, so this PR fills that in and links to the guide rather than duplicating it.

## Changes

- `docs/content/reference/environment.md` and its `.ko.md` twin:
  - The `NO_COLOR` row now names `--no-color` and `no_color = true` as equivalents, and states the real trigger condition.
  - The "Disable colour globally" example gained the flag, the config option, and the non-TTY note, with a runnable two-line block.
  - Added a link to `Colour & TTY behaviour` in the output guide.

## Testing

`crystal run scripts/docs_lint.cr`

```
==> docs lint — 46 pages under docs/content: 22 passed
```

`hwaro build -i docs` builds 46 pages clean. In the rendered HTML, `id="colour-tty-behaviour"` and `id="색상-및-tty-동작"` both exist and both new links resolve to them.

Behaviour checked against a built binary under a pty rather than read off the source, counting ANSI escapes in `dalfox --help`:

```
NO_COLOR unset  -> ESC count: 3
NO_COLOR empty  -> ESC count: 0
NO_COLOR=1      -> ESC count: 0
--no-color      -> ESC count: 0
piped (no pty)  -> ESC count: 0
```

No `.rs` changed. `cargo test` is 2160 + 208 passing, 0 failing, and `cargo fmt --check` plus `cargo clippy --all-targets --all-features -D warnings` are clean, all unaffected by this diff.

## Notes for reviewers

The old wording said `NO_COLOR` disables colour "when set to any non-empty value". That is not what the code does. `src/main.rs:118` and `src/cmd/scan/mod.rs:186` both use `std::env::var("NO_COLOR").is_ok()`, so `NO_COLOR=` with an empty value disables colour too. The row above is written to match the code, and the "Follows the NO_COLOR convention" phrasing became "See the NO_COLOR convention" because no-color.org exempts the empty string and Dalfox does not.

If you would rather the code match the convention than the docs match the code, the fix is a one-line `is_ok_and(|v| !v.is_empty())` at both sites. Happy to send that as a separate PR and revert this row to the stricter wording.
