### PR TITLE
docs: add --inject-marker usage examples (query + header)

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,6 +83,8 @@ dalfox [mode] [target] [flags]
 * Single URL: `dalfox scan http://example.com -b https://callback`
 * File Mode: `dalfox scan urls.txt --custom-payload mypayloads.txt`
 * Pipeline: `cat urls.txt | dalfox scan --headers "AuthToken: xxx"`
+* Custom injection point (query): `dalfox scan 'https://example.com/?q=FUZZ&page=1' --inject-marker FUZZ`
+* Custom injection point (header): `dalfox scan https://example.com -H 'X-Search: FUZZ' --inject-marker FUZZ`
 
 Check the [CLI reference](https://dalfox.hahwul.com/reference/cli/) and [Quick start](https://dalfox.hahwul.com/getting-started/quick-start/) documents for more examples.
 

--- a/docs/content/guide/parameters.ko.md
+++ b/docs/content/guide/parameters.ko.md
@@ -127,6 +127,16 @@ dalfox https://target.app/api \
 
 Dalfox는 모든 `FUZZ`를 각 페이로드로 치환해 요청을 보냅니다.
 
+쿼리 파라미터나 헤더를 직접 지정할 수도 있습니다:
+
+```bash
+# 쿼리 파라미터
+dalfox scan 'https://example.com/?q=FUZZ&page=1' --inject-marker FUZZ
+
+# 헤더
+dalfox scan https://example.com -H 'X-Search: FUZZ' --inject-marker FUZZ
+```
+
 ## 자동 사전 인코딩(Auto pre-encoding)
 
 일부 엔드포인트는 페이로드를 원시 텍스트로 받아들이지 않습니다. 이들은 어떤 구조적 인코딩(base64, JSON, JWT 등)으로 감싸진 형태를 기대합니다. Dalfox는 탐색 중 각 파라미터의 기존 값을 검사하고, 구조를 알아보면 페이로드가 같은 래핑을 그대로 거쳐 왕복(round-trip)하도록 투명한 인코딩 파이프라인을 구성합니다. 설정할 것은 없습니다. 디버그 출력에서 `pre_encoding`이나 `pre_encoding_pipeline`을 찾아보세요.

--- a/docs/content/guide/parameters.md
+++ b/docs/content/guide/parameters.md
@@ -127,6 +127,16 @@ dalfox https://target.app/api \
 
 Dalfox replaces every `FUZZ` with each payload and sends the request.
 
+You can also target a query parameter or a header directly:
+
+```bash
+# Query parameter
+dalfox scan 'https://example.com/?q=FUZZ&page=1' --inject-marker FUZZ
+
+# Header
+dalfox scan https://example.com -H 'X-Search: FUZZ' --inject-marker FUZZ
+```
+
 ## Auto pre-encoding
 
 Some endpoints don't accept a payload as raw text. They expect it wrapped in some structural encoding (base64, JSON, JWT, and so on). Dalfox inspects each parameter's existing value during discovery and, when it recognises a structure, builds a transparent encoding pipeline so payloads round-trip through the same wrapping. There's nothing to configure: look for `pre_encoding` or `pre_encoding_pipeline` in debug output.


### PR DESCRIPTION
Closes #1332

Adds two worked --inject-marker examples (query parameter + header) to:
- README.md (Usage section)
- docs/content/guide/parameters.md — extends the existing "Injection markers" section
- docs/content/guide/parameters.ko.md — matching KO translation

`just docs-lint` passes (22/22 checks).