### PR TITLE
feat: suggest closest payload selector

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -16,6 +16,42 @@ const KNOWN_SELECTORS: &[&str] = &[
     "blind",
 ];
 
+fn levenshtein_distance(left: &str, right: &str) -> usize {
+    let right_chars: Vec<_> = right.chars().collect();
+    let mut previous: Vec<_> = (0..=right_chars.len()).collect();
+    let mut current = vec![0; right_chars.len() + 1];
+
+    for (left_index, left_char) in left.chars().enumerate() {
+        current[0] = left_index + 1;
+
+        for (right_index, right_char) in right_chars.iter().enumerate() {
+            let substitution_cost = usize::from(left_char != *right_char);
+            current[right_index + 1] = (current[right_index] + 1)
+                .min(previous[right_index + 1] + 1)
+                .min(previous[right_index] + substitution_cost);
+        }
+
+        std::mem::swap(&mut previous, &mut current);
+    }
+
+    previous[right_chars.len()]
+}
+
+fn closest_selector(input: &str) -> Option<&'static str> {
+    let mut best_match = None;
+
+    for &selector in KNOWN_SELECTORS {
+        let distance = levenshtein_distance(input, selector);
+        if best_match.is_none_or(|(_, best_distance)| distance < best_distance) {
+            best_match = Some((selector, distance));
+        }
+    }
+
+    best_match
+        .filter(|(_, distance)| *distance <= 2)
+        .map(|(selector, _)| selector)
+}
+
 /// Manage or inspect payloads (no local flags).
 ///
 /// Note:
@@ -322,6 +358,9 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
         }
         Some(other) => {
             eprintln!("Unknown selector: {}", other);
+            if let Some(selector) = closest_selector(other) {
+                eprintln!("Did you mean: {}?", selector);
+            }
             eprintln!("Available selectors: {}", KNOWN_SELECTORS.join(", "));
             ScanOutcome::Error
         }

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -1,5 +1,5 @@
 use super::{
-    KNOWN_SELECTORS, PayloadArgs, awesome_alert_payloads, fetch_and_print_remote,
+    KNOWN_SELECTORS, PayloadArgs, awesome_alert_payloads, closest_selector, fetch_and_print_remote,
     functions_payloads, print_summary, run_payload, special_chars_payloads, static_selector_counts,
     summary_block, uri_scheme_payloads,
 };
@@ -83,6 +83,12 @@ fn test_run_payload_unknown_selector_returns_error() {
         selector: Some("not-a-selector".to_string()),
     });
     assert_eq!(outcome, ScanOutcome::Error);
+}
+
+#[test]
+fn test_closest_selector_suggests_only_near_matches() {
+    assert_eq!(closest_selector("event-handler"), Some("event-handlers"));
+    assert_eq!(closest_selector("not-a-selector"), None);
 }
 
 #[test]


### PR DESCRIPTION
## Summary

- suggest the nearest known payload selector for edit-distance near misses
- keep the complete selector list and existing error outcome unchanged
- avoid suggestions for unrelated input

Closes #1329

## Validation

- cargo test cmd::payload::tests — 10 passed
- cargo fmt --all -- --check
- CLI smoke: event-handler suggests event-handlers; not-a-selector has no suggestion
- cargo test — 2159 passed; 2 existing local-wire tests failed because their mock target was not reached
- cargo clippy --all-targets --all-features -- -D warnings — blocked by two pre-existing collapsible_match warnings in src/payload/js_breakout.rs