### PR TITLE
fix(scan): stop fan-out cuts from deleting the finding they bound

### DIFF
--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -112,19 +112,52 @@ async fn pre_collapse_query_probe(client: &reqwest::Client, target: &Target) -> 
     first_text
 }
 
-/// Build the synthetic "any" Query param used as the lone discovered
-/// param when sentinel collapse fires. Mirrors the post-collapse path
-/// at the end of `probe_dictionary_params`.
-fn make_any_query_param(text: &str) -> Param {
-    let context = detect_injection_context(text);
-    let (valid, invalid) = crate::parameter_analysis::classify_special_chars(text);
-    Param {
+/// Identity of a parameter *slot*, used to tell the params a mining stage
+/// inherited apart from the ones it mined itself. `Location` is not `Hash`, so
+/// the key is built from its `Debug` rendering — the same shape
+/// `discovery::dedupe_reflection_params` uses.
+fn param_slot_key(p: &Param) -> String {
+    format!("{}|{:?}", p.name, p.location)
+}
+
+/// Snapshot the parameter slots already present before a mining stage starts.
+///
+/// Mining stages run sequentially (see [`mine_parameters`]), so this is a
+/// stable "everything Stage 1 discovery — or an earlier mining stage — already
+/// found" set, and a later collapse can subtract from it safely.
+async fn snapshot_param_slots(
+    reflection_params: &Arc<Mutex<Vec<Param>>>,
+) -> std::collections::HashSet<String> {
+    reflection_params
+        .lock()
+        .await
+        .iter()
+        .map(param_slot_key)
+        .collect()
+}
+
+/// Build the synthetic `any` param standing in for "this target echoes
+/// arbitrary parameter names at `location`".
+///
+/// Metadata comes from whichever sample the caller has: the response body that
+/// proved arbitrary names reflect (sentinel path), or one of the params the
+/// stage mined before collapsing (EWMA path). Both describe how an *arbitrary*
+/// name behaves here, which is what `any` represents. The params the target
+/// actually carries are deliberately not used as the sample — their measured
+/// specials belong to them, and copying those onto `any` produced findings that
+/// reported one parameter's evidence under another's name.
+fn make_any_param(
+    location: Location,
+    response_text: Option<&str>,
+    mined_sample: Option<&Param>,
+) -> Param {
+    let mut param = Param {
         name: "any".to_string(),
         value: crate::scanning::markers::bracketed_marker().to_string(),
-        location: Location::Query,
-        injection_context: Some(context),
-        valid_specials: Some(valid),
-        invalid_specials: Some(invalid),
+        location,
+        injection_context: Some(InjectionContext::Html(None)),
+        valid_specials: None,
+        invalid_specials: None,
         pre_encoding: None,
         pre_encoding_pipeline: None,
         wire_name: None,
@@ -132,29 +165,75 @@ fn make_any_query_param(text: &str) -> Param {
         form_origin_url: None,
         framework_sink: None,
         escaped_specials: None,
-        js_breakout: detect_js_breakout(text),
+        js_breakout: None,
+    };
+    if let Some(text) = response_text {
+        let (valid, invalid) = crate::parameter_analysis::classify_special_chars(text);
+        param.injection_context = Some(detect_injection_context(text));
+        param.valid_specials = Some(valid);
+        param.invalid_specials = Some(invalid);
+        param.js_breakout = detect_js_breakout(text);
+    } else if let Some(sample) = mined_sample {
+        param.value = sample.value.clone();
+        param.injection_context = sample.injection_context.clone();
+        param.valid_specials = sample.valid_specials.clone();
+        param.invalid_specials = sample.invalid_specials.clone();
+        param.js_breakout = sample.js_breakout.clone();
     }
+    param
 }
 
-/// Replace every `Query`-located param in `reflection_params` with a single
-/// synthetic `any` param. Non-Query params (Body, Header, Path, JsonBody,
-/// Cookie, Fragment) are preserved. Mirrors the EWMA post-processing path
-/// so sentinel collapse and EWMA collapse produce identical downstream
-/// state — Stage 3-6 sees one Query injection point regardless of which
-/// route triggered the collapse.
-async fn collapse_to_any_query_param(
-    reflection_params: Arc<Mutex<Vec<Param>>>,
-    response_text: &str,
+/// Collapse the params *this mining stage itself discovered* at `location`
+/// into the single synthetic `any` param, leaving everything else untouched.
+///
+/// Collapse is a cost control. Once a target is known to echo arbitrary
+/// parameter names, walking the rest of the wordlist only manufactures
+/// injection points that all behave identically, and each one costs a full
+/// Stage 3-6 payload run. Dropping *those* is the point of the mechanism.
+///
+/// Dropping the parameters the target actually carries is not. Those come from
+/// Stage 1 discovery — the URL query string, form fields, headers — and were
+/// confirmed to reflect before mining ever ran. Earlier revisions cleared every
+/// param at `location` regardless of origin, so on any page that echoes its
+/// whole query string (a debug endpoint, a framework error page that dumps
+/// `request.query_params`) the genuinely vulnerable parameter was deleted
+/// before Stage 3 ever saw it: the scan then reported a POC against `any` — a
+/// parameter the application does not have — and missed the real one entirely.
+/// `preexisting` is the guard against that, and it is why every caller must
+/// snapshot with [`snapshot_param_slots`] before it starts pushing.
+async fn collapse_mined_params(
+    reflection_params: &Arc<Mutex<Vec<Param>>>,
+    preexisting: &std::collections::HashSet<String>,
+    location: Location,
+    response_text: Option<&str>,
 ) {
     let mut guard = reflection_params.lock().await;
-    let non_query: Vec<Param> = guard
+    let mut mined_sample: Option<Param> = None;
+    guard.retain(|p| {
+        if p.location != location || preexisting.contains(&param_slot_key(p)) {
+            return true;
+        }
+        if mined_sample.is_none() {
+            mined_sample = Some(p.clone());
+        }
+        false
+    });
+    // Don't add a second `any` to a slot that already has one. That covers the
+    // synthetic left by an earlier stage collapsing the same location, and —
+    // more importantly — a target that genuinely carries a parameter called
+    // `any`: it is a real, discovered param and overwriting it with the
+    // synthetic stand-in would reintroduce exactly the data loss this function
+    // exists to prevent.
+    if !guard
         .iter()
-        .filter(|p| !matches!(p.location, Location::Query))
-        .cloned()
-        .collect();
-    guard.clear();
-    guard.extend(non_query);
-    guard.push(make_any_query_param(response_text));
+        .any(|p| p.location == location && p.name == "any")
+    {
+        guard.push(make_any_param(
+            location,
+            response_text,
+            mined_sample.as_ref(),
+        ));
+    }
 }
 
 #[derive(Debug)]
@@ -562,6 +641,9 @@ pub async fn probe_dictionary_params(
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
     let client = target.build_client_or_default();
+    // Taken before this stage pushes anything, so a collapse below can drop
+    // what the wordlist mined without touching what discovery already found.
+    let preexisting = snapshot_param_slots(&reflection_params).await;
 
     // Resolve candidate parameter names (remote, file, or built-ins)
     let mut params: Vec<String> = Vec::new();
@@ -615,19 +697,26 @@ pub async fn probe_dictionary_params(
 
     // Sentinel pre-probe: 3 unique random param names. If every one reflects,
     // the page echoes arbitrary input and the wordlist would just balloon
-    // into Stage 3-6 cost. Replace it with a single "any" param and bail.
-    // Skip when the wordlist is small enough that the pre-probe is more
-    // expensive than just running it.
+    // into Stage 3-6 cost. Skip the wordlist and add a single "any" param
+    // instead — the params discovered before this stage are kept and still
+    // scanned. Skip when the wordlist is small enough that the pre-probe is
+    // more expensive than just running it.
     if params.len() > SENTINEL_PROBE_COUNT * 5
         && let Some(text) = pre_collapse_query_probe(&client, target).await
     {
         if !silence {
             eprintln!(
                 "[mining-collapse] sentinel pre-probe collapsed Query mining: \
-                 every random param name reflected; using single 'any' param"
+                 every random param name reflected; adding single 'any' param"
             );
         }
-        collapse_to_any_query_param(reflection_params.clone(), &text).await;
+        collapse_mined_params(
+            &reflection_params,
+            &preexisting,
+            Location::Query,
+            Some(&text),
+        )
+        .await;
         if let Some(ref pb) = pb {
             pb.finish_and_clear();
         }
@@ -866,58 +955,12 @@ pub async fn probe_dictionary_params(
     } // end chunk loop
 
     // Apply collapse post-processing once (instead of inside tasks mutating aggressively).
-    // Only collapse Query params — preserve params discovered via other channels
-    // (Body from form discovery, Header from header discovery, Path, etc.).
+    // Only the Query params *this stage mined* collapse — params discovered via
+    // other channels (Body, Header, Path, JsonBody, …) and the Query params
+    // Stage 1 discovery already confirmed are left alone.
     let st_final = stats.lock().await;
     if st_final.collapsed {
-        let mut guard = reflection_params.lock().await;
-        // Preserve non-Query params (Body, Header, Path, JsonBody, Cookie, etc.)
-        let non_query: Vec<Param> = guard
-            .iter()
-            .filter(|p| !matches!(p.location, crate::parameter_analysis::Location::Query))
-            .cloned()
-            .collect();
-        let preserved = guard
-            .iter()
-            .find(|p| matches!(p.location, crate::parameter_analysis::Location::Query))
-            .cloned();
-        guard.clear();
-        guard.extend(non_query);
-        if let Some(orig) = preserved {
-            guard.push(Param {
-                name: "any".to_string(),
-                value: orig.value.clone(),
-                location: crate::parameter_analysis::Location::Query,
-                injection_context: orig.injection_context.clone(),
-                valid_specials: orig.valid_specials.clone(),
-                invalid_specials: orig.invalid_specials.clone(),
-                pre_encoding: None,
-                pre_encoding_pipeline: None,
-                wire_name: None,
-                form_action_url: None,
-                form_origin_url: None,
-                framework_sink: None,
-                escaped_specials: None,
-                js_breakout: orig.js_breakout.clone(),
-            });
-        } else {
-            guard.push(Param {
-                name: "any".to_string(),
-                value: crate::scanning::markers::bracketed_marker().to_string(),
-                location: crate::parameter_analysis::Location::Query,
-                injection_context: Some(crate::parameter_analysis::InjectionContext::Html(None)),
-                valid_specials: None,
-                invalid_specials: None,
-                pre_encoding: None,
-                pre_encoding_pipeline: None,
-                wire_name: None,
-                form_action_url: None,
-                form_origin_url: None,
-                framework_sink: None,
-                escaped_specials: None,
-                js_breakout: None,
-            });
-        }
+        collapse_mined_params(&reflection_params, &preexisting, Location::Query, None).await;
     }
 }
 
@@ -931,6 +974,7 @@ pub async fn probe_body_params(
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
     let client = target.build_client_or_default();
+    let preexisting = snapshot_param_slots(&reflection_params).await;
 
     if let Some(data) = &args.data {
         // Assume form data for now (application/x-www-form-urlencoded)
@@ -1096,59 +1140,12 @@ pub async fn probe_body_params(
             guard.extend(batch);
         }
 
-        // If collapsed after attempts, normalize Body params to single 'any' param.
-        // Preserve non-Body params discovered via other channels.
+        // If collapsed after attempts, normalize the Body params this stage
+        // mined to a single 'any' param. Params discovered via other channels
+        // — and the Body params that were already known — are preserved.
         let st_final = stats.lock().await;
         if st_final.collapsed {
-            let mut guard = reflection_params.lock().await;
-            let non_body: Vec<Param> = guard
-                .iter()
-                .filter(|p| !matches!(p.location, Location::Body))
-                .cloned()
-                .collect();
-            let preserved = guard
-                .iter()
-                .find(|p| matches!(p.location, Location::Body))
-                .cloned();
-            guard.clear();
-            guard.extend(non_body);
-            if let Some(orig) = preserved {
-                guard.push(Param {
-                    name: "any".to_string(),
-                    value: orig.value.clone(),
-                    location: Location::Body,
-                    injection_context: orig.injection_context.clone(),
-                    valid_specials: orig.valid_specials.clone(),
-                    invalid_specials: orig.invalid_specials.clone(),
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: orig.js_breakout.clone(),
-                });
-            } else {
-                guard.push(Param {
-                    name: "any".to_string(),
-                    value: crate::scanning::markers::bracketed_marker().to_string(),
-                    location: Location::Body,
-                    injection_context: Some(crate::parameter_analysis::InjectionContext::Html(
-                        None,
-                    )),
-                    valid_specials: None,
-                    invalid_specials: None,
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: None,
-                });
-            }
+            collapse_mined_params(&reflection_params, &preexisting, Location::Body, None).await;
         }
     }
 }
@@ -1163,6 +1160,7 @@ pub async fn probe_response_id_params(
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
     let client = target.build_client_or_default();
+    let preexisting = snapshot_param_slots(&reflection_params).await;
 
     // First, get the HTML to find input ids and names
     let base_request = crate::utils::build_request(
@@ -1225,10 +1223,16 @@ pub async fn probe_response_id_params(
             if !silence {
                 eprintln!(
                     "[mining-collapse] sentinel pre-probe collapsed DOM mining: \
-                     every random param name reflected; using single 'any' param"
+                     every random param name reflected; adding single 'any' param"
                 );
             }
-            collapse_to_any_query_param(reflection_params.clone(), &text).await;
+            collapse_mined_params(
+                &reflection_params,
+                &preexisting,
+                Location::Query,
+                Some(&text),
+            )
+            .await;
             if let Some(ref pb) = pb {
                 pb.finish_and_clear();
             }
@@ -1383,59 +1387,13 @@ pub async fn probe_response_id_params(
             let mut guard = reflection_params.lock().await;
             guard.extend(batch);
         }
-        // Collapse post-processing (single 'any' param) if adaptive stats triggered it.
-        // Preserve non-Query params discovered via other channels.
+        // Collapse post-processing (single 'any' param) if adaptive stats
+        // triggered it. Only the Query params this stage mined are folded in;
+        // params discovered via other channels — and the ones discovery already
+        // confirmed — survive.
         let st_final = stats.lock().await;
         if st_final.collapsed {
-            let mut guard = reflection_params.lock().await;
-            let non_query: Vec<Param> = guard
-                .iter()
-                .filter(|p| !matches!(p.location, crate::parameter_analysis::Location::Query))
-                .cloned()
-                .collect();
-            let preserved = guard
-                .iter()
-                .find(|p| matches!(p.location, crate::parameter_analysis::Location::Query))
-                .cloned();
-            guard.clear();
-            guard.extend(non_query);
-            if let Some(orig) = preserved {
-                guard.push(Param {
-                    name: "any".to_string(),
-                    value: orig.value.clone(),
-                    location: crate::parameter_analysis::Location::Query,
-                    injection_context: orig.injection_context.clone(),
-                    valid_specials: orig.valid_specials.clone(),
-                    invalid_specials: orig.invalid_specials.clone(),
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: orig.js_breakout.clone(),
-                });
-            } else {
-                guard.push(Param {
-                    name: "any".to_string(),
-                    value: crate::scanning::markers::bracketed_marker().to_string(),
-                    location: crate::parameter_analysis::Location::Query,
-                    injection_context: Some(crate::parameter_analysis::InjectionContext::Html(
-                        None,
-                    )),
-                    valid_specials: None,
-                    invalid_specials: None,
-                    pre_encoding: None,
-                    pre_encoding_pipeline: None,
-                    wire_name: None,
-                    form_action_url: None,
-                    form_origin_url: None,
-                    framework_sink: None,
-                    escaped_specials: None,
-                    js_breakout: None,
-                });
-            }
+            collapse_mined_params(&reflection_params, &preexisting, Location::Query, None).await;
         }
     }
 }
@@ -1450,6 +1408,7 @@ pub async fn probe_json_body_params(
     let arc_target = Arc::new(target.clone());
     let silence = args.silence;
     let client = target.build_client_or_default();
+    let preexisting = snapshot_param_slots(&reflection_params).await;
 
     // Detect JSON body from args.data; only proceed if it's a JSON object
     let base_json: serde_json::Value = match &args.data {
@@ -1635,57 +1594,11 @@ pub async fn probe_json_body_params(
         guard.extend(batch);
     }
 
-    // Collapse normalization to single 'any' JSON param if triggered.
-    // Preserve non-JsonBody params discovered via other channels.
+    // Collapse normalization to single 'any' JSON param if triggered. Only the
+    // JsonBody params this stage mined fold in; everything else is preserved.
     let st_final = stats.lock().await;
     if st_final.collapsed {
-        let mut guard = reflection_params.lock().await;
-        let non_json: Vec<Param> = guard
-            .iter()
-            .filter(|p| !matches!(p.location, Location::JsonBody))
-            .cloned()
-            .collect();
-        let preserved = guard
-            .iter()
-            .find(|p| matches!(p.location, Location::JsonBody))
-            .cloned();
-        guard.clear();
-        guard.extend(non_json);
-        if let Some(orig) = preserved {
-            guard.push(Param {
-                name: "any".to_string(),
-                value: orig.value.clone(),
-                location: Location::JsonBody,
-                injection_context: orig.injection_context.clone(),
-                valid_specials: orig.valid_specials.clone(),
-                invalid_specials: orig.invalid_specials.clone(),
-                pre_encoding: None,
-                pre_encoding_pipeline: None,
-                wire_name: None,
-                form_action_url: None,
-                form_origin_url: None,
-                framework_sink: None,
-                escaped_specials: None,
-                js_breakout: orig.js_breakout.clone(),
-            });
-        } else {
-            guard.push(Param {
-                name: "any".to_string(),
-                value: crate::scanning::markers::bracketed_marker().to_string(),
-                location: Location::JsonBody,
-                injection_context: Some(crate::parameter_analysis::InjectionContext::Html(None)),
-                valid_specials: None,
-                invalid_specials: None,
-                pre_encoding: None,
-                pre_encoding_pipeline: None,
-                wire_name: None,
-                form_action_url: None,
-                form_origin_url: None,
-                framework_sink: None,
-                escaped_specials: None,
-                js_breakout: None,
-            });
-        }
+        collapse_mined_params(&reflection_params, &preexisting, Location::JsonBody, None).await;
     }
 }
 

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -584,13 +584,13 @@ fn test_framework_html_sink_returns_none_for_empty_marker() {
     );
 }
 
-// --- Pure-helper coverage: make_any_query_param / collapse_to_any_query_param ---
+// --- Pure-helper coverage: make_any_param / collapse_mined_params ---
 
 #[test]
-fn test_make_any_query_param_fills_classification_and_context() {
+fn test_make_any_param_fills_classification_and_context() {
     let marker = crate::scanning::markers::open_marker();
     let body = format!("<div>{} '\"<>(){{}}</div>", marker);
-    let p = make_any_query_param(&body);
+    let p = make_any_param(Location::Query, Some(&body), None);
     assert_eq!(p.name, "any");
     assert_eq!(p.location, Location::Query);
     assert_eq!(p.value, crate::scanning::markers::bracketed_marker());
@@ -604,72 +604,189 @@ fn test_make_any_query_param_fills_classification_and_context() {
     assert!(invalid.contains(&'\\'));
 }
 
+/// With no response body to classify, `any` inherits the measurements of a
+/// param the *stage itself mined* — an actual observation of how an arbitrary
+/// name behaves at this location. It must never inherit them from a param the
+/// target really carries, or a finding ends up reporting one parameter's
+/// evidence under another parameter's name.
+#[test]
+fn test_make_any_param_inherits_mined_sample_metadata() {
+    let mined = Param {
+        name: "mined_word".into(),
+        value: "MINEDVALUE".into(),
+        location: Location::Query,
+        injection_context: Some(InjectionContext::Html(None)),
+        valid_specials: Some(vec!['<', '>']),
+        invalid_specials: Some(vec!['"']),
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    };
+    let p = make_any_param(Location::Query, None, Some(&mined));
+    assert_eq!(p.name, "any");
+    assert_eq!(p.value, "MINEDVALUE");
+    assert_eq!(p.valid_specials, Some(vec!['<', '>']));
+    assert_eq!(p.invalid_specials, Some(vec!['"']));
+
+    // No sample at all still yields a usable param: payload selection needs an
+    // injection context, so the generic HTML default stands in.
+    let bare = make_any_param(Location::Body, None, None);
+    assert_eq!(bare.location, Location::Body);
+    assert_eq!(bare.injection_context, Some(InjectionContext::Html(None)));
+}
+
+fn bare_param(name: &str, location: Location) -> Param {
+    Param {
+        name: name.into(),
+        value: format!("{name}_value"),
+        location,
+        injection_context: None,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    }
+}
+
+fn names_at(params: &[Param], location: Location) -> Vec<&str> {
+    params
+        .iter()
+        .filter(|p| p.location == location)
+        .map(|p| p.name.as_str())
+        .collect()
+}
+
+/// Collapse folds away only what the *current mining stage* discovered.
+///
+/// Regression guard for the `any` false positive: on a page that echoes its
+/// whole query string, collapse used to clear every Query param — including the
+/// ones Stage 1 discovery had already confirmed reflect. The genuinely
+/// vulnerable parameter was deleted before Stage 3 saw it, so the scan reported
+/// a POC against `any` (a parameter the app does not have) and reported zero
+/// findings for the real one.
 #[tokio::test]
-async fn test_collapse_to_any_query_param_keeps_non_query_and_replaces_query() {
-    let initial = vec![
-        Param {
-            name: "q_old".into(),
-            value: "v".into(),
-            location: Location::Query,
-            injection_context: None,
-            valid_specials: None,
-            invalid_specials: None,
-            pre_encoding: None,
-            pre_encoding_pipeline: None,
-            wire_name: None,
-            form_action_url: None,
-            form_origin_url: None,
-            framework_sink: None,
-            escaped_specials: None,
-            js_breakout: None,
-        },
-        Param {
-            name: "q_old_2".into(),
-            value: "v".into(),
-            location: Location::Query,
-            injection_context: None,
-            valid_specials: None,
-            invalid_specials: None,
-            pre_encoding: None,
-            pre_encoding_pipeline: None,
-            wire_name: None,
-            form_action_url: None,
-            form_origin_url: None,
-            framework_sink: None,
-            escaped_specials: None,
-            js_breakout: None,
-        },
-        Param {
-            name: "h".into(),
-            value: "hv".into(),
-            location: Location::Header,
-            injection_context: None,
-            valid_specials: None,
-            invalid_specials: None,
-            pre_encoding: None,
-            pre_encoding_pipeline: None,
-            wire_name: None,
-            form_action_url: None,
-            form_origin_url: None,
-            framework_sink: None,
-            escaped_specials: None,
-            js_breakout: None,
-        },
-    ];
-    let params = Arc::new(Mutex::new(initial));
-    collapse_to_any_query_param(params.clone(), "<html></html>").await;
+async fn test_collapse_mined_params_keeps_discovered_params_and_folds_only_mined() {
+    let params = Arc::new(Mutex::new(vec![
+        bare_param("q_real", Location::Query),
+        bare_param("h", Location::Header),
+    ]));
+    // Snapshot is taken before the stage mines anything, exactly as the
+    // probe_* functions do.
+    let preexisting = snapshot_param_slots(&params).await;
+    params
+        .lock()
+        .await
+        .extend([bare_param("mined_a", Location::Query), {
+            let mut p = bare_param("mined_b", Location::Query);
+            p.valid_specials = Some(vec!['<']);
+            p
+        }]);
+
+    collapse_mined_params(&params, &preexisting, Location::Query, None).await;
+
     let guard = params.lock().await;
-    assert_eq!(guard.len(), 2);
-    assert!(
-        guard
-            .iter()
-            .any(|p| p.name == "h" && p.location == Location::Header)
+    assert_eq!(
+        names_at(&guard, Location::Query),
+        vec!["q_real", "any"],
+        "the discovered Query param must survive and `any` is appended, not substituted"
     );
+    assert_eq!(
+        names_at(&guard, Location::Header),
+        vec!["h"],
+        "params at other locations are untouched"
+    );
+    // `any` samples a mined param, never the target's own parameter.
     let any_q = guard
         .iter()
-        .find(|p| p.location == Location::Query)
+        .find(|p| p.name == "any")
         .expect("any query param present");
-    assert_eq!(any_q.name, "any");
+    assert_eq!(any_q.value, "mined_a_value");
+}
+
+/// Two stages can collapse the same location (dictionary mining, then DOM
+/// mining). The second must replace the first `any` rather than stack a
+/// duplicate injection point on top of it.
+#[tokio::test]
+async fn test_collapse_mined_params_replaces_a_previous_any_instead_of_duplicating() {
+    let params = Arc::new(Mutex::new(vec![bare_param("q_real", Location::Query)]));
+    let first_stage = snapshot_param_slots(&params).await;
+    collapse_mined_params(&params, &first_stage, Location::Query, None).await;
+
+    // Second stage snapshots *after* the first collapse, so `any` is in its
+    // preexisting set — the dedupe has to be explicit.
+    let second_stage = snapshot_param_slots(&params).await;
+    collapse_mined_params(&params, &second_stage, Location::Query, None).await;
+
+    let guard = params.lock().await;
+    assert_eq!(names_at(&guard, Location::Query), vec!["q_real", "any"]);
+}
+
+/// A target may genuinely carry a parameter called `any`. It is a discovered
+/// param like any other, so collapse must keep it — and must not stack the
+/// synthetic stand-in on top of it.
+#[tokio::test]
+async fn test_collapse_mined_params_preserves_a_real_param_named_any() {
+    let params = Arc::new(Mutex::new(vec![{
+        let mut p = bare_param("any", Location::Query);
+        p.valid_specials = Some(vec!['<', '>']);
+        p
+    }]));
+    let preexisting = snapshot_param_slots(&params).await;
+    params
+        .lock()
+        .await
+        .push(bare_param("mined_word", Location::Query));
+
+    collapse_mined_params(&params, &preexisting, Location::Query, None).await;
+
+    let guard = params.lock().await;
+    assert_eq!(names_at(&guard, Location::Query), vec!["any"]);
+    let real = &guard[0];
+    assert_eq!(
+        real.value, "any_value",
+        "the target's own `any` keeps its discovered value"
+    );
+    assert_eq!(
+        real.valid_specials,
+        Some(vec!['<', '>']),
+        "and its measured specials — the synthetic must not overwrite them"
+    );
+}
+
+/// The same guard for a non-Query location: a Body collapse must not wipe the
+/// body fields the user supplied via `-d`.
+#[tokio::test]
+async fn test_collapse_mined_params_scopes_to_one_location() {
+    let params = Arc::new(Mutex::new(vec![
+        bare_param("username", Location::Body),
+        bare_param("q_real", Location::Query),
+    ]));
+    let preexisting = snapshot_param_slots(&params).await;
+    params
+        .lock()
+        .await
+        .push(bare_param("mined_body", Location::Body));
+
+    collapse_mined_params(&params, &preexisting, Location::Body, None).await;
+
+    let guard = params.lock().await;
+    assert_eq!(names_at(&guard, Location::Body), vec!["username", "any"]);
+    assert_eq!(
+        names_at(&guard, Location::Query),
+        vec!["q_real"],
+        "a Body collapse must not add or remove Query params"
+    );
 }
 
 // --- Server-driven coverage for probe_* functions ---

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1583,16 +1583,26 @@ enum PhaseFlow {
 /// shapes that already failed, so cutting them is recall-neutral.
 const INERT_ECHO_BUDGET: u32 = 256;
 
-/// Issue #1156 — *consecutive* 5xx responses that end the DOM phase.
+/// Issue #1156 — *consecutive* dead-server responses that end the DOM phase.
 ///
 /// Scoped to **server errors (`status >= 500`) only**, deliberately *excluding*
 /// 4xx WAF blocks (`403`/`406`/`429`): a payload *variant* can bypass a WAF
 /// filter, so early-exiting on a 4xx block would risk cutting a working bypass
-/// (those are handled by the reflection-path WAF backoff instead). A 5xx, by
-/// contrast, is the server failing — no payload variant "bypasses" it and an
-/// error page cannot carry executable evidence — so a long consecutive run is a
-/// safe, recall-neutral stop. A single non-5xx response resets the streak, so a
-/// transient blip cannot abandon a recoverable parameter.
+/// (those are handled by the reflection-path WAF backoff instead). A 5xx that
+/// tells us nothing back is the server failing — no payload variant "bypasses"
+/// it — so a long consecutive run is a safe, recall-neutral stop. A single
+/// response that does not qualify resets the streak, so a transient blip cannot
+/// abandon a recoverable parameter.
+///
+/// A 5xx that **echoes the payload** is explicitly *not* counted. That
+/// combination is a framework development error page (Kemal, Werkzeug, Rails,
+/// Symfony …), which renders the request path, query string, or an exception
+/// message built from user input — one of the most common reflected-XSS sinks
+/// there is, and a 500 by construction. Counting it lost the entire class:
+/// after 64 payloads dalfox abandoned DOM verification and could only ever
+/// report `[R]` for a parameter that `--deep-scan` verifies as `[V]`. Fan-out
+/// on such an endpoint stays bounded by [`INERT_ECHO_BUDGET`], which is the
+/// budget designed for "reflects everything, verifies nothing".
 const BLOCKED_STREAK_LIMIT: u32 = 64;
 
 /// True for statuses that signal the endpoint will not yield a DOM verification
@@ -1600,6 +1610,9 @@ const BLOCKED_STREAK_LIMIT: u32 = 64;
 /// WAF blocks are intentionally excluded (see [`BLOCKED_STREAK_LIMIT`]); `0`
 /// (request error) is likewise not blocking — a transient network error should
 /// not, on its own, end the phase.
+///
+/// Status alone is not the whole test: see [`next_blocked_streak`], which
+/// additionally spares a 5xx that reflected the payload.
 fn is_blocking_dom_status(status: u16) -> bool {
     status >= 500
 }
@@ -1615,9 +1628,14 @@ fn next_inert_echo_count(prev: u32, reflected: bool) -> u32 {
 /// Fold one DOM response's status into the consecutive blocked streak: increment
 /// on a blocking status, reset to 0 otherwise. The reset is what makes the
 /// streak *consecutive* (one good response clears it), preserving recall on
-/// intermittently-failing endpoints. Pure for unit testing.
-fn next_blocked_streak(prev: u32, status: u16) -> u32 {
-    if is_blocking_dom_status(status) {
+/// intermittently-failing endpoints.
+///
+/// `reflected` spares the responses a 5xx status alone would condemn: a server
+/// error that hands our payload back is a rendered error page, not a dead
+/// server, and error pages are a first-class XSS sink (see
+/// [`BLOCKED_STREAK_LIMIT`]). Pure for unit testing.
+fn next_blocked_streak(prev: u32, status: u16, reflected: bool) -> u32 {
+    if is_blocking_dom_status(status) && !reflected {
         prev + 1
     } else {
         0
@@ -2323,7 +2341,7 @@ impl ScanWorkerCtx {
             // false`) must not be miscounted as an inert echo.
             if !dom_verified {
                 inert_echo_count = next_inert_echo_count(inert_echo_count, reflected);
-                blocked_streak = next_blocked_streak(blocked_streak, status);
+                blocked_streak = next_blocked_streak(blocked_streak, status, reflected);
             }
             if let Some(ref pb) = self.pb {
                 pb.inc(1);

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -959,14 +959,44 @@ fn test_is_blocking_dom_status_is_5xx_only() {
 
 #[test]
 fn test_next_blocked_streak_resets_on_non_block() {
-    // Consecutive 5xx accumulate…
-    assert_eq!(next_blocked_streak(0, 503), 1);
-    assert_eq!(next_blocked_streak(63, 503), 64);
+    // Consecutive silent 5xx accumulate…
+    assert_eq!(next_blocked_streak(0, 503, false), 1);
+    assert_eq!(next_blocked_streak(63, 503, false), 64);
     // …but ANY non-5xx response resets the streak to 0 — this is what makes the
     // streak *consecutive*, so 64 non-consecutive blocks never early-exit.
-    assert_eq!(next_blocked_streak(63, 200), 0);
-    assert_eq!(next_blocked_streak(63, 403), 0); // 4xx WAF block does not count
-    assert_eq!(next_blocked_streak(63, 0), 0); // request error does not count
+    assert_eq!(next_blocked_streak(63, 200, false), 0);
+    assert_eq!(next_blocked_streak(63, 403, false), 0); // 4xx WAF block does not count
+    assert_eq!(next_blocked_streak(63, 0, false), 0); // request error does not count
+}
+
+/// A 5xx that echoes the payload is a rendered error page, not a dead server.
+///
+/// Regression guard: framework development error pages (Kemal, Werkzeug, Rails,
+/// Symfony) reflect the request path / query string / an exception message built
+/// from user input, and they are a 500 by construction — GHSA-2x8p-5jvx-v7jw is
+/// exactly this shape. Counting them toward the streak ended the DOM phase after
+/// `BLOCKED_STREAK_LIMIT` payloads, so the parameter could only ever be reported
+/// `[R]` even though `--deep-scan` verifies it as `[V]`. Fan-out on these
+/// endpoints is bounded by `INERT_ECHO_BUDGET` instead, which is the budget
+/// meant for "reflects everything, verifies nothing".
+#[test]
+fn test_next_blocked_streak_spares_reflecting_error_pages() {
+    // A reflecting 5xx never accumulates, no matter how long the run.
+    assert_eq!(next_blocked_streak(0, 500, true), 0);
+    assert_eq!(next_blocked_streak(63, 500, true), 0);
+    assert_eq!(next_blocked_streak(63, 503, true), 0);
+    // …and it clears a streak built by preceding silent errors, exactly like any
+    // other response that proves the endpoint is still rendering.
+    assert_eq!(
+        next_blocked_streak(next_blocked_streak(0, 500, false), 500, true),
+        0
+    );
+    // The early exit therefore never fires on this endpoint via the streak.
+    assert!(!dom_phase_should_early_exit(
+        false,
+        0,
+        next_blocked_streak(63, 500, true)
+    ));
 }
 
 #[test]

--- a/tests/error_page_recall_test.rs
+++ b/tests/error_page_recall_test.rs
@@ -1,0 +1,263 @@
+//! End-to-end recall guards for the *interaction* between a real sink and the
+//! scanner's fan-out cuts.
+//!
+//! Both regressions these cover shipped while their ingredients were already
+//! under test — and that is the point of this file:
+//!
+//! * `src/scanning/mod.rs` unit-tests every cut helper (`next_blocked_streak`,
+//!   `dom_phase_should_early_exit`, …) in isolation, which says nothing about
+//!   whether a cut fires while a real vulnerability is still undiscovered.
+//! * `tests/functional/mock_cases/realworld/framework_error_pages.toml` has 5xx
+//!   error-page cases, and other corpus files have `<title>` sinks — but no case
+//!   combines them, and the corpus runner is `#[ignore]`d out of CI anyway.
+//! * `mining::tests::test_probe_dictionary_params_sentinel_pre_probe_collapses`
+//!   asserted the collapse for the whole life of the `any` bug, because it
+//!   starts from an *empty* parameter set and so could never observe the
+//!   deletion.
+//!
+//! So these two tests deliberately sit at the intersection: a target where the
+//! cut *does* fire, and detection is only correct if it fires without taking
+//! the finding with it. Both run by default — no `#[ignore]`.
+
+use axum::Router;
+use axum::extract::Query;
+use axum::http::{HeaderMap, HeaderValue, StatusCode};
+use axum::routing::get;
+use dalfox::cmd::scan::{ScanArgs, run_scan};
+use std::collections::HashMap;
+use std::path::{Path, PathBuf};
+use std::time::{SystemTime, UNIX_EPOCH};
+use tokio::net::TcpListener;
+
+fn html_headers() -> HeaderMap {
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "content-type",
+        HeaderValue::from_static("text/html; charset=utf-8"),
+    );
+    headers
+}
+
+fn escape(s: &str) -> String {
+    s.replace('&', "&amp;")
+        .replace('<', "&lt;")
+        .replace('>', "&gt;")
+        .replace('"', "&quot;")
+}
+
+/// Two targets, each modelled on a real application:
+///
+/// `/boom` — a framework development error page. Kemal, Werkzeug, Rails and
+/// Symfony all build the page title from the exception message, applications
+/// build that message from user input (`raise "User #{name} not found"`), and
+/// the response is a **500 by construction**. The sink is inside `<title>`, so
+/// every ordinary HTML payload is echoed inert and only an end-tag breakout can
+/// verify — the payload arrives well after the first response. That is exactly
+/// the window in which a "the server is failing, give up" heuristic can eat the
+/// finding. (Kemal GHSA-2x8p-5jvx-v7jw.)
+///
+/// `/echo` — a page that dumps every query parameter it received (escaped, so
+/// the dump itself is inert) *and* reflects `name` into the document raw. The
+/// dump makes an arbitrary parameter name appear to reflect, which is what
+/// trips Stage 2's "this target echoes everything" collapse; `name` is the real
+/// vulnerability the collapse must not take with it.
+async fn spawn_app() -> (String, tokio::task::JoinHandle<()>) {
+    let app = Router::new()
+        .route(
+            "/boom",
+            get(|q: Query<HashMap<String, String>>| async move {
+                let name = q.get("name").cloned().unwrap_or_default();
+                let mut names: Vec<&String> = q.keys().collect();
+                names.sort();
+                let dump: String = names
+                    .iter()
+                    .map(|k| {
+                        format!(
+                            "<dt>{}</dt><dd><pre>{}</pre></dd>",
+                            escape(k),
+                            escape(q.get(*k).map(String::as_str).unwrap_or(""))
+                        )
+                    })
+                    .collect();
+                (
+                    StatusCode::INTERNAL_SERVER_ERROR,
+                    html_headers(),
+                    // The shape these pages actually have: the message is raw in
+                    // <title> (the sink) and escaped everywhere it is displayed,
+                    // plus a dump of the request that echoes every parameter.
+                    format!(
+                        "<html><head><title>Internal Server Error at GET /boom - \
+                         User '{name}' not found</title></head><body>\
+                         <h1 class=\"title\">User '{escaped}' not found</h1>\
+                         <div class=\"trace\"><pre>app.rb:42:in `lookup'\n  \
+                         raise \"User '{escaped}' not found\"</pre></div>\
+                         <h3>Query params</h3><dl>{dump}</dl></body></html>",
+                        escaped = escape(&name)
+                    ),
+                )
+            }),
+        )
+        .route(
+            "/echo",
+            get(|q: Query<HashMap<String, String>>| async move {
+                let mut names: Vec<&String> = q.keys().collect();
+                names.sort();
+                let rows: String = names
+                    .iter()
+                    .map(|k| {
+                        format!(
+                            "<tr><td>{}</td><td>{}</td></tr>",
+                            escape(k),
+                            escape(q.get(*k).map(String::as_str).unwrap_or(""))
+                        )
+                    })
+                    .collect();
+                let raw = q.get("name").cloned().unwrap_or_default();
+                (
+                    html_headers(),
+                    format!(
+                        "<html><body><table>{rows}</table><div id=out>{raw}</div></body></html>"
+                    ),
+                )
+            }),
+        );
+
+    let listener = TcpListener::bind("127.0.0.1:0").await.expect("bind");
+    let addr = listener.local_addr().expect("addr");
+    let handle = tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    (format!("http://{}", addr), handle)
+}
+
+fn unique_temp_path(prefix: &str) -> PathBuf {
+    let mut path = std::env::temp_dir();
+    let nanos = SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .expect("system time")
+        .as_nanos();
+    path.push(format!(
+        "dalfox-{}-{}-{}.json",
+        prefix,
+        std::process::id(),
+        nanos
+    ));
+    path
+}
+
+/// Discovery stays ON (the target's own `name` param is the point of both
+/// tests); everything not under test is switched off to keep the runs quick.
+fn base_args(target: &str, output: &Path) -> ScanArgs {
+    ScanArgs {
+        input_type: "url".to_string(),
+        format: "json".to_string(),
+        output: Some(output.to_string_lossy().to_string()),
+        silence: true,
+        targets: vec![target.to_string()],
+        skip_reflection_header: true,
+        skip_reflection_cookie: true,
+        skip_reflection_path: true,
+        skip_waf_probe: true,
+        skip_ast_analysis: true,
+        insecure: Some(true),
+        ..ScanArgs::default()
+    }
+}
+
+fn read_findings(path: &Path) -> Vec<serde_json::Value> {
+    let content = std::fs::read_to_string(path).expect("output should exist");
+    let parsed: serde_json::Value = serde_json::from_str(&content).expect("valid JSON");
+    parsed["findings"]
+        .as_array()
+        .cloned()
+        .unwrap_or_else(Vec::new)
+}
+
+fn summarize(findings: &[serde_json::Value]) -> Vec<String> {
+    findings
+        .iter()
+        .map(|f| {
+            format!(
+                "{}:{}",
+                f["type"].as_str().unwrap_or("?"),
+                f["param"].as_str().unwrap_or("?")
+            )
+        })
+        .collect()
+}
+
+/// A 5xx that hands our payload back is a rendered error page, not a dead
+/// server — DOM verification has to keep going long enough to reach the
+/// breakout payload that escapes `<title>`.
+///
+/// Before the fix, every response scored `status >= 500`, `blocked_streak` hit
+/// `BLOCKED_STREAK_LIMIT` (64) before any end-tag payload was tried, the DOM
+/// phase quit, and this parameter could only ever be reported `[R]` — while
+/// `--deep-scan`, which disables the cut, verified it.
+#[tokio::test]
+async fn error_page_rawtext_sink_is_verified_not_merely_reflected() {
+    let (base, server) = spawn_app().await;
+    let out = unique_temp_path("error-page-rawtext");
+    let mut args = base_args(&format!("{}/boom?name=test", base), &out);
+    // The sink is the URL's own parameter; mining would only add noise here.
+    args.skip_mining = true;
+    args.skip_mining_dict = true;
+    args.skip_mining_dom = true;
+
+    let _ = run_scan(&args).await;
+    server.abort();
+
+    let findings = read_findings(&out);
+    let _ = std::fs::remove_file(&out);
+
+    assert!(
+        findings
+            .iter()
+            .any(|f| f["type"] == "V" && f["param"] == "name"),
+        "a 500 error page reflecting `name` into <title> must be VERIFIED, not just \
+         reported reflected — got {:?}",
+        summarize(&findings)
+    );
+}
+
+/// Stage 2's collapse may fold away the parameters it mined itself; it may not
+/// take the target's own parameters with them.
+///
+/// Before the fix, `/echo`'s parameter dump made all three sentinel probes
+/// reflect, the collapse cleared every `Query` param, and the scan reported a
+/// POC against the synthetic `any` — a parameter this application does not
+/// have — while `name`, which discovery had already confirmed reflects, was
+/// gone before the payload stages ever saw it.
+#[tokio::test]
+async fn reflect_everything_page_keeps_the_parameter_the_target_really_has() {
+    let (base, server) = spawn_app().await;
+    let out = unique_temp_path("reflect-everything");
+    // Mining must run: the dictionary stage is what probes the sentinels and
+    // fires the collapse. It stays cheap precisely because the collapse fires —
+    // the wordlist is skipped after three probes.
+    let args = base_args(&format!("{}/echo?name=test", base), &out);
+
+    let _ = run_scan(&args).await;
+    server.abort();
+
+    let findings = read_findings(&out);
+    let _ = std::fs::remove_file(&out);
+
+    assert!(
+        !findings.is_empty(),
+        "the raw `name` reflection must still be found at all"
+    );
+    assert!(
+        findings.iter().any(|f| f["param"] == "name"),
+        "the collapse must not delete the parameter the target actually carries \
+         — got {:?}",
+        summarize(&findings)
+    );
+    assert!(
+        findings
+            .iter()
+            .any(|f| f["type"] == "V" && f["param"] == "name"),
+        "`name` reflects raw into the document, so it must verify — got {:?}",
+        summarize(&findings)
+    );
+}


### PR DESCRIPTION
Two independent cost-control heuristics each dropped a real vulnerability on the same class of target — a framework development error page. Reproduced against Kemal ([GHSA-2x8p-5jvx-v7jw](https://github.com/kemalcr/kemal/security/advisories/GHSA-2x8p-5jvx-v7jw)) on **both v3.2.0 and main**: dalfox reported a POC against a parameter the application does not have, and zero findings for the one that was actually vulnerable.

```
before:  WRN XSS found 0 XSS (+1 R)
         [POC][R] /user-lookup?name=test&any=<svg onload=alert(1) ...>   <- `any` does not exist

after:   WRN XSS found 1 XSS (+2 R)
         [POC][V] /user-lookup?name=</title><IMG src=x onerror=alert(1) ...>
```

## 1. Stage 2 mining collapse deleted what Stage 1 discovery had found

`collapse_to_any_query_param` and the three EWMA post-collapse blocks cleared **every** param at a `Location` and pushed a synthetic `any`. On a page that echoes its whole query string — a debug endpoint, an error page that dumps `request.query_params` — the sentinel pre-probe fired and the genuinely vulnerable parameter was erased before Stage 3 ever saw it. The EWMA blocks additionally copied the *first* param's measured `valid_specials` onto `any`, so a finding carried one parameter's evidence under another parameter's name.

Collapse is a cost control — don't iterate a wordlist on a page that echoes everything — not a statement that the target's own parameters are uninteresting. The five sites are now one `collapse_mined_params`, which folds away only what the stage itself mined; every `probe_*` snapshots the pre-existing slots before it pushes anything. A target that genuinely carries a parameter called `any` keeps it.

## 2. `is_blocking_dom_status` treated every 5xx as a dead server

Its premise — *"an error page cannot carry executable evidence"* — is false. Framework development error pages (Kemal, Werkzeug, Rails, Symfony) render the request path, the query string, or an exception message built from user input, and they are a **500 by construction**. Every payload scored as blocked, `blocked_streak` hit its limit of 64 before the end-tag breakout payload was tried, the DOM phase quit, and the parameter could only ever be reported `[R]` — while `--deep-scan`, which disables the cut, verified **77 [V]** on the same target.

A 5xx that *reflects* the payload now resets the streak. Fan-out stays bounded by `INERT_ECHO_BUDGET`, the budget meant for "reflects everything, verifies nothing", and `classify_reflection` keeps sanitizing endpoints out of that budget.

## Why a green suite missed both

- The cut helpers (`next_blocked_streak`, `dom_phase_should_early_exit`) are unit-tested **in isolation**, which says nothing about a cut firing while a real finding is still pending.
- The corpus has 5xx error-page cases (`realworld/framework_error_pages.toml`) and `<title>` sinks in 10 other files — but **no case combines them**, and `test_realworld_xss_scenarios` is `#[ignore]`d out of CI anyway.
- `test_probe_dictionary_params_sentinel_pre_probe_collapses` asserted the collapse for the whole life of this bug because it starts from an **empty** parameter set, so the deletion was unobservable.

`tests/error_page_recall_test.rs` supplies the missing intersection: a target where the cut fires *and* a real finding is still pending. Both tests run by default (no `#[ignore]`, 0.8s) and were verified to fail without each fix.

> Note on fixture fidelity: the first cut of that fixture used a bare `<title>` sink and **passed on the unfixed code** — the breakout payload landed inside the streak window. It only reproduces once the mock matches the real page shape (raw payload in `<title>` + escaped copies in `<h1>`/traceback + a dump of every query param).

## Cost

| target | before | after |
|---|---|---|
| vulnerable Kemal | 89 req, 0 XSS | 776 req, **1 [V]** |
| patched Kemal | 89 req, 0 XSS | 922 req, 0 XSS (no FP) |

Bounded by `INERT_ECHO_BUDGET` (256/param). Endpoints returning < 500 are unaffected: `next_blocked_streak` already returned 0 for them regardless of `reflected`.

## Verification

- 2261 lib tests + all integration bins green; `clippy`/`fmt` clean
- 4 new regression tests + 2 new e2e tests, **all mutation-verified in both directions** (fail without the fix, pass with it)
- End-to-end against a real Kemal build, vulnerable and patched
- Sibling sweep: all 5 collapse sites unified, no destructive `clear()` left in `mining.rs`. Three further 5xx-skip sites in mining (`mining.rs:806/1174/1299`) were reviewed and **deliberately left** — they suppress mining FP explosion on error pages and are a separate trade-off.