### PR TITLE
Add a 'just lint' recipe (fmt --check + clippy -D warnings)

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -18,9 +18,10 @@ Dalfox v3 is written in Rust. The Go (v2.x) sources live on the [`v2` branch](ht
 just build    # cargo build --release
 just dev      # cargo build (debug)
 just test     # unit + integration tests
+just lint     # cargo fmt --check + clippy -D warnings (read-only, matches CI)
 ```
 
-Before opening a PR, please run `just fix` (runs `cargo fmt` + `cargo clippy --fix`) and `just test`.
+Before opening a PR, please run `just fix` (runs `cargo fmt` + `cargo clippy --fix`) and `just test`. To check formatting and lints without modifying files, run `just lint`.
 
 ## Reporting Issues
 

--- a/justfile
+++ b/justfile
@@ -42,6 +42,12 @@ fix:
     cargo fmt
     cargo clippy --fix --allow-dirty
 
+# Check formatting and lints without modifying files (matches CI).
+[group('build')]
+lint:
+    cargo fmt --all -- --check
+    cargo clippy --all-targets --all-features -- -D warnings
+
 # Report dalfox version across all version-bearing files.
 [group('release')]
 version-check:


### PR DESCRIPTION
## Summary

`just fix` mutates the tree (`cargo fmt` + `cargo clippy --fix`). This adds a read-only `just lint` that only checks, so contributors and CI can fail on unformatted code or clippy warnings without changing files.

## Context

Fixes #1333.

## Changes

- `justfile`: new `lint` recipe in the `build` group.
- `CONTRIBUTING.md`: one line pointing at it next to the existing `just fix` / `just test` guidance.

```just
# Check formatting and lints without modifying files (matches CI).
[group('build')]
lint:
    cargo fmt --all -- --check
    cargo clippy --all-targets --all-features -- -D warnings
```

## Testing

- `just --list` shows `lint` under the build group.
- `just lint` exits 0 on a clean tree and leaves it unmodified (`git status` clean after).
- Appending an unformatted function makes `just lint` exit 1 and report the fmt diff; reverting returns it to exit 0. So it is a real gate, not a no-op.

## Notes for reviewers

I used the CI-literal commands rather than the shorter form in the issue. CI (`.github/workflows/ci.yml`) runs `cargo fmt --all -- --check` and `cargo clippy --all-targets --all-features -- -D warnings`. A local check that drops `--all` / `--all-features` can pass while CI fails, which defeats the point of a local reproduction, so `just lint` matches CI exactly.

No alias added (e.g. `l`). Happy to add one for symmetry with `f` = `fix` if you want it.
