### PR TITLE
refactor: readability, parallel-execution safety, and safer structure

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -68,7 +68,7 @@ async fn record_session_baseline(
 
 pub(crate) async fn run_preflight_and_analysis(
     args: &ScanArgs,
-    host_groups: &mut std::collections::HashMap<String, Vec<Target>>,
+    host_groups: &mut std::collections::BTreeMap<String, Vec<Target>>,
     state: &ScanState,
 ) {
     // Rebind the shared state to owned locals so the loop body below is
@@ -116,8 +116,9 @@ pub(crate) async fn run_preflight_and_analysis(
         }
 
         // Bound overall concurrency for preflight + analysis with the same cap as scanning
-        let pre_analyze_semaphore =
-            Arc::new(tokio::sync::Semaphore::new(args.max_concurrent_targets));
+        let pre_analyze_semaphore = Arc::new(tokio::sync::Semaphore::new(
+            crate::utils::semaphore_permits(args.max_concurrent_targets),
+        ));
 
         // Move targets out of the group to own them in spawned tasks
         let mut drained: Vec<Target> = Vec::new();

--- a/src/cmd/scan/baseline.rs
+++ b/src/cmd/scan/baseline.rs
@@ -65,6 +65,28 @@ impl Baseline {
     }
 }
 
+/// The fields a finding's identity is derived from.
+///
+/// Named rather than positional: [`finding_key`] used to take these as nine
+/// consecutive `&str` parameters, so any two could be swapped and still
+/// compile. That is not a cosmetic risk here. The key is derived on two
+/// independent paths — from a live [`Result`] and from a loaded
+/// [`BaselineFinding`], whose field declaration orders differ — and both must
+/// produce byte-identical keys. Transpose one and every finding either reads
+/// as new (noise) or, under `filter` mode, collides with an unrelated one and
+/// is suppressed: the silent false-clean this module exists to avoid.
+struct FindingIdentity<'a> {
+    data: &'a str,
+    param: &'a str,
+    location: &'a str,
+    inject_type: &'a str,
+    cwe: &'a str,
+    tier: &'a str,
+    evidence: &'a str,
+    detection_method: &'a str,
+    payload: &'a str,
+}
+
 /// Stable cross-run identity of a finding.
 ///
 /// Deliberately built from *what the finding is* and not *how this particular
@@ -85,42 +107,31 @@ impl Baseline {
 ///     falling back to the detection method for everything else. The raw
 ///     evidence string is *not* used — it carries line/column numbers and
 ///     payload text that shift for unrelated reasons.
-#[allow(clippy::too_many_arguments)]
-fn finding_key(
-    data: &str,
-    param: &str,
-    location: &str,
-    inject_type: &str,
-    cwe: &str,
-    tier: &str,
-    evidence: &str,
-    detection_method: &str,
-    payload: &str,
-) -> String {
+fn finding_key(id: FindingIdentity<'_>) -> String {
     format!(
         "v1|{}|{}|{}|{}|{}|{}|{}",
-        identity_path(data, location, payload),
-        param,
-        location,
-        inject_type,
-        cwe,
-        tier,
-        evidence_family(evidence, detection_method),
+        identity_path(id.data, id.location, id.payload),
+        id.param,
+        id.location,
+        id.inject_type,
+        id.cwe,
+        id.tier,
+        evidence_family(id.evidence, id.detection_method),
     )
 }
 
 pub(crate) fn key_for_result(r: &Result) -> String {
-    finding_key(
-        &r.data,
-        &r.param,
-        &r.location,
-        &r.inject_type,
-        &r.cwe,
-        r.result_type.short(),
-        &r.evidence,
-        r.detection_method.as_str(),
-        &r.payload,
-    )
+    finding_key(FindingIdentity {
+        data: &r.data,
+        param: &r.param,
+        location: &r.location,
+        inject_type: &r.inject_type,
+        cwe: &r.cwe,
+        tier: r.result_type.short(),
+        evidence: &r.evidence,
+        detection_method: r.detection_method.as_str(),
+        payload: &r.payload,
+    })
 }
 
 /// The payload-invariant part of a finding URL: scheme + host + path, with the
@@ -273,17 +284,17 @@ pub(crate) fn load(path: &str, mode: &str) -> Baseline {
         if f.data.is_empty() && f.param.is_empty() {
             continue;
         }
-        keys.insert(finding_key(
-            &f.data,
-            &f.param,
-            &f.location,
-            &f.inject_type,
-            &f.cwe,
-            &f.tier,
-            &f.evidence,
-            &f.detection_method,
-            &f.payload,
-        ));
+        keys.insert(finding_key(FindingIdentity {
+            data: &f.data,
+            param: &f.param,
+            location: &f.location,
+            inject_type: &f.inject_type,
+            cwe: &f.cwe,
+            tier: &f.tier,
+            evidence: &f.evidence,
+            detection_method: &f.detection_method,
+            payload: &f.payload,
+        }));
     }
 
     // Entries were present but none of them looked like findings: the file

--- a/src/cmd/scan/baseline/tests.rs
+++ b/src/cmd/scan/baseline/tests.rs
@@ -41,6 +41,47 @@ fn report(findings: &[Result]) -> String {
 
 // ---------------------------------------------------------------- key identity
 
+/// The identity key is derived on two independent paths — from a live `Result`
+/// and from a `BaselineFinding` parsed back out of a written report — and the
+/// two structs declare their fields in different orders. If either mapping is
+/// transposed, a saved baseline stops matching the run that produced it: every
+/// finding reads as new under `report` mode, and under `filter` mode a
+/// collision suppresses a real finding as already-known.
+///
+/// Every identity field is given a *distinct* value here, so swapping any two
+/// of them changes the key and fails this test. That is the whole point — the
+/// old positional `finding_key` took nine consecutive `&str`s, so no swap was
+/// a compile error.
+#[test]
+fn baseline_roundtrip_key_matches_the_live_finding_key() {
+    let mut f = finding(FindingType::Verified, "https://example.test/a?q=1", "q");
+    f.location = "Header".to_string();
+    f.detection_method = FindingMethod::DomVerification;
+    f.inject_type = "inJS-double(2)".to_string();
+    f.cwe = "CWE-80".to_string();
+    f.evidence = "Source: location.hash , Sink: innerHTML".to_string();
+
+    let live = key_for_result(&f);
+
+    // Round-trip through the exact bytes `--format json --output` writes.
+    let path = tmp("roundtrip-identity", &report(std::slice::from_ref(&f)));
+    let loaded = load(path.to_str().expect("utf-8 path"), BASELINE_MODE_FILTER);
+    let _ = std::fs::remove_file(&path);
+
+    assert!(
+        loaded.warning.is_none(),
+        "baseline should load cleanly, got: {:?}",
+        loaded.warning
+    );
+    assert!(
+        loaded.keys.contains(&live),
+        "a finding must match itself through a saved baseline;\n  live key: {}\n  loaded:   {:?}",
+        live,
+        loaded.keys
+    );
+    assert_eq!(loaded.keys.len(), 1);
+}
+
 #[test]
 fn key_ignores_the_payload_in_the_url() {
     // Two runs of the same scan embed different payloads in `data`. That is

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -632,8 +632,15 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     };
 
     // Group targets by host
-    let mut host_groups: std::collections::HashMap<String, Vec<Target>> =
-        std::collections::HashMap::new();
+    // A `BTreeMap`, not a `HashMap`: host order is user-visible in four places
+    // — the preflight/analysis pass, `--dry-run`, `--only-discovery`, and the
+    // scan loop's bounded dispatch (which decides what a `--limit` or Ctrl-C
+    // run reaches, and what a `--state-file` run records as completed).
+    // `HashMap` iterates under a per-process `RandomState` seed, so those all
+    // varied run to run and `--only-discovery --format json` could not be
+    // diffed against itself.
+    let mut host_groups: std::collections::BTreeMap<String, Vec<Target>> =
+        std::collections::BTreeMap::new();
     for target in parsed_targets {
         let host = target.url.host_str().unwrap_or("unknown").to_string();
         host_groups.entry(host).or_default().push(target);

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -15,7 +15,7 @@ use crate::target_parser::Target;
 
 pub(crate) async fn render_dry_run(
     args: &ScanArgs,
-    host_groups: &std::collections::HashMap<String, Vec<Target>>,
+    host_groups: &std::collections::BTreeMap<String, Vec<Target>>,
     state: &ScanState,
 ) -> ScanOutcome {
     let skipped_targets = &state.skipped_targets;
@@ -202,7 +202,7 @@ pub(crate) async fn render_dry_run(
 
 pub(crate) fn render_only_discovery(
     args: &ScanArgs,
-    host_groups: &std::collections::HashMap<String, Vec<Target>>,
+    host_groups: &std::collections::BTreeMap<String, Vec<Target>>,
     state: &ScanState,
 ) -> ScanOutcome {
     // Collect once so we can render both human-readable plain

--- a/src/cmd/scan/scan_loop.rs
+++ b/src/cmd/scan/scan_loop.rs
@@ -10,9 +10,31 @@ use super::logging::start_spinner;
 use super::poc::render_finding_block;
 use super::session::{ProbePhase, SessionMonitor};
 use crate::target_parser::Target;
+use crate::utils::semaphore_permits;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+
+/// Host-group slots per configured concurrent target. Groups are cheap
+/// relative to targets and spend part of their life holding no target permit,
+/// so they are oversubscribed rather than matched 1:1 — the target semaphore
+/// stays the throttle that governs in-flight work.
+const HOST_GROUP_OVERSUBSCRIBE: usize = 4;
+
+/// Floor for host-group slots, so a low `--max-concurrent-targets` still lets
+/// several hosts prepare in parallel.
+const MIN_HOST_GROUP_SLOTS: usize = 32;
+
+/// How many host-group tasks may be alive at once for a given
+/// `--max-concurrent-targets`. See the call site for why this is deliberately
+/// looser than the target bound rather than equal to it.
+fn host_group_slots(max_concurrent_targets: usize) -> usize {
+    semaphore_permits(
+        max_concurrent_targets
+            .saturating_mul(HOST_GROUP_OVERSUBSCRIBE)
+            .max(MIN_HOST_GROUP_SLOTS),
+    )
+}
 
 /// Complete once `flag` is observed set. Used to mirror the process-wide
 /// SIGINT (Ctrl-C) flag into a per-target cancel flag from inside a
@@ -40,8 +62,9 @@ async fn poll_cancel(flag: &AtomicBool) {
 /// instead, never the shared `sigint` flag. A real Ctrl-C is mirrored from
 /// `sigint` into `target_cancel` so in-flight workers still stop. `fut` is
 /// driven to completion either way (not just dropped): `run_scanning`'s
-/// per-parameter workers are detached `tokio::spawn` tasks that a dropped
-/// future would leave hammering the target, so we keep polling until the
+/// per-parameter workers now live in a `JoinSet` and *are* aborted if this
+/// future is dropped, but aborting them mid-request skips their result
+/// collapse and progress accounting, so we still keep polling until the
 /// cooperative-cancel checkpoints let them drain. Returns whether the cap
 /// fired (callers print the per-target notice).
 async fn run_target_capped<T>(
@@ -73,7 +96,7 @@ async fn run_target_capped<T>(
 
 pub(crate) async fn run_scan_loop(
     args: &ScanArgs,
-    host_groups: std::collections::HashMap<String, Vec<Target>>,
+    host_groups: std::collections::BTreeMap<String, Vec<Target>>,
     state: &ScanState,
     cancel_flag: Arc<AtomicBool>,
     stream_findings_enabled: bool,
@@ -117,7 +140,9 @@ pub(crate) async fn run_scan_loop(
         );
     }
 
-    let global_semaphore = Arc::new(tokio::sync::Semaphore::new(args.max_concurrent_targets));
+    let global_semaphore = Arc::new(tokio::sync::Semaphore::new(semaphore_permits(
+        args.max_concurrent_targets,
+    )));
     let (finding_tx, finding_printer_handle) = if stream_findings_enabled {
         let (tx, mut rx) =
             tokio::sync::mpsc::unbounded_channel::<crate::scanning::result::Result>();
@@ -169,17 +194,62 @@ pub(crate) async fn run_scan_loop(
         (None, None)
     };
 
-    let mut group_handles = vec![];
+    // One `ScanArgs` for the whole run. This used to be cloned per host group —
+    // a deep copy of every `String`/`Vec<String>` field once per distinct host.
+    let args_arc = Arc::new(args.clone());
+
+    // Bound on host-group tasks alive at once. Previously one task was spawned
+    // per distinct host with no gate, so a target file spanning N hosts created
+    // N tasks — each holding a target list and, when a progress bar is drawn,
+    // each running the payload precount below before acquiring a single target
+    // permit. That is CPU and memory proportional to the host count rather than
+    // to the configured concurrency.
+    //
+    // Deliberately *loose* rather than mirroring `max_concurrent_targets`: a
+    // group can occupy a slot while holding zero target permits (during the
+    // precount, while walking targets skipped for session loss, and while
+    // draining at the end), so a tight bound would leave the target semaphore —
+    // the real throttle — idle. This only has to stop unbounded growth.
+    let group_semaphore = Arc::new(tokio::sync::Semaphore::new(host_group_slots(
+        args.max_concurrent_targets,
+    )));
+
+    // A `JoinSet`, not `Vec<JoinHandle>`: the `--limit` break below abandons the
+    // groups that haven't finished, and a dropped `JoinHandle` detaches its task
+    // instead of aborting it. Those groups kept scanning and kept pushing into
+    // `results` after this function returned, while the caller was already
+    // rendering output. Same failure the per-parameter workers hit; see the
+    // `JoinSet` note in `scanning::run_scanning`.
+    let mut group_handles = tokio::task::JoinSet::new();
+
+    // Stop dispatching once the user pressed Ctrl-C or `--limit` was reached.
+    // Checked *after* the permit is granted, not before: dispatch now blocks on
+    // `acquire_owned()`, so a check made before that await reads state from
+    // however long ago the loop parked. On a run with more host groups than
+    // slots that window is seconds, and admitting one more group then costs a
+    // full synchronous payload precount before its inner loop notices.
+    let should_stop = |flag: &AtomicBool, count: &std::sync::atomic::AtomicUsize| {
+        flag.load(Ordering::Relaxed)
+            || args
+                .limit
+                .is_some_and(|lim| count.load(Ordering::Relaxed) >= lim)
+    };
 
     for (host, group) in host_groups {
-        if let Some(lim) = args.limit
-            && findings_count.load(Ordering::Relaxed) >= lim
-        {
+        if should_stop(&cancel_flag, &findings_count) {
+            break;
+        }
+        // Backpressure: block dispatch once `group_slots` groups are live.
+        let Ok(group_permit) = group_semaphore.clone().acquire_owned().await else {
+            break;
+        };
+        // Re-check with the permit in hand — the state above may be stale.
+        if should_stop(&cancel_flag, &findings_count) {
             break;
         }
         let global_semaphore_clone = global_semaphore.clone();
         let multi_pb_clone = multi_pb.clone();
-        let args_arc = Arc::new(args.clone());
+        let args_arc = args_arc.clone();
         let results_clone = results.clone();
         let findings_count_group = findings_count.clone();
         let finding_tx_group = finding_tx.clone();
@@ -196,7 +266,9 @@ pub(crate) async fn run_scan_loop(
         // session; a dead session on one of them says nothing about a
         // different host in the same run.
         let session_lost_group = Arc::new(AtomicBool::new(false));
-        let group_handle = tokio::spawn(async move {
+        group_handles.spawn(async move {
+            // Released when this group finishes, admitting the next one.
+            let _group_permit = group_permit;
             // Skip the (expensive) payload-counting loop entirely when no
             // overall progress bar will be drawn — generating ~10k payloads
             // per param twice (here and again inside run_scanning) added a
@@ -259,7 +331,11 @@ pub(crate) async fn run_scan_loop(
                 None
             };
 
-            let mut target_handles = vec![];
+            // Also a `JoinSet`: when the run stops early under `--limit` the
+            // group task itself is aborted, and a `Vec<JoinHandle>` would let
+            // its in-flight targets detach and keep issuing requests. A
+            // `JoinSet` aborts them when it drops.
+            let mut target_handles = tokio::task::JoinSet::new();
 
             for target in group {
                 if let Some(lim) = args_arc.limit
@@ -321,7 +397,7 @@ pub(crate) async fn run_scan_loop(
                 let state_file_target = state_file_group.clone();
 
                 let multi_pb_active = multi_pb_clone_inner.is_some();
-                let target_handle = tokio::spawn(async move {
+                target_handles.spawn(async move {
                     if !args_clone.skip_xss_scanning && !args_clone.only_discovery {
                         // Re-validate the session before spending this target's
                         // request budget. Throttled: on a short run the preflight
@@ -386,15 +462,15 @@ pub(crate) async fn run_scan_loop(
                         let scan_fut = crate::scanning::run_scanning(
                             &target,
                             args_clone.clone(),
-                            results_clone_inner,
-                            multi_pb_clone_inner,
-                            overall_pb_clone,
-                            findings_count_target,
-                            Some(target_cancel.clone()),
-                            finding_tx_target,
-                            // CLI renders its own indicatif progress bar; no
-                            // external params_tested counter to feed.
-                            None,
+                            // No `params_done`: the CLI renders its own
+                            // indicatif progress bar instead.
+                            crate::scanning::ScanRunHandles::new(
+                                results_clone_inner,
+                                findings_count_target,
+                            )
+                            .with_progress(multi_pb_clone_inner, overall_pb_clone)
+                            .with_cancel(target_cancel.clone())
+                            .with_finding_tx(finding_tx_target),
                         );
                         // Honor --scan-timeout as a hard wall-clock cap per
                         // target. When a slow endpoint streams a partial body
@@ -480,14 +556,13 @@ pub(crate) async fn run_scan_loop(
                     }
                     drop(permit);
                 });
-                target_handles.push(target_handle);
             }
 
-            for handle in target_handles {
+            while let Some(joined) = target_handles.join_next().await {
                 // Surface panics from per-target scan tasks instead of letting
                 // them disappear silently — a panic here points to a bug in
                 // the scanning pipeline and operators need a chance to see it.
-                if let Err(e) = handle.await
+                if let Err(e) = joined
                     && e.is_panic()
                 {
                     eprintln!("[scan] target task panicked: {}", e);
@@ -505,11 +580,10 @@ pub(crate) async fn run_scan_loop(
                 );
             }
         });
-        group_handles.push(group_handle);
     }
 
-    for handle in group_handles {
-        if let Err(e) = handle.await
+    while let Some(joined) = group_handles.join_next().await {
+        if let Err(e) = joined
             && e.is_panic()
         {
             eprintln!("[scan] target-group task panicked: {}", e);
@@ -517,7 +591,22 @@ pub(crate) async fn run_scan_loop(
         if let Some(lim) = args.limit
             && findings_count.load(Ordering::Relaxed) >= lim
         {
-            break;
+            // Stop the groups still running — but cooperatively, and keep
+            // draining rather than breaking.
+            //
+            // Breaking used to drop the remaining `JoinHandle`s, which detaches
+            // rather than aborts: those groups kept scanning and kept appending
+            // to `results` after this function returned, while the caller was
+            // already rendering the report. `abort_all()` fixes that but
+            // overcorrects — it kills targets mid-`run_scanning`, so they skip
+            // `collapse_target_results` (leaving `R` findings a later `V` would
+            // have collapsed), skip their `skipped_targets` marker (so
+            // `target_summary` calls a half-scanned target clean), and skip
+            // `finish_scan_bar` (orphaning a progress line).
+            //
+            // Setting the shared cancel flag instead stops them at their next
+            // checkpoint and lets each one run its normal completion path.
+            cancel_flag.store(true, Ordering::Relaxed);
         }
     }
 
@@ -536,7 +625,10 @@ pub(crate) async fn run_scan_loop(
 
 #[cfg(test)]
 mod tests {
-    use super::{poll_cancel, run_target_capped};
+    use super::{
+        MIN_HOST_GROUP_SLOTS, host_group_slots, poll_cancel, run_target_capped, semaphore_permits,
+    };
+    use crate::utils::MAX_SEMAPHORE_PERMITS;
     use std::sync::Arc;
     use std::sync::atomic::{AtomicBool, Ordering};
     use std::time::Duration;
@@ -610,6 +702,49 @@ mod tests {
         assert!(!timed_out);
         assert!(!target_cancel.load(Ordering::Relaxed));
         assert!(!sigint.load(Ordering::Relaxed));
+    }
+
+    // Host-group dispatch must be bounded: one `tokio::spawn` per distinct host
+    // meant a target file spanning N hosts created N tasks — each holding a
+    // target list and, with a progress bar drawn, each running the payload
+    // precount — before a single request went out.
+    #[test]
+    fn host_group_slots_is_bounded_and_oversubscribed() {
+        // Never tighter than the floor, so a small --max-concurrent-targets
+        // still lets several hosts prepare at once.
+        assert_eq!(host_group_slots(1), MIN_HOST_GROUP_SLOTS);
+        assert_eq!(host_group_slots(0), MIN_HOST_GROUP_SLOTS);
+
+        // Above the floor it scales with the target bound, and stays LOOSER
+        // than it: a group can hold a slot while holding zero target permits
+        // (precount, session-loss skip walk, drain), so matching the target
+        // bound 1:1 would leave the target semaphore — the real throttle —
+        // idle behind groups doing no request work.
+        assert!(
+            host_group_slots(100) > 100,
+            "group admission must not throttle the target semaphore"
+        );
+
+        // Bounded, not unbounded: that is the whole point.
+        assert!(host_group_slots(usize::MAX) <= MAX_SEMAPHORE_PERMITS);
+    }
+
+    // `--max-concurrent-targets` is validated only as non-zero, and arrives
+    // from the CLI, a config file, REST `ScanOptions`, and MCP. A huge value
+    // used to reach `Semaphore::new` directly, which asserts above
+    // `MAX_PERMITS` — a panic driven straight by user input.
+    #[test]
+    fn semaphore_permits_never_exceeds_tokio_ceiling() {
+        assert_eq!(semaphore_permits(4), 4, "realistic values pass through");
+        assert_eq!(semaphore_permits(usize::MAX), MAX_SEMAPHORE_PERMITS);
+        // The lower bound matters more than the upper one: `Semaphore::new(0)`
+        // is not a slow scan, it is a permanent deadlock — every worker blocks
+        // on `acquire()` forever and the scan hangs with no output.
+        assert_eq!(semaphore_permits(0), 1, "zero permits would deadlock");
+
+        // The real assertion: constructing with the clamped value must not panic.
+        let _ = tokio::sync::Semaphore::new(semaphore_permits(usize::MAX));
+        let _ = tokio::sync::Semaphore::new(host_group_slots(usize::MAX));
     }
 
     #[tokio::test]

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -813,8 +813,8 @@ fn target_with_params(url: &str, params: Vec<Param>) -> Target {
 }
 
 /// Wrap targets into the `host_groups` shape the output renderers consume.
-fn host_group(targets: Vec<Target>) -> HashMap<String, Vec<Target>> {
-    let mut m = HashMap::new();
+fn host_group(targets: Vec<Target>) -> std::collections::BTreeMap<String, Vec<Target>> {
+    let mut m = std::collections::BTreeMap::new();
     m.insert("host".to_string(), targets);
     m
 }
@@ -2456,7 +2456,7 @@ async fn test_run_preflight_and_analysis_analyze_external_js_produces_finding() 
     args.skip_waf_probe = true;
 
     let state = make_scan_state(vec![]);
-    let mut host_groups = std::collections::HashMap::new();
+    let mut host_groups = std::collections::BTreeMap::new();
     host_groups.insert(host, vec![target]);
 
     run_preflight_and_analysis(&args, &mut host_groups, &state).await;

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -592,17 +592,16 @@ impl DalfoxMcp {
                         scan_report = crate::scanning::run_scanning(
                             &target,
                             scan_args.clone(),
-                            results_arc.clone(),
-                            None,
-                            None,
-                            findings_count.clone(),
-                            Some(cancel_flag.clone()),
-                            None,
+                            crate::scanning::ScanRunHandles::new(
+                                results_arc.clone(),
+                                findings_count.clone(),
+                            )
+                            .with_cancel(cancel_flag.clone())
                             // Feed the live per-parameter completion counter
                             // so get_results_dalfox reports `params_tested`
                             // (and estimated_completion_pct) advancing during
                             // the scan instead of staying at 0 until done.
-                            Some(progress.params_tested.clone()),
+                            .with_params_done(progress.params_tested.clone()),
                         )
                         .await;
 

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -370,85 +370,88 @@ pub async fn check_query_discovery(
         let target_clone = arc_target.clone();
 
         // Spawn a task that returns Option<Param> instead of locking per discovery.
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
-            let m = parsed_method;
-            let request =
-                crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
-            crate::record_outbound_request().await;
-            let mut discovered: Option<Param> = None;
-            if let Ok(resp) = request.send().await {
-                // Check for redirect reflection: if the response is a 3xx redirect,
-                // the Location header may contain the reflected marker value.
-                let is_redirect = resp.status().is_redirection();
-                let location_reflection = if is_redirect {
-                    resp.headers()
-                        .get("location")
-                        .and_then(|v| v.to_str().ok())
-                        .is_some_and(|loc| {
-                            crate::scanning::markers::classify_probe_reflection(loc).detected()
-                        })
-                } else {
-                    false
-                };
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+                let m = parsed_method;
+                let request =
+                    crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(resp) = request.send().await {
+                    // Check for redirect reflection: if the response is a 3xx redirect,
+                    // the Location header may contain the reflected marker value.
+                    let is_redirect = resp.status().is_redirection();
+                    let location_reflection = if is_redirect {
+                        resp.headers()
+                            .get("location")
+                            .and_then(|v| v.to_str().ok())
+                            .is_some_and(|loc| {
+                                crate::scanning::markers::classify_probe_reflection(loc).detected()
+                            })
+                    } else {
+                        false
+                    };
 
-                if location_reflection {
-                    // Redirect context: marker reflected in Location header.
-                    // Use Attribute context since the value is placed in a URI attribute.
-                    discovered = Some(Param {
-                        name,
-                        value,
-                        location: crate::parameter_analysis::Location::Query,
-                        injection_context: Some(
-                            crate::parameter_analysis::InjectionContext::AttributeUrl(None),
-                        ),
-                        valid_specials: None,
-                        invalid_specials: None,
-                        pre_encoding: None,
-                        pre_encoding_pipeline: None,
-                        wire_name: None,
-                        form_action_url: None,
-                        form_origin_url: None,
-                        framework_sink: None,
-                        escaped_specials: None,
-                        js_breakout: None,
-                    });
-                } else if let Ok(text) = crate::utils::http::read_body(resp).await
-                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
-                {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
-                        &text,
-                        crate::scanning::markers::bracketed_marker(),
-                    )
-                    .map(ToString::to_string);
-                    discovered = Some(Param {
-                        name,
-                        value,
-                        location: crate::parameter_analysis::Location::Query,
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        pre_encoding: None,
-                        pre_encoding_pipeline: None,
-                        wire_name: None,
-                        form_action_url: None,
-                        form_origin_url: None,
-                        framework_sink,
-                        escaped_specials: None,
-                        js_breakout: detect_js_breakout(&text),
-                    });
+                    if location_reflection {
+                        // Redirect context: marker reflected in Location header.
+                        // Use Attribute context since the value is placed in a URI attribute.
+                        discovered = Some(Param {
+                            name,
+                            value,
+                            location: crate::parameter_analysis::Location::Query,
+                            injection_context: Some(
+                                crate::parameter_analysis::InjectionContext::AttributeUrl(None),
+                            ),
+                            valid_specials: None,
+                            invalid_specials: None,
+                            pre_encoding: None,
+                            pre_encoding_pipeline: None,
+                            wire_name: None,
+                            form_action_url: None,
+                            form_origin_url: None,
+                            framework_sink: None,
+                            escaped_specials: None,
+                            js_breakout: None,
+                        });
+                    } else if let Ok(text) = crate::utils::http::read_body(resp).await
+                        && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                    {
+                        let (valid, invalid) = classify_special_chars(&text);
+                        let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
+                            &text,
+                            crate::scanning::markers::bracketed_marker(),
+                        )
+                        .map(ToString::to_string);
+                        discovered = Some(Param {
+                            name,
+                            value,
+                            location: crate::parameter_analysis::Location::Query,
+                            injection_context: Some(detect_injection_context(&text)),
+                            valid_specials: Some(valid),
+                            invalid_specials: Some(invalid),
+                            pre_encoding: None,
+                            pre_encoding_pipeline: None,
+                            wire_name: None,
+                            form_action_url: None,
+                            form_origin_url: None,
+                            framework_sink,
+                            escaped_specials: None,
+                            js_breakout: detect_js_breakout(&text),
+                        });
+                    }
                 }
-            }
-            if delay > 0 {
-                sleep(Duration::from_millis(delay)).await;
-            }
-            drop(permit);
-            discovered
-        });
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                discovered
+            },
+        ));
         handles.push(handle);
 
         // Drain this chunk before spawning more so the live task count (and the
@@ -840,51 +843,54 @@ pub async fn check_header_discovery(
         let target_clone = arc_target.clone();
 
         // Spawn task returning Option<Param> to batch reduce mutex contention
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
-            let m = parsed_method;
-            let base =
-                crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
-            let overrides = vec![(header_name.clone(), test_value.to_string())];
-            let request = crate::utils::apply_header_overrides(base, &overrides);
-            crate::record_outbound_request().await;
-            let mut discovered: Option<Param> = None;
-            if let Ok(resp) = request.send().await
-                && let Ok(text) = crate::utils::http::read_body(resp).await
-                && crate::scanning::markers::classify_probe_reflection(&text).detected()
-            {
-                let (valid, invalid) = classify_special_chars(&text);
-                let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
-                    &text,
-                    crate::scanning::markers::bracketed_marker(),
-                )
-                .map(ToString::to_string);
-                discovered = Some(Param {
-                    name: header_name,
-                    value: header_value,
-                    location: crate::parameter_analysis::Location::Header,
-                    injection_context: Some(detect_injection_context(&text)),
-                    valid_specials: Some(valid),
-                    invalid_specials: Some(invalid),
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink,
-                    escaped_specials: None,
-                    js_breakout: detect_js_breakout(&text),
-                });
-            }
-            if delay > 0 {
-                sleep(Duration::from_millis(delay)).await;
-            }
-            drop(permit);
-            discovered
-        });
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+                let m = parsed_method;
+                let base =
+                    crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
+                let overrides = vec![(header_name.clone(), test_value.to_string())];
+                let request = crate::utils::apply_header_overrides(base, &overrides);
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(resp) = request.send().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
+                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                {
+                    let (valid, invalid) = classify_special_chars(&text);
+                    let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
+                        &text,
+                        crate::scanning::markers::bracketed_marker(),
+                    )
+                    .map(ToString::to_string);
+                    discovered = Some(Param {
+                        name: header_name,
+                        value: header_value,
+                        location: crate::parameter_analysis::Location::Header,
+                        injection_context: Some(detect_injection_context(&text)),
+                        valid_specials: Some(valid),
+                        invalid_specials: Some(invalid),
+                        pre_encoding: None,
+                        pre_encoding_pipeline: None,
+                        wire_name: None,
+                        form_action_url: None,
+                        form_origin_url: None,
+                        framework_sink,
+                        escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
+                    });
+                }
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                discovered
+            },
+        ));
         handles.push(handle);
     }
 
@@ -969,111 +975,116 @@ pub async fn check_path_discovery(
         }
 
         // Spawn task returning Option<Param> for batched collection
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
-            let m = parsed_method;
-            let request = crate::utils::build_request(
-                &client_clone,
-                &target_clone,
-                m.clone(),
-                new_url,
-                data.clone(),
-            );
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+                let m = parsed_method;
+                let request = crate::utils::build_request(
+                    &client_clone,
+                    &target_clone,
+                    m.clone(),
+                    new_url,
+                    data.clone(),
+                );
 
-            crate::record_outbound_request().await;
-            let mut discovered: Option<Param> = None;
-            if let Ok(resp) = request.send().await {
-                // Pair discovery with the scan-time `should_suppress_path_*`
-                // policy so we don't pay payload-set requests for path
-                // segments the scanner would later throw away. Concretely:
-                //   * 2xx                              → always honor
-                //   * 3xx                              → drop (Location-only
-                //                                       echo, not a rendered
-                //                                       HTML sink)
-                //   * 4xx/5xx + marker only in URL attrs → drop (canonical
-                //                                       link / `<a href>`
-                //                                       echo noise)
-                //   * 4xx/5xx + marker outside URL attrs → keep
-                //                                       (genuine error-page
-                //                                       XSS — e.g. a 404
-                //                                       template that emits
-                //                                       `<td>{uri}</td>`).
-                let status = resp.status().as_u16();
-                if !(300..400).contains(&status)
-                    && let Ok(text) = crate::utils::http::read_body(resp).await
-                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
-                {
-                    let exploitable_context = (200..300).contains(&status)
-                        || !crate::scanning::check_reflection::marker_reflects_in_url_attr_only(
-                            &text,
-                            crate::scanning::markers::bracketed_marker(),
-                        );
-                    // For 4xx/5xx error pages whose templates echo the URL
-                    // path into text content, require the second probe
-                    // (`<MARKER>`) to come back with raw `<` and `>` before
-                    // declaring the segment scannable. If the server
-                    // entity-escapes either bracket, no HTML-tag payload
-                    // will ever reflect — keeping the segment would burn
-                    // thousands of requests on guaranteed-negative payloads.
-                    //
-                    // Known limitation: `t.contains(&needle)` is case-sensitive,
-                    // so a server that ASCII-uppercases / -lowercases reflected
-                    // path bytes (e.g. xssmaze's `obfuscation/level2` shape, but
-                    // applied to a 4xx path-echo) would slip past this gate and
-                    // get treated as inert. Real-world servers rarely case-fold
-                    // URL paths, so the trade-off is acceptable; if it surfaces
-                    // in benchmarks, swap to the `ascii_ci_contains` helper used
-                    // by `check_reflection::marker_case_fold_reflected`.
-                    let bracket_survives = if exploitable_context && !(200..300).contains(&status) {
-                        let needle = format!("<{}>", crate::scanning::markers::bracketed_marker());
-                        let probe = crate::utils::build_request(
-                            &client_clone,
-                            &target_clone,
-                            m.clone(),
-                            bracket_url,
-                            data.clone(),
-                        );
-                        crate::record_outbound_request().await;
-                        match probe.send().await {
-                            Ok(r) => match crate::utils::http::read_body(r).await {
-                                Ok(t) => t.contains(&needle),
-                                Err(_) => false,
-                            },
-                            Err(_) => false,
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(resp) = request.send().await {
+                    // Pair discovery with the scan-time `should_suppress_path_*`
+                    // policy so we don't pay payload-set requests for path
+                    // segments the scanner would later throw away. Concretely:
+                    //   * 2xx                              → always honor
+                    //   * 3xx                              → drop (Location-only
+                    //                                       echo, not a rendered
+                    //                                       HTML sink)
+                    //   * 4xx/5xx + marker only in URL attrs → drop (canonical
+                    //                                       link / `<a href>`
+                    //                                       echo noise)
+                    //   * 4xx/5xx + marker outside URL attrs → keep
+                    //                                       (genuine error-page
+                    //                                       XSS — e.g. a 404
+                    //                                       template that emits
+                    //                                       `<td>{uri}</td>`).
+                    let status = resp.status().as_u16();
+                    if !(300..400).contains(&status)
+                        && let Ok(text) = crate::utils::http::read_body(resp).await
+                        && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                    {
+                        let exploitable_context = (200..300).contains(&status)
+                            || !crate::scanning::check_reflection::marker_reflects_in_url_attr_only(
+                                &text,
+                                crate::scanning::markers::bracketed_marker(),
+                            );
+                        // For 4xx/5xx error pages whose templates echo the URL
+                        // path into text content, require the second probe
+                        // (`<MARKER>`) to come back with raw `<` and `>` before
+                        // declaring the segment scannable. If the server
+                        // entity-escapes either bracket, no HTML-tag payload
+                        // will ever reflect — keeping the segment would burn
+                        // thousands of requests on guaranteed-negative payloads.
+                        //
+                        // Known limitation: `t.contains(&needle)` is case-sensitive,
+                        // so a server that ASCII-uppercases / -lowercases reflected
+                        // path bytes (e.g. xssmaze's `obfuscation/level2` shape, but
+                        // applied to a 4xx path-echo) would slip past this gate and
+                        // get treated as inert. Real-world servers rarely case-fold
+                        // URL paths, so the trade-off is acceptable; if it surfaces
+                        // in benchmarks, swap to the `ascii_ci_contains` helper used
+                        // by `check_reflection::marker_case_fold_reflected`.
+                        let bracket_survives =
+                            if exploitable_context && !(200..300).contains(&status) {
+                                let needle =
+                                    format!("<{}>", crate::scanning::markers::bracketed_marker());
+                                let probe = crate::utils::build_request(
+                                    &client_clone,
+                                    &target_clone,
+                                    m.clone(),
+                                    bracket_url,
+                                    data.clone(),
+                                );
+                                crate::record_outbound_request().await;
+                                match probe.send().await {
+                                    Ok(r) => match crate::utils::http::read_body(r).await {
+                                        Ok(t) => t.contains(&needle),
+                                        Err(_) => false,
+                                    },
+                                    Err(_) => false,
+                                }
+                            } else {
+                                true
+                            };
+                        if exploitable_context && bracket_survives {
+                            let (valid, invalid) = classify_special_chars(&text);
+                            discovered = Some(Param {
+                                name: param_name,
+                                value: original_value,
+                                location: crate::parameter_analysis::Location::Path,
+                                injection_context: Some(detect_injection_context(&text)),
+                                valid_specials: Some(valid),
+                                invalid_specials: Some(invalid),
+                                pre_encoding: None,
+                                pre_encoding_pipeline: None,
+                                wire_name: None,
+                                form_action_url: None,
+                                form_origin_url: None,
+                                framework_sink: None,
+                                escaped_specials: None,
+                                js_breakout: detect_js_breakout(&text),
+                            });
                         }
-                    } else {
-                        true
-                    };
-                    if exploitable_context && bracket_survives {
-                        let (valid, invalid) = classify_special_chars(&text);
-                        discovered = Some(Param {
-                            name: param_name,
-                            value: original_value,
-                            location: crate::parameter_analysis::Location::Path,
-                            injection_context: Some(detect_injection_context(&text)),
-                            valid_specials: Some(valid),
-                            invalid_specials: Some(invalid),
-                            pre_encoding: None,
-                            pre_encoding_pipeline: None,
-                            wire_name: None,
-                            form_action_url: None,
-                            form_origin_url: None,
-                            framework_sink: None,
-                            escaped_specials: None,
-                            js_breakout: detect_js_breakout(&text),
-                        });
                     }
                 }
-            }
-            if delay > 0 {
-                sleep(Duration::from_millis(delay)).await;
-            }
-            drop(permit);
-            discovered
-        });
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                discovered
+            },
+        ));
         handles.push(handle);
         new_segments[idx] = saved;
     }
@@ -1132,57 +1143,60 @@ pub async fn check_cookie_discovery(
         let target_clone = arc_target.clone();
 
         // Spawn task returning Option<Param> for batched collection
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
-            let m = parsed_method;
-            // Compose cookie header overriding the probed cookie while preserving others
-            let others =
-                crate::utils::compose_cookie_header_excluding(&cookies, Some(&cookie_name));
-            let cookie_header = match others {
-                Some(s) => format!("{}; {}={}", s, cookie_name, test_value),
-                None => format!("{}={}", cookie_name, test_value),
-            };
-            let request = crate::utils::build_request_with_cookie(
-                &client_clone,
-                &target_clone,
-                m,
-                url,
-                data.clone(),
-                Some(cookie_header),
-            );
-            crate::record_outbound_request().await;
-            let mut discovered: Option<Param> = None;
-            if let Ok(resp) = request.send().await
-                && let Ok(text) = crate::utils::http::read_body(resp).await
-                && crate::scanning::markers::classify_probe_reflection(&text).detected()
-            {
-                let (valid, invalid) = classify_special_chars(&text);
-                discovered = Some(Param {
-                    name: cookie_name,
-                    value: cookie_value,
-                    location: crate::parameter_analysis::Location::Header,
-                    injection_context: Some(detect_injection_context(&text)),
-                    valid_specials: Some(valid),
-                    invalid_specials: Some(invalid),
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: detect_js_breakout(&text),
-                });
-            }
-            if delay > 0 {
-                sleep(Duration::from_millis(delay)).await;
-            }
-            drop(permit);
-            discovered
-        });
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+                let m = parsed_method;
+                // Compose cookie header overriding the probed cookie while preserving others
+                let others =
+                    crate::utils::compose_cookie_header_excluding(&cookies, Some(&cookie_name));
+                let cookie_header = match others {
+                    Some(s) => format!("{}; {}={}", s, cookie_name, test_value),
+                    None => format!("{}={}", cookie_name, test_value),
+                };
+                let request = crate::utils::build_request_with_cookie(
+                    &client_clone,
+                    &target_clone,
+                    m,
+                    url,
+                    data.clone(),
+                    Some(cookie_header),
+                );
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(resp) = request.send().await
+                    && let Ok(text) = crate::utils::http::read_body(resp).await
+                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                {
+                    let (valid, invalid) = classify_special_chars(&text);
+                    discovered = Some(Param {
+                        name: cookie_name,
+                        value: cookie_value,
+                        location: crate::parameter_analysis::Location::Header,
+                        injection_context: Some(detect_injection_context(&text)),
+                        valid_specials: Some(valid),
+                        invalid_specials: Some(invalid),
+                        pre_encoding: None,
+                        pre_encoding_pipeline: None,
+                        wire_name: None,
+                        form_action_url: None,
+                        form_origin_url: None,
+                        framework_sink: None,
+                        escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
+                    });
+                }
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                discovered
+            },
+        ));
         handles.push(handle);
     }
 

--- a/src/parameter_analysis/discovery/tests.rs
+++ b/src/parameter_analysis/discovery/tests.rs
@@ -959,3 +959,71 @@ fn test_explicit_param_names() {
         vec!["a".to_string(), "c".to_string()],
     );
 }
+
+/// Discovery fans its per-parameter probes out with `tokio::spawn`, and tokio
+/// task-locals are NOT inherited across `spawn`. Before those workers re-entered
+/// the captured scopes they wrote only to the process-wide globals, so a
+/// REST/MCP job's `requests_sent` under-counted the discovery and mining phase
+/// — and, the part that actually matters, those requests bypassed the per-job
+/// rate limiter, letting a job submitted with `rate_limit: N` hammer the target
+/// unthrottled for its whole analysis phase.
+///
+/// The assertion compares the per-job counter against what the server actually
+/// received. Asserting merely `> 0` is NOT enough and does not fail without the
+/// fix: `check_query_discovery` also issues several probes inline (outside any
+/// spawn), and those tick the per-job counter either way.
+#[tokio::test]
+async fn spawned_discovery_requests_reach_the_per_job_counter() {
+    crate::ensure_crypto_provider();
+
+    // Count what the server truly received, independent of dalfox's bookkeeping.
+    static SERVER_HITS: std::sync::atomic::AtomicUsize = std::sync::atomic::AtomicUsize::new(0);
+    SERVER_HITS.store(0, std::sync::atomic::Ordering::SeqCst);
+
+    async fn counting_handler(uri: Uri) -> axum::response::Html<String> {
+        SERVER_HITS.fetch_add(1, std::sync::atomic::Ordering::SeqCst);
+        let q = uri.query().unwrap_or("").to_string();
+        axum::response::Html(format!("<html><body><div>{q}</div></body></html>"))
+    }
+
+    let app = Router::new()
+        .route("/", any(counting_handler))
+        .route("/{*rest}", any(counting_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move { axum::serve(listener, app).await.expect("serve") });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+
+    let target = parse_target(&format!("http://{addr}/?a=1&b=2&c=3")).expect("target");
+    let per_job = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let params = std::sync::Arc::new(tokio::sync::Mutex::new(Vec::new()));
+
+    crate::REQUEST_COUNT_JOB
+        .scope(per_job.clone(), async {
+            check_query_discovery(
+                &target,
+                params.clone(),
+                std::sync::Arc::new(tokio::sync::Semaphore::new(4)),
+            )
+            .await;
+        })
+        .await;
+
+    let counted = per_job.load(std::sync::atomic::Ordering::Relaxed) as usize;
+    let served = SERVER_HITS.load(std::sync::atomic::Ordering::SeqCst);
+    assert!(served > 0, "the mock server should have been probed at all");
+    // `>=` rather than `==`: `record_outbound_request()` ticks *before*
+    // `send()`, so a request that fails at the transport layer is counted but
+    // never served, and this repo has a documented ephemeral-port-exhaustion
+    // flake class under parallel test runs. `>=` still fails loudly on the
+    // regression (uncounted spawned workers give counted < served) without
+    // turning an environment hiccup into a false regression report.
+    assert!(
+        counted >= served,
+        "every request the server saw must be billed to the per-job counter; \
+         {counted} counted vs {served} served means the spawned workers fell back \
+         to the process-wide globals — which is also the rate-limit bypass"
+    );
+}

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -680,109 +680,73 @@ pub async fn probe_dictionary_params(
             let pb_clone = pb.clone();
             let stats_clone = stats.clone();
 
-            let handle = tokio::spawn(async move {
-                let permit = semaphore_clone
-                    .acquire()
-                    .await
-                    .expect("acquire semaphore permit");
-                let request = crate::utils::build_request(
-                    &client_clone,
-                    &target_clone,
-                    parsed_method,
-                    url,
-                    data.clone(),
-                );
+            let handle = tokio::spawn(crate::with_job_scopes(
+                crate::JobScopes::capture(),
+                async move {
+                    let permit = semaphore_clone
+                        .acquire()
+                        .await
+                        .expect("acquire semaphore permit");
+                    let request = crate::utils::build_request(
+                        &client_clone,
+                        &target_clone,
+                        parsed_method,
+                        url,
+                        data.clone(),
+                    );
 
-                crate::record_outbound_request().await;
-                let resp = request.send().await;
+                    crate::record_outbound_request().await;
+                    let resp = request.send().await;
 
-                let mut discovered: Option<Param> = None;
-                if let Ok(r) = resp {
-                    // Skip server error responses (5xx) — debug error pages often
-                    // reflect query params in stack traces, causing false positives.
-                    let status = r.status();
-                    if status.is_server_error() {
-                        let mut st = stats_clone.lock().await;
-                        st.record_attempt();
-                        drop(permit);
-                        if delay > 0 {
-                            sleep(Duration::from_millis(delay)).await;
-                        }
-                        if let Some(ref pb) = pb_clone {
-                            pb.inc(1);
-                        }
-                        return discovered;
-                    }
-                    // Check for redirect reflection: if the response is a 3xx redirect,
-                    // the Location header may contain the reflected marker value.
-                    let is_redirect = status.is_redirection();
-                    let location_has_marker = if is_redirect {
-                        r.headers()
-                            .get("location")
-                            .and_then(|v| v.to_str().ok())
-                            .is_some_and(|loc| {
-                                crate::scanning::markers::classify_probe_reflection(loc).detected()
-                            })
-                    } else {
-                        false
-                    };
-
-                    if location_has_marker {
-                        // Redirect context: marker reflected in Location header.
-                        let mut st = stats_clone.lock().await;
-                        st.record_attempt();
-                        st.record_reflection();
-                        if !st.collapsed {
-                            discovered = Some(Param {
-                                name: param_name.clone(),
-                                value: crate::scanning::markers::bracketed_marker().to_string(),
-                                location: crate::parameter_analysis::Location::Query,
-                                injection_context: Some(
-                                    crate::parameter_analysis::InjectionContext::AttributeUrl(None),
-                                ),
-                                valid_specials: None,
-                                invalid_specials: None,
-                                pre_encoding: None,
-                                pre_encoding_pipeline: None,
-                                wire_name: None,
-                                form_action_url: None,
-                                form_origin_url: None,
-                                framework_sink: None,
-                                escaped_specials: None,
-                                js_breakout: None,
-                            });
-                            if !silence {
-                                eprintln!(
-                                    "Discovered parameter (redirect): {} (EWMA {:.2}, {}/{})",
-                                    param_name, st.ewma_ratio, st.reflections, st.attempts
-                                );
+                    let mut discovered: Option<Param> = None;
+                    if let Ok(r) = resp {
+                        // Skip server error responses (5xx) — debug error pages often
+                        // reflect query params in stack traces, causing false positives.
+                        let status = r.status();
+                        if status.is_server_error() {
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
+                            drop(permit);
+                            if delay > 0 {
+                                sleep(Duration::from_millis(delay)).await;
                             }
-                            if st.should_collapse() {
-                                st.collapsed = true;
-                                if !silence {
-                                    eprintln!(
-                                        "[mining-collapse] High reflection EWMA {:.2} after {} attempts ({} reflections)",
-                                        st.ewma_ratio, st.attempts, st.reflections
-                                    );
-                                }
+                            if let Some(ref pb) = pb_clone {
+                                pb.inc(1);
                             }
+                            return discovered;
                         }
-                    } else if let Ok(text) = crate::utils::http::read_body(r).await {
-                        let mut st = stats_clone.lock().await;
-                        st.record_attempt();
-                        if crate::scanning::markers::classify_probe_reflection(&text).detected() {
+                        // Check for redirect reflection: if the response is a 3xx redirect,
+                        // the Location header may contain the reflected marker value.
+                        let is_redirect = status.is_redirection();
+                        let location_has_marker = if is_redirect {
+                            r.headers()
+                                .get("location")
+                                .and_then(|v| v.to_str().ok())
+                                .is_some_and(|loc| {
+                                    crate::scanning::markers::classify_probe_reflection(loc)
+                                        .detected()
+                                })
+                        } else {
+                            false
+                        };
+
+                        if location_has_marker {
+                            // Redirect context: marker reflected in Location header.
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
                             st.record_reflection();
                             if !st.collapsed {
-                                let context = detect_injection_context(&text);
-                                let (valid, invalid) =
-                                    crate::parameter_analysis::classify_special_chars(&text);
                                 discovered = Some(Param {
                                     name: param_name.clone(),
                                     value: crate::scanning::markers::bracketed_marker().to_string(),
                                     location: crate::parameter_analysis::Location::Query,
-                                    injection_context: Some(context),
-                                    valid_specials: Some(valid),
-                                    invalid_specials: Some(invalid),
+                                    injection_context: Some(
+                                        crate::parameter_analysis::InjectionContext::AttributeUrl(
+                                            None,
+                                        ),
+                                    ),
+                                    valid_specials: None,
+                                    invalid_specials: None,
                                     pre_encoding: None,
                                     pre_encoding_pipeline: None,
                                     wire_name: None,
@@ -790,11 +754,11 @@ pub async fn probe_dictionary_params(
                                     form_origin_url: None,
                                     framework_sink: None,
                                     escaped_specials: None,
-                                    js_breakout: detect_js_breakout(&text),
+                                    js_breakout: None,
                                 });
                                 if !silence {
                                     eprintln!(
-                                        "Discovered parameter: {} (EWMA {:.2}, {}/{})",
+                                        "Discovered parameter (redirect): {} (EWMA {:.2}, {}/{})",
                                         param_name, st.ewma_ratio, st.reflections, st.attempts
                                     );
                                 }
@@ -808,21 +772,65 @@ pub async fn probe_dictionary_params(
                                     }
                                 }
                             }
-                        } else {
-                            st.record_non_reflection();
+                        } else if let Ok(text) = crate::utils::http::read_body(r).await {
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
+                            if crate::scanning::markers::classify_probe_reflection(&text).detected()
+                            {
+                                st.record_reflection();
+                                if !st.collapsed {
+                                    let context = detect_injection_context(&text);
+                                    let (valid, invalid) =
+                                        crate::parameter_analysis::classify_special_chars(&text);
+                                    discovered = Some(Param {
+                                        name: param_name.clone(),
+                                        value: crate::scanning::markers::bracketed_marker()
+                                            .to_string(),
+                                        location: crate::parameter_analysis::Location::Query,
+                                        injection_context: Some(context),
+                                        valid_specials: Some(valid),
+                                        invalid_specials: Some(invalid),
+                                        pre_encoding: None,
+                                        pre_encoding_pipeline: None,
+                                        wire_name: None,
+                                        form_action_url: None,
+                                        form_origin_url: None,
+                                        framework_sink: None,
+                                        escaped_specials: None,
+                                        js_breakout: detect_js_breakout(&text),
+                                    });
+                                    if !silence {
+                                        eprintln!(
+                                            "Discovered parameter: {} (EWMA {:.2}, {}/{})",
+                                            param_name, st.ewma_ratio, st.reflections, st.attempts
+                                        );
+                                    }
+                                    if st.should_collapse() {
+                                        st.collapsed = true;
+                                        if !silence {
+                                            eprintln!(
+                                                "[mining-collapse] High reflection EWMA {:.2} after {} attempts ({} reflections)",
+                                                st.ewma_ratio, st.attempts, st.reflections
+                                            );
+                                        }
+                                    }
+                                }
+                            } else {
+                                st.record_non_reflection();
+                            }
                         }
                     }
-                }
 
-                if delay > 0 {
-                    sleep(Duration::from_millis(delay)).await;
-                }
-                drop(permit);
-                if let Some(ref pb) = pb_clone {
-                    pb.inc(1);
-                }
-                discovered
-            });
+                    if delay > 0 {
+                        sleep(Duration::from_millis(delay)).await;
+                    }
+                    drop(permit);
+                    if let Some(ref pb) = pb_clone {
+                        pb.inc(1);
+                    }
+                    discovered
+                },
+            ));
 
             handles.push(handle);
         }
@@ -970,81 +978,92 @@ pub async fn probe_body_params(
             let pb_clone = pb.clone();
             let stats_clone = stats.clone();
 
-            let handle = tokio::spawn(async move {
-                let permit = semaphore_clone
-                    .acquire()
-                    .await
-                    .expect("acquire semaphore permit");
-                let m = parsed_method;
-                let base =
-                    crate::utils::build_request(&client_clone, &target_clone, m, url, Some(body));
-                let overrides = vec![(
-                    "Content-Type".to_string(),
-                    "application/x-www-form-urlencoded".to_string(),
-                )];
-                let request = crate::utils::apply_header_overrides(base, &overrides);
+            let handle = tokio::spawn(crate::with_job_scopes(
+                crate::JobScopes::capture(),
+                async move {
+                    let permit = semaphore_clone
+                        .acquire()
+                        .await
+                        .expect("acquire semaphore permit");
+                    let m = parsed_method;
+                    let base = crate::utils::build_request(
+                        &client_clone,
+                        &target_clone,
+                        m,
+                        url,
+                        Some(body),
+                    );
+                    let overrides = vec![(
+                        "Content-Type".to_string(),
+                        "application/x-www-form-urlencoded".to_string(),
+                    )];
+                    let request = crate::utils::apply_header_overrides(base, &overrides);
 
-                crate::record_outbound_request().await;
-                let resp = request.send().await;
+                    crate::record_outbound_request().await;
+                    let resp = request.send().await;
 
-                let mut discovered: Option<Param> = None;
-                if let Ok(r) = resp
-                    && let Ok(text) = crate::utils::http::read_body(r).await
-                {
-                    let mut st = stats_clone.lock().await;
-                    st.record_attempt();
-                    if crate::scanning::markers::classify_probe_reflection(&text).detected() {
-                        st.record_reflection();
-                        if !st.collapsed {
-                            let context = detect_injection_context(&text);
-                            let (valid, invalid) =
-                                crate::parameter_analysis::classify_special_chars(&text);
-                            discovered = Some(Param {
-                                name: param_name_cloned.clone(),
-                                value: crate::scanning::markers::bracketed_marker().to_string(),
-                                location: Location::Body,
-                                injection_context: Some(context),
-                                valid_specials: Some(valid),
-                                invalid_specials: Some(invalid),
-                                pre_encoding: None,
-                                pre_encoding_pipeline: None,
-                                wire_name: None,
-                                form_action_url: None,
-                                form_origin_url: None,
-                                framework_sink: None,
-                                escaped_specials: None,
-                                js_breakout: detect_js_breakout(&text),
-                            });
-                            if !silence {
-                                eprintln!(
-                                    "Discovered body param: {} (EWMA {:.2}, {}/{})",
-                                    param_name_cloned, st.ewma_ratio, st.reflections, st.attempts
-                                );
-                            }
-                            if st.should_collapse() {
-                                st.collapsed = true;
+                    let mut discovered: Option<Param> = None;
+                    if let Ok(r) = resp
+                        && let Ok(text) = crate::utils::http::read_body(r).await
+                    {
+                        let mut st = stats_clone.lock().await;
+                        st.record_attempt();
+                        if crate::scanning::markers::classify_probe_reflection(&text).detected() {
+                            st.record_reflection();
+                            if !st.collapsed {
+                                let context = detect_injection_context(&text);
+                                let (valid, invalid) =
+                                    crate::parameter_analysis::classify_special_chars(&text);
+                                discovered = Some(Param {
+                                    name: param_name_cloned.clone(),
+                                    value: crate::scanning::markers::bracketed_marker().to_string(),
+                                    location: Location::Body,
+                                    injection_context: Some(context),
+                                    valid_specials: Some(valid),
+                                    invalid_specials: Some(invalid),
+                                    pre_encoding: None,
+                                    pre_encoding_pipeline: None,
+                                    wire_name: None,
+                                    form_action_url: None,
+                                    form_origin_url: None,
+                                    framework_sink: None,
+                                    escaped_specials: None,
+                                    js_breakout: detect_js_breakout(&text),
+                                });
                                 if !silence {
                                     eprintln!(
-                                        "[mining-collapse] Body mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
-                                        st.ewma_ratio, st.attempts, st.reflections
+                                        "Discovered body param: {} (EWMA {:.2}, {}/{})",
+                                        param_name_cloned,
+                                        st.ewma_ratio,
+                                        st.reflections,
+                                        st.attempts
                                     );
                                 }
+                                if st.should_collapse() {
+                                    st.collapsed = true;
+                                    if !silence {
+                                        eprintln!(
+                                            "[mining-collapse] Body mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
+                                            st.ewma_ratio, st.attempts, st.reflections
+                                        );
+                                    }
+                                }
                             }
+                        } else {
+                            st.record_non_reflection();
                         }
-                    } else {
-                        st.record_non_reflection();
                     }
-                }
 
-                if delay > 0 {
-                    sleep(Duration::from_millis(delay)).await;
-                }
-                drop(permit);
-                if let Some(ref pb) = pb_clone {
-                    pb.inc(1);
-                }
-                discovered
-            });
+                    if delay > 0 {
+                        sleep(Duration::from_millis(delay)).await;
+                    }
+                    drop(permit);
+                    if let Some(ref pb) = pb_clone {
+                        pb.inc(1);
+                    }
+                    discovered
+                },
+            ));
 
             handles.push(handle);
         }
@@ -1241,89 +1260,99 @@ pub async fn probe_response_id_params(
             let pb_clone = pb.clone();
             let stats_clone = stats.clone();
 
-            let handle = tokio::spawn(async move {
-                let permit = semaphore_clone
-                    .acquire()
-                    .await
-                    .expect("acquire semaphore permit");
-                let m = parsed_method;
-                let request =
-                    crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
-                // Prepare optional discovered Param container for batched return
-                let mut discovered: Option<Param> = None;
-                crate::record_outbound_request().await;
-                let __resp = request.send().await;
-                if let Ok(resp) = __resp {
-                    // Skip 5xx error responses — debug pages often reflect params
-                    if resp.status().is_server_error() {
-                        let mut st = stats_clone.lock().await;
-                        st.record_attempt();
-                        drop(permit);
-                        if delay > 0 {
-                            sleep(Duration::from_millis(delay)).await;
+            let handle = tokio::spawn(crate::with_job_scopes(
+                crate::JobScopes::capture(),
+                async move {
+                    let permit = semaphore_clone
+                        .acquire()
+                        .await
+                        .expect("acquire semaphore permit");
+                    let m = parsed_method;
+                    let request = crate::utils::build_request(
+                        &client_clone,
+                        &target_clone,
+                        m,
+                        url,
+                        data.clone(),
+                    );
+                    // Prepare optional discovered Param container for batched return
+                    let mut discovered: Option<Param> = None;
+                    crate::record_outbound_request().await;
+                    let __resp = request.send().await;
+                    if let Ok(resp) = __resp {
+                        // Skip 5xx error responses — debug pages often reflect params
+                        if resp.status().is_server_error() {
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
+                            drop(permit);
+                            if delay > 0 {
+                                sleep(Duration::from_millis(delay)).await;
+                            }
+                            if let Some(ref pb) = pb_clone {
+                                pb.inc(1);
+                            }
+                            return discovered;
                         }
-                        if let Some(ref pb) = pb_clone {
-                            pb.inc(1);
-                        }
-                        return discovered;
-                    }
-                    if let Ok(text) = crate::utils::http::read_body(resp).await {
-                        let mut st = stats_clone.lock().await;
-                        st.record_attempt();
-                        if crate::scanning::markers::classify_probe_reflection(&text).detected() {
-                            st.record_reflection();
-                            if !st.collapsed {
-                                let context = detect_injection_context(&text);
-                                let (valid, invalid) =
-                                    crate::parameter_analysis::classify_special_chars(&text);
-                                // Store discovered Param for return (batched later)
-                                discovered = Some(Param {
-                                    name: param.clone(),
-                                    value: crate::scanning::markers::bracketed_marker().to_string(),
-                                    location: crate::parameter_analysis::Location::Query,
-                                    injection_context: Some(context),
-                                    valid_specials: Some(valid),
-                                    invalid_specials: Some(invalid),
-                                    pre_encoding: None,
-                                    pre_encoding_pipeline: None,
-                                    wire_name: None,
-                                    form_action_url: None,
-                                    form_origin_url: None,
-                                    framework_sink: None,
-                                    escaped_specials: None,
-                                    js_breakout: detect_js_breakout(&text),
-                                });
-                                if !silence {
-                                    eprintln!(
-                                        "Discovered DOM param: {} (EWMA {:.2}, {}/{})",
-                                        param, st.ewma_ratio, st.reflections, st.attempts
-                                    );
-                                }
-                                if st.should_collapse() {
-                                    st.collapsed = true;
+                        if let Ok(text) = crate::utils::http::read_body(resp).await {
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
+                            if crate::scanning::markers::classify_probe_reflection(&text).detected()
+                            {
+                                st.record_reflection();
+                                if !st.collapsed {
+                                    let context = detect_injection_context(&text);
+                                    let (valid, invalid) =
+                                        crate::parameter_analysis::classify_special_chars(&text);
+                                    // Store discovered Param for return (batched later)
+                                    discovered = Some(Param {
+                                        name: param.clone(),
+                                        value: crate::scanning::markers::bracketed_marker()
+                                            .to_string(),
+                                        location: crate::parameter_analysis::Location::Query,
+                                        injection_context: Some(context),
+                                        valid_specials: Some(valid),
+                                        invalid_specials: Some(invalid),
+                                        pre_encoding: None,
+                                        pre_encoding_pipeline: None,
+                                        wire_name: None,
+                                        form_action_url: None,
+                                        form_origin_url: None,
+                                        framework_sink: None,
+                                        escaped_specials: None,
+                                        js_breakout: detect_js_breakout(&text),
+                                    });
                                     if !silence {
                                         eprintln!(
-                                            "[mining-collapse] DOM mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
-                                            st.ewma_ratio, st.attempts, st.reflections
+                                            "Discovered DOM param: {} (EWMA {:.2}, {}/{})",
+                                            param, st.ewma_ratio, st.reflections, st.attempts
                                         );
                                     }
+                                    if st.should_collapse() {
+                                        st.collapsed = true;
+                                        if !silence {
+                                            eprintln!(
+                                                "[mining-collapse] DOM mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
+                                                st.ewma_ratio, st.attempts, st.reflections
+                                            );
+                                        }
+                                    }
                                 }
+                            } else {
+                                st.record_non_reflection();
                             }
-                        } else {
-                            st.record_non_reflection();
                         }
                     }
-                }
-                if delay > 0 {
-                    sleep(Duration::from_millis(delay)).await;
-                }
-                drop(permit);
-                if let Some(ref pb) = pb_clone {
-                    pb.inc(1);
-                }
-                // Return discovered Param (if any) for batch processing
-                discovered
-            });
+                    if delay > 0 {
+                        sleep(Duration::from_millis(delay)).await;
+                    }
+                    drop(permit);
+                    if let Some(ref pb) = pb_clone {
+                        pb.inc(1);
+                    }
+                    // Return discovered Param (if any) for batch processing
+                    discovered
+                },
+            ));
             handles.push(handle);
         }
 
@@ -1467,110 +1496,113 @@ pub async fn probe_json_body_params(
         let stats_clone = stats.clone();
         let base_json_clone = base_json.clone();
 
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
 
-            // Build mutated JSON with this key set to marker
-            let mut root = base_json_clone;
-            if let Some(map) = root.as_object_mut() {
-                map.insert(
-                    param_name_cloned.clone(),
-                    serde_json::Value::String(
-                        crate::scanning::markers::bracketed_marker().to_string(),
-                    ),
+                // Build mutated JSON with this key set to marker
+                let mut root = base_json_clone;
+                if let Some(map) = root.as_object_mut() {
+                    map.insert(
+                        param_name_cloned.clone(),
+                        serde_json::Value::String(
+                            crate::scanning::markers::bracketed_marker().to_string(),
+                        ),
+                    );
+                } else {
+                    let mut map = serde_json::Map::new();
+                    map.insert(
+                        param_name_cloned.clone(),
+                        serde_json::Value::String(
+                            crate::scanning::markers::bracketed_marker().to_string(),
+                        ),
+                    );
+                    root = serde_json::Value::Object(map);
+                }
+                let body = serde_json::to_string(&root).unwrap_or_else(|_| {
+                    format!(
+                        "{{\"{}\":\"{}\"}}",
+                        param_name_cloned,
+                        crate::scanning::markers::bracketed_marker()
+                    )
+                });
+
+                let base = crate::utils::build_request(
+                    &client_clone,
+                    &target_clone,
+                    parsed_method,
+                    url,
+                    Some(body),
                 );
-            } else {
-                let mut map = serde_json::Map::new();
-                map.insert(
-                    param_name_cloned.clone(),
-                    serde_json::Value::String(
-                        crate::scanning::markers::bracketed_marker().to_string(),
-                    ),
-                );
-                root = serde_json::Value::Object(map);
-            }
-            let body = serde_json::to_string(&root).unwrap_or_else(|_| {
-                format!(
-                    "{{\"{}\":\"{}\"}}",
-                    param_name_cloned,
-                    crate::scanning::markers::bracketed_marker()
-                )
-            });
+                let overrides = vec![("Content-Type".to_string(), "application/json".to_string())];
+                let request = crate::utils::apply_header_overrides(base, &overrides);
 
-            let base = crate::utils::build_request(
-                &client_clone,
-                &target_clone,
-                parsed_method,
-                url,
-                Some(body),
-            );
-            let overrides = vec![("Content-Type".to_string(), "application/json".to_string())];
-            let request = crate::utils::apply_header_overrides(base, &overrides);
+                crate::record_outbound_request().await;
+                let resp = request.send().await;
 
-            crate::record_outbound_request().await;
-            let resp = request.send().await;
-
-            let mut discovered: Option<Param> = None;
-            if let Ok(r) = resp
-                && let Ok(text) = crate::utils::http::read_body(r).await
-            {
-                let mut st = stats_clone.lock().await;
-                st.record_attempt();
-                if crate::scanning::markers::classify_probe_reflection(&text).detected() {
-                    st.record_reflection();
-                    if !st.collapsed {
-                        let context = detect_injection_context(&text);
-                        let (valid, invalid) =
-                            crate::parameter_analysis::classify_special_chars(&text);
-                        discovered = Some(Param {
-                            name: param_name_cloned.clone(),
-                            value: crate::scanning::markers::bracketed_marker().to_string(),
-                            location: Location::JsonBody,
-                            injection_context: Some(context),
-                            valid_specials: Some(valid),
-                            invalid_specials: Some(invalid),
-                            pre_encoding: None,
-                            pre_encoding_pipeline: None,
-                            wire_name: None,
-                            form_action_url: None,
-                            form_origin_url: None,
-                            framework_sink: None,
-                            escaped_specials: None,
-                            js_breakout: detect_js_breakout(&text),
-                        });
-                        if !silence {
-                            eprintln!(
-                                "Discovered JSON body param: {} (EWMA {:.2}, {}/{})",
-                                param_name_cloned, st.ewma_ratio, st.reflections, st.attempts
-                            );
-                        }
-                        if st.should_collapse() {
-                            st.collapsed = true;
+                let mut discovered: Option<Param> = None;
+                if let Ok(r) = resp
+                    && let Ok(text) = crate::utils::http::read_body(r).await
+                {
+                    let mut st = stats_clone.lock().await;
+                    st.record_attempt();
+                    if crate::scanning::markers::classify_probe_reflection(&text).detected() {
+                        st.record_reflection();
+                        if !st.collapsed {
+                            let context = detect_injection_context(&text);
+                            let (valid, invalid) =
+                                crate::parameter_analysis::classify_special_chars(&text);
+                            discovered = Some(Param {
+                                name: param_name_cloned.clone(),
+                                value: crate::scanning::markers::bracketed_marker().to_string(),
+                                location: Location::JsonBody,
+                                injection_context: Some(context),
+                                valid_specials: Some(valid),
+                                invalid_specials: Some(invalid),
+                                pre_encoding: None,
+                                pre_encoding_pipeline: None,
+                                wire_name: None,
+                                form_action_url: None,
+                                form_origin_url: None,
+                                framework_sink: None,
+                                escaped_specials: None,
+                                js_breakout: detect_js_breakout(&text),
+                            });
                             if !silence {
                                 eprintln!(
-                                    "[mining-collapse] JSON mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
-                                    st.ewma_ratio, st.attempts, st.reflections
+                                    "Discovered JSON body param: {} (EWMA {:.2}, {}/{})",
+                                    param_name_cloned, st.ewma_ratio, st.reflections, st.attempts
                                 );
                             }
+                            if st.should_collapse() {
+                                st.collapsed = true;
+                                if !silence {
+                                    eprintln!(
+                                        "[mining-collapse] JSON mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
+                                        st.ewma_ratio, st.attempts, st.reflections
+                                    );
+                                }
+                            }
                         }
+                    } else {
+                        st.record_non_reflection();
                     }
-                } else {
-                    st.record_non_reflection();
                 }
-            }
 
-            if delay > 0 {
-                sleep(Duration::from_millis(delay)).await;
-            }
-            drop(permit);
-            if let Some(ref pb) = pb_clone {
-                pb.inc(1);
-            }
-            discovered
-        });
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                if let Some(ref pb) = pb_clone {
+                    pb.inc(1);
+                }
+                discovered
+            },
+        ));
 
         handles.push(handle);
     }
@@ -1703,61 +1735,65 @@ pub async fn probe_multipart_params(
         let pairs_clone = pairs.clone();
         let field_name = field.clone();
 
-        let handle = tokio::spawn(async move {
-            let permit = semaphore_clone
-                .acquire()
-                .await
-                .expect("acquire semaphore permit");
-            let mut form = reqwest::multipart::Form::new();
-            let mut placed = false;
-            for (k, v) in &pairs_clone {
-                if *k == field_name {
-                    form = form.text(k.clone(), marker.to_string());
-                    placed = true;
-                } else {
-                    form = form.text(k.clone(), v.clone());
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+                let mut form = reqwest::multipart::Form::new();
+                let mut placed = false;
+                for (k, v) in &pairs_clone {
+                    if *k == field_name {
+                        form = form.text(k.clone(), marker.to_string());
+                        placed = true;
+                    } else {
+                        form = form.text(k.clone(), v.clone());
+                    }
                 }
-            }
-            if !placed {
-                form = form.text(field_name.clone(), marker.to_string());
-            }
-
-            let method = crate::scanning::url_inject::body_location_method(&target_clone.method);
-            let request =
-                crate::utils::build_request(&client_clone, &target_clone, method, url, None)
-                    .multipart(form);
-            crate::record_outbound_request().await;
-
-            let mut discovered: Option<Param> = None;
-            if let Ok(r) = request.send().await
-                && let Ok(text) = crate::utils::http::read_body(r).await
-                && crate::scanning::markers::classify_probe_reflection(&text).detected()
-            {
-                let context = detect_injection_context(&text);
-                let (valid, invalid) = crate::parameter_analysis::classify_special_chars(&text);
-                if !silence {
-                    eprintln!("Discovered multipart field: {}", field_name);
+                if !placed {
+                    form = form.text(field_name.clone(), marker.to_string());
                 }
-                discovered = Some(Param {
-                    name: field_name,
-                    value: marker.to_string(),
-                    location: Location::MultipartBody,
-                    injection_context: Some(context),
-                    valid_specials: Some(valid),
-                    invalid_specials: Some(invalid),
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: detect_js_breakout(&text),
-                });
-            }
-            drop(permit);
-            discovered
-        });
+
+                let method =
+                    crate::scanning::url_inject::body_location_method(&target_clone.method);
+                let request =
+                    crate::utils::build_request(&client_clone, &target_clone, method, url, None)
+                        .multipart(form);
+                crate::record_outbound_request().await;
+
+                let mut discovered: Option<Param> = None;
+                if let Ok(r) = request.send().await
+                    && let Ok(text) = crate::utils::http::read_body(r).await
+                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                {
+                    let context = detect_injection_context(&text);
+                    let (valid, invalid) = crate::parameter_analysis::classify_special_chars(&text);
+                    if !silence {
+                        eprintln!("Discovered multipart field: {}", field_name);
+                    }
+                    discovered = Some(Param {
+                        name: field_name,
+                        value: marker.to_string(),
+                        location: Location::MultipartBody,
+                        injection_context: Some(context),
+                        valid_specials: Some(valid),
+                        invalid_specials: Some(invalid),
+                        pre_encoding: None,
+                        pre_encoding_pipeline: None,
+                        wire_name: None,
+                        form_action_url: None,
+                        form_origin_url: None,
+                        framework_sink: None,
+                        escaped_specials: None,
+                        js_breakout: detect_js_breakout(&text),
+                    });
+                }
+                drop(permit);
+                discovered
+            },
+        ));
         handles.push(handle);
     }
 

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -867,29 +867,37 @@ pub async fn active_probe_param(
             let param_clone = param.clone();
             let valid_ref = valid_specials.clone();
             let invalid_ref = invalid_specials.clone();
-            handles.push(tokio::spawn(async move {
-                let probe = format!(
-                    "{}{}{}",
-                    crate::scanning::markers::open_marker(),
-                    c,
-                    crate::scanning::markers::close_marker()
-                );
-                let pp = crate::encoding::pre_encoding::apply_param_encoding(&probe, &param_clone);
-                let _permit = sem.acquire().await.expect("acquire semaphore permit");
-                let resp =
-                    send_probe_request_for_param(&client_clone, &target_clone, &param_clone, &pp)
-                        .await;
-                let ok = resp
-                    .as_deref()
-                    .and_then(extract_reflected_segment)
-                    .map(|seg| char_reflected_in_segment(seg, c))
-                    .unwrap_or(false);
-                if ok {
-                    valid_ref.lock().await.push(c);
-                } else {
-                    invalid_ref.lock().await.push(c);
-                }
-            }));
+            handles.push(tokio::spawn(crate::with_job_scopes(
+                crate::JobScopes::capture(),
+                async move {
+                    let probe = format!(
+                        "{}{}{}",
+                        crate::scanning::markers::open_marker(),
+                        c,
+                        crate::scanning::markers::close_marker()
+                    );
+                    let pp =
+                        crate::encoding::pre_encoding::apply_param_encoding(&probe, &param_clone);
+                    let _permit = sem.acquire().await.expect("acquire semaphore permit");
+                    let resp = send_probe_request_for_param(
+                        &client_clone,
+                        &target_clone,
+                        &param_clone,
+                        &pp,
+                    )
+                    .await;
+                    let ok = resp
+                        .as_deref()
+                        .and_then(extract_reflected_segment)
+                        .map(|seg| char_reflected_in_segment(seg, c))
+                        .unwrap_or(false);
+                    if ok {
+                        valid_ref.lock().await.push(c);
+                    } else {
+                        invalid_ref.lock().await.push(c);
+                    }
+                },
+            )));
         }
         for h in handles {
             let _ = h.await;
@@ -1067,7 +1075,9 @@ pub async fn analyze_parameters(
 
     // === Stage 1: Discovery — identify reflecting parameters ===
     let reflection_params = Arc::new(Mutex::new(Vec::new()));
-    let semaphore = Arc::new(Semaphore::new(target.workers));
+    let semaphore = Arc::new(Semaphore::new(crate::utils::semaphore_permits(
+        target.workers,
+    )));
     check_discovery(target, args, reflection_params.clone(), semaphore.clone()).await;
 
     // === Stage 2: Mining — discover additional parameters from HTML/JS/dict ===
@@ -1122,15 +1132,18 @@ pub async fn analyze_parameters(
     target.reflection_params = params;
 
     // === Stage 3: Active Probing — confirm specials, detect pre_encoding ===
-    let probe_semaphore = Arc::new(Semaphore::new(target.workers));
+    let probe_semaphore = Arc::new(Semaphore::new(crate::utils::semaphore_permits(
+        target.workers,
+    )));
     let probe_target = Arc::new(target.clone());
     let mut param_handles = Vec::new();
     for p in std::mem::take(&mut target.reflection_params) {
         let target_ref = probe_target.clone();
         let sem = probe_semaphore.clone();
-        param_handles.push(tokio::spawn(async move {
-            active_probe_param(target_ref.as_ref(), p, sem).await
-        }));
+        param_handles.push(tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move { active_probe_param(target_ref.as_ref(), p, sem).await },
+        )));
     }
     let mut probed = Vec::with_capacity(param_handles.len());
     for h in param_handles {

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -19,7 +19,7 @@
 //! the stored payload. Applies `pre_encoding` as `encoded_payload` for the
 //! request but checks DOM evidence against the raw `payload`.
 
-use crate::parameter_analysis::{Location, Param};
+use crate::parameter_analysis::Param;
 use crate::target_parser::Target;
 use reqwest::Client;
 use std::sync::OnceLock;
@@ -774,114 +774,13 @@ pub async fn check_dom_verification(
     check_dom_verification_with_client(&client, target, param, payload, args).await
 }
 
-/// Build the HTTP request for injecting the payload based on the parameter location.
-fn build_inject_request(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    encoded_payload: &str,
-) -> reqwest::RequestBuilder {
-    let default_method = target.parse_method();
-    match param.location {
-        Location::Header => crate::scanning::url_inject::build_header_request(
-            client,
-            target,
-            param,
-            encoded_payload,
-            default_method,
-        ),
-        Location::Body => build_body_request(client, target, param, encoded_payload),
-        Location::JsonBody => build_json_body_request(client, target, param, encoded_payload),
-        Location::MultipartBody => build_multipart_request(client, target, param, encoded_payload),
-        _ => build_url_inject_request(client, target, param, encoded_payload, default_method),
-    }
-}
-
-fn resolve_form_action_url(param: &Param, target: &Target) -> url::Url {
-    param
-        .form_action_url
-        .as_ref()
-        .and_then(|u| url::Url::parse(u).ok())
-        .unwrap_or_else(|| target.url.clone())
-}
-
-fn build_body_request(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    encoded_payload: &str,
-) -> reqwest::RequestBuilder {
-    let parsed_url = resolve_form_action_url(param, target);
-    let body = Some(crate::scanning::url_inject::urlencoded_body(
-        target.data.as_deref(),
-        &param.name,
-        encoded_payload,
-    ));
-    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-    let base = crate::utils::build_request(client, target, method, parsed_url, body);
-    crate::utils::apply_header_overrides(
-        base,
-        &[(
-            "Content-Type".to_string(),
-            "application/x-www-form-urlencoded".to_string(),
-        )],
-    )
-}
-
-fn build_json_body_request(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    encoded_payload: &str,
-) -> reqwest::RequestBuilder {
-    let parsed_url = resolve_form_action_url(param, target);
-    let body = Some(crate::scanning::url_inject::json_body(
-        target.data.as_deref(),
-        &param.name,
-        &param.value,
-        encoded_payload,
-    ));
-    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-    let base = crate::utils::build_request(client, target, method, parsed_url, body);
-    crate::utils::apply_header_overrides(
-        base,
-        &[("Content-Type".to_string(), "application/json".to_string())],
-    )
-}
-
-fn build_multipart_request(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    encoded_payload: &str,
-) -> reqwest::RequestBuilder {
-    let parsed_url = resolve_form_action_url(param, target);
-    let form = crate::scanning::url_inject::multipart_form(
-        target.data.as_deref(),
-        &param.name,
-        encoded_payload,
-    );
-    let method = crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-    crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
-}
-
-fn build_url_inject_request(
-    client: &Client,
-    target: &Target,
-    param: &Param,
-    encoded_payload: &str,
-    method: reqwest::Method,
-) -> reqwest::RequestBuilder {
-    // Query params discovered through a `<form action=...>` must be verified
-    // at the action URL — that's where the sink lives. Path params keep
-    // target.url because path-segment injection depends on the original
-    // path layout.
-    let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
-    let inject_url_str =
-        crate::scanning::url_inject::build_injected_url(&base_url, param, encoded_payload);
-    let inject_url = url::Url::parse(&inject_url_str).unwrap_or_else(|_| base_url.clone());
-    crate::utils::build_request(client, target, method, inject_url, target.data.clone())
-}
+// The injection request builders live in `url_inject` so the reflection,
+// light-verify, and DOM-verify paths cannot drift apart again (they had:
+// light-verify was omitting the urlencoded `Content-Type`). Re-exported so
+// this module's tests keep addressing them through `super::*`.
+pub(crate) use crate::scanning::url_inject::build_inject_request;
+#[cfg(test)]
+pub(crate) use crate::scanning::url_inject::{build_json_body_request, build_multipart_request};
 
 /// Verify DOM evidence in a stored XSS scenario by checking secondary URLs.
 async fn verify_sxss_dom(

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1732,93 +1732,11 @@ async fn fetch_injection_response_with_client(
     // decodes the encoding and reflects the raw content.
     let encoded_payload = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
 
-    // Build injection request based on parameter location
-    let default_method = target.parse_method();
-    let inject_request = match param.location {
-        Location::Header => {
-            // Header injection. Shared with the DOM-verification and
-            // light-verify paths because a cookie param must go into the
-            // `Cookie` header, not a header named after the cookie — see
-            // `build_header_request`.
-            crate::scanning::url_inject::build_header_request(
-                client,
-                target,
-                param,
-                &encoded_payload,
-                default_method,
-            )
-        }
-        Location::Body => {
-            // Body injection: use form action URL if available, else original URL.
-            // Form-discovered sinks stay POST; own-body preserves QUERY/PUT/….
-            let method =
-                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let body = Some(crate::scanning::url_inject::urlencoded_body(
-                target.data.as_deref(),
-                &param.name,
-                &encoded_payload,
-            ));
-            let rb = crate::utils::build_request(client, target, method, parsed_url, body);
-            rb.header("Content-Type", "application/x-www-form-urlencoded")
-        }
-        Location::JsonBody => {
-            // JSON body injection: use form action URL if available, else original URL.
-            // Form-discovered sinks stay POST; own-body preserves QUERY/PUT/….
-            let method =
-                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let body = Some(crate::scanning::url_inject::json_body(
-                target.data.as_deref(),
-                &param.name,
-                &param.value,
-                &encoded_payload,
-            ));
-            let rb = crate::utils::build_request(client, target, method, parsed_url, body);
-            rb.header("Content-Type", "application/json")
-        }
-        Location::MultipartBody => {
-            let method =
-                crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let form = crate::scanning::url_inject::multipart_form(
-                target.data.as_deref(),
-                &param.name,
-                &encoded_payload,
-            );
-            crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
-        }
-        _ => {
-            // Query / Path: inject encoded payload into the URL.
-            // `effective_query_base` rebases Query params discovered through
-            // a `<form action=...>` onto the action endpoint; Path keeps
-            // target.url because path-segment injection depends on the
-            // original path layout.
-            let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
-            let inject_url =
-                crate::scanning::url_inject::build_injected_url(&base_url, param, &encoded_payload);
-            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
-            crate::utils::build_request(
-                client,
-                target,
-                default_method,
-                parsed_url,
-                target.data.clone(),
-            )
-        }
-    };
+    // Build injection request based on parameter location. Shared with the
+    // light-verify and DOM-verify paths so the per-location URL, method, and
+    // Content-Type rules cannot drift apart again.
+    let inject_request =
+        crate::scanning::url_inject::build_inject_request(client, target, param, &encoded_payload);
 
     // Send the injection request. send_with_retry acquires a --rate-limit
     // permit and applies the --retries / --retry-delay policy internally.

--- a/src/scanning/light_verify.rs
+++ b/src/scanning/light_verify.rs
@@ -1,4 +1,4 @@
-use crate::parameter_analysis::{Location, Param};
+use crate::parameter_analysis::Param;
 use crate::target_parser::Target;
 use reqwest::Client;
 
@@ -25,76 +25,11 @@ pub async fn verify_dom_xss_light_with_client(
     param: &Param,
     payload: &str,
 ) -> (bool, Option<String>, Option<String>) {
-    let default_method = target.parse_method();
-    let body_method =
-        crate::scanning::url_inject::body_location_method_for_param(&target.method, param);
-    let request = match param.location {
-        Location::Header => crate::scanning::url_inject::build_header_request(
-            client,
-            target,
-            param,
-            payload,
-            default_method,
-        ),
-        Location::Body => {
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let body = Some(crate::scanning::url_inject::urlencoded_body(
-                target.data.as_deref(),
-                &param.name,
-                payload,
-            ));
-            crate::utils::build_request(client, target, body_method, parsed_url, body)
-        }
-        Location::JsonBody => {
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let body = Some(crate::scanning::url_inject::json_body(
-                target.data.as_deref(),
-                &param.name,
-                &param.value,
-                payload,
-            ));
-            let rb = crate::utils::build_request(client, target, body_method, parsed_url, body);
-            rb.header("Content-Type", "application/json")
-        }
-        Location::MultipartBody => {
-            let parsed_url = param
-                .form_action_url
-                .as_ref()
-                .and_then(|u| url::Url::parse(u).ok())
-                .unwrap_or_else(|| target.url.clone());
-            let form = crate::scanning::url_inject::multipart_form(
-                target.data.as_deref(),
-                &param.name,
-                payload,
-            );
-            crate::utils::build_request(client, target, body_method, parsed_url, None)
-                .multipart(form)
-        }
-        _ => {
-            // GET form discovery sets form_action_url; light-verify must
-            // follow it to the action endpoint — otherwise the reflection
-            // we're confirming lives on a different URL.
-            let base_url = crate::scanning::url_inject::effective_query_base(&target.url, param);
-            let inject_url =
-                crate::scanning::url_inject::build_injected_url(&base_url, param, payload);
-            let parsed_url = url::Url::parse(&inject_url).unwrap_or_else(|_| base_url.clone());
-            crate::utils::build_request(
-                client,
-                target,
-                default_method,
-                parsed_url,
-                target.data.clone(),
-            )
-        }
-    };
+    // Shared with the reflection and DOM-verify paths. This path used to
+    // build its own request and omitted the urlencoded `Content-Type`, so a
+    // form-parsing server never bound the param and light verification came
+    // back negative on Body params.
+    let request = crate::scanning::url_inject::build_inject_request(client, target, param, payload);
 
     let mut note: Option<String> = None;
     // Honor --rate-limit on this verification re-request without changing the

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -2434,30 +2434,120 @@ pub struct ScanRunReport {
     pub worker_panics: usize,
 }
 
-#[allow(clippy::too_many_arguments)]
+/// The shared handles a [`run_scanning`] call needs beyond its target and args.
+///
+/// Grouped into a struct because the positional form took nine parameters, and
+/// the interchangeable ones sat next to each other: two `Option<Arc<..>>`
+/// progress bars in a row, then two *different* atomic counters
+/// (`findings_count`, a running findings tally, and `params_done`, a
+/// per-parameter completion counter) separated only by more `Option`s.
+/// Transposing any of them compiled fine and failed silently at runtime —
+/// which already happened once, when a caller stored the findings tally into
+/// `params_tested` (see the note in `server/job_runner.rs`).
+///
+/// Deliberately **not** `Default`. The two shared handles below are required,
+/// and defaulting them would be its own silent failure: a defaulted `results`
+/// is a private `Vec` nobody reads (every finding discarded), and a defaulted
+/// `findings_count` is a private counter nobody else writes (so `--limit`
+/// never fires). Trading "transpose two arguments" for "forget a field" would
+/// not have been an improvement — construct via [`ScanRunHandles::new`] and
+/// add the optional front-end handles with the `with_*` methods.
+#[derive(Clone)]
+pub struct ScanRunHandles {
+    /// Accumulates findings across every target in the run.
+    pub results: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+    /// Running findings tally, shared run-wide so `--limit` can stop the scan.
+    pub findings_count: Arc<AtomicUsize>,
+    /// CLI progress container; `None` for the REST/MCP front-ends.
+    pub multi_pb: Option<Arc<MultiProgress>>,
+    /// The run-wide bar this target ticks; `None` when no bar is drawn.
+    pub overall_pb: Option<Arc<indicatif::ProgressBar>>,
+    /// Cooperative cancellation, checked at per-parameter checkpoints.
+    pub cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
+    /// Mid-scan finding stream; `None` disables streaming output.
+    pub finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
+    /// Live "parameters finished" counter for async front-ends (REST server,
+    /// MCP). Each per-parameter worker bumps it on completion so pollers see
+    /// `params_tested` climb during the scan instead of staying pinned at 0
+    /// until the very end. `None` for the CLI, which renders its own
+    /// indicatif progress bar from `total_tasks` instead.
+    pub params_done: Option<Arc<AtomicU32>>,
+}
+
+impl ScanRunHandles {
+    /// The two run-wide handles every caller must share; all optional
+    /// front-end handles start disabled.
+    pub fn new(
+        results: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+        findings_count: Arc<AtomicUsize>,
+    ) -> Self {
+        Self {
+            results,
+            findings_count,
+            multi_pb: None,
+            overall_pb: None,
+            cancel: None,
+            finding_tx: None,
+            params_done: None,
+        }
+    }
+
+    /// Attach the CLI's indicatif bars.
+    pub fn with_progress(
+        mut self,
+        multi_pb: Option<Arc<MultiProgress>>,
+        overall_pb: Option<Arc<indicatif::ProgressBar>>,
+    ) -> Self {
+        self.multi_pb = multi_pb;
+        self.overall_pb = overall_pb;
+        self
+    }
+
+    /// Attach the cooperative cancellation flag.
+    pub fn with_cancel(mut self, cancel: Arc<std::sync::atomic::AtomicBool>) -> Self {
+        self.cancel = Some(cancel);
+        self
+    }
+
+    /// Stream findings as they are confirmed instead of only at end-of-scan.
+    pub fn with_finding_tx(
+        mut self,
+        tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
+    ) -> Self {
+        self.finding_tx = tx;
+        self
+    }
+
+    /// Feed an async front-end's live `params_tested` counter.
+    pub fn with_params_done(mut self, params_done: Arc<AtomicU32>) -> Self {
+        self.params_done = Some(params_done);
+        self
+    }
+}
+
 pub async fn run_scanning(
     target: &Target,
     args: Arc<ScanArgs>,
-    results: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
-    multi_pb: Option<Arc<MultiProgress>>,
-    overall_pb: Option<Arc<indicatif::ProgressBar>>,
-    findings_count: Arc<AtomicUsize>,
-    cancel: Option<Arc<std::sync::atomic::AtomicBool>>,
-    finding_tx: Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
-    // Live "parameters finished" counter for async front-ends (REST server,
-    // MCP). Each per-parameter worker bumps it on completion so pollers see
-    // `params_tested` climb during the scan instead of staying pinned at 0
-    // until the very end. `None` for the CLI, which renders its own
-    // indicatif progress bar from `total_tasks` instead.
-    params_done: Option<Arc<AtomicU32>>,
+    handles: ScanRunHandles,
 ) -> ScanRunReport {
+    let ScanRunHandles {
+        results,
+        multi_pb,
+        overall_pb,
+        findings_count,
+        cancel,
+        finding_tx,
+        params_done,
+    } = handles;
     // Short-circuit scanning when skip_xss_scanning is enabled (e.g., in unit tests)
     if args.skip_xss_scanning {
         return ScanRunReport::default();
     }
     let arc_target = Arc::new(target.clone());
     let shared_client = Arc::new(arc_target.build_client_or_default());
-    let semaphore = Arc::new(Semaphore::new(if args.sxss { 1 } else { target.workers }));
+    let semaphore = Arc::new(Semaphore::new(crate::utils::semaphore_permits(
+        if args.sxss { 1 } else { target.workers },
+    )));
     let limit_result_type: Arc<str> = Arc::from(args.limit_result_type.to_uppercase());
 
     // Reset WAF block counters for this scan

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -1041,13 +1041,7 @@ async fn test_xss_scanning_get_query() {
     run_scanning(
         &target,
         Arc::new(args),
-        results,
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results, Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1080,13 +1074,7 @@ async fn test_xss_scanning_post_body() {
     run_scanning(
         &target,
         Arc::new(args),
-        results,
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results, Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1133,13 +1121,7 @@ async fn test_run_scanning_with_reflection_params() {
     run_scanning(
         &target,
         Arc::new(args),
-        results,
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results, Arc::new(AtomicUsize::new(0))),
     )
     .await;
 }
@@ -1208,13 +1190,7 @@ async fn test_run_scanning_realworld_level1_shape_promotes_to_verified() {
     run_scanning(
         &target,
         args,
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1331,13 +1307,7 @@ async fn test_run_scanning_dom_phase_early_exits_on_inert_echo() {
     run_scanning(
         &target,
         Arc::new(integration_scan_args(false)),
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1426,13 +1396,7 @@ async fn test_run_scanning_dom_phase_preserves_recall_on_executable_echo() {
     run_scanning(
         &target,
         Arc::new(integration_scan_args(false)),
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1527,13 +1491,7 @@ async fn test_run_scanning_dom_phase_inert_echo_count_is_cumulative() {
     run_scanning(
         &target,
         Arc::new(integration_scan_args(false)),
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -1598,13 +1556,11 @@ async fn test_run_scanning_increments_params_done_counter() {
     run_scanning(
         &target,
         Arc::new(integration_scan_args(false)),
-        Arc::new(Mutex::new(Vec::new())),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        Some(params_done.clone()),
+        ScanRunHandles::new(
+            Arc::new(Mutex::new(Vec::new())),
+            Arc::new(AtomicUsize::new(0)),
+        )
+        .with_params_done(params_done.clone()),
     )
     .await;
 
@@ -1635,13 +1591,7 @@ async fn test_run_scanning_empty_params() {
     run_scanning(
         &target,
         Arc::new(args),
-        results,
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results, Arc::new(AtomicUsize::new(0))),
     )
     .await;
 }
@@ -2602,13 +2552,7 @@ async fn test_run_scanning_hpp_phase_reports_duplicated_param_bypass() {
     run_scanning(
         &target,
         args,
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 
@@ -2707,13 +2651,7 @@ async fn test_run_scanning_without_hpp_flag_reports_no_hpp_finding() {
     run_scanning(
         &target,
         args,
-        results.clone(),
-        None,
-        None,
-        Arc::new(AtomicUsize::new(0)),
-        None,
-        None,
-        None,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
     )
     .await;
 

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -670,5 +670,117 @@ pub fn multipart_form(data: Option<&str>, name: &str, value: &str) -> reqwest::m
     form
 }
 
+/// Resolve the URL a body-bearing injection must be sent to: the discovered
+/// `<form action=...>` endpoint when the param came from a form, else the
+/// target's own URL. A form-discovered body param reflects at the action
+/// endpoint, not at the page that contained the form.
+pub fn resolve_form_action_url(param: &Param, target: &Target) -> url::Url {
+    param
+        .form_action_url
+        .as_ref()
+        .and_then(|u| url::Url::parse(u).ok())
+        .unwrap_or_else(|| target.url.clone())
+}
+
+/// `application/x-www-form-urlencoded` body injection.
+pub fn build_body_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let parsed_url = resolve_form_action_url(param, target);
+    let body = Some(urlencoded_body(target.data.as_deref(), &param.name, value));
+    let method = body_location_method_for_param(&target.method, param);
+    let base = crate::utils::build_request(client, target, method, parsed_url, body);
+    crate::utils::apply_header_overrides(
+        base,
+        &[(
+            "Content-Type".to_string(),
+            "application/x-www-form-urlencoded".to_string(),
+        )],
+    )
+}
+
+/// `application/json` body injection.
+pub fn build_json_body_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let parsed_url = resolve_form_action_url(param, target);
+    let body = Some(json_body(
+        target.data.as_deref(),
+        &param.name,
+        &param.value,
+        value,
+    ));
+    let method = body_location_method_for_param(&target.method, param);
+    let base = crate::utils::build_request(client, target, method, parsed_url, body);
+    crate::utils::apply_header_overrides(
+        base,
+        &[("Content-Type".to_string(), "application/json".to_string())],
+    )
+}
+
+/// `multipart/form-data` body injection. No explicit `Content-Type` override:
+/// reqwest derives it from the form, and it must carry the generated boundary.
+pub fn build_multipart_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let parsed_url = resolve_form_action_url(param, target);
+    let form = multipart_form(target.data.as_deref(), &param.name, value);
+    let method = body_location_method_for_param(&target.method, param);
+    crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
+}
+
+/// Query / Path injection: the payload goes into the URL and the target's own
+/// body (if any) rides along unchanged.
+pub fn build_url_inject_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+    method: reqwest::Method,
+) -> reqwest::RequestBuilder {
+    // Query params discovered through a `<form action=...>` must be injected at
+    // the action URL — that's where the sink lives. Path params keep
+    // `target.url` because path-segment injection depends on the original path
+    // layout.
+    let base_url = effective_query_base(&target.url, param);
+    let inject_url_str = build_injected_url(&base_url, param, value);
+    let inject_url = url::Url::parse(&inject_url_str).unwrap_or_else(|_| base_url.clone());
+    crate::utils::build_request(client, target, method, inject_url, target.data.clone())
+}
+
+/// Build the injection request for `value` at `param`'s location.
+///
+/// Single source of truth for the reflection / light-verify / DOM-verify
+/// request builders, which were three near-identical copies of this `match`.
+/// They had already drifted: the light-verify copy sent an urlencoded body
+/// with **no `Content-Type`**, so form-parsing servers never bound the param
+/// and the verification silently came back negative.
+pub fn build_inject_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let default_method = target.parse_method();
+    match param.location {
+        // A cookie param must go into the `Cookie` header, not a header named
+        // after the cookie — see `build_header_request`.
+        Location::Header => build_header_request(client, target, param, value, default_method),
+        Location::Body => build_body_request(client, target, param, value),
+        Location::JsonBody => build_json_body_request(client, target, param, value),
+        Location::MultipartBody => build_multipart_request(client, target, param, value),
+        _ => build_url_inject_request(client, target, param, value, default_method),
+    }
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -991,6 +991,125 @@ fn test_build_header_request_still_sets_plain_headers() {
     );
 }
 
+/// A `Body` injection must declare `application/x-www-form-urlencoded`.
+///
+/// Regression: the reflection and DOM-verify paths set this, but the
+/// light-verify path built its own request and omitted it. A form-parsing
+/// server given a body with no `Content-Type` never binds the parameter, so
+/// the payload never reached the sink and light verification reported a
+/// negative — a silent false negative on every `Body` param it re-checked.
+/// All three paths now share `build_inject_request`, so the header is set once.
+#[test]
+fn test_build_inject_request_body_sets_urlencoded_content_type() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    let param = make_param(Location::Body, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    assert_eq!(
+        req.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/x-www-form-urlencoded"),
+        "a urlencoded body must declare its Content-Type or the server won't parse it"
+    );
+    let body = req
+        .body()
+        .and_then(|b| b.as_bytes())
+        .map(|b| String::from_utf8_lossy(b).to_string())
+        .expect("a body is sent");
+    assert!(
+        body.contains("q=PAYLOAD"),
+        "payload must be in the body: {body}"
+    );
+}
+
+/// A `JsonBody` injection must declare `application/json`.
+#[test]
+fn test_build_inject_request_json_body_sets_json_content_type() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    let param = make_param(Location::JsonBody, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    assert_eq!(
+        req.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json")
+    );
+}
+
+/// Multipart must NOT get a hand-written `Content-Type`: reqwest derives it
+/// from the form so it carries the generated boundary. Overriding it with a
+/// bare `multipart/form-data` would make the body unparseable.
+#[test]
+fn test_build_inject_request_multipart_keeps_generated_boundary() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    let param = make_param(Location::MultipartBody, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    let ct = req
+        .headers()
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .expect("multipart sets a Content-Type");
+    assert!(
+        ct.starts_with("multipart/form-data; boundary="),
+        "multipart Content-Type must carry the boundary, got: {ct}"
+    );
+}
+
+/// A cookie param routes to the `Cookie` header, not a same-named header —
+/// the dispatcher must keep delegating `Header` to `build_header_request`.
+#[test]
+fn test_build_inject_request_header_location_routes_cookies() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let target = cookie_target(&[("session", "abc")]);
+    let param = make_param(Location::Header, "session");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    assert!(
+        req.headers()
+            .get(reqwest::header::COOKIE)
+            .and_then(|v| v.to_str().ok())
+            .is_some_and(|c| c.contains("session=PAYLOAD")),
+        "a cookie param must be injected into the Cookie header"
+    );
+    assert!(req.headers().get("session").is_none());
+}
+
+/// Query injection puts the payload in the URL and leaves headers alone.
+#[test]
+fn test_build_inject_request_query_injects_into_url() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let target = crate::target_parser::parse_target("http://example.test/?q=1").expect("target");
+    let param = make_param(Location::Query, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    assert!(
+        req.url().as_str().contains("q=PAYLOAD"),
+        "payload must be in the query string, got: {}",
+        req.url()
+    );
+}
+
 /// A target carrying `cookies`, for the cookie-injection tests above.
 fn cookie_target(cookies: &[(&str, &str)]) -> Target {
     let mut target = crate::target_parser::parse_target("http://example.test/").expect("target");

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -679,16 +679,15 @@ pub(crate) async fn run_scan_job(
                     scan_report = crate::scanning::run_scanning(
                         &target,
                         args.clone(),
-                        results.clone(),
-                        None,
-                        None,
-                        findings_count.clone(),
-                        Some(cancel_flag.clone()),
-                        None,
+                        crate::scanning::ScanRunHandles::new(
+                            results.clone(),
+                            findings_count.clone(),
+                        )
+                        .with_cancel(cancel_flag.clone())
                         // Feed the live per-parameter completion counter so
                         // GET /scan/{id} reports `params_tested` climbing
                         // during the scan instead of staying at 0 until done.
-                        Some(progress.params_tested.clone()),
+                        .with_params_done(progress.params_tested.clone()),
                     )
                     .await;
 

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -14,6 +14,31 @@ pub mod scan_id;
 pub mod shimmer;
 pub mod term;
 
+/// Largest permit count `tokio::sync::Semaphore::new` accepts; it asserts
+/// above this. Taken from tokio's own public constant rather than hand-copying
+/// its `usize::MAX >> 3` definition, which is a private detail tokio is free to
+/// change — a stale local copy would make this clamp itself the panic.
+pub const MAX_SEMAPHORE_PERMITS: usize = tokio::sync::Semaphore::MAX_PERMITS;
+
+/// Clamp a configured concurrency into the range `Semaphore::new` accepts.
+///
+/// Concurrency knobs (`--workers`, `--max-concurrent-targets`) reach a
+/// semaphore from four surfaces: the CLI, a config file, the REST
+/// `ScanOptions`, and MCP. Only the CLI path runs `validate_numeric_args`, and
+/// even there `max_concurrent_targets` is checked for zero but has no upper
+/// bound — so an absurd value used to reach `Semaphore::new` and panic the
+/// scanner on user input.
+///
+/// Both ends matter, and the lower one is the more damaging: `Semaphore::new(0)`
+/// is not a slow scan, it is a permanent deadlock — every worker blocks on
+/// `acquire()` forever and the scan hangs with no output. A helper whose whole
+/// point is holding regardless of which validator ran must therefore floor at 1
+/// as well as cap. Anything near the ceiling is already "effectively
+/// unlimited", so no realistic scan changes.
+pub fn semaphore_permits(requested: usize) -> usize {
+    requested.clamp(1, MAX_SEMAPHORE_PERMITS)
+}
+
 // Re-export banner helpers at `crate::utils::*`
 pub use banner::print_banner_once;
 // Re-export scan_id helpers at `crate::utils::*`

--- a/src/utils/tests.rs
+++ b/src/utils/tests.rs
@@ -116,3 +116,256 @@ async fn test_init_remote_resources_accepts_unknown_provider_tokens() {
     let result = init_remote_resources(&payloads, &wordlists).await;
     assert!(result.is_ok());
 }
+
+/// True when the parenthesised group starting at `s[0] == '('` closes exactly
+/// at the end of `s` — i.e. the call is the entire expression, not one operand
+/// of a larger one.
+fn call_spans_to_end(s: &str) -> bool {
+    let mut depth = 0usize;
+    for (i, c) in s.char_indices() {
+        match c {
+            '(' => depth += 1,
+            ')' => {
+                depth -= 1;
+                if depth == 0 {
+                    // A rustfmt-wrapped call leaves a trailing comma.
+                    return s[i + 1..].trim().trim_end_matches(',').trim().is_empty();
+                }
+            }
+            _ => {}
+        }
+    }
+    false
+}
+
+/// Whether the argument text of a `Semaphore::new(..)` call is safe — either
+/// already clamped, or a value that cannot exceed tokio's `MAX_PERMITS`.
+///
+/// Split out from the scan below so the accept/reject table can be pinned
+/// directly (see `semaphore_arg_classifier_rejects_bypass_shapes`) instead of
+/// only being exercised through whatever shapes the tree happens to contain.
+fn semaphore_arg_is_clamped(arg: &str) -> bool {
+    // `split_whitespace` already trims and collapses internal runs.
+    let t = arg.split_whitespace().collect::<Vec<_>>().join(" ");
+    let t = t.as_str();
+
+    // Already routed through the clamp, directly or via `host_group_slots`
+    // (which clamps internally). The whole argument must BE that call — a
+    // `contains` check would accept `semaphore_permits(base) + args.workers`
+    // and `max(semaphore_permits(a), raw_workers)`, both of which still panic.
+    for call in ["semaphore_permits(", "host_group_slots("] {
+        if let Some(at) = t.find(call) {
+            // Everything before the call must be a path prefix (`crate::utils::`).
+            let prefix_ok = t[..at]
+                .chars()
+                .all(|c| c.is_alphanumeric() || c == '_' || c == ':');
+            // ...and the call must run to the end of the argument.
+            let closes_at_end = call_spans_to_end(&t[at + call.len() - 1..]);
+            if prefix_ok && closes_at_end {
+                return true;
+            }
+        }
+    }
+    // A bare integer literal: `1`, `64`, `1_024usize`. Matched WHOLE — a
+    // leading-digit check would also accept `2 * args.workers`.
+    let lit = t.trim_end_matches("usize");
+    if !lit.is_empty() && lit.chars().all(|c| c.is_ascii_digit() || c == '_') {
+        return true;
+    }
+    // A SCREAMING_CASE constant: `MAX_CONCURRENT_PREFLIGHT`. Matched WHOLE — a
+    // leading-uppercase check would also accept every type-qualified path, e.g.
+    // `ScanOptions::from(o).workers`, which is exactly the shape a "thread the
+    // config through a builder" refactor produces.
+    if t.starts_with(|c: char| c.is_ascii_uppercase())
+        && t.chars()
+            .all(|c| c.is_ascii_uppercase() || c.is_ascii_digit() || c == '_')
+    {
+        return true;
+    }
+    false
+}
+
+/// Pins the classifier's accept/reject table, including the bypass shapes a
+/// first-character-only check would have waved through.
+#[test]
+fn semaphore_arg_classifier_rejects_bypass_shapes() {
+    // Safe.
+    for ok in [
+        "crate::utils::semaphore_permits(target.workers)",
+        "host_group_slots(args.max_concurrent_targets)",
+        "MAX_CONCURRENT_PREFLIGHT",
+        "8",
+        "1_024usize",
+        "crate::utils::semaphore_permits(if args.sxss { 1 } else { target.workers })",
+    ] {
+        assert!(semaphore_arg_is_clamped(ok), "should be accepted: {ok}");
+    }
+
+    // Unclamped, user-controlled. Every one of these panics `Semaphore::new`
+    // for a large enough `--workers` / `--max-concurrent-targets`.
+    for bad in [
+        "args.max_concurrent_targets",
+        "target.workers",
+        // Type-qualified paths: accepted by a leading-uppercase check.
+        "ScanOptions::from(o).workers",
+        "Self::worker_count(args)",
+        "Config::get().workers",
+        // Arithmetic: accepted by a leading-digit check.
+        "2 * args.workers",
+        "1 + target.workers",
+        // An accept-term as one OPERAND of a larger expression: the clamp runs,
+        // then the result is added to / maxed with an unclamped value.
+        "crate::utils::semaphore_permits(base) + args.workers",
+        "std::cmp::max(crate::utils::semaphore_permits(a), raw_workers)",
+    ] {
+        assert!(!semaphore_arg_is_clamped(bad), "should be rejected: {bad}");
+    }
+}
+
+/// Every `Semaphore::new` in production code must take either a compile-time
+/// constant or a value clamped by [`super::semaphore_permits`].
+///
+/// `tokio::sync::Semaphore::new` asserts above `MAX_PERMITS` (`usize::MAX >> 3`),
+/// so an unclamped concurrency knob is a panic driven straight by user input.
+/// `--workers` is capped by `CLI_MAX_WORKERS`, but only on the CLI path —
+/// `validate_numeric_args` runs inside `run_scan`, which the REST and MCP job
+/// runners never call — and `--max-concurrent-targets` has no upper bound at
+/// all (`validation.rs` only rejects zero). Clamping at construction is what
+/// holds regardless of which validator ran.
+///
+/// A source-level guard rather than a behavioral test because the risky call
+/// sites sit deep inside 500–700 line orchestration functions that a unit test
+/// cannot cheaply drive. It fails on any NEW unclamped site, which is the part
+/// that actually regresses.
+#[test]
+fn every_semaphore_new_clamps_its_permit_count() {
+    fn rs_files(dir: &std::path::Path, out: &mut Vec<std::path::PathBuf>) {
+        let Ok(entries) = std::fs::read_dir(dir) else {
+            return;
+        };
+        for e in entries.flatten() {
+            let p = e.path();
+            if p.is_dir() {
+                rs_files(&p, out);
+            } else if p.extension().is_some_and(|x| x == "rs")
+                && p.file_name().is_some_and(|n| n != "tests.rs")
+            {
+                out.push(p);
+            }
+        }
+    }
+
+    /// Remove every `#[cfg(test)] mod .. { .. }` block, brace-matched. Other
+    /// `#[cfg(test)]` items (a single `use`, a single `fn`) are left in place;
+    /// they carry no `Semaphore::new`.
+    fn strip_cfg_test_modules(text: &str) -> String {
+        let mut out = String::with_capacity(text.len());
+        let mut rest = text;
+        while let Some(at) = rest.find("#[cfg(test)]") {
+            let after = &rest[at + "#[cfg(test)]".len()..];
+            // Only a `mod` item opens a block worth skipping.
+            let is_mod = after.trim_start().starts_with("mod ");
+            let Some(brace) = after.find('{').filter(|_| is_mod) else {
+                out.push_str(&rest[..at + "#[cfg(test)]".len()]);
+                rest = after;
+                continue;
+            };
+            out.push_str(&rest[..at]);
+            let block = &after[brace..];
+            let mut depth = 0usize;
+            let mut end = block.len();
+            for (i, c) in block.char_indices() {
+                match c {
+                    '{' => depth += 1,
+                    '}' => {
+                        depth -= 1;
+                        if depth == 0 {
+                            end = i + 1;
+                            break;
+                        }
+                    }
+                    _ => {}
+                }
+            }
+            rest = &block[end..];
+        }
+        out.push_str(rest);
+        out
+    }
+
+    /// The argument text of the call whose `(` is at `open`, found by paren
+    /// depth rather than a fixed window. A fixed window runs past the end of
+    /// its own statement and picks up whatever follows — which in this tree
+    /// meant an accept-term from the *next* call could vouch for an unclamped
+    /// one two lines away. `get` rather than `[..]` so a multibyte char on the
+    /// boundary is a miss, not a panic.
+    fn call_argument(src: &str, open: usize) -> Option<&str> {
+        let mut depth = 0usize;
+        for (i, c) in src[open..].char_indices() {
+            match c {
+                '(' => depth += 1,
+                ')' => {
+                    depth -= 1;
+                    if depth == 0 {
+                        return src.get(open + 1..open + i);
+                    }
+                }
+                _ => {}
+            }
+        }
+        None
+    }
+
+    let mut files = Vec::new();
+    rs_files(std::path::Path::new("src"), &mut files);
+    assert!(!files.is_empty(), "should have found source files");
+
+    let mut offenders = Vec::new();
+    for path in files {
+        let Ok(text) = std::fs::read_to_string(&path) else {
+            continue;
+        };
+        // Drop `#[cfg(test)] mod { .. }` blocks by brace matching. Truncating
+        // at the FIRST `#[cfg(test)]` instead would blank most of a file: in
+        // `scanning/mod.rs` that marker appears at line 58 while the
+        // `Semaphore::new` this guard exists to watch is at line 2548, and a
+        // single-item `#[cfg(test)] pub(crate) use ..;` (as in
+        // `check_dom_verification.rs`) would blank everything after it too.
+        let code = strip_cfg_test_modules(&text);
+        // Drop whole-line comments so prose mentioning a `Semaphore::new(..)`
+        // call is not scanned as code, and so a comment *inside* an argument
+        // does not hide the clamp. Whole-line only: stripping from a trailing
+        // `//` would also eat the tail of any line holding a URL literal.
+        let stripped: String = code
+            .as_str()
+            .lines()
+            .filter(|l| !l.trim_start().starts_with("//"))
+            .collect::<Vec<_>>()
+            .join("\n");
+
+        let needle = "Semaphore::new";
+        let mut from = 0;
+        while let Some(rel) = stripped[from..].find(needle) {
+            let at = from + rel;
+            from = at + needle.len();
+            let Some(open) = stripped[from..].find('(').map(|o| from + o) else {
+                continue;
+            };
+            let Some(raw) = call_argument(&stripped, open) else {
+                continue;
+            };
+            if !semaphore_arg_is_clamped(raw) {
+                let arg = raw.split_whitespace().collect::<Vec<_>>().join(" ");
+                offenders.push(format!("{}: Semaphore::new({})", path.display(), arg));
+            }
+        }
+    }
+
+    assert!(
+        offenders.is_empty(),
+        "unclamped Semaphore::new — wrap the permit count in \
+         crate::utils::semaphore_permits(..) or this panics on a large \
+         --workers / --max-concurrent-targets:\n  {}",
+        offenders.join("\n  ")
+    );
+}


### PR DESCRIPTION
Refactor pass aimed at readability, parallel-execution safety, and structures that make silent misuse impossible. Behaviour-preserving except for the four bug fixes below.

## Bug fixes

| Bug | Impact |
|---|---|
| light-verify sent urlencoded bodies with **no `Content-Type`** | form-parsing servers never bound the parameter, so verification returned negative — a silent false negative on every `Body` param it re-checked |
| `--limit` dropped remaining `JoinHandle`s | dropping detaches rather than aborts; those groups kept scanning and appending to `results` after `run_scan_loop` returned, while the caller was already rendering |
| `Semaphore::new` took unvalidated concurrency | `max_concurrent_targets` is checked only for zero, and only on the CLI path — which the REST and MCP runners never take. A large value panicked the scanner; `0` would deadlock it |
| discovery/mining spawns missed per-job task-locals | a REST/MCP job with `rate_limit: N` ran its **entire** discovery and mining phase unthrottled. Measured: 1 of 4 requests reached the per-job counter |

## Structural changes

- **One injection request builder.** Three paths had their own copy of the same `match param.location`; they had drifted (hence the `Content-Type` bug). Now `url_inject::build_inject_request`.
- **`run_scanning` takes `ScanRunHandles`** instead of 9 positional args. Not `Default` — defaulting the two *required* handles would trade "transpose two args" for "forget a field", where a defaulted `results` discards every finding.
- **`finding_key` takes `FindingIdentity`** instead of 9 consecutive `&str`. The key is derived on two paths whose field orders differ; a transposition means every finding reads as new, or collides and is suppressed as already-known.
- **Bounded host-group dispatch**, deliberately looser than `max_concurrent_targets` — a group holds a slot while holding zero target permits, so a 1:1 bound would idle the target semaphore.
- **`host_groups` is a `BTreeMap`.** Host order is user-visible in the analysis pass, `--dry-run`, `--only-discovery`, and what a `--state-file` run records; `HashMap`'s per-process seed made all four vary run to run.

## Verification

- **2,195 unit/integration tests** (from 2,184), `clippy --all-targets --all-features -D warnings` clean.
- Release-build harnesses: `surface_parity` 46, `output_conformance` 111, `replay_corpus` 42, `hostile_scan` 23, `docs_lint` 22 — all pass.
- `server_mcp_smoke` 43 pass with **1 pre-existing failure** (MCP `isError` vs JSON-RPC error channel), unrelated to this branch.
- `replay_corpus` regenerated with **byte-identical findings, evidence, and detection methods** — only timestamps and random marker suffixes differed. That is the behaviour-preservation evidence for the detection-path changes.

Each new regression test was mutation-checked: the fix was reverted and the test confirmed to fail. Three of them initially passed against broken code and were rewritten.

## Deliberately not included

- **`payload/remote.rs` `OnceLock`** leaks payloads between concurrent server jobs, but process-cached remote init is an explicit AGENTS.md invariant — needs an owner decision, not a drive-by change.
- **The analysis phase is uncancellable** (`DELETE /scan/{id}` reports `cancelled: true` while mining continues). A design change, not a mechanical fix.
- **No `validation.rs` upper bound** for `max_concurrent_targets` — clamping at construction holds no matter which validator ran; a validation rule would change error semantics on four surfaces.
- `JobScopes::capture()` is not hoisted out of the spawn loops (nanoseconds against a per-iteration network request), and `with_finding_tx` keeps its `Option` parameter (compile-checked, matches its call site).
