### PR TITLE
fix: harden against crashes, hangs, and silently-clean scans

### DIFF
--- a/src/cmd/mod.rs
+++ b/src/cmd/mod.rs
@@ -43,6 +43,12 @@ pub mod error_codes {
     /// `status: "incomplete"` (it ran, but the session was gone by the end).
     /// The distinction that matters to a consumer: neither is `"clean"`.
     pub const SESSION_LOST: &str = "SESSION_LOST";
+    /// A dalfox task handling this target panicked, so the target was never
+    /// analyzed. Carried on `target_summary` entries with `status: "skipped"`.
+    /// Reporting the target as skipped rather than letting it fall through to
+    /// `"clean"` is the whole point: a crash inside the scanner must never be
+    /// indistinguishable from "we looked and found nothing".
+    pub const INTERNAL_ERROR: &str = "INTERNAL_ERROR";
 }
 
 #[cfg(test)]

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -144,6 +144,9 @@ pub(crate) async fn run_preflight_and_analysis(
                 let mut handles = vec![];
 
                 for mut target in drained {
+            // Kept outside the task so a panicking task can still be reported
+            // against its target instead of vanishing (see the collector).
+            let panic_target_url = target.url.to_string();
             let args_clone = args_outer.clone();
             let sem = pre_analyze_semaphore_outer.clone();
             let preflight_idx_clone = preflight_idx_outer.clone();
@@ -158,7 +161,7 @@ pub(crate) async fn run_preflight_and_analysis(
             let session_baselines_clone = session_baselines_outer.clone();
             let session_lost_clone = session_lost_outer.clone();
 
-            handles.push(tokio::task::spawn_local(async move {
+            handles.push((panic_target_url, tokio::task::spawn_local(async move {
                 // Bound concurrency across targets for preflight + analysis
                 let Ok(_permit) = sem.acquire_owned().await else {
                     return None;
@@ -768,16 +771,42 @@ pub(crate) async fn run_preflight_and_analysis(
                 }
 
                 Some(target)
-            }));
+            })));
         }
 
         // Collect processed targets (skipping those filtered by preflight)
                 let mut processed: Vec<Target> = Vec::new();
-                for handle in handles {
-                    if let Ok(res) = handle.await
-                        && let Some(t) = res {
-                            processed.push(t);
+                for (target_url, handle) in handles {
+                    match handle.await {
+                        Ok(Some(t)) => processed.push(t),
+                        // Preflight deliberately dropped this target; it has
+                        // already recorded its own `skipped_targets` entry.
+                        Ok(None) => {}
+                        // A panic in here used to be swallowed whole: the
+                        // target silently disappeared from `processed`, never
+                        // reached the injection stage, and the run finished
+                        // `0 XSS` with exit 0 — a scanner reporting "clean" for
+                        // a target it crashed on. Surface it and record the
+                        // target as skipped so `target_summary` says
+                        // INTERNAL_ERROR instead of clean. The injection
+                        // stage in `scan_loop.rs` does the same.
+                        Err(e) => {
+                            // Sanitized: a `JoinError`'s Display carries the
+                            // panic message, and panic messages quote the data
+                            // that caused them — a slice-boundary panic embeds
+                            // bytes straight from the scanned response. A raw
+                            // CR/LF there would let a target forge log lines.
+                            eprintln!(
+                                "[scan] preflight/analysis task failed for {}: {}",
+                                crate::utils::log::sanitize_log_message(&target_url),
+                                crate::utils::log::sanitize_log_message(&e.to_string())
+                            );
+                            skipped_targets_outer
+                                .lock()
+                                .await
+                                .insert(target_url, crate::cmd::error_codes::INTERNAL_ERROR);
                         }
+                    }
                 }
                 processed
             }).await

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -89,6 +89,15 @@ pub const CLI_MAX_RATE_LIMIT: u32 = 100_000;
 /// Sanity cap for `--retries`. Retrying more than this turns a transient
 /// blip into a multi-minute hang per request.
 pub const CLI_MAX_RETRIES: u32 = 100;
+/// Sanity cap for `--sxss-retries`. Much tighter than [`CLI_MAX_RETRIES`]
+/// because the stored-XSS re-check backoff is `500ms * attempt`, i.e. the total
+/// wait grows *quadratically*: 20 retries is ~1.6 minutes per check URL, while
+/// the un-capped 3000 someone could type is ~26 days. Applied per check URL and
+/// per verified payload, so it multiplies.
+pub const CLI_MAX_SXSS_RETRIES: u32 = 20;
+/// Ceiling on a single stored-XSS re-check backoff sleep. Bounds the tail of
+/// the `500ms * attempt` ramp so the last attempts stay responsive.
+pub const MAX_SXSS_BACKOFF_MS: u64 = 5_000;
 /// Sanity cap for `--retry-delay` (ms), matching `--delay`'s ceiling.
 pub const CLI_MAX_RETRY_DELAY_MS: u64 = 60_000;
 /// Sanity cap for `--scan-timeout` (seconds). Kept in lockstep with the async
@@ -592,6 +601,15 @@ pub struct ScanArgs {
 
     #[clap(help_heading = "XSS SCANNING")]
     /// Only test custom payloads. Example: --only-custom-payload --custom-payload=p.txt
+    //
+    // Deliberately NOT `requires = "custom_payload"`. The pairing is real — on
+    // its own this flag yields an empty payload set and a scan that reports
+    // clean without sending anything — but clap validates argument
+    // relationships *before* the config file is overlaid, so `requires` would
+    // reject the legitimate `--only-custom-payload` + `custom_payload = "…"`
+    // in a config file. The check therefore lives in `run_scan`, which runs
+    // after `finalize_scan_args` has merged the config, plus in
+    // `Config::normalize_and_validate` for the all-config form.
     #[arg(long)]
     pub only_custom_payload: bool,
 
@@ -647,7 +665,11 @@ pub struct ScanArgs {
 
     #[clap(help_heading = "XSS SCANNING")]
     /// HTTP method for checking Stored XSS (default "GET")
-    #[arg(long, default_value = "GET")]
+    // Same parser as `--method`. Without it `--sxss-method post` went on the
+    // wire as the literal extension verb `post` (`reqwest::Method` is
+    // case-sensitive) and `--sxss-method "GET junk"` failed to parse and
+    // silently degraded to GET.
+    #[arg(long, default_value = "GET", value_parser = parse_http_method_arg)]
     pub sxss_method: String,
 
     #[clap(help_heading = "XSS SCANNING")]

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -568,17 +568,27 @@ pub(crate) async fn resolve_targets(
                     if args.method != DEFAULT_METHOD {
                         target.method = args.method.clone();
                     }
-                    if let Some(ua) = &args.user_agent {
+                    // An empty `--user-agent ""` must not become a literal
+                    // `User-Agent:` header on every request (the server/MCP path
+                    // already guards this); it means "no override".
+                    if let Some(ua) = args.user_agent.as_ref().filter(|ua| !ua.is_empty()) {
                         target.headers.push(("User-Agent".to_string(), ua.clone()));
                         target.user_agent = Some(ua.clone());
                     } else {
                         target.user_agent = Some("".to_string());
                     }
+                    // `--cookies "a=1; b=2"` is one flag carrying a whole Cookie
+                    // header value, which a bare `split_once('=')` folded into
+                    // a single cookie named `a` with value `1; b=2`. Requests
+                    // still went out byte-identical, but cookie-parameter
+                    // coverage silently lost every cookie after the first: the
+                    // discovery stage iterates `target.cookies`, so `b` was
+                    // never enumerated or probed. Server and MCP have always
+                    // used this shared splitter.
                     target.cookies = args
                         .cookies
                         .iter()
-                        .filter_map(|c| c.split_once("="))
-                        .map(|(k, v)| (k.to_string(), v.to_string()))
+                        .flat_map(|c| crate::job::split_cookie_pairs(c))
                         .collect();
                     target.timeout = args.timeout;
                     target.delay = args.delay;
@@ -1102,18 +1112,17 @@ fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
                 .push((name.trim().to_string(), value.trim().to_string()));
         }
     }
-    if let Some(ua) = &args.user_agent {
+    // Empty `--user-agent ""` means "no override", not a literal empty header.
+    if let Some(ua) = args.user_agent.as_ref().filter(|ua| !ua.is_empty()) {
         target.headers.push(("User-Agent".to_string(), ua.clone()));
         target.user_agent = Some(ua.clone());
     } else if target.user_agent.is_none() {
         target.user_agent = Some("".to_string());
     }
+    // Shared splitter: a `--cookies "a=1; b=2"` value carries several cookies
+    // and every one of them has to become its own probe-able parameter.
     for c in &args.cookies {
-        if let Some((k, v)) = c.split_once('=') {
-            target
-                .cookies
-                .push((k.trim().to_string(), v.trim().to_string()));
-        }
+        target.cookies.extend(crate::job::split_cookie_pairs(c));
     }
     target.timeout = args.timeout;
     target.delay = args.delay;

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -45,13 +45,14 @@ mod validation;
 
 pub use args::{
     BASELINE_MODE_VALUES, BlindOobArgs, CLI_MAX_DELAY_MS, CLI_MAX_RATE_LIMIT, CLI_MAX_RETRIES,
-    CLI_MAX_RETRY_DELAY_MS, CLI_MAX_TIMEOUT_SECS, CLI_MAX_WORKERS, CUSTOM_ALERT_TYPE_VALUES,
-    DEDUP_URLS_VALUES, DEFAULT_DEDUP_URLS, DEFAULT_DELAY_MS, DEFAULT_ENCODERS,
-    DEFAULT_MAX_CONCURRENT_TARGETS, DEFAULT_MAX_TARGETS_PER_HOST, DEFAULT_METHOD,
+    CLI_MAX_RETRY_DELAY_MS, CLI_MAX_SXSS_RETRIES, CLI_MAX_TIMEOUT_SECS, CLI_MAX_WORKERS,
+    CUSTOM_ALERT_TYPE_VALUES, DEDUP_URLS_VALUES, DEFAULT_DEDUP_URLS, DEFAULT_DELAY_MS,
+    DEFAULT_ENCODERS, DEFAULT_MAX_CONCURRENT_TARGETS, DEFAULT_MAX_TARGETS_PER_HOST, DEFAULT_METHOD,
     DEFAULT_PAYLOAD_SAFETY_CAP, DEFAULT_RATE_LIMIT, DEFAULT_RETRIES, DEFAULT_RETRY_DELAY_MS,
     DEFAULT_TIMEOUT_SECS, DEFAULT_WAF_MIN_CONFIDENCE, DEFAULT_WORKERS, ENCODER_VALUES,
-    FORMAT_VALUES, LIMIT_RESULT_TYPE_VALUES, ON_SESSION_LOSS_VALUES, ONLY_POC_VALUES,
-    POC_TYPE_VALUES, PreflightOptions, ScanArgs, WAF_BYPASS_VALUES, format_is_machine,
+    FORMAT_VALUES, LIMIT_RESULT_TYPE_VALUES, MAX_SXSS_BACKOFF_MS, ON_SESSION_LOSS_VALUES,
+    ONLY_POC_VALUES, POC_TYPE_VALUES, PreflightOptions, ScanArgs, WAF_BYPASS_VALUES,
+    format_is_machine,
 };
 pub(crate) use args::{parse_force_waf_arg, parse_http_method_arg};
 pub(crate) use logging::{log_info, log_warn};
@@ -287,6 +288,24 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
             &args.format,
             crate::cmd::error_codes::PARSE_ERROR,
             &format!("--session-check-url is not a valid absolute URL: {u}"),
+        );
+        return ScanOutcome::Error;
+    }
+
+    // `--only-custom-payload` with no `--custom-payload` at all is the same
+    // catastrophe as an unreadable file — `get_dynamic_payloads` takes the
+    // only-custom branch, finds no file to read, and returns an empty vec, so
+    // the reflection phase sends *zero* attack payloads and the run prints
+    // `0 XSS` and exits 0. That is indistinguishable from a clean target, which
+    // is exactly what a CI gate keys on. The check below only runs inside
+    // `if let Some(path)`, so this pairing has to be rejected before it.
+    // Reachable from a config file too (`only_custom_payload = true`), which is
+    // why `Config::normalize_and_validate` carries the same rule.
+    if args.only_custom_payload && args.custom_payload.is_none() {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::INVALID_INPUT_TYPE,
+            "--only-custom-payload requires --custom-payload <FILE>",
         );
         return ScanOutcome::Error;
     }
@@ -738,7 +757,15 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // registration outage never aborts the scan. Injection then runs over
     // whichever channel(s) are configured; the OOB poller is spawned once
     // `stream_findings_enabled` is known (below) and drained before rendering.
-    let blind_active = !args.dry_run && !args.only_discovery;
+    // `--skip-xss-scanning` means "send no attack payloads". Blind XSS payloads
+    // are attack payloads — stored ones, at that: they persist in the target
+    // after the run. Only the per-target injection stage used to honour the
+    // flag (scan_loop.rs), so `--skip-xss-scanning -b <callback>` (with `-b`
+    // commonly living in a shared config file) still wrote live stored-XSS
+    // payloads into every parameter and form of a production system the
+    // operator had explicitly asked not to attack. This also skips OOB session
+    // registration, which is correct: there is nothing left to call back.
+    let blind_active = !args.dry_run && !args.only_discovery && !args.skip_xss_scanning;
     let oob_session: Option<Arc<crate::oob::OobSession>> =
         if blind_active && args.blind_oob_enabled() {
             match crate::oob::OobSession::start(&args.oob_config()).await {

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -118,7 +118,7 @@ pub(crate) async fn render_dry_run(
         .sum();
     let skipped = skipped_targets.lock().await;
 
-    if args.format == "json" || args.format == "jsonl" {
+    let report = if args.format == "json" || args.format == "jsonl" {
         let mut meta = serde_json::json!({
             "dalfox_version": env!("CARGO_PKG_VERSION"),
             "targets_input": args.targets.len(),
@@ -146,56 +146,66 @@ pub(crate) async fn render_dry_run(
             "targets": dry_run_targets,
         });
         if args.format == "json" {
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&output).unwrap_or_default()
-            );
+            serde_json::to_string_pretty(&output).unwrap_or_default()
         } else {
-            println!("{}", serde_json::to_string(&output).unwrap_or_default());
+            serde_json::to_string(&output).unwrap_or_default()
         }
     } else {
-        println!("Dry-run summary:");
-        println!("  Targets (input):     {}", args.targets.len());
-        println!("  Targets (scannable): {}", dry_run_targets.len());
-        println!("  Targets (skipped):   {}", skipped.len());
+        use std::fmt::Write as _;
+        let mut out = String::new();
+        let _ = writeln!(out, "Dry-run summary:");
+        let _ = writeln!(out, "  Targets (input):     {}", args.targets.len());
+        let _ = writeln!(out, "  Targets (scannable): {}", dry_run_targets.len());
+        let _ = writeln!(out, "  Targets (skipped):   {}", skipped.len());
         if state.dedup.collapsed > 0 {
-            println!(
+            let _ = writeln!(
+                out,
                 "  Targets (deduped):   {} ({} mode)",
                 state.dedup.collapsed, state.dedup.mode
             );
         }
         if state.resumed_skipped > 0 {
-            println!(
+            let _ = writeln!(
+                out,
                 "  Targets (resumed):   {} already completed",
                 state.resumed_skipped
             );
         }
-        println!("  Params discovered:   {}", total_params);
-        println!("  Estimated requests:  {}", total_estimated);
+        let _ = writeln!(out, "  Params discovered:   {}", total_params);
+        let _ = writeln!(out, "  Estimated requests:  {}", total_estimated);
         if !warnings.is_empty() {
-            println!("  Warnings:");
+            let _ = writeln!(out, "  Warnings:");
             for w in &warnings {
-                println!("    - {}", w);
+                let _ = writeln!(out, "    - {}", w);
             }
         }
-        println!();
+        let _ = writeln!(out);
         for t in &dry_run_targets {
-            println!(
+            let _ = writeln!(
+                out,
                 "  {} ({}):",
                 t["target"].as_str().unwrap_or("?"),
                 t["method"].as_str().unwrap_or("?")
             );
             if let Some(params) = t["params"].as_array() {
                 for p in params {
-                    println!(
+                    let _ = writeln!(
+                        out,
                         "    - {} ({})",
                         p["name"].as_str().unwrap_or("?"),
                         p["location"].as_str().unwrap_or("?")
                     );
                 }
             }
-            println!("    estimated_requests: {}", t["estimated_requests"]);
+            let _ = writeln!(out, "    estimated_requests: {}", t["estimated_requests"]);
         }
+        // Trailing newline comes from the emitter, matching the JSON branches.
+        out.pop();
+        out
+    };
+
+    if write_output_or_stdout(args, &report) {
+        return ScanOutcome::Error;
     }
     ScanOutcome::Clean
 }
@@ -229,7 +239,8 @@ pub(crate) fn render_only_discovery(
             "targets_skipped_completed": state.resumed_skipped,
         })
     });
-    match args.format.as_str() {
+    use std::fmt::Write as _;
+    let report = match args.format.as_str() {
         "json" => {
             let mut meta = serde_json::json!({
                 "dalfox_version": env!("CARGO_PKG_VERSION"),
@@ -243,10 +254,7 @@ pub(crate) fn render_only_discovery(
                 "meta": meta,
                 "params": entries,
             });
-            println!(
-                "{}",
-                serde_json::to_string_pretty(&envelope).unwrap_or_default()
-            );
+            serde_json::to_string_pretty(&envelope).unwrap_or_default()
         }
         "jsonl" => {
             // Meta line first (consistent with `-f jsonl` for scans),
@@ -260,21 +268,30 @@ pub(crate) fn render_only_discovery(
                 inner["resumed"] = r.clone();
             }
             let meta = serde_json::json!({ "meta": inner });
-            println!("{}", serde_json::to_string(&meta).unwrap_or_default());
+            let mut out = serde_json::to_string(&meta).unwrap_or_default();
             for e in &entries {
-                println!("{}", serde_json::to_string(e).unwrap_or_default());
+                let _ = write!(out, "\n{}", serde_json::to_string(e).unwrap_or_default());
             }
+            out
         }
         _ => {
+            let mut out = String::new();
             for e in &entries {
-                println!(
+                let _ = writeln!(
+                    out,
                     "[{}] {} ({})",
                     e["url"].as_str().unwrap_or(""),
                     e["param"].as_str().unwrap_or(""),
                     e["location"].as_str().unwrap_or("")
                 );
             }
+            out.pop();
+            out
         }
+    };
+
+    if write_output_or_stdout(args, &report) {
+        return ScanOutcome::Error;
     }
     ScanOutcome::Clean
 }
@@ -666,6 +683,21 @@ pub(crate) async fn render_results(
         output
     };
 
+    let output_write_failed = write_output_or_stdout(args, &output_content);
+
+    (final_results, output_write_failed)
+}
+
+/// Write a rendered report to `--output`, or to stdout when no file was asked
+/// for. Returns whether the file write failed.
+///
+/// Shared by the end-of-scan renderer and by the `--dry-run` /
+/// `--only-discovery` previews. Those two return before `render_results`, which
+/// used to be the only place that read `args.output`, so `-o plan.json` was
+/// silently ignored and the command still exited 0 — a pipeline consuming that
+/// file read a stale one, or failed on a missing one, with no indication that
+/// dalfox had skipped the write.
+fn write_output_or_stdout(args: &ScanArgs, output_content: &str) -> bool {
     let mut output_write_failed = false;
     if let Some(output_path) = &args.output {
         // Surface `..` traversal so the operator notices before a
@@ -691,7 +723,13 @@ pub(crate) async fn render_results(
         // in which escapes belong here; strip unconditionally rather than
         // mirroring the gate. Non-plain formats never contain escapes, so this
         // is a no-op for them.
-        let file_content = crate::utils::term::strip_ansi(&output_content);
+        let mut file_content = crate::utils::term::strip_ansi(output_content);
+        // A report file ends with a newline. stdout gets one from `cprintln!`;
+        // the file branch has to add its own, and the JSON/JSONL renderers
+        // produce a buffer without a trailing one.
+        if !file_content.ends_with('\n') {
+            file_content.push('\n');
+        }
         match std::fs::write(output_path, &file_content) {
             Ok(_) => {
                 if !args.silence {
@@ -716,6 +754,5 @@ pub(crate) async fn render_results(
         // is in effect so the final POC/finding block stays plain.
         crate::cprintln!("{}", output_content);
     }
-
-    (final_results, output_write_failed)
+    output_write_failed
 }

--- a/src/cmd/scan/scan_loop.rs
+++ b/src/cmd/scan/scan_loop.rs
@@ -72,14 +72,18 @@ async fn run_target_capped<T>(
     scan_timeout_secs: u64,
     sigint: &AtomicBool,
     target_cancel: &AtomicBool,
-) -> bool {
+) -> (bool, T) {
     tokio::pin!(fut);
     let deadline = tokio::time::Instant::now() + Duration::from_secs(scan_timeout_secs);
     let mut timed_out = false;
+    let out;
     loop {
         tokio::select! {
             biased;
-            _ = &mut fut => break,
+            // The cap cancels *cooperatively*: it flips `target_cancel` and
+            // keeps polling, so the future always runs to completion and
+            // always yields its report.
+            res = &mut fut => { out = res; break }
             // Mirror a process-wide Ctrl-C into this target's flag, then keep
             // draining. Disabled once already cancelled (by either source).
             _ = poll_cancel(sigint), if !target_cancel.load(Ordering::Relaxed) => {
@@ -91,7 +95,7 @@ async fn run_target_capped<T>(
             }
         }
     }
-    timed_out
+    (timed_out, out)
 }
 
 pub(crate) async fn run_scan_loop(
@@ -336,6 +340,10 @@ pub(crate) async fn run_scan_loop(
             // its in-flight targets detach and keep issuing requests. A
             // `JoinSet` aborts them when it drops.
             let mut target_handles = tokio::task::JoinSet::new();
+            // task id -> target URL, so a panicking task can be attributed to
+            // the target it was scanning (a `JoinError` carries only the id).
+            let mut panicked_target_of: std::collections::HashMap<tokio::task::Id, String> =
+                std::collections::HashMap::new();
 
             for target in group {
                 if let Some(lim) = args_arc.limit
@@ -397,7 +405,8 @@ pub(crate) async fn run_scan_loop(
                 let state_file_target = state_file_group.clone();
 
                 let multi_pb_active = multi_pb_clone_inner.is_some();
-                target_handles.spawn(async move {
+                let panic_target_url = target.url.to_string();
+                let spawned = target_handles.spawn(async move {
                     if !args_clone.skip_xss_scanning && !args_clone.only_discovery {
                         // Re-validate the session before spending this target's
                         // request budget. Throttled: on a short run the preflight
@@ -478,7 +487,7 @@ pub(crate) async fn run_scan_loop(
                         // the per-target scan would otherwise serialize each
                         // phase × per-request timeout and run far longer than
                         // the user expects. Setting the cap to 0 disables it.
-                        let timed_out = if timeout_set {
+                        let (timed_out, scan_report) = if timeout_set {
                             run_target_capped(
                                 scan_fut,
                                 args_clone.scan_timeout,
@@ -487,8 +496,7 @@ pub(crate) async fn run_scan_loop(
                             )
                             .await
                         } else {
-                            scan_fut.await;
-                            false
+                            (false, scan_fut.await)
                         };
                         if timed_out && !args_clone.silence {
                             eprintln!(
@@ -526,13 +534,19 @@ pub(crate) async fn run_scan_loop(
                         // Terminal state for `--state-file`. Only a target that
                         // ran to the end under a live session is `completed`
                         // and therefore skippable next run; a Ctrl-C, a
-                        // `--scan-timeout` expiry, or a session that died
-                        // mid-scan all leave coverage unknown, so they are
-                        // recorded `cancelled` and retried.
+                        // `--scan-timeout` expiry, a session that died
+                        // mid-scan, or a `--limit` cap that cut the dispatch
+                        // loop short all leave coverage unknown, so they are
+                        // recorded `cancelled` and retried. `--limit` matters
+                        // as much as the others even though the run "succeeded":
+                        // `limit` is part of the config hash, so re-running the
+                        // identical command would skip this target forever with
+                        // most of its parameters never tested.
                         if let Some(sf) = &state_file_target {
                             let outcome = if timed_out
                                 || cancel_flag_inner.load(Ordering::Relaxed)
                                 || session_died
+                                || scan_report.limit_stopped
                             {
                                 super::state_file::TargetOutcome::Cancelled
                             } else {
@@ -556,6 +570,7 @@ pub(crate) async fn run_scan_loop(
                     }
                     drop(permit);
                 });
+                panicked_target_of.insert(spawned.id(), panic_target_url);
             }
 
             while let Some(joined) = target_handles.join_next().await {
@@ -565,7 +580,23 @@ pub(crate) async fn run_scan_loop(
                 if let Err(e) = joined
                     && e.is_panic()
                 {
-                    eprintln!("[scan] target task panicked: {}", e);
+                    // Sanitized: a panic message quotes the data that caused
+                    // it, which for this pipeline can be bytes straight from a
+                    // scanned response — raw CR/LF there forges log lines.
+                    eprintln!(
+                        "[scan] target task panicked: {}",
+                        crate::utils::log::sanitize_log_message(&e.to_string())
+                    );
+                    // Logging alone still left the target reported `clean`:
+                    // it produced no findings and nothing marked it otherwise,
+                    // which for a scanner is the worst possible outcome. Record
+                    // it the same way the preflight/analysis stage does.
+                    if let Some(url) = panicked_target_of.get(&e.id()) {
+                        skipped_targets_group
+                            .lock()
+                            .await
+                            .insert(url.clone(), crate::cmd::error_codes::INTERNAL_ERROR);
+                    }
                 }
                 // Update global overall progress line when multiple targets
                 overall_done_clone.fetch_add(1, Ordering::Relaxed);
@@ -652,7 +683,7 @@ mod tests {
         let fut = cooperative_worker(target_cancel.clone());
         // 1s is the smallest expressible budget; the cap fires and the
         // cooperative worker then drains via the per-target flag.
-        let timed_out = run_target_capped(fut, 1, &sigint, &target_cancel).await;
+        let (timed_out, ()) = run_target_capped(fut, 1, &sigint, &target_cancel).await;
         assert!(timed_out, "the per-target cap should fire");
         assert!(
             target_cancel.load(Ordering::Relaxed),
@@ -678,7 +709,7 @@ mod tests {
             sig.store(true, Ordering::Relaxed);
         });
         // Budget far larger than the SIGINT delay so the cap can't be the cause.
-        let timed_out = run_target_capped(fut, 3600, &sigint, &target_cancel).await;
+        let (timed_out, ()) = run_target_capped(fut, 3600, &sigint, &target_cancel).await;
         assert!(
             !timed_out,
             "ended via SIGINT mirror, not the wall-clock cap"
@@ -698,7 +729,7 @@ mod tests {
         let fut = async {
             tokio::time::sleep(Duration::from_millis(10)).await;
         };
-        let timed_out = run_target_capped(fut, 3600, &sigint, &target_cancel).await;
+        let (timed_out, ()) = run_target_capped(fut, 3600, &sigint, &target_cancel).await;
         assert!(!timed_out);
         assert!(!target_cancel.load(Ordering::Relaxed));
         assert!(!sigint.load(Ordering::Relaxed));

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -111,6 +111,38 @@ fn validate_numeric_args_rejects_delay_over_cap() {
 }
 
 #[test]
+fn validate_numeric_args_rejects_sxss_retries_over_cap() {
+    // The stored-XSS re-check backoff is `500ms * attempt`, so the *total* wait
+    // grows quadratically: the un-capped 3000 someone could type is ~26 days,
+    // per check URL and per verified payload.
+    let mut args = default_scan_args();
+    args.sxss_retries = crate::cmd::scan::CLI_MAX_SXSS_RETRIES + 1;
+    let err = validate_numeric_args(&args).unwrap_err();
+    assert!(
+        err.1.contains("sxss-retries"),
+        "message must name the flag, got: {}",
+        err.1
+    );
+}
+
+#[test]
+fn validate_numeric_args_accepts_sxss_retries_at_cap() {
+    let mut args = default_scan_args();
+    args.sxss_retries = crate::cmd::scan::CLI_MAX_SXSS_RETRIES;
+    assert!(validate_numeric_args(&args).is_ok());
+}
+
+#[test]
+fn sxss_method_uses_the_same_parser_as_method() {
+    // `--sxss-method` had no value parser, so `post` went on the wire as the
+    // literal extension verb (reqwest's Method is case-sensitive) and
+    // `"GET junk"` failed to parse and silently degraded to GET.
+    use crate::cmd::scan::parse_http_method_arg;
+    assert_eq!(parse_http_method_arg("post").unwrap(), "POST");
+    assert!(parse_http_method_arg("GET junk").is_err());
+}
+
+#[test]
 fn validate_numeric_args_rejects_zero_concurrent_targets() {
     let mut args = default_scan_args();
     args.max_concurrent_targets = 0;

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -1981,6 +1981,56 @@ async fn test_resolve_targets_url_applies_cli_overrides() {
 }
 
 #[tokio::test]
+async fn test_resolve_targets_splits_multi_cookie_values() {
+    // `--cookies "a=1; b=2"` is one flag carrying a whole Cookie header value.
+    // A bare `split_once('=')` folded it into a single cookie named `a` with
+    // value `1; b=2`: requests still went out byte-identical, so nothing looked
+    // wrong, but `b` was never enumerated as a cookie parameter and therefore
+    // never probed — a silent false negative for cookie-reflected XSS.
+    let mut args = default_scan_args();
+    args.input_type = "url".to_string();
+    args.targets = vec!["https://example.com/".to_string()];
+    args.cookies = vec!["session=abc; csrf=xyz".to_string()];
+    let targets = resolve(&args).await.expect("resolve ok");
+    assert_eq!(
+        targets[0].cookies,
+        vec![
+            ("session".to_string(), "abc".to_string()),
+            ("csrf".to_string(), "xyz".to_string()),
+        ]
+    );
+}
+
+#[tokio::test]
+async fn test_resolve_targets_drops_nameless_cookie_pairs() {
+    let mut args = default_scan_args();
+    args.input_type = "url".to_string();
+    args.targets = vec!["https://example.com/".to_string()];
+    args.cookies = vec!["=orphan; k=v".to_string()];
+    let targets = resolve(&args).await.expect("resolve ok");
+    assert_eq!(targets[0].cookies, vec![("k".to_string(), "v".to_string())]);
+}
+
+#[tokio::test]
+async fn test_resolve_targets_empty_user_agent_sends_no_header() {
+    // `--user-agent ""` means "no override", not "send a literal empty
+    // User-Agent header on every request" (the server path already guarded
+    // this; the CLI did not).
+    let mut args = default_scan_args();
+    args.input_type = "url".to_string();
+    args.targets = vec!["https://example.com/".to_string()];
+    args.user_agent = Some(String::new());
+    let targets = resolve(&args).await.expect("resolve ok");
+    assert!(
+        !targets[0]
+            .headers
+            .iter()
+            .any(|(n, _)| n.eq_ignore_ascii_case("user-agent")),
+        "an empty --user-agent must not push a User-Agent header"
+    );
+}
+
+#[tokio::test]
 async fn test_resolve_targets_dedupes_identical() {
     let mut args = default_scan_args();
     args.input_type = "url".to_string();

--- a/src/cmd/scan/validation.rs
+++ b/src/cmd/scan/validation.rs
@@ -111,6 +111,16 @@ pub(crate) fn validate_numeric_args(
             ),
         ));
     }
+    if args.sxss_retries > crate::cmd::scan::CLI_MAX_SXSS_RETRIES {
+        return Err((
+            crate::cmd::error_codes::INVALID_INPUT_TYPE,
+            format!(
+                "--sxss-retries must be at most {} (got {}); the re-check backoff is 500ms × attempt, so the total wait grows quadratically",
+                crate::cmd::scan::CLI_MAX_SXSS_RETRIES,
+                args.sxss_retries
+            ),
+        ));
+    }
     if args.retry_delay > CLI_MAX_RETRY_DELAY_MS {
         return Err((
             crate::cmd::error_codes::INVALID_INPUT_TYPE,

--- a/src/config.rs
+++ b/src/config.rs
@@ -714,6 +714,20 @@ impl ScanConfig {
             }
         }
 
+        // `sxss_method` — same normalization as `method` above. `--sxss-method`
+        // now carries clap's parser, but a config value never passes through
+        // clap, so `sxss_method = "post"` would still reach
+        // `reqwest::Method::from_str` as the literal extension verb `post`.
+        if let Some(m) = &self.sxss_method {
+            match crate::cmd::scan::parse_http_method_arg(m) {
+                Ok(upper) => self.sxss_method = Some(upper),
+                Err(e) => {
+                    warnings.push(format!("config scan.sxss_method: {e}; ignoring"));
+                    self.sxss_method = None;
+                }
+            }
+        }
+
         // `force_waf` — lowercase + validate against the known WAF aliases,
         // mirroring `--force-waf`'s parser so a typo doesn't fall into the
         // silent `WafType::Unknown` bucket that skips targeted bypasses.
@@ -825,6 +839,14 @@ impl ScanConfig {
             );
             self.limit = None;
         }
+
+        // NOTE: the `only_custom_payload` / `custom_payload` pairing is
+        // deliberately NOT checked here. This validator runs on the config file
+        // alone, before CLI args are merged, so rejecting a config
+        // `only_custom_payload = true` whose file comes from `--custom-payload`
+        // on the command line would silently drop a flag the operator did set.
+        // `run_scan` enforces the rule post-merge, where it can see both
+        // sources, and errors out rather than running a payload-less scan.
 
         warnings
     }

--- a/src/config/tests.rs
+++ b/src/config/tests.rs
@@ -436,6 +436,57 @@ fn test_normalize_and_validate_accepts_full_valid_config() {
 }
 
 #[test]
+fn test_normalize_and_validate_leaves_only_custom_payload_alone() {
+    // The pairing rule lives in `run_scan`, post-merge. Enforcing it here — on
+    // the config file alone — would drop the flag whenever the operator
+    // supplied the file with `--custom-payload` on the command line instead.
+    let mut cfg = Config {
+        scan: Some(ScanConfig {
+            only_custom_payload: Some(true),
+            ..Default::default()
+        }),
+    };
+    let warnings = cfg.normalize_and_validate();
+    assert!(
+        !warnings.iter().any(|w| w.contains("only_custom_payload")),
+        "config validation must not second-guess a CLI-supplied --custom-payload, got: {warnings:?}"
+    );
+    assert_eq!(
+        cfg.scan.as_ref().unwrap().only_custom_payload,
+        Some(true),
+        "the flag must survive to be merged with the CLI args"
+    );
+}
+
+#[test]
+fn test_normalize_and_validate_uppercases_sxss_method() {
+    // Same class as `method`: a config value skips clap's parser, so `"post"`
+    // reached `reqwest::Method::from_str` as the literal extension verb.
+    let mut cfg = Config {
+        scan: Some(ScanConfig {
+            sxss_method: Some("post".to_string()),
+            ..Default::default()
+        }),
+    };
+    let warnings = cfg.normalize_and_validate();
+    assert!(warnings.is_empty(), "got: {warnings:?}");
+    assert_eq!(
+        cfg.scan.as_ref().unwrap().sxss_method.as_deref(),
+        Some("POST")
+    );
+
+    let mut bad = Config {
+        scan: Some(ScanConfig {
+            sxss_method: Some("GET junk".to_string()),
+            ..Default::default()
+        }),
+    };
+    let warnings = bad.normalize_and_validate();
+    assert!(warnings.iter().any(|w| w.contains("sxss_method")));
+    assert_eq!(bad.scan.as_ref().unwrap().sxss_method, None);
+}
+
+#[test]
 fn test_normalize_and_validate_none_scan_is_noop() {
     let mut cfg = Config { scan: None };
     assert!(cfg.normalize_and_validate().is_empty());

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -125,6 +125,39 @@ pub fn validate_encoders(encoders: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate a list of `Name: value` header strings, rejecting anything reqwest
+/// cannot put on the wire.
+///
+/// Shared by the REST server and MCP so the two front ends agree. Catching this
+/// at the boundary matters because reqwest fails on the *builder*, for every
+/// request in the job: the reachability probe then fails and the scan settles
+/// `unreachable` / `CONNECTION_FAILED`, blaming a perfectly live target for
+/// what is really malformed input. Note obs-text is legal in a value, so
+/// `X-Note: café` passes.
+pub fn validate_header_list(headers: &[String]) -> Result<(), String> {
+    for h in headers {
+        let Some((name, value)) = h.split_once(':') else {
+            return Err(format!(
+                "header must be in 'Name: value' form (got '{}')",
+                crate::utils::log::sanitize_log_message(h)
+            ));
+        };
+        if reqwest::header::HeaderName::try_from(name.trim()).is_err() {
+            return Err(format!(
+                "invalid header name '{}'",
+                crate::utils::log::sanitize_log_message(name.trim())
+            ));
+        }
+        if reqwest::header::HeaderValue::try_from(value.trim()).is_err() {
+            return Err(format!(
+                "invalid header value for '{}'",
+                crate::utils::log::sanitize_log_message(name.trim())
+            ));
+        }
+    }
+    Ok(())
+}
+
 /// Truncate a target's discovered parameter set to [`MAX_DISCOVERED_PARAMS`],
 /// returning how many were dropped (0 if already under the cap). Shared by the
 /// REST server, MCP, and both preflight paths so every async front-end bounds
@@ -141,13 +174,20 @@ pub fn cap_reflection_params(target: &mut Target) -> usize {
 
 /// Split an HTTP-style `Cookie` header value (`a=b; c=d`) into `(name, value)`
 /// pairs, trimming whitespace around each pair and around the `=`. Shared by the
-/// REST server and the MCP scan/preflight paths so a multi-cookie value parses
-/// identically everywhere (a single `split_once('=')` would fold `; c=d` into
-/// the first value and leave `=`-adjacent whitespace in).
+/// CLI (`--cookies`, `--cookie-from-raw`), the REST server and the MCP
+/// scan/preflight paths so a multi-cookie value parses identically everywhere
+/// (a single `split_once('=')` would fold `; c=d` into the first value and
+/// leave `=`-adjacent whitespace in).
+///
+/// Nameless segments (`=orphan`, or a stray `;;`) are dropped: they cannot be
+/// re-serialized into a valid `Cookie` header, and keeping them burned a probe
+/// per scan on a cookie that can never exist. The raw-request and HAR parsers
+/// already apply the same rule.
 pub fn split_cookie_pairs(raw: &str) -> Vec<(String, String)> {
     raw.split(';')
         .filter_map(|p| p.trim().split_once('='))
         .map(|(k, v)| (k.trim().to_string(), v.trim().to_string()))
+        .filter(|(k, _)| !k.is_empty())
         .collect()
 }
 

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1205,6 +1205,12 @@ browser execution; only detection_method=oob observes a real browser."
                 None,
             ));
         }
+        // Same shared check the REST server runs: a malformed header makes
+        // reqwest fail on the builder for every request in the job, which
+        // surfaces as the *target* being reported unreachable.
+        if let Err(e) = crate::job::validate_header_list(&headers) {
+            return Err(ErrorData::invalid_params(e, None));
+        }
         if workers == 0 || workers > MAX_WORKERS {
             return Err(ErrorData::invalid_params(
                 format!(
@@ -1407,14 +1413,24 @@ browser execution; only detection_method=oob observes a real browser."
         // registries before the scan reads them. Mirrors the REST server and
         // CLI; without this the `remote_payloads`/`remote_wordlists` fields
         // would be silently inert on the MCP path.
-        if !scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty() {
-            let _ = crate::utils::init_remote_resources_with_options(
+        // A failure is logged rather than swallowed: the scan otherwise runs
+        // without the list the caller asked for and still reports success,
+        // which an agent reads as "scanned, found nothing".
+        if (!scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty())
+            && let Err(e) = crate::utils::init_remote_resources_with_options(
                 &scan_args.remote_payloads,
                 &scan_args.remote_wordlists,
                 Some(scan_args.timeout),
                 scan_args.proxy.clone(),
             )
-            .await;
+            .await
+        {
+            Self::log(
+                "WRN",
+                &format!(
+                    "remote resource fetch failed ({e}); scanning without the requested remote lists"
+                ),
+            );
         }
 
         // Run the scan on tokio's managed blocking-threadpool. We still need a
@@ -1813,6 +1829,8 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
         let method = crate::cmd::scan::parse_http_method_arg(&params.method)
             .map_err(|e| ErrorData::invalid_params(e, None))?;
         crate::job::validate_encoders(&params.encoders)
+            .map_err(|e| ErrorData::invalid_params(e, None))?;
+        crate::job::validate_header_list(&params.headers)
             .map_err(|e| ErrorData::invalid_params(e, None))?;
 
         let mut target = match parse_target(&target_url) {

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -22,7 +22,6 @@ use crate::parameter_analysis::{
 };
 use crate::scanning::url_inject::build_injected_url;
 use crate::target_parser::Target;
-use scraper;
 use std::sync::{Arc, OnceLock};
 use tokio::sync::{Mutex, Semaphore};
 use tokio::time::{Duration, sleep};
@@ -1241,6 +1240,11 @@ pub async fn check_form_discovery(
         Err(_) => return,
     };
 
+    /// Most fields probed per discovered form. See the truncation site below:
+    /// the probing cost is quadratic in the field count, so this bounds what a
+    /// single hostile (or generated) page can make a scan spend.
+    const MAX_FORM_FIELDS: usize = 200;
+
     // Fully-owned form descriptor extracted from the HTML. Keeping these as
     // Send-safe `String` / `Url` lets the scraper document get dropped before
     // the async probing loop below, which is a prerequisite for ever moving
@@ -1255,7 +1259,7 @@ pub async fn check_form_discovery(
     // Parse forms in a tight scope so `scraper::Html` (which is !Send) never
     // escapes. Collect into `Vec<FormInfo>` before touching any await.
     let forms: Vec<FormInfo> = {
-        let document = scraper::Html::parse_document(&html);
+        let document = crate::utils::html::parse_document_bounded(&html);
         let form_sel = selectors::form();
         let input_sel = selectors::input_textarea_select();
 
@@ -1287,6 +1291,29 @@ pub async fn check_form_discovery(
             if fields.is_empty() {
                 continue;
             }
+            // Cap the field list. Probing a form is O(fields²) in work *and* in
+            // bytes: each field gets its own request, and each of those
+            // requests rebuilds the entire multipart body. A page serving a
+            // form with 50 000 inputs therefore costs 50 000 requests carrying
+            // ~2.5e9 field copies between them. `MAX_DISCOVERED_PARAMS` bounds
+            // the params a scan carries, but only *after* discovery has already
+            // paid for them, and only on the server/MCP paths.
+            //
+            // Note what is capped: the number of fields *probed*, not the field
+            // list itself. Truncating `fields` looked equivalent but was not —
+            // the same vector builds the submitted body, so a >200-field form
+            // would be probed with an incomplete body. Servers reject a form
+            // submission missing its required fields, so those probes come back
+            // non-reflecting and the form can lose discovery of *every* one of
+            // its parameters, not just the ones past the cap.
+            if fields.len() > MAX_FORM_FIELDS {
+                crate::dbg_log!(
+                    "form at {} has {} fields; probing the first {} (all are still submitted)",
+                    form_url,
+                    fields.len(),
+                    MAX_FORM_FIELDS
+                );
+            }
 
             out.push(FormInfo {
                 url: form_url,
@@ -1309,7 +1336,9 @@ pub async fn check_form_discovery(
     {
         if is_post && is_multipart {
             // Multipart form: test each field via multipart/form-data POST
-            for (field_idx, (field_name, field_value)) in fields.iter().enumerate() {
+            for (field_idx, (field_name, field_value)) in
+                fields.iter().enumerate().take(MAX_FORM_FIELDS)
+            {
                 let _permit = semaphore.acquire().await.expect("acquire semaphore permit");
                 let mut form = reqwest::multipart::Form::new();
                 for (i, (n, v)) in fields.iter().enumerate() {
@@ -1370,7 +1399,9 @@ pub async fn check_form_discovery(
                 url::form_urlencoded::byte_serialize(test_value.as_bytes()).collect();
 
             // Test each field for reflection via POST
-            for (field_idx, (field_name, field_value)) in fields.iter().enumerate() {
+            for (field_idx, (field_name, field_value)) in
+                fields.iter().enumerate().take(MAX_FORM_FIELDS)
+            {
                 let _permit = semaphore.acquire().await.expect("acquire semaphore permit");
                 // Build body by joining pre-encoded pairs, substituting the target field
                 let body = encoded_fields.iter().enumerate().fold(

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -21,7 +21,6 @@ use crate::parameter_analysis::{DelimiterType, InjectionContext, Location, Param
 use crate::payload::mining::GF_PATTERNS_PARAMS;
 use crate::target_parser::Target;
 use crate::utils::shimmer::ShimmerSpinner;
-use scraper;
 use std::sync::Arc;
 
 use tokio::sync::{Mutex, Semaphore};
@@ -247,13 +246,35 @@ pub fn detect_js_breakout(text: &str) -> Option<String> {
 /// `detect_js_breakout` with a caller-supplied marker string (mirrors
 /// `detect_injection_context_with_marker`). Used by probes that inject a
 /// non-standard marker, e.g. the numeric-only discovery probe.
+/// Offset of the last ASCII-case-insensitive occurrence of `needle` in
+/// `bytes[..before]`.
+///
+/// Allocation-free on purpose. The obvious spelling — `text[..mp]
+/// .to_ascii_lowercase().rfind(..)` — copies the whole prefix, and that prefix
+/// can be the full `read_body_capped` 16 MiB, once per probed parameter.
+/// Bounding the search window instead would have cost recall: framework apps
+/// routinely inline a serialized state blob or a whole bundle in one
+/// `<script>`, and a reflection several hundred KiB into it is ordinary, so any
+/// window short enough to be a useful cost bound also silently dropped those
+/// reflections back to the fixed catalog. Not allocating removes the need to
+/// choose. (`MAX_OPEN_DEPTH` in `js_breakout` remains the guard that stops a
+/// hostile prefix from producing a giant closer.)
+fn rfind_ascii_case_insensitive(bytes: &[u8], before: usize, needle: &[u8]) -> Option<usize> {
+    let before = before.min(bytes.len());
+    if needle.is_empty() || needle.len() > before {
+        return None;
+    }
+    (0..=before - needle.len())
+        .rev()
+        .find(|&start| bytes[start..start + needle.len()].eq_ignore_ascii_case(needle))
+}
+
 pub fn detect_js_breakout_with_marker(text: &str, marker: &str) -> Option<String> {
     let mp = text.find(marker)?;
     // Find the enclosing inline `<script …>` opening tag before the reflection.
     // `<script` (case-insensitive) never matches a closing `</script>` tag (the
-    // char after `<` is `/`, not `s`), so `rfind` lands on a real opener.
-    let lower_before = text[..mp].to_ascii_lowercase();
-    let open_tag = lower_before.rfind("<script")?;
+    // char after `<` is `/`, not `s`), so the last match is a real opener.
+    let open_tag = rfind_ascii_case_insensitive(text.as_bytes(), mp, b"<script")?;
     // Script content begins just after the `>` that ends the opening tag.
     let gt = text[open_tag..mp].find('>')?;
     let content_start = open_tag + gt + 1;
@@ -291,7 +312,7 @@ pub fn detect_injection_context_with_marker(text: &str, marker: &str) -> Injecti
     }
 
     // Parse HTML and locate marker via element text/attributes/script
-    let document = scraper::Html::parse_document(text);
+    let document = crate::utils::html::parse_document_bounded(text);
 
     // Heuristic to infer surrounding quote delimiter around the first marker.
     // Picks the *closest* opening quote before the marker (the one that
@@ -406,25 +427,18 @@ pub fn detect_injection_context_with_marker(text: &str, marker: &str) -> Injecti
         }
     }
 
-    // 3) HTML text context: marker in non-script, non-style text nodes
-    {
-        let any = selectors::universal();
-        for el in document.select(any) {
-            let tag = el.value().name();
-            if tag.eq_ignore_ascii_case("script") || tag.eq_ignore_ascii_case("style") {
-                continue;
-            }
-            let s = el.text().fold(String::new(), |mut acc, t| {
-                acc.push_str(t);
-                acc
-            });
-            if s.contains(marker) {
-                return InjectionContext::Html(None);
-            }
-        }
-    }
-
-    // Fallback to HTML
+    // 3) HTML text context — deliberately not scanned.
+    //
+    // There used to be a loop here that walked every element and materialized
+    // `el.text()` (that element's *entire subtree* text) looking for the
+    // marker, returning `InjectionContext::Html(None)` on a hit. It could not
+    // change the answer: the fallback below is the same value, so the loop's
+    // only observable effect was its cost — and that cost is quadratic, since
+    // each of N elements re-collects the text of everything beneath it. A body
+    // of `<div>` × 500 000 with the marker in a *comment* node (which matches
+    // no element, so the loop never short-circuits) ran it to completion.
+    //
+    // Fallback to HTML.
     InjectionContext::Html(None)
 }
 
@@ -450,7 +464,7 @@ pub fn detect_framework_html_sink(text: &str, marker: &str) -> Option<&'static s
     if marker.is_empty() || !text.contains(marker) {
         return None;
     }
-    let document = scraper::Html::parse_document(text);
+    let document = crate::utils::html::parse_document_bounded(text);
     let any = selectors::universal();
     let mut found: Option<&'static str> = None;
     for el in document.select(any) {
@@ -1170,7 +1184,7 @@ pub async fn probe_response_id_params(
         // subsequent .await points. Extract owned String data, then drop
         // the document before hitting the async code below.
         let params_to_check: std::collections::HashSet<String> = {
-            let document = scraper::Html::parse_document(&text);
+            let document = crate::utils::html::parse_document_bounded(&text);
             let selector = selectors::input_with_id_or_name();
             let mut set = std::collections::HashSet::new();
             for element in document.select(selector) {

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1241,3 +1241,43 @@ async fn test_dom_mining_collapse_preserves_non_query_params() {
         "still exactly one collapsed Query param"
     );
 }
+
+#[test]
+fn test_detect_js_breakout_scans_a_huge_body_without_copying_it() {
+    // Smoke test at the `read_body_capped` ceiling: a 16 MiB body must not make
+    // breakout detection blow up. Deliberately NOT claimed as the regression
+    // test for the allocation — one 16 MiB `to_ascii_lowercase` is ~30 ms, so a
+    // wall-clock assertion cannot tell the allocating implementation from the
+    // allocation-free one. What the allocation-free search actually buys is
+    // recall, and that IS pinned:
+    // `test_detect_js_breakout_still_works_behind_a_large_inline_script` fails
+    // if any search window is reintroduced.
+    let marker = crate::scanning::markers::open_marker();
+    let body = format!("<script>{}\"{}", "var pad = 1;\n".repeat(1_300_000), marker);
+    assert!(
+        body.len() > 15 * 1024 * 1024,
+        "body is {} bytes",
+        body.len()
+    );
+    let start = std::time::Instant::now();
+    let _ = detect_js_breakout(&body);
+    assert!(
+        start.elapsed().as_secs() < 10,
+        "breakout detection took {:?} on a {} MiB body",
+        start.elapsed(),
+        body.len() / (1024 * 1024)
+    );
+}
+
+#[test]
+fn test_detect_js_breakout_still_works_behind_a_large_inline_script() {
+    // A framework app routinely inlines a serialized state blob or a whole
+    // bundle in one `<script>`, and a reflection after several hundred KiB of
+    // it is ordinary. At the original 64 KiB window such a reflection silently
+    // lost its computed closer and fell back to the fixed catalog — a recall
+    // loss on exactly the nested JS contexts this computation exists to cover.
+    let marker = crate::scanning::markers::open_marker();
+    let filler = "var pad = 1;\n".repeat(40_000); // ~520 KiB
+    let body = format!("<script>{filler}foo(\"{marker}\");</script>");
+    assert_eq!(detect_js_breakout(&body).as_deref(), Some("\")"));
+}

--- a/src/payload/js_breakout.rs
+++ b/src/payload/js_breakout.rs
@@ -54,17 +54,38 @@ enum State {
     Block,    // /* … */
 }
 
+/// Deepest run of unbalanced `(`/`[`/`{`/`${` we will build a closer for.
+/// See the `push_open!` comment in [`compute_js_breakout`] — this bounds both
+/// the returned string and every payload it is interpolated into.
+const MAX_OPEN_DEPTH: usize = 256;
+
 /// Compute the minimal closer sequence that, injected at the end of `prefix`,
 /// escapes any open string/comment and unbalanced `()[]{}`/`${}` so a following
 /// `;<payload>//` reaches executable statement position.
 ///
 /// Returns an empty string when `prefix` already ends at statement/expression
-/// position (nothing to close).
+/// position (nothing to close), or when the prefix nests deeper than
+/// [`MAX_OPEN_DEPTH`].
 pub fn compute_js_breakout(prefix: &str) -> String {
     let chars: Vec<char> = prefix.chars().collect();
     let mut state = State::Code;
     let mut stack: Vec<Open> = Vec::new();
     let mut i = 0;
+
+    macro_rules! push_open {
+        ($opener:expr) => {{
+            stack.push($opener);
+            // The closer is one byte per unbalanced opener and is carried into
+            // every payload synthesized for the parameter, so an input like
+            // `foo(` × 1 000 000 turns one reflection into megabyte payloads.
+            // Nothing real nests this deep; past the bound we return "no
+            // breakout" and the caller falls back to the fixed catalog, which
+            // is the same path an already-balanced prefix takes.
+            if stack.len() > MAX_OPEN_DEPTH {
+                return String::new();
+            }
+        }};
+    }
 
     while i < chars.len() {
         let c = chars[i];
@@ -73,9 +94,9 @@ pub fn compute_js_breakout(prefix: &str) -> String {
                 '\'' => state = State::Single,
                 '"' => state = State::Double,
                 '`' => state = State::Template,
-                '(' => stack.push(Open::Paren),
-                '[' => stack.push(Open::Bracket),
-                '{' => stack.push(Open::Brace),
+                '(' => push_open!(Open::Paren),
+                '[' => push_open!(Open::Bracket),
+                '{' => push_open!(Open::Brace),
                 ')' => {
                     if stack.last() == Some(&Open::Paren) {
                         stack.pop();
@@ -130,7 +151,7 @@ pub fn compute_js_breakout(prefix: &str) -> String {
                 } else if c == '`' {
                     state = State::Code;
                 } else if c == '$' && i + 1 < chars.len() && chars[i + 1] == '{' {
-                    stack.push(Open::TplExpr);
+                    push_open!(Open::TplExpr);
                     state = State::Code;
                     i += 2;
                     continue;

--- a/src/payload/js_breakout/tests.rs
+++ b/src/payload/js_breakout/tests.rs
@@ -285,3 +285,41 @@ fn escaped_breakout_executes_under_escaping_where_naive_fails() {
         );
     }
 }
+
+// --- hostile-prefix bounds --------------------------------------------------
+
+#[test]
+fn deeply_nested_prefix_yields_no_closer_instead_of_a_giant_one() {
+    // A response body of `foo(` × 1 000 000 used to produce a 1 MB closer that
+    // was then stored on the Param and cloned into every synthesized payload.
+    let prefix = "(".repeat(1_000_000);
+    let start = std::time::Instant::now();
+    let closer = compute_js_breakout(&prefix);
+    assert!(
+        closer.is_empty(),
+        "past the depth cap the closer must be empty"
+    );
+    assert!(
+        start.elapsed().as_millis() < 500,
+        "capped computation took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn nesting_within_the_cap_still_produces_a_closer() {
+    let prefix = format!("foo{}\"x", "(".repeat(200));
+    let closer = compute_js_breakout(&prefix);
+    assert!(closer.starts_with('"'), "must close the open string first");
+    assert_eq!(
+        closer.matches(')').count(),
+        200,
+        "all 200 parens must close"
+    );
+}
+
+#[test]
+fn template_expression_nesting_is_capped_too() {
+    let prefix = "`${".repeat(1_000);
+    assert!(compute_js_breakout(&prefix).is_empty());
+}

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -120,6 +120,17 @@ pub async fn init_remote_payloads_with(
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
 
+    // Never cache "we got nothing" for a provider set that named real URLs.
+    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
+    // single egress blip during the *first* remote-fetch job would otherwise
+    // poison every later job for the process's lifetime: each one short-circuits
+    // on the already-set cache, scans with an empty list, and reports `done`
+    // with no indication that what it asked for was never fetched. Leaving the
+    // cell unset costs one retry and keeps the failure transient.
+    if dedup_sorted.is_empty() {
+        return Err("remote payload fetch returned no usable entries".into());
+    }
+
     let _ = REMOTE_PAYLOADS.set(Arc::new(dedup_sorted));
     Ok(())
 }
@@ -145,6 +156,17 @@ pub async fn init_remote_wordlists_with(
     let lines = fetch_multiple_text_lists(&client, &urls).await;
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
+
+    // Never cache "we got nothing" for a provider set that named real URLs.
+    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
+    // single egress blip during the *first* remote-fetch job would otherwise
+    // poison every later job for the process's lifetime: each one short-circuits
+    // on the already-set cache, scans with an empty list, and reports `done`
+    // with no indication that what it asked for was never fetched. Leaving the
+    // cell unset costs one retry and keeps the failure transient.
+    if dedup_sorted.is_empty() {
+        return Err("remote wordlist fetch returned no usable entries".into());
+    }
 
     let _ = REMOTE_WORDS.set(Arc::new(dedup_sorted));
     Ok(())
@@ -175,6 +197,17 @@ pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn st
     let lines = fetch_multiple_text_lists(&client, &urls).await;
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
+
+    // Never cache "we got nothing" for a provider set that named real URLs.
+    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
+    // single egress blip during the *first* remote-fetch job would otherwise
+    // poison every later job for the process's lifetime: each one short-circuits
+    // on the already-set cache, scans with an empty list, and reports `done`
+    // with no indication that what it asked for was never fetched. Leaving the
+    // cell unset costs one retry and keeps the failure transient.
+    if dedup_sorted.is_empty() {
+        return Err("remote payload fetch returned no usable entries".into());
+    }
 
     let _ = REMOTE_PAYLOADS.set(Arc::new(dedup_sorted));
     Ok(())
@@ -211,6 +244,17 @@ pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn s
     let lines = fetch_multiple_text_lists(&client, &urls).await;
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
+
+    // Never cache "we got nothing" for a provider set that named real URLs.
+    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
+    // single egress blip during the *first* remote-fetch job would otherwise
+    // poison every later job for the process's lifetime: each one short-circuits
+    // on the already-set cache, scans with an empty list, and reports `done`
+    // with no indication that what it asked for was never fetched. Leaving the
+    // cell unset costs one retry and keeps the failure transient.
+    if dedup_sorted.is_empty() {
+        return Err("remote wordlist fetch returned no usable entries".into());
+    }
 
     let _ = REMOTE_WORDS.set(Arc::new(dedup_sorted));
     Ok(())

--- a/src/scanning/ast_dom_analysis.rs
+++ b/src/scanning/ast_dom_analysis.rs
@@ -1333,7 +1333,17 @@ impl<'a> DomXssVisitor<'a> {
             if before_ok && after_ok {
                 return true;
             }
-            from = start + 1;
+            // Advance past the whole match, never by one byte: `start` is a
+            // char boundary and the match spans exactly `name.len()` bytes, so
+            // `start + name.len()` is one too. `start + 1` lands *inside* the
+            // needle's first codepoint whenever that codepoint is multi-byte
+            // (JS identifiers may start with any ID_Start char, and a Trusted
+            // Types callback parameter name comes straight off the scanned
+            // page), and the next `src[from..]` then panics with "byte index N
+            // is not a char boundary". Skipping the match is also correct:
+            // an overlapping later occurrence starts inside `name`, so it is
+            // preceded by an identifier byte and could never pass `before_ok`.
+            from = start + name.len();
         }
         false
     }

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4288,6 +4288,55 @@ el.innerHTML = policy.createHTML(location.search);
     );
 }
 
+// --- non-ASCII Trusted Types callback parameter names -----------------------
+//
+// `identifier_referenced` used to advance its search cursor by one byte after
+// a rejected match, which lands inside a multi-byte codepoint and panics on the
+// next slice. A scanned page controls the callback parameter name, and JS
+// identifiers may start with any ID_Start character, so this was a
+// remote-triggerable panic: the analysis task died and the target was reported
+// clean with exit 0. All three cases below panicked before the fix.
+
+#[test]
+fn test_tt_non_ascii_param_sanitizer_branch_does_not_panic() {
+    // Sanitizer branch: the param is referenced only inside `sanitize(…)`, and
+    // `한글x` is a *different* identifier — so the wrapper is strict.
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: function(한글){ var 한글x = 1; return DOMPurify.sanitize(한글); } });
+el.innerHTML = policy.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "non-ASCII param sanitized wrapper must clear taint (and must not panic)"
+    );
+}
+
+#[test]
+fn test_tt_non_ascii_param_no_sanitizer_does_not_panic() {
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: function(한글){ var 한글x = 1; return ""; } });
+el.innerHTML = policy.createHTML(location.hash);
+"#;
+    assert!(
+        tt_findings(code, false).is_empty(),
+        "non-ASCII param never referenced is strict (and must not panic)"
+    );
+}
+
+#[test]
+fn test_tt_non_ascii_param_passthrough_still_permissive() {
+    // The real reference sits *after* a rejected `한글x` match, so this also
+    // proves the cursor advance does not skip past a genuine later occurrence.
+    let code = r#"
+const policy = trustedTypes.createPolicy('p', { createHTML: function(한글){ var 한글x = 1; return 한글; } });
+el.innerHTML = policy.createHTML(location.hash);
+"#;
+    assert!(
+        !tt_findings(code, false).is_empty(),
+        "non-ASCII param passed through must keep the finding"
+    );
+}
+
 #[test]
 fn test_tt_method_shorthand_strict_wrapper_clears() {
     // `createHTML(s) { return DOMPurify.sanitize(s); }` method shorthand.

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -11,7 +11,7 @@ use super::selectors;
 /// JS file has no `document.createElement('script')` of its own. The
 /// caller threads the returned set into `AstDomAnalyzer::with_script_element_ids`.
 pub fn extract_script_element_ids(html: &str) -> HashSet<String> {
-    let document = Html::parse_document(html);
+    let document = crate::utils::html::parse_document_bounded(html);
     script_element_ids_from_document(&document)
 }
 
@@ -37,7 +37,7 @@ fn script_element_ids_from_document(document: &Html) -> HashSet<String> {
 /// Extract JavaScript code from HTML response
 /// Looks for <script> tags and inline event handlers
 pub fn extract_javascript_from_html(html: &str) -> Vec<String> {
-    let document = Html::parse_document(html);
+    let document = crate::utils::html::parse_document_bounded(html);
     js_blocks_from_document(&document)
 }
 
@@ -48,7 +48,7 @@ pub fn extract_javascript_from_html(html: &str) -> Vec<String> {
 /// parsed the full response through html5ever twice. Sharing one parse tree
 /// yields byte-identical results at half the HTML-parse cost.
 pub fn extract_js_and_script_ids(html: &str) -> (Vec<String>, HashSet<String>) {
-    let document = Html::parse_document(html);
+    let document = crate::utils::html::parse_document_bounded(html);
     let js_blocks = js_blocks_from_document(&document);
     let script_ids = script_element_ids_from_document(&document);
     (js_blocks, script_ids)
@@ -119,7 +119,7 @@ fn js_blocks_from_document(document: &Html) -> Vec<String> {
 /// Collect resolved, deduped, same-origin `<script src>` URLs from `html`,
 /// resolved relative to `base` (the response URL). Cross-origin srcs are dropped.
 pub fn extract_same_origin_script_srcs(html: &str, base: &url::Url) -> Vec<url::Url> {
-    let document = Html::parse_document(html);
+    let document = crate::utils::html::parse_document_bounded(html);
     let selector = selectors::script();
     let mut seen = HashSet::new();
     let mut out = Vec::new();

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -408,7 +408,7 @@ pub(crate) fn has_marker_evidence(payload: &str, text: &str) -> bool {
     if !payload_has_any_marker(payload) {
         return false;
     }
-    let document = scraper::Html::parse_document(text);
+    let document = crate::utils::html::parse_document_bounded(text);
     has_marker_evidence_in_doc(payload, &document)
 }
 
@@ -679,7 +679,7 @@ pub(crate) fn classify_dom_evidence(payload: &str, text: &str) -> Option<DomEvid
         return None;
     }
     if needs_markers || needs_attrs || needs_html_struct {
-        let document = scraper::Html::parse_document(text);
+        let document = crate::utils::html::parse_document_bounded(text);
         if needs_markers && has_marker_evidence_in_doc(payload, &document) {
             return Some(DomEvidenceKind::Marker);
         }
@@ -732,7 +732,7 @@ fn has_inline_handler_breakout_evidence(payload: &str, text: &str) -> bool {
     // single substring search cover the dominant on*-attribute escape
     // pattern that servers use (`&#39;` for `'`, `&quot;` for `"`).
     let decoded = decode_html_entities(text);
-    let document = scraper::Html::parse_document(&decoded);
+    let document = crate::utils::html::parse_document_bounded(&decoded);
     let selector = selectors::universal();
     for node in document.select(selector) {
         // Issue #1183: a handler on a `<input type="hidden">` — even one the
@@ -796,7 +796,11 @@ async fn verify_sxss_dom(
     for sxss_url in &check_urls {
         for attempt in 0u64..retries {
             if attempt > 0 {
-                sleep(Duration::from_millis(500 * attempt)).await;
+                // Clamped; see the twin loop in check_reflection.rs.
+                sleep(Duration::from_millis(
+                    (500 * attempt).min(crate::cmd::scan::MAX_SXSS_BACKOFF_MS),
+                ))
+                .await;
             }
             let method = args.sxss_method.parse().unwrap_or(reqwest::Method::GET);
             let check_request =

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -260,7 +260,7 @@ fn next_char_boundary(s: &str, mut idx: usize) -> usize {
 /// Like `is_in_safe_context` but also checks decoded forms of the payload.
 /// This catches cases where an encoded payload (URL/HTML-entity) is sent,
 /// the server decodes it, and reflects the decoded form inside a safe tag.
-fn is_in_safe_context_decoded(html: &str, payload: &str) -> bool {
+pub(crate) fn is_in_safe_context_decoded(html: &str, payload: &str) -> bool {
     // Check the raw payload form (only if it's actually present in the HTML)
     if html.contains(payload) && is_in_safe_context(html, payload) {
         return true;
@@ -384,7 +384,10 @@ pub(crate) fn marker_reflects_in_url_attr_only(html: &str, marker: &str) -> bool
         }
         any = true;
         let abs = search_start + pos;
-        if !occurrence_is_in_url_attr(bytes, abs) {
+        // `None` (walk budget exhausted) takes the same branch as
+        // "not in a URL attribute": both mean we cannot claim URL-attr-only,
+        // so the URL-echo suppression does not apply and the finding stays.
+        if occurrence_is_in_url_attr(bytes, abs) != Some(true) {
             return false;
         }
         search_start = next_char_boundary(html, abs + 1);
@@ -435,25 +438,48 @@ fn url_valued_attr_name_before_eq(bytes: &[u8], eq: usize) -> bool {
 /// "reconcile" them by tightening this one, or the legitimate
 /// `href="javascript:…"` `[R]` is lost; nor loosen the gates, or the #1153
 /// self-/canonical-link false positive returns.
-fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> bool {
+/// How far back [`occurrence_is_in_url_attr`] will walk looking for the `=`
+/// that opens the attribute value it might be inside.
+///
+/// `MAX_PAYLOAD_OCCURRENCES` caps how many times that walk is *started* per
+/// body, not how far each one runs. A 16 MiB body containing no `=`, `<` or `>`
+/// makes every one of those walks scan all the way to offset 0, and the
+/// decoded-form × variant fan-out multiplies it — tens of seconds of pure byte
+/// comparison per parameter, on a body a hostile target serves for free. No
+/// real attribute value comes close to 8 KiB.
+const MAX_ATTR_BACKWALK: usize = 8 * 1024;
+
+/// `Some(true)` / `Some(false)` when the walk reached a verdict; `None` when it
+/// hit [`MAX_ATTR_BACKWALK`] first and the answer is genuinely unknown.
+///
+/// The tri-state is deliberate. Each caller below suppresses a finding on a
+/// *different* polarity of this answer, so there is no single boolean that is
+/// "the safe default" for all of them — collapsing `None` into `false` would
+/// silently suppress findings at two of the three sites. Every caller instead
+/// maps `None` onto whichever branch **keeps** the finding.
+fn occurrence_is_in_url_attr(bytes: &[u8], at: usize) -> Option<bool> {
     if at == 0 || at > bytes.len() {
-        return false;
+        return Some(false);
     }
     // Walk back to the attribute's `=` without crossing a tag boundary.
     let mut i = at;
+    let floor = at.saturating_sub(MAX_ATTR_BACKWALK);
     loop {
         if i == 0 {
-            return false;
+            return Some(false);
+        }
+        if i <= floor {
+            return None;
         }
         i -= 1;
         match bytes[i] {
             b'=' => break,
             // Crossing a tag boundary means we're outside any attribute.
-            b'<' | b'>' => return false,
+            b'<' | b'>' => return Some(false),
             _ => {}
         }
     }
-    url_valued_attr_name_before_eq(bytes, i)
+    Some(url_valued_attr_name_before_eq(bytes, i))
 }
 
 /// True when a decoded payload form is a JS-executable URL scheme — the schemes
@@ -1217,7 +1243,9 @@ fn url_encoded_payload_reflects_in_unsafe_url_context(html: &str, payload: &str)
             return true;
         }
         let abs = search_start + pos;
-        if occurrence_is_in_url_attr(bytes, abs) {
+        // `None` keeps the finding here, and so does `Some(true)`: the caller
+        // suppresses only on `false`.
+        if occurrence_is_in_url_attr(bytes, abs) != Some(false) {
             return true;
         }
         search_start = next_char_boundary(html, abs + 1);
@@ -1323,7 +1351,9 @@ fn is_inert_encoded_reflection(html: &str, payload: &str) -> bool {
                     return false;
                 }
                 let abs = start + pos;
-                if occurrence_is_in_url_attr(bytes, abs) {
+                // Same rule as the other two sites: anything but a definite
+                // `false` keeps the finding.
+                if occurrence_is_in_url_attr(bytes, abs) != Some(false) {
                     return false;
                 }
                 start = next_char_boundary(decoded, abs + 1);
@@ -1803,7 +1833,12 @@ async fn fetch_injection_response_with_client(
             // Retry with delay to handle session / content propagation
             for attempt in 0u64..retries {
                 if attempt > 0 {
-                    sleep(Duration::from_millis(500 * attempt)).await;
+                    // Clamped: the ramp is quadratic in total, so the tail of a
+                    // long retry run would otherwise sleep for minutes at a time.
+                    sleep(Duration::from_millis(
+                        (500 * attempt).min(crate::cmd::scan::MAX_SXSS_BACKOFF_MS),
+                    ))
+                    .await;
                 }
                 let method = args.sxss_method.parse().unwrap_or(reqwest::Method::GET);
                 let check_request =

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -2335,3 +2335,53 @@ async fn test_hpp_reflection_falls_back_to_target_url_when_hpp_url_is_unparseabl
         "the fallback must have hit the target URL"
     );
 }
+
+// --- URL-attribute back-walk budget ----------------------------------------
+
+#[test]
+fn url_attr_backwalk_length_is_bounded() {
+    // `MAX_PAYLOAD_OCCURRENCES` caps how many times the back-walk is *started*
+    // per body; it said nothing about how far each one runs. On a body with no
+    // `=`, `<` or `>` every walk ran to offset 0, so cost was
+    // occurrences × body-size — tens of seconds of byte comparison per
+    // parameter on a body a hostile target serves for free.
+    //
+    // This calls the looping helper directly and deliberately: the public
+    // `is_in_safe_context_decoded` chain is an ordered OR, and an earlier gate
+    // short-circuits before this loop is reached, while
+    // `marker_reflects_in_url_attr_only` returns after its first occurrence.
+    // Neither can expose the blowup, so neither is a valid regression site.
+    // Must decode to a dangerous scheme, or the function early-returns before
+    // ever reaching the occurrence loop this test is about.
+    let payload = "%6A%61%76%61%73%63%72%69%70%74%3Aalert1";
+    let filler = "A".repeat(1024);
+    let mut body = String::with_capacity(5 * 1024 * 1024);
+    for _ in 0..4200 {
+        body.push_str(&filler);
+        body.push_str(payload);
+    }
+    let start = std::time::Instant::now();
+    let _ = url_encoded_payload_reflects_in_unsafe_url_context(&body, payload);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 5,
+        "bounded back-walk took {elapsed:?} on a {} MiB body",
+        body.len() / (1024 * 1024)
+    );
+}
+
+#[test]
+fn url_attr_backwalk_verdicts_are_unchanged_for_normal_markup() {
+    // The budget must not alter the answer for ordinary attribute distances.
+    let payload = "%6A%61%76%61%73%63%72%69%70%74%3Aalert(1)";
+    let in_href = format!(r#"<html><body><a href="{payload}">x</a></body></html>"#);
+    assert!(
+        url_encoded_payload_reflects_in_unsafe_url_context(&in_href, payload),
+        "an encoded javascript: URL inside href is an unsafe URL context"
+    );
+    let in_text = format!("<html><body><div>{payload}</div></body></html>");
+    assert!(
+        !url_encoded_payload_reflects_in_unsafe_url_context(&in_text, payload),
+        "the same bytes in body text are not"
+    );
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -659,7 +659,10 @@ async fn run_ast_dom_analysis(
             if !source_uses_url_surface {
                 ast_result.request = Some(build_request_text(target, param, &payload));
             }
-            ast_result.response = Some(response_text.to_string());
+            ast_result.response = Some(crate::scanning::result::bound_evidence_body(
+                response_text.to_string(),
+                &payload,
+            ));
             // Lightweight runtime verification (non-headless)
             let (verified, rt_resp, note) =
                 crate::scanning::light_verify::verify_dom_xss_light_with_client(
@@ -667,7 +670,10 @@ async fn run_ast_dom_analysis(
                 )
                 .await;
             if let Some(runtime_response) = rt_resp {
-                ast_result.response = Some(runtime_response);
+                ast_result.response = Some(crate::scanning::result::bound_evidence_body(
+                    runtime_response,
+                    &payload,
+                ));
             }
             if verified {
                 ast_result.result_type = FindingType::Verified;
@@ -1022,7 +1028,7 @@ fn compute_waf_strategy(
 /// that logic, shared so the server / MCP surfaces cannot analyse a different
 /// policy than the CLI does for the same page.
 pub(crate) fn extract_meta_csp(html: &str) -> Option<(String, String)> {
-    let doc = scraper::Html::parse_document(html);
+    let doc = crate::utils::html::parse_document_bounded(html);
     // Prefer an ENFORCING `Content-Security-Policy` meta over a report-only one,
     // mirroring the header path's enforcing-over-report-only `.or_else`. A page
     // may carry both (report-only for telemetry, enforcing for protection), and
@@ -2152,7 +2158,9 @@ impl ScanWorkerCtx {
                     // line, which is the real evidence for that vector. Only
                     // execution-inferring consumers above are gated on
                     // `renderable`.
-                    result.response = reflection_body.map(|b| b.text);
+                    result.response = reflection_body.map(|b| {
+                        crate::scanning::result::bound_evidence_body(b.text, &reflection_payload)
+                    });
 
                     self.stream_finding(&result);
                     // Defer pushing to shared results (batched)
@@ -2297,7 +2305,8 @@ impl ScanWorkerCtx {
                             .build();
                     result.location = format!("{:?}", param.location);
                     result.request = Some(build_request_text(&self.target, param, &dom_payload));
-                    result.response = response_text;
+                    result.response = response_text
+                        .map(|t| crate::scanning::result::bound_evidence_body(t, &dom_payload));
 
                     self.stream_finding(&result);
                     // Defer pushing to shared results (batched)
@@ -2411,7 +2420,8 @@ impl ScanWorkerCtx {
                                 ))
                                 .build();
                         result.location = format!("{:?}", param.location);
-                        result.response = response_text;
+                        result.response = response_text
+                            .map(|t| crate::scanning::result::bound_evidence_body(t, hpp_payload));
                         self.stream_finding(&result);
                         state.local_results.push(result);
                         break 'hpp_outer; // One HPP finding per param is enough
@@ -2422,16 +2432,21 @@ impl ScanWorkerCtx {
     }
 }
 
-/// Outcome of a `run_scanning` call. Currently carries only the number of
-/// per-parameter worker tasks that panicked. The CLI ignores it (it returns it
-/// as a statement value); the REST server and MCP runners inspect
+/// Outcome of a `run_scanning` call. The REST server and MCP runners inspect
 /// `worker_panics` so a scan that lost workers to a panic can be surfaced as a
 /// partial/failed result instead of being silently reported `done` — a worker
 /// panic means the param's findings are incomplete, indistinguishable from
-/// "scanned, found nothing" otherwise.
+/// "scanned, found nothing" otherwise. The CLI additionally uses
+/// `limit_stopped` to decide a target's `--state-file` terminal state.
 #[derive(Debug, Default, Clone, Copy)]
 pub struct ScanRunReport {
     pub worker_panics: usize,
+    /// The dispatch loop stopped early because `--limit` was reached, so this
+    /// target's remaining parameters were never tested. Distinguishing this
+    /// from a clean finish matters for `--state-file`: a target recorded
+    /// `completed` is skipped on every later run of the same command, which
+    /// would make those parameters permanently unscanned.
+    pub limit_stopped: bool,
 }
 
 /// The shared handles a [`run_scanning`] call needs beyond its target and args.
@@ -2598,6 +2613,9 @@ pub async fn run_scanning(
     // worker to completion, so partial/complete results and the panic tally are
     // unchanged.
     let mut handles = tokio::task::JoinSet::new();
+    // Set when the `--limit` cap cuts the dispatch loop short, so the caller
+    // can tell "finished this target" from "stopped part-way through it".
+    let mut limit_stopped = false;
     // Capture the per-job task-local scopes (request counter, WAF backoff, rate
     // limiter) bound by the REST/MCP runners. `tokio::spawn` does NOT inherit
     // task-locals, so each worker re-enters them via `with_job_scopes`;
@@ -2641,6 +2659,7 @@ pub async fn run_scanning(
         // worker-panic tally, and let late findings race the server's result
         // snapshot. The tail finishes the progress bar with "Completed scanning".
         if ctx.limit_reached() {
+            limit_stopped = true;
             break;
         }
 
@@ -2673,7 +2692,12 @@ pub async fn run_scanning(
             if e.is_panic() {
                 worker_panics += 1;
             }
-            eprintln!("[!] scanning task failed: {e}");
+            // Sanitized for the same reason as the sibling sites: the panic
+            // message can embed response bytes.
+            eprintln!(
+                "[!] scanning task failed: {}",
+                crate::utils::log::sanitize_log_message(&e.to_string())
+            );
         }
     }
 
@@ -2692,7 +2716,10 @@ pub async fn run_scanning(
         );
     }
 
-    ScanRunReport { worker_panics }
+    ScanRunReport {
+        worker_panics,
+        limit_stopped,
+    }
 }
 
 /// Drop Reflected findings on the *current target* that are already covered

--- a/src/scanning/result.rs
+++ b/src/scanning/result.rs
@@ -258,6 +258,52 @@ pub struct Result {
     pub response: Option<String>,
 }
 
+/// Largest response body kept on a finding as evidence.
+///
+/// Findings accumulate in one in-memory `Vec` for the whole run, and each one
+/// used to carry its response body in full — up to the 16 MiB `read_body_capped`
+/// ceiling. That is fine for a handful of findings and fatal for a scan that
+/// produces thousands: `--deep-scan` lifts the first-hit-wins reflection lock,
+/// so a reflect-everything endpoint emits a finding **per payload**, and a
+/// 1 MiB page × a 3000-payload catalog is ~3 GB resident before anything is
+/// rendered. In the server that vector is submitter-controlled and takes the
+/// whole daemon — every concurrent scan and every retained result — with it.
+pub const MAX_EVIDENCE_BODY_BYTES: usize = 64 * 1024;
+
+/// Bound a response body kept as finding evidence, keeping the window around
+/// the payload rather than a blind prefix.
+///
+/// Centering on the payload is what makes the truncation safe: the body is read
+/// back by `extract_context` to render the `L1:` evidence line, which searches
+/// for the payload, so a prefix cut would silently blank that line whenever the
+/// reflection sat past the cap. Bodies within the cap — effectively all of them
+/// — are returned untouched. Only the reported line *number* degrades for
+/// oversized bodies, since it is counted within the retained window.
+pub fn bound_evidence_body(body: String, payload: &str) -> String {
+    if body.len() <= MAX_EVIDENCE_BODY_BYTES {
+        return body;
+    }
+    let half = MAX_EVIDENCE_BODY_BYTES / 2;
+    let center = body.find(payload).unwrap_or(0);
+    let mut start = center.saturating_sub(half);
+    while start > 0 && !body.is_char_boundary(start) {
+        start -= 1;
+    }
+    let mut end = (start + MAX_EVIDENCE_BODY_BYTES).min(body.len());
+    while end > start && !body.is_char_boundary(end) {
+        end -= 1;
+    }
+    let mut out = String::with_capacity(end - start + 32);
+    if start > 0 {
+        out.push_str("…[truncated]…");
+    }
+    out.push_str(&body[start..end]);
+    if end < body.len() {
+        out.push_str("…[truncated]…");
+    }
+    out
+}
+
 impl Result {
     /// Start building a finding. `result_type` is the only required field;
     /// every other field starts empty (`""` / `0` / `None`) and is filled in

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2661,3 +2661,77 @@ async fn test_run_scanning_without_hpp_flag_reports_no_hpp_finding() {
         "HPP findings must require --hpp"
     );
 }
+
+// --- evidence-body bounding -------------------------------------------------
+
+#[test]
+fn bound_evidence_body_leaves_normal_bodies_untouched() {
+    let body = "<html><body>PAYLOAD</body></html>".to_string();
+    assert_eq!(
+        crate::scanning::result::bound_evidence_body(body.clone(), "PAYLOAD"),
+        body
+    );
+}
+
+#[test]
+fn bound_evidence_body_keeps_the_window_around_the_payload() {
+    // A reflection far past the cap must survive: `extract_context` searches
+    // the retained body for the payload to render the `L1:` line, so a blind
+    // prefix cut would silently blank that evidence.
+    use crate::scanning::result::{MAX_EVIDENCE_BODY_BYTES, bound_evidence_body};
+    let payload = "<svg onload=alert(1)>";
+    let body = format!(
+        "{}{}{}",
+        "A".repeat(4 * 1024 * 1024),
+        payload,
+        "B".repeat(1024)
+    );
+    let bounded = bound_evidence_body(body, payload);
+    assert!(
+        bounded.len() < MAX_EVIDENCE_BODY_BYTES + 64,
+        "bounded body is {} bytes",
+        bounded.len()
+    );
+    assert!(
+        bounded.contains(payload),
+        "the payload must survive the cut"
+    );
+    assert!(bounded.starts_with('…'), "an elided prefix must be marked");
+}
+
+#[test]
+fn bound_evidence_body_cuts_on_char_boundaries() {
+    use crate::scanning::result::bound_evidence_body;
+    // Multi-byte characters straddling both cut points must not panic and must
+    // leave valid UTF-8 (the return type guarantees it; the point is no panic).
+    let body = format!("{}PAY{}", "한".repeat(1_000_000), "글".repeat(1_000_000));
+    let bounded = bound_evidence_body(body, "PAY");
+    assert!(bounded.contains("PAY"));
+}
+
+#[test]
+fn bound_evidence_body_falls_back_to_a_prefix_when_the_payload_is_absent() {
+    use crate::scanning::result::{MAX_EVIDENCE_BODY_BYTES, bound_evidence_body};
+    let body = "Z".repeat(4 * 1024 * 1024);
+    let bounded = bound_evidence_body(body, "not-present");
+    assert!(bounded.len() < MAX_EVIDENCE_BODY_BYTES + 64);
+    assert!(bounded.ends_with('…'), "an elided suffix must be marked");
+}
+
+// --- URL-attribute back-walk budget ----------------------------------------
+
+#[test]
+fn url_attr_reflection_in_a_normal_href_is_still_recognised() {
+    // The budget must not change the answer for ordinary markup: this is the
+    // suppression the back-walk exists to enable.
+    let html = r#"<html><body><a href="/path/MARKER1">x</a></body></html>"#;
+    assert!(
+        crate::scanning::check_reflection::marker_reflects_in_url_attr_only(html, "MARKER1"),
+        "a marker echoed only inside href must still read as URL-attr-only"
+    );
+    let text = r#"<html><body><div>MARKER1</div></body></html>"#;
+    assert!(
+        !crate::scanning::check_reflection::marker_reflects_in_url_attr_only(text, "MARKER1"),
+        "a marker in body text is not URL-attr-only"
+    );
+}

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -433,7 +433,7 @@ pub async fn blind_scan_forms_with(
         fields: Vec<FormField>,
     }
     let forms: Vec<FormInfo> = {
-        let document = scraper::Html::parse_document(&html);
+        let document = crate::utils::html::parse_document_bounded(&html);
         let form_sel = crate::scanning::selectors::form();
         let input_sel = crate::scanning::selectors::input_textarea_select();
 

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -513,8 +513,16 @@ pub fn get_dynamic_payloads(
         }
     }
 
-    // Include remote payloads if available (initialized via --remote-payloads at runtime)
-    if let Some(remotes) = crate::payload::get_remote_payloads()
+    // Include remote payloads, but only for a scan that actually asked for
+    // them. The cache behind `get_remote_payloads` is a process-global
+    // `OnceLock`, which is fine for the one-scan-per-process CLI and wrong for
+    // the long-lived server/MCP daemon: reading it unconditionally meant a job
+    // that requested **no** remote payloads still got whatever list some
+    // earlier job had fetched appended to every parameter's catalog — thousands
+    // of requests the submitter never asked for, against a target they had
+    // scoped deliberately.
+    if !args.remote_payloads.is_empty()
+        && let Some(remotes) = crate::payload::get_remote_payloads()
         && !remotes.is_empty()
     {
         base_payloads.extend(remotes.iter().cloned());

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -252,6 +252,51 @@ pub(crate) async fn options_scan_handler(
 }
 
 // GET /scan handler for JSONP-friendly GET inputs (URL + options via query)
+/// Split the `GET /scan` `header=` query value into individual headers.
+///
+/// The query form has always packed several headers into one comma-separated
+/// value, but a comma is also perfectly legal *inside* a header value —
+/// `Accept: text/html,application/xhtml+xml` is the canonical example. A blind
+/// `split(',')` therefore chopped that into `Accept: text/html` plus a
+/// nameless `application/xhtml+xml` fragment: before header validation existed
+/// the fragment was silently dropped and a truncated `Accept` went on the wire;
+/// with validation it would 400 an otherwise valid request.
+///
+/// So only split at a comma that actually starts a new header — one followed by
+/// `Name:`. Commas inside a value are kept, and the multi-header form keeps
+/// working. (`POST /scan` takes a JSON array and needs none of this.)
+pub(crate) fn split_header_query_param(raw: &str) -> Vec<String> {
+    if raw.trim().is_empty() {
+        return vec![];
+    }
+    let bytes = raw.as_bytes();
+    let mut out = Vec::new();
+    let mut start = 0usize;
+    for (i, &b) in bytes.iter().enumerate() {
+        if b != b',' {
+            continue;
+        }
+        // Does a `Name:` begin right after this comma?
+        let rest = raw[i + 1..].trim_start();
+        let name_len = rest
+            .bytes()
+            .take_while(|c| c.is_ascii_alphanumeric() || *c == b'-' || *c == b'_')
+            .count();
+        if name_len > 0 && rest[name_len..].starts_with(':') {
+            let piece = raw[start..i].trim();
+            if !piece.is_empty() {
+                out.push(piece.to_string());
+            }
+            start = i + 1;
+        }
+    }
+    let last = raw[start..].trim();
+    if !last.is_empty() {
+        out.push(last.to_string());
+    }
+    out
+}
+
 pub(crate) async fn get_scan_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
@@ -306,15 +351,7 @@ pub(crate) async fn get_scan_handler(
 
     // Build ScanOptions from query parameters
     let headers_param = params.get("header").cloned().unwrap_or_default();
-    let opt_headers: Vec<String> = if headers_param.is_empty() {
-        vec![]
-    } else {
-        headers_param
-            .split(',')
-            .map(|s| s.trim().to_string())
-            .filter(|s| !s.is_empty())
-            .collect()
-    };
+    let opt_headers: Vec<String> = split_header_query_param(&headers_param);
     let encoders_param = params.get("encoders").cloned().unwrap_or_default();
     let encoders: Vec<String> = if encoders_param.is_empty() {
         vec!["url".to_string(), "html".to_string()]

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -355,15 +355,27 @@ pub(crate) async fn run_scan_job(
         ..Default::default()
     });
 
-    // Initialize remote resources if requested (honor timeout/proxy)
-    if !args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty() {
-        let _ = crate::utils::init_remote_resources_with_options(
+    // Initialize remote resources if requested (honor timeout/proxy).
+    // A failure here is not cosmetic: the scan proceeds without the payload or
+    // wordlist the caller explicitly asked for and still settles `done`, which
+    // reads as "scanned, found nothing". Log it so the difference is visible.
+    if (!args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty())
+        && let Err(e) = crate::utils::init_remote_resources_with_options(
             &args.remote_payloads,
             &args.remote_wordlists,
             Some(args.timeout),
             args.proxy.clone(),
         )
-        .await;
+        .await
+    {
+        log(
+            &state,
+            "WRN",
+            &format!(
+                "job {}: remote resource fetch failed ({}); scanning without the requested remote lists",
+                job_id, e
+            ),
+        );
     }
     let results = Arc::new(Mutex::new(Vec::<ScanResult>::new()));
 

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -144,6 +144,24 @@ pub async fn run_server(args: ServerArgs) {
         allowed_hosts.push(bind_host);
     }
 
+    // Prove `--log-file` is writable before serving anything. Every later write
+    // is a best-effort `let _ =` inside the log helper (a logging failure must
+    // not take a request down), so without this check a bad path — a typo, a
+    // missing directory, a read-only mount — made the flag a silent no-op for
+    // the whole process lifetime: logs still scrolled past on stdout, and the
+    // operator only discovered the empty file after the incident they wanted it
+    // for. Creating it up front also means the file exists immediately, so
+    // `tail -F` works from before the first request.
+    if let Some(path) = &args.log_file
+        && let Err(e) = std::fs::OpenOptions::new()
+            .create(true)
+            .append(true)
+            .open(path)
+    {
+        eprintln!("Cannot open --log-file {}: {}", path, e);
+        return;
+    }
+
     let state = AppState {
         api_key,
         jobs: Arc::new(Mutex::new(HashMap::new())),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -875,7 +875,7 @@ async fn test_get_scan_handler_success_parses_query_options_and_jsonp() {
     let mut params = Map::new();
     params.insert("cb".to_string(), "getCb".to_string());
     params.insert("url".to_string(), "http://127.0.0.1:1/".to_string());
-    params.insert("header".to_string(), "X-A:1,Invalid,X-B:2".to_string());
+    params.insert("header".to_string(), "X-A:1,X-B:2".to_string());
     params.insert("encoders".to_string(), "url,html,base64".to_string());
     params.insert("worker".to_string(), "3".to_string());
     params.insert("delay".to_string(), "1".to_string());
@@ -921,6 +921,72 @@ async fn test_get_scan_handler_success_parses_query_options_and_jsonp() {
 }
 
 #[test]
+fn test_split_header_query_param_keeps_commas_inside_values() {
+    // `GET /scan?header=...` packs several headers into one comma-separated
+    // value, but a comma is legal inside a header value. A blind split chopped
+    // `Accept: text/html,application/xhtml+xml` into a truncated Accept plus a
+    // nameless fragment — silently dropped before header validation existed,
+    // and a 400 for an otherwise valid request afterwards.
+    assert_eq!(
+        split_header_query_param("Accept: text/html,application/xhtml+xml"),
+        vec!["Accept: text/html,application/xhtml+xml".to_string()]
+    );
+    // The multi-header form still works.
+    assert_eq!(
+        split_header_query_param("X-A: 1,X-B: 2"),
+        vec!["X-A: 1".to_string(), "X-B: 2".to_string()]
+    );
+    // Mixed: a value with commas followed by a genuine second header.
+    assert_eq!(
+        split_header_query_param("Accept: a/b,c/d,X-Trace: 9"),
+        vec!["Accept: a/b,c/d".to_string(), "X-Trace: 9".to_string()]
+    );
+    assert!(split_header_query_param("").is_empty());
+    assert!(split_header_query_param("   ").is_empty());
+}
+
+#[tokio::test]
+async fn test_get_scan_handler_rejects_a_malformed_header_entry() {
+    // A header entry with no `Name: value` shape used to be dropped on the
+    // floor and the scan queued anyway, so a caller whose header never went out
+    // got a `200 OK` and a "clean" result. reqwest rejects it on every request
+    // in the job, which surfaced as the *target* being reported unreachable.
+    // Refuse at the boundary and name the offender instead.
+    let state = make_state(None, None, false, true, "cb");
+    let mut params = Map::new();
+    params.insert("url".to_string(), "http://127.0.0.1:1/".to_string());
+    // A leading entry with no `Name: value` shape is unambiguously malformed.
+    // (A bare fragment *after* a valid header is not: the comma-packed query
+    // form cannot tell it apart from a comma inside that header's value, so
+    // `split_header_query_param` keeps it as part of the value — see
+    // `test_split_header_query_param_keeps_commas_inside_values`.)
+    params.insert("header".to_string(), "Invalid,X-B:2".to_string());
+    let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::BAD_REQUEST);
+    assert!(state.jobs.lock().await.is_empty(), "no job may be queued");
+}
+
+#[tokio::test]
+async fn test_get_scan_handler_accepts_a_comma_bearing_header_value() {
+    // Regression for the interaction between the comma-packed `header=` query
+    // form and strict header validation: `Accept: text/html,application/xhtml+xml`
+    // must not be chopped into a nameless fragment and 400 the request.
+    let state = make_state(None, None, false, true, "cb");
+    let mut params = Map::new();
+    params.insert("url".to_string(), "http://127.0.0.1:1/".to_string());
+    params.insert(
+        "header".to_string(),
+        "Accept: text/html,application/xhtml+xml".to_string(),
+    );
+    let resp = get_scan_handler(State(state.clone()), HeaderMap::new(), Query(params))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+}
+
+#[test]
 fn test_split_cookie_pairs_handles_http_style_header() {
     // Regression: previously the server's singular `cookie` option was
     // fed through a single `split_once('=')`, so `"a=b; c=d"` collapsed to
@@ -961,18 +1027,15 @@ fn test_split_cookie_pairs_handles_http_style_header() {
     assert!(split_cookie_pairs("").is_empty());
     // Single piece without an `=` is dropped (no empty name/value pair).
     assert!(split_cookie_pairs("nosemi").is_empty());
-    // Empty key (e.g. `=v`) is preserved as a pair with an empty name —
-    // matches the upstream `split_once('=')` contract. Callers that need
-    // to reject empty names must do so themselves, but record the current
-    // behavior so a future refactor doesn't silently change it.
+    // A nameless pair (`=v`) is dropped. It used to be preserved to match the
+    // raw `split_once('=')` contract, but no caller could do anything useful
+    // with it: `compose_cookie_header` re-serializes it as a leading `=v` that
+    // no server parses as a cookie, and the discovery stage spent a probe per
+    // scan injecting into a cookie that cannot exist. The raw-HTTP and HAR
+    // parsers already dropped nameless cookies, so this also makes the four
+    // cookie sources agree.
     let leading_eq = split_cookie_pairs("=v; k=w");
-    assert_eq!(
-        leading_eq,
-        vec![
-            ("".to_string(), "v".to_string()),
-            ("k".to_string(), "w".to_string()),
-        ]
-    );
+    assert_eq!(leading_eq, vec![("k".to_string(), "w".to_string())]);
     // Empty value (`k=`) is preserved as an empty string, mirroring how
     // real browsers send `Set-Cookie: k=` to clear the cookie.
     let empty_val = split_cookie_pairs("k=; j=1");
@@ -2129,6 +2192,42 @@ async fn test_preflight_handler_unreachable_target() {
 #[test]
 fn test_validate_scan_options_accepts_defaults() {
     assert!(validate_scan_options(&mut ScanOptions::default()).is_ok());
+}
+
+#[test]
+fn test_validate_scan_options_rejects_malformed_headers() {
+    // Both REST (`POST /scan`, `GET /scan`) and MCP funnel through here, so
+    // this is the one place that has to know a header is unusable. reqwest
+    // errors on the builder for these, which made *every* request in the job
+    // fail — surfacing as the target being reported unreachable rather than as
+    // the caller's malformed input.
+    for bad in [
+        "no-colon-at-all",
+        "X Custom: v",             // space in the name
+        "X-Bad: a\r\nInjected: 1", // CRLF in the value
+        "X-Null: a\0b",            // NUL in the value
+    ] {
+        let mut opts = ScanOptions {
+            header: Some(vec![bad.to_string()]),
+            ..ScanOptions::default()
+        };
+        assert!(
+            validate_scan_options(&mut opts).is_err(),
+            "header {bad:?} must be rejected"
+        );
+    }
+
+    // Legal headers still pass, including obs-text in a value (`café`), which
+    // `HeaderValue` accepts and an over-strict check would have broken.
+    let mut ok = ScanOptions {
+        header: Some(vec![
+            "X-Api-Key: abc123".to_string(),
+            "Accept: text/html,application/xhtml+xml".to_string(),
+            "X-Note: caf\u{e9}".to_string(),
+        ]),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&mut ok).is_ok());
 }
 
 #[test]

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -158,7 +158,16 @@ pub(crate) struct ApiResponse<T> {
     pub(crate) data: Option<T>,
 }
 
+/// `deny_unknown_fields` for the same reason [`ScanOptions`] carries it, one
+/// level up. Without it the *envelope* silently swallowed anything it did not
+/// recognise — and the shape callers get wrong is precisely a flat option dict
+/// (`{"target": ..., "worker": 5, "header": [...]}`, the MCP spelling) instead
+/// of the nested `{"target": ..., "options": {...}}`. That returned `200 OK`
+/// with **every option discarded**: default workers, no headers, no cookies, no
+/// blind callback — and the resulting "clean" scan looked like a successful one.
+/// The inner struct's validation never ran because nothing ever reached it.
 #[derive(Debug, Clone, Deserialize)]
+#[serde(deny_unknown_fields)]
 pub(crate) struct ScanRequest {
     /// Scan target. Named `target` to match the MCP `scan_with_dalfox` tool and
     /// the response payload's `target` field; `url` is accepted as a backwards-

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -86,6 +86,11 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
             c
         ));
     }
+    // Header syntax, checked here rather than discovered mid-scan. Shared with
+    // MCP so both front ends refuse the same inputs.
+    if let Some(headers) = &opts.header {
+        crate::job::validate_header_list(headers)?;
+    }
     Ok(())
 }
 

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -311,6 +311,57 @@ pub(crate) fn is_skippable_request_header(name: &str) -> bool {
     SKIP.iter().any(|s| name.eq_ignore_ascii_case(s))
 }
 
+/// The body of a raw HTTP request: everything after the blank line that ends
+/// the header block, byte-for-byte apart from one optional trailing newline.
+/// `None` when there is no separator or nothing follows it.
+///
+/// Operates on the original text rather than on a `lines()` re-join so that
+/// CRLF line endings *inside* the body survive: a `multipart/form-data` body
+/// captured from a real request uses CRLF around its boundaries, and RFC 7578
+/// parsers that match `\r\n--boundary` see zero parts once those become bare
+/// LFs.
+///
+/// Two details that a naive "find the first \r\n\r\n" gets wrong:
+///
+/// * **The separator must be found the same way the header loop finds it.**
+///   That loop ends on the first line whose `trim_end()` is empty, so a
+///   separator line carrying stray whitespace (`\r\n \r\n`) ends the headers
+///   there. Scanning for a literal `\r\n\r\n` would miss it and report no
+///   body at all, silently dropping every body parameter from the scan.
+/// * **A trailing newline is a file artifact, not body content.** Every text
+///   editor terminates a file with one, and the old `lines()` fold dropped it.
+///   Keeping it verbatim appended a `\n` to the last body parameter's value,
+///   which then rode along percent-encoded (`b=2%0A`) on every request of the
+///   scan. Exactly one trailing terminator is removed, so a multipart body's
+///   internal CRLFs — and its `--boundary--` close delimiter — are untouched.
+fn raw_http_body(raw: &str) -> Option<&str> {
+    let bytes = raw.as_bytes();
+    let mut line_start = 0usize;
+    let body_start = loop {
+        if line_start >= bytes.len() {
+            return None;
+        }
+        let rel_end = raw[line_start..]
+            .find('\n')
+            .map(|r| line_start + r)
+            .unwrap_or(bytes.len());
+        let line = &raw[line_start..rel_end];
+        let next = (rel_end + 1).min(bytes.len());
+        if line.trim_end().is_empty() {
+            break next;
+        }
+        line_start = next;
+    };
+    let mut body = &raw[body_start..];
+    // Drop one trailing terminator (CRLF or LF), never more.
+    if let Some(stripped) = body.strip_suffix("\r\n") {
+        body = stripped;
+    } else if let Some(stripped) = body.strip_suffix('\n') {
+        body = stripped;
+    }
+    (!body.is_empty()).then_some(body)
+}
+
 /// Parse a raw HTTP request into a Target.
 /// Supports:
 /// - Request line with absolute-form URI: GET http://example.com/path HTTP/1.1
@@ -390,15 +441,15 @@ pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::E
         }
     }
 
-    // 3) Body (remaining lines after the first blank line)
-    let body = lines.fold(String::new(), |mut acc, l| {
-        if !acc.is_empty() {
-            acc.push('\n');
-        }
-        acc.push_str(l);
-        acc
-    });
-    let data = if body.is_empty() { None } else { Some(body) };
+    // 3) Body — sliced verbatim out of the original text after the blank line
+    //    that ends the header block.
+    //
+    //    Rebuilding it by joining `lines()` with `\n` corrupted every body whose
+    //    line endings are load-bearing: a `multipart/form-data` body captured
+    //    from a real request uses CRLF around its boundaries, and RFC 7578
+    //    parsers that match `\r\n--boundary` see *zero* parts once the CRLFs
+    //    become bare LFs. The same fold also swallowed a leading blank line.
+    let data = raw_http_body(raw).map(str::to_string);
 
     // 4) Build URL
     let url = if uri.starts_with("http://") || uri.starts_with("https://") {
@@ -859,6 +910,89 @@ mod raw_http_tests {
         assert_eq!(t.method, "POST");
         assert_eq!(t.url.as_str(), "http://example.com/submit");
         assert_eq!(t.data.as_deref(), Some("a=1&b=2"));
+    }
+
+    #[test]
+    fn raw_http_body_preserves_crlf_line_endings() {
+        // A multipart body's CRLFs are load-bearing: RFC 7578 parsers match
+        // `\r\n--boundary`. Rebuilding the body from `lines()` joined with `\n`
+        // turned every one of them into a bare LF, so a strict server saw zero
+        // parts and the whole body-parameter scan silently tested nothing.
+        //
+        // The body's *final* terminator is a separate question — it is a file
+        // artifact and is dropped (see
+        // `raw_http_body_drops_exactly_one_trailing_newline`); the close
+        // delimiter itself and every internal CRLF survive.
+        let body = "--X\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\nv\r\n--X--";
+        let raw = format!(
+            "POST /u HTTP/1.1\r\nHost: e.com\r\nContent-Type: multipart/form-data; boundary=X\r\n\r\n{body}\r\n"
+        );
+        let t = parse_raw_http_request(&raw).expect("should parse");
+        assert_eq!(t.data.as_deref(), Some(body));
+    }
+
+    #[test]
+    fn raw_http_body_preserves_a_leading_blank_line() {
+        // The old `lines()` fold started the accumulator empty, so a body that
+        // legitimately begins with a blank line lost it.
+        let raw = "POST /u HTTP/1.1\r\nHost: e.com\r\n\r\n\r\nreal body";
+        let t = parse_raw_http_request(raw).expect("should parse");
+        assert_eq!(t.data.as_deref(), Some("\r\nreal body"));
+    }
+
+    #[test]
+    fn raw_http_lf_only_request_still_finds_its_body() {
+        let raw = "POST /u HTTP/1.1\nHost: e.com\n\na=1&b=2";
+        let t = parse_raw_http_request(raw).expect("should parse");
+        assert_eq!(t.data.as_deref(), Some("a=1&b=2"));
+    }
+
+    #[test]
+    fn raw_http_without_a_body_has_none() {
+        let raw = "GET /u HTTP/1.1\r\nHost: e.com\r\n\r\n";
+        let t = parse_raw_http_request(raw).expect("should parse");
+        assert_eq!(t.data, None);
+    }
+
+    #[test]
+    fn raw_http_body_drops_exactly_one_trailing_newline() {
+        // Every text editor terminates a file with a newline; keeping it made
+        // the last body parameter's value `2\n`, which then rode along
+        // percent-encoded on every request of the scan.
+        let t = parse_raw_http_request("POST /u HTTP/1.1\r\nHost: e\r\n\r\na=1&b=2\r\n")
+            .expect("should parse");
+        assert_eq!(t.data.as_deref(), Some("a=1&b=2"));
+        let lf =
+            parse_raw_http_request("POST /u HTTP/1.1\nHost: e\n\na=1&b=2\n").expect("should parse");
+        assert_eq!(lf.data.as_deref(), Some("a=1&b=2"));
+        // Only ONE terminator goes: a body that really ends in a blank line
+        // keeps the rest.
+        let two = parse_raw_http_request("POST /u HTTP/1.1\r\nHost: e\r\n\r\na=1\r\n\r\n")
+            .expect("should parse");
+        assert_eq!(two.data.as_deref(), Some("a=1\r\n"));
+    }
+
+    #[test]
+    fn raw_http_body_survives_a_whitespace_bearing_separator_line() {
+        // The header loop ends on the first line whose `trim_end()` is empty,
+        // so a separator carrying a stray space ends the headers there.
+        // Scanning for a literal `\r\n\r\n` missed it and reported NO body,
+        // silently dropping every body parameter from the scan.
+        let t = parse_raw_http_request("POST /u HTTP/1.1\r\nHost: e\r\n \r\na=1&b=2")
+            .expect("should parse");
+        assert_eq!(t.data.as_deref(), Some("a=1&b=2"));
+    }
+
+    #[test]
+    fn raw_http_multipart_close_delimiter_is_preserved() {
+        // The trailing-newline strip must not eat a multipart body's own CRLF
+        // structure; only the final terminator goes.
+        let body = "--X\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\nv\r\n--X--";
+        let raw = format!(
+            "POST /u HTTP/1.1\r\nHost: e\r\nContent-Type: multipart/form-data; boundary=X\r\n\r\n{body}\r\n"
+        );
+        let t = parse_raw_http_request(&raw).expect("should parse");
+        assert_eq!(t.data.as_deref(), Some(body));
     }
 
     #[test]

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -1,0 +1,326 @@
+/*!
+Bounded HTML parsing.
+
+Every response dalfox looks at is parsed by html5ever (via `scraper`) several
+times — meta-CSP extraction, injection-context detection, DOM verification,
+inline-script collection. html5ever's tree builder consults the *open elements
+stack* on essentially every tag (the "have element in scope" checks), so its
+cost is `O(depth)` per element and therefore **quadratic in nesting depth** for
+a document that nests without bound. There is no depth limit inside html5ever.
+
+Measured against the real scanner (debug build, localhost server):
+
+| body                       | size    | one scan |
+|----------------------------|---------|----------|
+| 8 000 `<div>` nested       |  88 KiB |    7.2 s |
+| 8 000 `<div>` **siblings** |  96 KiB |    0.26 s |
+| 16 000 `<div>` nested      | 176 KiB |     29 s |
+| 60 000 `<div>` nested      | 660 KiB |  > 150 s |
+
+Size is not the driver — depth is; doubling depth quadruples the time. A single
+hostile (or merely generated) response could therefore stall a scan
+indefinitely, which is a worse outcome than analyzing a truncated document:
+a wedged target is 100% recall loss *plus* a hang.
+
+So: estimate nesting depth with one cheap linear pass, and when a document
+nests past [`MAX_HTML_NESTING_DEPTH`], hand the parser only the prefix up to
+that point. Browsers do the same thing — Blink and Gecko both cap HTML parser
+tree depth in the same ballpark (512) and flatten anything deeper — so markup
+past the bound does not nest the way it claims in a real browser either.
+
+Only the tree-based analyses are bounded by this. The byte/text-level
+reflection checks never parse HTML and always see the full body.
+*/
+
+use std::borrow::Cow;
+
+/// Maximum element nesting depth handed to html5ever. Matches the order of the
+/// caps real browser parsers apply; real-world documents are one to two orders
+/// of magnitude shallower.
+pub const MAX_HTML_NESTING_DEPTH: usize = 512;
+
+/// Elements that never nest: they have no end tag at all.
+const VOID_ELEMENTS: &[&str] = &[
+    "area", "base", "br", "col", "embed", "hr", "img", "input", "link", "meta", "param", "source",
+    "track", "wbr",
+];
+
+/// Start tags that implicitly close an already-open element, and the barrier
+/// elements that stop that search.
+///
+/// `(start_tag, closes, barriers)`: seeing `start_tag` pops the stack down to
+/// and including the nearest open element named in `closes`, unless one of
+/// `barriers` is reached first. This is what makes ordinary sloppy markup — a
+/// 600-item `<ul>` whose `<li>`s are never closed, a table whose `<td>`s are
+/// never closed — read as depth 2 rather than depth 601.
+///
+/// The barriers are what keep *deliberately* deep markup honest: `<ul><li>`
+/// repeated 30 000 times really is 30 000 levels deep in a browser, and the
+/// intervening `ul` stops the implied close, so the estimate grows with it.
+/// Without barriers this table would be an attacker's way around the guard.
+const IMPLIED_END_TAGS: &[(&str, &[&str], &[&str])] = &[
+    ("li", &["li"], &["ul", "ol", "menu"]),
+    ("dt", &["dt", "dd"], &["dl"]),
+    ("dd", &["dt", "dd"], &["dl"]),
+    ("p", &["p"], &[]),
+    ("option", &["option"], &["select", "datalist", "optgroup"]),
+    ("optgroup", &["option", "optgroup"], &["select", "datalist"]),
+    ("tr", &["td", "th", "tr"], &["table"]),
+    ("td", &["td", "th"], &["table", "tr"]),
+    ("th", &["td", "th"], &["table", "tr"]),
+    (
+        "thead",
+        &["td", "th", "tr", "thead", "tbody", "tfoot"],
+        &["table"],
+    ),
+    (
+        "tbody",
+        &["td", "th", "tr", "thead", "tbody", "tfoot"],
+        &["table"],
+    ),
+    (
+        "tfoot",
+        &["td", "th", "tr", "thead", "tbody", "tfoot"],
+        &["table"],
+    ),
+    ("rt", &["rt", "rp"], &["ruby"]),
+    ("rp", &["rt", "rp"], &["ruby"]),
+];
+
+/// Elements whose content is raw text, not markup. `<script>if (a<b) {}</script>`
+/// must not be read as opening a `<b>`.
+const RAWTEXT_ELEMENTS: &[&str] = &["script", "style", "textarea", "title"];
+
+/// Lowercased ASCII tag name starting at `bytes[i]` (just past `<` or `</`),
+/// plus the offset just after it. Empty when the byte is not a name start.
+fn tag_name_at(bytes: &[u8], i: usize) -> (String, usize) {
+    let mut end = i;
+    while end < bytes.len() && (bytes[end].is_ascii_alphanumeric() || bytes[end] == b'-') {
+        end += 1;
+    }
+    (
+        String::from_utf8_lossy(&bytes[i..end]).to_ascii_lowercase(),
+        end,
+    )
+}
+
+/// Offset of the byte just past the `>` that ends the tag starting at `from`
+/// (or the end of input).
+///
+/// Quote-aware: a `>` inside a quoted attribute value does not end the tag.
+/// Without that, `<iframe srcdoc="<div><div>…">` ended the tag at the first
+/// `>` inside `srcdoc` and the rest of the attribute value was rescanned as
+/// markup — 600 `<div>`s in an attribute read as 600 open elements and
+/// truncated a 3 KiB document. Raw `<` and `>` are legal inside a quoted
+/// attribute value, and html5ever treats all of it as text.
+fn skip_to_gt(bytes: &[u8], from: usize) -> usize {
+    let mut i = from;
+    let mut quote: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) if b == q => quote = None,
+            Some(_) => {}
+            None if b == b'"' || b == b'\'' => quote = Some(b),
+            None if b == b'>' => return i + 1,
+            None => {}
+        }
+        i += 1;
+    }
+    bytes.len()
+}
+
+/// Whether the tag that ends at `gt_end` (offset just past its `>`) was
+/// self-closing (`<div/>`).
+fn tag_is_self_closing(bytes: &[u8], gt_end: usize) -> bool {
+    gt_end >= 2 && bytes[gt_end - 1] == b'>' && bytes[gt_end - 2] == b'/'
+}
+
+/// Offset of the first ASCII-case-insensitive occurrence of `needle` in
+/// `bytes[from..]`, as an absolute offset.
+///
+/// Allocation-free on purpose. The obvious spelling — lowercasing the rest of
+/// the document and calling `find` — allocates a copy of the *remaining* body
+/// at each call site, so a page with 10 000 `<script>` tags would allocate
+/// 10 000 progressively shorter copies: quadratic memory traffic inside the
+/// very guard that exists to stop a quadratic blowup.
+fn find_ascii_case_insensitive(bytes: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || from >= bytes.len() {
+        return None;
+    }
+    let first = needle[0];
+    let end = bytes.len().checked_sub(needle.len())?;
+    (from..=end).find(|&start| {
+        bytes[start].eq_ignore_ascii_case(&first)
+            && bytes[start..start + needle.len()].eq_ignore_ascii_case(needle)
+    })
+}
+
+/// The estimator's open-element stack, with an O(1) "is this name open?" test.
+///
+/// The count map is what lets an end tag unwind without a lookback limit. The
+/// previous version capped the search at 32 entries, which meant an end tag
+/// whose match sat deeper simply popped nothing — so every unclosed inline
+/// element inside it leaked one stack entry *permanently*, and ordinary legacy
+/// markup (20 blog posts each with 35 unclosed `<font>`s) crossed a 512 cap on
+/// a 9 KiB page whose real depth is 3. Here a name that is not open at all is
+/// rejected in O(1), and a name that is open is always unwound to; since every
+/// entry is pushed once and popped once, the total work stays linear.
+#[derive(Default)]
+struct OpenElements {
+    stack: Vec<String>,
+    counts: std::collections::HashMap<String, usize>,
+}
+
+impl OpenElements {
+    fn len(&self) -> usize {
+        self.stack.len()
+    }
+
+    fn is_open(&self, name: &str) -> bool {
+        self.counts.get(name).is_some_and(|&n| n > 0)
+    }
+
+    fn push(&mut self, name: String) {
+        *self.counts.entry(name.clone()).or_insert(0) += 1;
+        self.stack.push(name);
+    }
+
+    /// Pop everything above `idx`, plus `idx` itself.
+    fn truncate_including(&mut self, idx: usize) {
+        for name in self.stack.drain(idx..) {
+            if let Some(c) = self.counts.get_mut(&name) {
+                *c = c.saturating_sub(1);
+            }
+        }
+    }
+
+    /// Index of the topmost open element named `name`, searching down from the
+    /// top and stopping at any of `barriers`. `None` when a barrier is reached
+    /// first or the name is not open.
+    fn nearest(&self, names: &[&str], barriers: &[&str]) -> Option<usize> {
+        if !names.iter().any(|n| self.is_open(n)) {
+            return None;
+        }
+        self.stack
+            .iter()
+            .rposition(|open| names.contains(&open.as_str()) || barriers.contains(&open.as_str()))
+            .filter(|&idx| names.contains(&self.stack[idx].as_str()))
+    }
+}
+
+/// Byte offset of the `<` whose element would push nesting past `limit`, or
+/// `None` when the document stays within it.
+///
+/// A deliberately approximate scanner: it models only what drives html5ever's
+/// cost (how deep the open-elements stack gets). Where it is inexact it is
+/// inexact toward *under*-estimating, because an over-estimate truncates a
+/// legitimate page and silently costs findings, while an under-estimate only
+/// costs parse time. (An earlier version got this backwards — see
+/// [`OpenElements`].)
+fn nesting_overflow_offset(html: &str, limit: usize) -> Option<usize> {
+    let bytes = html.as_bytes();
+    let mut open = OpenElements::default();
+    let mut i = 0usize;
+
+    while i < bytes.len() {
+        if bytes[i] != b'<' {
+            i += 1;
+            continue;
+        }
+        let tag_start = i;
+        let next = i + 1;
+        if next >= bytes.len() {
+            break;
+        }
+        match bytes[next] {
+            // Comment, doctype, CDATA, processing instruction: no element.
+            b'!' | b'?' => {
+                if bytes[next..].starts_with(b"!--") {
+                    i = match html[next + 3..].find("-->") {
+                        Some(rel) => next + 3 + rel + 3,
+                        None => bytes.len(),
+                    };
+                } else {
+                    i = skip_to_gt(bytes, next);
+                }
+            }
+            // End tag: unwind to the matching open element if there is one.
+            // Doing this for *every* name is what clears the inline elements a
+            // `</td>` or `</div>` implicitly closes.
+            b'/' => {
+                let (name, name_end) = tag_name_at(bytes, next + 1);
+                i = skip_to_gt(bytes, name_end);
+                if name.is_empty() || !open.is_open(&name) {
+                    continue;
+                }
+                if let Some(idx) = open.stack.iter().rposition(|o| *o == name) {
+                    open.truncate_including(idx);
+                }
+            }
+            _ => {
+                let (name, name_end) = tag_name_at(bytes, next);
+                if name.is_empty() {
+                    // A bare `<` in text ("a < b"): not a tag at all.
+                    i = next;
+                    continue;
+                }
+                let gt_end = skip_to_gt(bytes, name_end);
+                if RAWTEXT_ELEMENTS.contains(&name.as_str()) {
+                    // Jump over the raw-text content wholesale; its `<`s are
+                    // data. The search starts at `gt_end`, which is already
+                    // past this tag's `>`, so the cursor always advances.
+                    let close = format!("</{name}");
+                    i = find_ascii_case_insensitive(bytes, gt_end, close.as_bytes())
+                        .unwrap_or(bytes.len());
+                    continue;
+                }
+                i = gt_end;
+                if VOID_ELEMENTS.contains(&name.as_str()) || tag_is_self_closing(bytes, gt_end) {
+                    continue;
+                }
+                // Implied end tags: `<li>` after an open `<li>` closes it, and
+                // so does `<td>` after an open `<td>` — unless a barrier
+                // (`<ul>`, `<table>`, …) says the new one is genuinely nested.
+                if let Some((_, closes, barriers)) = IMPLIED_END_TAGS
+                    .iter()
+                    .find(|(start, _, _)| *start == name.as_str())
+                    && let Some(idx) = open.nearest(closes, barriers)
+                {
+                    open.truncate_including(idx);
+                }
+                open.push(name);
+                if open.len() > limit {
+                    return Some(tag_start);
+                }
+            }
+        }
+    }
+    None
+}
+
+/// `html`, truncated just before the point where its element nesting would
+/// exceed [`MAX_HTML_NESTING_DEPTH`]. Borrows unchanged in the overwhelmingly
+/// common case that the document is within the bound.
+pub fn bound_html_nesting(html: &str) -> Cow<'_, str> {
+    match nesting_overflow_offset(html, MAX_HTML_NESTING_DEPTH) {
+        Some(cut) => {
+            crate::dbg_log!(
+                "html nesting exceeds {} levels at byte {}; parsing the prefix only",
+                MAX_HTML_NESTING_DEPTH,
+                cut
+            );
+            Cow::Borrowed(&html[..cut])
+        }
+        None => Cow::Borrowed(html),
+    }
+}
+
+/// `scraper::Html::parse_document` with the nesting guard applied. Use this
+/// anywhere the input is (or could be) a response body.
+pub fn parse_document_bounded(html: &str) -> scraper::Html {
+    scraper::Html::parse_document(&bound_html_nesting(html))
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/utils/html/tests.rs
+++ b/src/utils/html/tests.rs
@@ -1,0 +1,349 @@
+use super::*;
+use std::time::Instant;
+
+#[test]
+fn ordinary_document_is_borrowed_unchanged() {
+    let html = "<html><body><div><p>hi</p><span>x</span></div></body></html>";
+    let bounded = bound_html_nesting(html);
+    assert!(matches!(bounded, Cow::Borrowed(_)));
+    assert_eq!(bounded.len(), html.len());
+}
+
+#[test]
+fn depth_just_under_the_cap_is_untouched() {
+    let n = MAX_HTML_NESTING_DEPTH - 8;
+    let html = format!(
+        "<html><body>{}MARK{}</body></html>",
+        "<div>".repeat(n),
+        "</div>".repeat(n)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn depth_past_the_cap_is_truncated_at_a_tag_boundary() {
+    let n = MAX_HTML_NESTING_DEPTH * 4;
+    let html = format!(
+        "<html><body>{}MARK{}</body></html>",
+        "<div>".repeat(n),
+        "</div>".repeat(n)
+    );
+    let bounded = bound_html_nesting(&html);
+    assert!(
+        bounded.len() < html.len(),
+        "deep document must be truncated"
+    );
+    assert!(bounded.ends_with('>'), "cut must land on a tag boundary");
+    // Everything kept is still valid UTF-8 prefix of the original.
+    assert!(html.starts_with(bounded.as_ref()));
+}
+
+#[test]
+fn sibling_elements_never_trip_the_guard() {
+    // 20 000 siblings are depth 3, not depth 20 000.
+    let html = format!(
+        "<html><body>{}</body></html>",
+        "<div>x</div>".repeat(20_000)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn unclosed_optional_end_tags_never_trip_the_guard() {
+    // A 5 000-item list whose <li>s are never closed is ordinary markup.
+    let html = format!(
+        "<html><body><ul>{}</ul></body></html>",
+        "<li>item".repeat(5_000)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+    let rows = format!("<table><tr>{}</tr></table>", "<td>c".repeat(5_000));
+    assert_eq!(bound_html_nesting(&rows).len(), rows.len());
+}
+
+#[test]
+fn void_elements_do_not_accumulate_depth() {
+    let html = format!(
+        "<html><body>{}</body></html>",
+        "<br><img src=x><input>".repeat(5_000)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn self_closing_tags_do_not_accumulate_depth() {
+    let html = format!(
+        "<html><body>{}</body></html>",
+        "<custom-tag/>".repeat(5_000)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn script_contents_are_not_read_as_markup() {
+    // `a<b` inside a script must not open 5 000 <b> elements.
+    let js = "if (a<b) { c(); }".repeat(5_000);
+    let html = format!("<html><body><script>{js}</script></body></html>");
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn comments_are_skipped_wholesale() {
+    let html = format!("<html><body><!--{}--></body></html>", "<div>".repeat(5_000));
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn bare_less_than_in_text_is_not_a_tag() {
+    let html = format!(
+        "<html><body>{}</body></html>",
+        "a < b and c < d ".repeat(5_000)
+    );
+    assert_eq!(bound_html_nesting(&html).len(), html.len());
+}
+
+#[test]
+fn mismatched_end_tags_do_not_cost_quadratic_time() {
+    // The pathological shape for an unbounded end-tag lookback.
+    let html = format!("{}{}", "<div>".repeat(400), "</span>".repeat(50_000));
+    let start = Instant::now();
+    let _ = bound_html_nesting(&html);
+    assert!(
+        start.elapsed().as_millis() < 500,
+        "end-tag lookback must stay bounded, took {:?}",
+        start.elapsed()
+    );
+}
+
+#[test]
+fn deeply_nested_document_parses_promptly() {
+    // The regression this module exists for: unguarded, 16 000 levels took ~29 s
+    // through the scanner. Through the guard the parse must be near-instant.
+    let n = 16_000;
+    let html = format!(
+        "<html><body>{}MARK{}</body></html>",
+        "<div>".repeat(n),
+        "</div>".repeat(n)
+    );
+    let start = Instant::now();
+    let doc = parse_document_bounded(&html);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 2,
+        "bounded parse of a {n}-deep document took {elapsed:?}"
+    );
+    // Still a usable document: the outer levels survive.
+    assert!(doc.select(crate::scanning::selectors::universal()).count() > 100);
+}
+
+#[test]
+fn shallow_document_parse_is_equivalent_to_unbounded() {
+    let html = r#"<html><head><meta http-equiv="Content-Security-Policy" content="default-src 'self'"></head>
+                  <body><div id="a">hello</div><input name="q" value="v"></body></html>"#;
+    let bounded = parse_document_bounded(html);
+    let direct = scraper::Html::parse_document(html);
+    assert_eq!(bounded.html(), direct.html());
+}
+
+#[test]
+fn many_rawtext_elements_do_not_cost_quadratic_time() {
+    // The rawtext skip used to lowercase the *rest of the document* on every
+    // <script> it met, so a page with many small scripts allocated one
+    // progressively-shorter copy each — quadratic work inside the guard whose
+    // whole job is preventing quadratic work.
+    let html = format!(
+        "<html><body>{}</body></html>",
+        "<script>var a = 1;</script><div>x</div>".repeat(20_000)
+    );
+    let start = Instant::now();
+    let bounded = bound_html_nesting(&html);
+    let elapsed = start.elapsed();
+    assert_eq!(bounded.len(), html.len(), "this page is shallow, not deep");
+    assert!(
+        elapsed.as_millis() < 500,
+        "rawtext skip must stay linear, took {elapsed:?} on {} KiB",
+        html.len() / 1024
+    );
+}
+
+#[test]
+fn empty_and_unterminated_rawtext_elements_terminate() {
+    // Cursor-advance edge cases: an empty script, an unclosed script, a lone
+    // `<`, a lone `</`, and an unterminated comment must all return promptly.
+    for html in [
+        "<html><script></script><div>x</div></html>",
+        "<html><script>never closed",
+        "<html><body>trailing <",
+        "<html><body></",
+        "<html><body><!-- never closed",
+        "<",
+        "",
+    ] {
+        let start = Instant::now();
+        let bounded = bound_html_nesting(html);
+        assert!(
+            start.elapsed().as_millis() < 200,
+            "input {html:?} did not terminate promptly"
+        );
+        assert_eq!(bounded.len(), html.len());
+    }
+}
+
+#[test]
+fn uppercase_close_tag_ends_rawtext() {
+    // The rawtext skip is ASCII-case-insensitive, so `</SCRIPT>` closes the
+    // block and the markup after it is scanned normally.
+    let deep = "<div>".repeat(MAX_HTML_NESTING_DEPTH * 2);
+    let html = format!("<html><SCRIPT>a<b</SCRIPT>{deep}</html>");
+    assert!(
+        bound_html_nesting(&html).len() < html.len(),
+        "nesting after an uppercase </SCRIPT> must still be seen"
+    );
+}
+
+// --- over-estimation regressions (adversarial review, 2026-08-13) -----------
+//
+// The first version of this estimator claimed every approximation
+// under-estimates. It did not: elements with optional end tags were never
+// pushed, so `</td>` / `</li>` could not unwind the inline elements inside
+// them, and a 32-entry end-tag lookback left permanent residue. Ordinary
+// legacy markup therefore crossed the 512 cap and had its tail truncated —
+// silent recall loss on a real page. Each case below is a real-world markup
+// shape whose true depth is single-digit.
+
+/// The tail marker must survive: if it does, nothing was truncated.
+fn assert_not_truncated(name: &str, html: &str) {
+    let bounded = bound_html_nesting(html);
+    assert_eq!(
+        bounded.len(),
+        html.len(),
+        "{name}: a {}-byte page with single-digit real depth was truncated to {}",
+        html.len(),
+        bounded.len()
+    );
+    assert!(bounded.contains("MARK"), "{name}: tail marker was cut");
+}
+
+#[test]
+fn legacy_posts_with_unclosed_font_are_not_truncated() {
+    // 20 blog posts, each with 35 unclosed <font>s closed only by </div>.
+    let block = format!("<div class=post>{}Text</div>", "<font size=2>".repeat(35));
+    let html = format!(
+        "<html><body>{}<div id=late>MARK</div></body></html>",
+        block.repeat(20)
+    );
+    assert_not_truncated("legacy_font_posts", &html);
+}
+
+#[test]
+fn table_rows_with_unclosed_inline_elements_are_not_truncated() {
+    // `</td>` must unwind the <font> inside it. Real depth: table>tr>td>font.
+    let html = format!(
+        "<html><body><table>{}</table><div id=late>MARK</div></body></html>",
+        "<tr><td><font color=red>x</td></tr>".repeat(600)
+    );
+    assert_not_truncated("table_rows_unclosed_font", &html);
+
+    let anchors = format!(
+        "<html><body><table>{}</table><div id=late>MARK</div></body></html>",
+        "<tr><td><a href=#>x</td></tr>".repeat(600)
+    );
+    assert_not_truncated("td_unclosed_anchor", &anchors);
+}
+
+#[test]
+fn list_items_with_unclosed_inline_elements_are_not_truncated() {
+    // No `</li>` at all: the implied end tag has to close the previous item.
+    let html = format!(
+        "<html><body><ul>{}</ul><div id=late>MARK</div></body></html>",
+        "<li><span>x".repeat(600)
+    );
+    assert_not_truncated("list_unclosed_span", &html);
+}
+
+#[test]
+fn paragraphs_and_definition_lists_do_not_accumulate() {
+    let ps = format!(
+        "<html><body>{}<div id=late>MARK</div></body></html>",
+        "<p><b>bold text".repeat(600)
+    );
+    assert_not_truncated("unclosed_p_with_bold", &ps);
+    let dl = format!(
+        "<html><body><dl>{}</dl><div id=late>MARK</div></body></html>",
+        "<dt><i>term<dd><i>def".repeat(400)
+    );
+    assert_not_truncated("unclosed_dt_dd", &dl);
+}
+
+#[test]
+fn markup_inside_a_quoted_attribute_is_not_counted() {
+    // `<iframe srcdoc="…">` legitimately carries raw markup in an attribute.
+    let html = format!(
+        r#"<html><body><iframe srcdoc="{}"></iframe><div id=late>MARK</div></body></html>"#,
+        "<div>".repeat(600)
+    );
+    assert_not_truncated("iframe_srcdoc", &html);
+}
+
+// --- the attack shapes must still be caught ---------------------------------
+
+/// Deliberately deep markup must still trip the guard, whatever tag it uses:
+/// the implied-end-tag barriers exist so a nested list cannot smuggle depth
+/// past the estimator.
+fn assert_truncated(name: &str, html: &str) {
+    let bounded = bound_html_nesting(html);
+    assert!(
+        bounded.len() < html.len(),
+        "{name}: {}-byte deeply-nested document was NOT truncated",
+        html.len()
+    );
+}
+
+#[test]
+fn deliberately_nested_lists_are_still_caught() {
+    let n = 20_000;
+    let html = format!(
+        "<html><body>{}MARK{}</body></html>",
+        "<ul><li>".repeat(n),
+        "</li></ul>".repeat(n)
+    );
+    assert_truncated("nested_list_attack", &html);
+}
+
+#[test]
+fn deliberately_nested_inline_elements_are_still_caught() {
+    for tag in ["span", "font", "b", "a"] {
+        let n = 20_000;
+        let html = format!(
+            "<html><body>{}MARK{}</body></html>",
+            format!("<{tag}>").repeat(n),
+            format!("</{tag}>").repeat(n)
+        );
+        assert_truncated(&format!("nested_{tag}_attack"), &html);
+    }
+}
+
+#[test]
+fn deliberately_nested_table_cells_are_still_caught() {
+    // Each `<table>` is a barrier, so genuinely nested tables keep their depth.
+    let n = 5_000;
+    let html = format!(
+        "<html><body>{}MARK{}</body></html>",
+        "<table><tr><td>".repeat(n),
+        "</td></tr></table>".repeat(n)
+    );
+    assert_truncated("nested_table_attack", &html);
+}
+
+#[test]
+fn unmatched_end_tags_stay_linear_with_a_deep_stack() {
+    // The count map must reject a never-opened end tag in O(1); otherwise a
+    // near-full stack plus a flood of unmatched end tags is quadratic again.
+    let html = format!("{}{}", "<div>".repeat(400), "</span>".repeat(200_000));
+    let start = Instant::now();
+    let _ = bound_html_nesting(&html);
+    assert!(
+        start.elapsed().as_millis() < 1000,
+        "unmatched end tags took {:?}",
+        start.elapsed()
+    );
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -7,6 +7,7 @@ This module re-exports commonly used helpers so other modules can simply
 
 pub mod banner;
 pub mod fs;
+pub mod html;
 pub mod http;
 pub mod log;
 pub mod rate_limit;
@@ -160,13 +161,38 @@ pub async fn init_remote_resources(
         timeout_secs: None,
         proxy: None,
     };
-    if !payload_providers.is_empty() {
-        crate::payload::init_remote_payloads_with(payload_providers, opts.clone()).await?;
+    fetch_both(payload_providers, wordlist_providers, opts).await
+}
+
+/// Fetch both remote lists, **not** short-circuiting on the first failure, and
+/// report every failure together.
+///
+/// The `?`-chained version stopped at the first error, which mattered once an
+/// all-failed fetch started returning `Err` instead of caching an empty list: a
+/// payload-provider outage silently skipped the wordlist fetch too, so a scan
+/// that asked for both lost the one that was actually reachable.
+async fn fetch_both(
+    payload_providers: &[String],
+    wordlist_providers: &[String],
+    opts: crate::payload::RemoteFetchOptions,
+) -> Result<(), Box<dyn std::error::Error>> {
+    let mut errors: Vec<String> = Vec::new();
+    if !payload_providers.is_empty()
+        && let Err(e) =
+            crate::payload::init_remote_payloads_with(payload_providers, opts.clone()).await
+    {
+        errors.push(format!("payloads: {e}"));
     }
-    if !wordlist_providers.is_empty() {
-        crate::payload::init_remote_wordlists_with(wordlist_providers, opts).await?;
+    if !wordlist_providers.is_empty()
+        && let Err(e) = crate::payload::init_remote_wordlists_with(wordlist_providers, opts).await
+    {
+        errors.push(format!("wordlists: {e}"));
     }
-    Ok(())
+    if errors.is_empty() {
+        Ok(())
+    } else {
+        Err(errors.join("; ").into())
+    }
 }
 
 /// Initialize remote resources with explicit options (timeout/proxy).
@@ -181,13 +207,7 @@ pub async fn init_remote_resources_with_options(
         timeout_secs,
         proxy,
     };
-    if !payload_providers.is_empty() {
-        crate::payload::init_remote_payloads_with(payload_providers, opts.clone()).await?;
-    }
-    if !wordlist_providers.is_empty() {
-        crate::payload::init_remote_wordlists_with(wordlist_providers, opts).await?;
-    }
-    Ok(())
+    fetch_both(payload_providers, wordlist_providers, opts).await
 }
 
 #[cfg(test)]


### PR DESCRIPTION
## Summary

A stability pass focused on **crashes, hangs, and scans that silently report clean**. Found by a multi-lens audit of `src/` with every finding adversarially verified, plus empirical fuzzing against a hostile HTTP server. The fix itself was then put through a second adversarial review, which found 26 defects **in the fix** — those are fixed here too.

The two headline defects are remote-triggerable by a scanned page.

### 1. A hostile page crashed the scanner — and the run reported "clean"

`identifier_referenced` advanced its search cursor by exactly one byte after a rejected match. A Trusted Types callback parameter with a non-ASCII name (JS identifiers may start with any `ID_Start` codepoint, and the name comes straight off the scanned page) put that cursor **inside a multi-byte codepoint**, and the next slice panicked.

Worse than the panic: the preflight/analysis collector was `if let Ok(res) = handle.await`, which **discards the `JoinError`**. The target silently vanished, and the run finished:

```
WRN XSS found 0 XSS
$ echo $?
0
```

A target could disable scanning of itself and be reported clean. Verified live before/after:

| | baseline | this PR |
|---|---|---|
| `<script>trustedTypes.createPolicy('p',{createHTML:function(한글){var 한글x=1;…}})</script>` | panic, `0 XSS`, exit 0 | `[POC][A][GET][DOM-XSS]` reported |

Fixed the cursor advance (`from = start + name.len()`) **and** the swallowing — a panicked target is now recorded `skipped` / `INTERNAL_ERROR` instead of falling through to `clean`. The same hole in the injection stage (`scan_loop.rs`) is closed too, attributing the panic to its target via the task id.

### 2. Deeply nested HTML hung the scanner

html5ever has no nesting limit and its tree builder consults the open-elements stack on essentially every tag, so parse cost is **quadratic in nesting depth**. dalfox parses each response body several times. Measured end-to-end:

| body | size | before | after |
|---|---|---|---|
| 8 000 `<div>` nested | 88 KiB | 7.2 s | 0.19 s |
| 8 000 `<div>` **siblings** | 96 KiB | 0.26 s | 0.26 s |
| 16 000 `<div>` nested | 176 KiB | **29 s** | **0.22 s** |
| 60 000 `<div>` nested, full scan | 660 KiB | **killed at 150 s** | **11 s** |

Size is not the driver — depth is; doubling depth quadruples the time. New `utils::html::parse_document_bounded` estimates nesting depth in one linear pass and hands the parser only the prefix up to `MAX_HTML_NESTING_DEPTH` (512, the order browsers themselves cap at). All 12 response-parse sites route through it.

## Everything else

**OOM / unbounded work**
- `compute_js_breakout` built its closer from an unbounded script prefix: `<script>foo(` + `(`×16 M yielded a 16 MiB closer stored on the `Param` and cloned into *every* synthesized payload. Capped at `MAX_OPEN_DEPTH = 256`; the opener search is now allocation-free (no window, so no recall cost).
- Findings retained the full response body each — under `--deep-scan` on a reflect-everything endpoint that is ~3 GB for one parameter. Bounded to 64 KiB **centred on the payload**, so `extract_context`'s `L1:` evidence line still works.
- `occurrence_is_in_url_attr` walked back to offset 0 on a body with no `=`/`<`/`>`; the occurrence *count* was capped, the walk *length* was not. Now bounded — and returns `Option<bool>` so each of the three callers maps "unknown" onto the branch that **keeps** the finding (they suppress on different polarities; a plain `false` would have silently suppressed at two of them).
- `detect_injection_context_with_marker` had a per-element `el.text()` loop, O(nodes²), that returned exactly what the fallback returned — deleted, zero behaviour change.
- Form-field probing is capped at 200 fields. The cap is on the probe *loop*, not the field vector, because that vector also builds the submitted body.

**Scans that reported clean without scanning**
- `--only-custom-payload` without `--custom-payload` produced an empty payload set: **zero attack requests, `0 XSS`, exit 0**. Now a hard error. (Deliberately not clap `requires` — clap validates before the config overlay, which would break a config-supplied `custom_payload`.)
- `--skip-xss-scanning` did not gate the blind-XSS stage, so `--skip-xss-scanning -b <cb>` still wrote **stored** payloads into every param and form of a system the operator asked not to attack.
- A target cut short by `--limit` was recorded `completed` in `--state-file`, so re-running the same command skipped it forever with most params never tested.
- `--dry-run` / `--only-discovery` returned before the only code that reads `args.output`, so `-o plan.json` was silently never written and the command exited 0.

**Input parsing**
- `--cookies "a=1; b=2"` folded into one cookie named `a`. Requests were byte-identical so nothing looked wrong, but `b` was never enumerated or probed — a silent FN for cookie-reflected XSS. Now uses the same `split_cookie_pairs` the server/MCP always did (which also now drops nameless pairs).
- Raw-HTTP body was rebuilt from `lines()` joined with `\n`, turning a multipart body's load-bearing CRLFs into bare LFs — strict RFC 7578 parsers then see **zero parts**. Now sliced verbatim, using the same separator rule as the header loop, minus one trailing file-artifact newline.
- `--user-agent ""` emitted a literal empty `User-Agent:` header.
- `--sxss-method` had no value parser (`post` went on the wire as an extension verb); `--sxss-retries` was uncapped with a `500ms × attempt` backoff — `3000` is ~26 days.

**Server / MCP**
- `ScanRequest` lacked `deny_unknown_fields`, so a flat option dict (`{"target":…,"worker":5,"header":[…]}`) returned `200 OK` with **every option discarded** — the exact failure `ScanOptions`' own comment calls out, one level up.
- Malformed headers are refused at the boundary (shared by REST and MCP) instead of failing reqwest's builder on every request and reporting the live target as `unreachable`. The `GET /scan` `header=` splitter now only splits at a comma that starts a new `Name:`, so `Accept: text/html,application/xhtml+xml` survives.
- The remote-payload cache is a process-global `OnceLock`: a job that requested **no** remote payloads still got whichever list an earlier job fetched. Consumer is now gated, an all-failed fetch is no longer cached forever, and the failure is logged instead of `let _ =`.
- `--log-file` is opened at startup, so an unwritable path fails fast instead of being a silent no-op for the process lifetime.

**Log injection**: panic messages quote the data that caused them, which here can be bytes straight from a scanned response — the three panic-log sites now route through `sanitize_log_message`.

## Verification

- **2253 lib + 255 integration tests pass**; `cargo fmt --check` and `clippy --all-targets` clean.
- **Every new regression test was mutation-tested** — the fix reverted, the test confirmed red. Two tests that could *not* fail were caught in review and rewritten; the back-walk one now fails at **18.7 s vs 0.00 s** against the unfixed code.
- **Recall unchanged.** A/B against a `git worktree` of `main` over 25 endpoints (raw/escaped/filtered/WAF/multi-byte/truncated reflections): 24 identical, and the one difference is recall *recovered* — the page that used to panic now reports its finding.
- The nesting guard is tested against real-world-messy markup, not just the attack: unclosed `<font>` in blog posts, `<td>`/`<li>` never closed, `<iframe srcdoc>` carrying raw markup — all must stay untruncated, while nested lists/tables/inline elements must still be caught.

## Note on the second review

The first version of the nesting guard **over-estimated** depth on ordinary legacy markup — it skipped optional-end-tag elements, so `</td>` could not unwind the inline elements inside it, and a 32-entry end-tag lookback left permanent residue. 600 table rows with an unclosed `<font>` (real depth 4) crossed the 512 cap on a 21 KB page and had their tail truncated. Its own doc comment asserted this was impossible, and the unit tests passed because they were written from the same wrong model. It took an independent reimplementation to find. The estimator now uses implied-end-tag semantics with scope barriers, an O(1) open-name map, and quote-aware tag scanning.

---
https://claude.ai/code/session_01VMiiWcb7ofr93WdGhf5Nof
