### PR TITLE
feat: detect Alpine.js, Preact, Lit, and SolidJS

### DIFF
--- a/src/scanning/tech_detect.rs
+++ b/src/scanning/tech_detect.rs
@@ -16,6 +16,10 @@ pub enum TechType {
     Angular,
     React,
     Vue,
+    Alpine,
+    Preact,
+    Lit,
+    Solid,
     JQuery,
     Handlebars,
     Svelte,
@@ -36,6 +40,10 @@ impl std::fmt::Display for TechType {
             TechType::Angular => write!(f, "Angular"),
             TechType::React => write!(f, "React"),
             TechType::Vue => write!(f, "Vue.js"),
+            TechType::Alpine => write!(f, "Alpine.js"),
+            TechType::Preact => write!(f, "Preact"),
+            TechType::Lit => write!(f, "Lit"),
+            TechType::Solid => write!(f, "SolidJS"),
             TechType::JQuery => write!(f, "jQuery"),
             TechType::Handlebars => write!(f, "Handlebars"),
             TechType::Svelte => write!(f, "Svelte"),
@@ -242,6 +250,26 @@ pub fn detect_technologies(headers: &HeaderMap, body: Option<&str>) -> TechDetec
                 pattern: "vue.global",
                 tech: TechType::Vue,
                 evidence: "vue.global script",
+            },
+            BodyDetectRule {
+                pattern: "x-data",
+                tech: TechType::Alpine,
+                evidence: "x-data attribute (Alpine.js)",
+            },
+            BodyDetectRule {
+                pattern: "preact.min.js",
+                tech: TechType::Preact,
+                evidence: "preact.min.js script",
+            },
+            BodyDetectRule {
+                pattern: "lit-element",
+                tech: TechType::Lit,
+                evidence: "lit-element reference",
+            },
+            BodyDetectRule {
+                pattern: "_$hy",
+                tech: TechType::Solid,
+                evidence: "_$HY hydration marker (SolidJS)",
             },
             // jQuery
             BodyDetectRule {
@@ -544,7 +572,11 @@ pub fn get_tech_specific_payloads(techs: &TechDetectionResult) -> Vec<String> {
                 ));
             }
             // Server-side techs: no specific client-side payloads needed
-            TechType::Svelte
+            TechType::Alpine
+            | TechType::Preact
+            | TechType::Lit
+            | TechType::Solid
+            | TechType::Svelte
             | TechType::Backbone
             | TechType::ASPNet
             | TechType::PHP

--- a/src/scanning/tech_detect/tests.rs
+++ b/src/scanning/tech_detect/tests.rs
@@ -37,6 +37,21 @@ fn test_detect_vue_from_body() {
 }
 
 #[test]
+fn test_detect_modern_frameworks_from_body() {
+    let headers = make_headers(&[]);
+    for (body, tech, name) in [
+        ("<div x-data></div>", TechType::Alpine, "Alpine.js"),
+        ("<script src=preact.min.js>", TechType::Preact, "Preact"),
+        ("<lit-element>", TechType::Lit, "Lit"),
+        ("<script>_$HY</script>", TechType::Solid, "SolidJS"),
+    ] {
+        let result = detect_technologies(&headers, Some(body));
+        assert!(result.has(&tech));
+        assert_eq!(tech.to_string(), name);
+    }
+}
+
+#[test]
 fn test_detect_jquery_from_body() {
     let headers = make_headers(&[]);
     let body = "<script src='https://code.jquery.com/jquery.min.js'></script>";


### PR DESCRIPTION
Fixes #1327

## Summary

- Add technology variants and display names for Alpine.js, Preact, Lit, and SolidJS.
- Detect a representative response-body marker for each framework.
- Cover all four detections and display strings with a table-driven unit test.

## Tests

- `cargo +1.96.1 test scanning::tech_detect` (41 passed)
- `cargo +1.96.1 clippy --lib --tests -- -D warnings`
- `cargo +1.96.1 fmt --check`
