### PR TITLE
Show per-selector item counts in the 'dalfox payload' summary

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -126,9 +126,47 @@ fn print_lines<T: std::fmt::Display>(selector: &str, list: &[T]) {
     crate::dbg_log!("{}: {} items", selector, list.len());
 }
 
-fn print_summary() {
-    let js_count = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len();
+/// Every static selector paired with the number of entries it prints. The
+/// remote selectors (`payloadbox`, `portswigger`) are absent: their size is
+/// only known after a fetch, and the summary must not touch the network.
+fn static_selector_counts() -> Vec<(&'static str, usize)> {
+    vec![
+        (
+            "event-handlers",
+            crate::payload::xss_event::common_event_handler_names().len(),
+        ),
+        (
+            "useful-tags",
+            crate::payload::xss_html::useful_html_tag_names().len(),
+        ),
+        ("uri-scheme", uri_scheme_payloads().len()),
+        ("special-chars", special_chars_payloads().len()),
+        ("functions", functions_payloads().len()),
+        ("awesome-alert", awesome_alert_payloads().len()),
+        (
+            "dom-clobbering",
+            crate::payload::get_dom_clobbering_payloads().len(),
+        ),
+        ("mxss", crate::payload::get_mxss_payloads().len()),
+        ("blind", crate::payload::XSS_BLIND_PAYLOADS.len()),
+    ]
+}
 
+/// The `Summary:` block, built as text so the rendered counts are assertable
+/// without capturing stdout.
+fn summary_block() -> String {
+    let mut out = String::from("Summary:\n");
+    out.push_str(&format!(
+        "- Canonical JavaScript payloads: {}\n",
+        crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
+    ));
+    for (selector, count) in static_selector_counts() {
+        out.push_str(&format!("- {}: {}\n", selector, count));
+    }
+    out
+}
+
+fn print_summary() {
     println!("Dalfox payload");
     println!("----------------");
     println!("Provide a selector to list payloads. Examples:");
@@ -144,8 +182,7 @@ fn print_summary() {
     println!("  dalfox payload mxss");
     println!("  dalfox payload blind\n");
 
-    println!("Summary:");
-    println!("- Canonical JavaScript payloads: {}", js_count);
+    print!("{}", summary_block());
 
     println!("\nTips:");
     println!("- Use scanning to apply payloads: dalfox scan <target>");

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -1,8 +1,11 @@
 use super::{
-    PayloadArgs, awesome_alert_payloads, fetch_and_print_remote, functions_payloads, print_summary,
-    run_payload, special_chars_payloads, uri_scheme_payloads,
+    KNOWN_SELECTORS, PayloadArgs, awesome_alert_payloads, fetch_and_print_remote,
+    functions_payloads, print_summary, run_payload, special_chars_payloads, static_selector_counts,
+    summary_block, uri_scheme_payloads,
 };
 use crate::cmd::scan::ScanOutcome;
+
+const NETWORK_SELECTORS: [&str; 2] = ["payloadbox", "portswigger"];
 
 #[test]
 fn test_uri_scheme_payloads_shape() {
@@ -108,4 +111,82 @@ fn test_fetch_and_print_remote_unknown_provider_no_network_path() {
 #[test]
 fn test_print_summary_executes() {
     print_summary();
+}
+
+#[test]
+fn test_static_selector_counts_cover_every_local_selector() {
+    let named: Vec<&str> = static_selector_counts().iter().map(|(s, _)| *s).collect();
+
+    for selector in KNOWN_SELECTORS {
+        if NETWORK_SELECTORS.contains(selector) {
+            assert!(
+                !named.contains(selector),
+                "{} needs a fetch and must not be counted",
+                selector
+            );
+        } else {
+            assert!(named.contains(selector), "{} is missing a count", selector);
+        }
+    }
+    assert_eq!(named.len(), KNOWN_SELECTORS.len() - NETWORK_SELECTORS.len());
+}
+
+#[test]
+fn test_static_selector_counts_match_the_lists_they_describe() {
+    let counts = static_selector_counts();
+    let count_of = |selector: &str| -> usize {
+        counts
+            .iter()
+            .find(|(s, _)| *s == selector)
+            .unwrap_or_else(|| panic!("no count for {}", selector))
+            .1
+    };
+
+    assert_eq!(
+        count_of("event-handlers"),
+        crate::payload::xss_event::common_event_handler_names().len()
+    );
+    assert_eq!(
+        count_of("useful-tags"),
+        crate::payload::xss_html::useful_html_tag_names().len()
+    );
+    assert_eq!(count_of("uri-scheme"), uri_scheme_payloads().len());
+    assert_eq!(count_of("special-chars"), special_chars_payloads().len());
+    assert_eq!(count_of("functions"), functions_payloads().len());
+    assert_eq!(count_of("awesome-alert"), awesome_alert_payloads().len());
+    assert_eq!(
+        count_of("dom-clobbering"),
+        crate::payload::get_dom_clobbering_payloads().len()
+    );
+    assert_eq!(count_of("mxss"), crate::payload::get_mxss_payloads().len());
+    assert_eq!(count_of("blind"), crate::payload::XSS_BLIND_PAYLOADS.len());
+
+    // Distinct lists, so a copy-pasted accessor would collapse two counts.
+    assert_ne!(count_of("special-chars"), count_of("functions"));
+    assert!(counts.iter().all(|(_, n)| *n > 0));
+}
+
+#[test]
+fn test_summary_block_renders_a_line_per_static_selector() {
+    let rendered = summary_block();
+
+    assert!(rendered.starts_with("Summary:\n"));
+    assert!(rendered.contains(&format!(
+        "- Canonical JavaScript payloads: {}\n",
+        crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
+    )));
+    for (selector, count) in static_selector_counts() {
+        assert!(
+            rendered.contains(&format!("- {}: {}\n", selector, count)),
+            "summary is missing the {} count",
+            selector
+        );
+    }
+    for selector in NETWORK_SELECTORS {
+        assert!(
+            !rendered.contains(selector),
+            "{} must not appear in the summary counts",
+            selector
+        );
+    }
 }


### PR DESCRIPTION
## Summary

`dalfox payload` with no selector reported a single number, so there was no way to see what a selector would produce without running it. The summary now counts every static selector.

```
Summary:
- Canonical JavaScript payloads: 26
- event-handlers: 98
- useful-tags: 26
- uri-scheme: 5
- special-chars: 40
- functions: 21
- awesome-alert: 10
- dom-clobbering: 8
- mxss: 204
- blind: 3
```

## Context

Fixes #1334.

## Changes

- `static_selector_counts()` in `src/cmd/payload.rs` pairs each static selector with the `.len()` of the exact list its dispatch arm prints. `payloadbox` and `portswigger` are excluded, since their size is only known after a fetch and the summary must not touch the network.
- `summary_block()` renders the `Summary:` section as text, and `print_summary()` prints it. Building the text rather than printing inline is what makes the counts assertable without capturing stdout.
- Three tests in `src/cmd/payload/tests.rs`.

I kept the existing `- Canonical JavaScript payloads:` line. It counts `XSS_JAVASCRIPT_PAYLOADS`, which is not a selector, so the per-selector lines do not replace it and dropping it would lose information the issue did not ask to remove. Say the word if you would rather match the mockup literally.

## Testing

```
cargo test          2163 passed, 0 failed  (2160 before, +3 new)
cargo fmt --all -- --check                 clean
cargo clippy --all-targets --all-features -- -D warnings    0 warnings
crystal run scripts/surface_parity.cr      46 passed
```

Every count above matches what `dalfox payload <selector> | wc -l` printed independently before the change.

Mutation check on the two tests that carry the weight. Pairing `special-chars` with `functions_payloads()` fails `test_static_selector_counts_match_the_lists_they_describe`; dropping `awesome-alert` from the table fails `test_static_selector_counts_cover_every_local_selector` with `awesome-alert is missing a count`.

`test_summary_block_renders_a_line_per_static_selector` survives both sabotages. It derives its expectations from the same table, so it pins the line format and the absence of the network selectors, not the correctness of the counts. The other two cover that.

## Notes for reviewers

#1346 (`all` selector) and #1343 (`--json`) touch the same two files. #1346 edits the line directly above the `Summary:` block and #1343 changes the `print_lines` signature, so whoever lands second gets a small rebase. Neither implements the counts and this does not depend on either. Happy to rebase on whichever you merge first.
