### PR TITLE
waf: add Wallarm, NAXSI, and SafeLine fingerprint rules

### DIFF
--- a/src/waf/bypass.rs
+++ b/src/waf/bypass.rs
@@ -372,6 +372,12 @@ pub fn get_bypass_strategy(waf: &WafType) -> BypassStrategy {
             ],
             extra_delay_hint_ms: 0,
         },
+        // No WAF-specific mutation strategy yet; use the conservative
+        // generic strategy until fingerprint-specific bypass behavior is
+        // validated.
+        WafType::Wallarm => unknown_strategy_for("Wallarm"),
+        WafType::Naxsi => unknown_strategy_for("NAXSI"),
+        WafType::SafeLine => unknown_strategy_for("SafeLine"),
         WafType::Unknown(hint) => unknown_strategy_for(hint),
     }
 }

--- a/src/waf/mod.rs
+++ b/src/waf/mod.rs
@@ -37,6 +37,13 @@ pub enum WafType {
     /// `Connection` header (`nnCoection` / `Cneonction`) and `citrix_ns_id`
     /// / `ns_af` persistence cookies.
     Citrix,
+    /// Wallarm. Fingerprinted by its `Server: nginx-wallarm` header.
+    Wallarm,
+    /// NAXSI (Nginx Anti XSS & SQL Injection). Fingerprinted by the
+    /// `X-Data-Origin: naxsi` header or "blocked by naxsi" body text.
+    Naxsi,
+    /// SafeLine. Fingerprinted by its `sl-session` cookie.
+    SafeLine,
     Unknown(String),
 }
 
@@ -58,6 +65,9 @@ impl std::fmt::Display for WafType {
             WafType::Fastly => write!(f, "Fastly"),
             WafType::Wordfence => write!(f, "Wordfence"),
             WafType::Citrix => write!(f, "Citrix NetScaler"),
+            WafType::Wallarm => write!(f, "Wallarm"),
+            WafType::Naxsi => write!(f, "NAXSI"),
+            WafType::SafeLine => write!(f, "SafeLine"),
             WafType::Unknown(hint) => write!(f, "Unknown ({})", hint),
         }
     }
@@ -154,6 +164,9 @@ fn parse_waf_type_from_rule(name: &str) -> WafType {
         "Fastly" => WafType::Fastly,
         "Wordfence" => WafType::Wordfence,
         "Citrix" => WafType::Citrix,
+        "Wallarm" => WafType::Wallarm,
+        "Naxsi" => WafType::Naxsi,
+        "SafeLine" => WafType::SafeLine,
         other => WafType::Unknown(other.to_string()),
     }
 }

--- a/src/waf/rules.toml
+++ b/src/waf/rules.toml
@@ -325,6 +325,30 @@ waf_type = "Citrix"
 confidence = 0.85
 evidence_label = "ns_af AppFirewall cookie (NetScaler)"
 
+# Wallarm
+[[header]]
+header = "server"
+value_contains = "nginx-wallarm"
+waf_type = "Wallarm"
+confidence = 0.9
+evidence_label = "Server: nginx-wallarm"
+
+# NAXSI
+[[header]]
+header = "x-data-origin"
+value_contains = "naxsi"
+waf_type = "Naxsi"
+confidence = 0.9
+evidence_label = "x-data-origin: naxsi header"
+
+# SafeLine
+[[header]]
+header = "set-cookie"
+value_contains = "sl-session="
+waf_type = "SafeLine"
+confidence = 0.85
+evidence_label = "sl-session cookie (SafeLine)"
+
 
 # ── Body rules ──────────────────────────────────────────────────────────
 
@@ -501,3 +525,10 @@ pattern = "google cloud armor"
 waf_type = "CloudArmor"
 confidence = 0.9
 evidence_label = "Google Cloud Armor in body"
+
+# NAXSI
+[[body]]
+pattern = "blocked by naxsi"
+waf_type = "Naxsi"
+confidence = 0.85
+evidence_label = "NAXSI block message in body"

--- a/src/waf/tests.rs
+++ b/src/waf/tests.rs
@@ -183,6 +183,9 @@ fn rules_toml_loads_and_covers_all_waf_families() {
         "Fastly",
         "Wordfence",
         "Citrix",
+        "Wallarm",
+        "Naxsi",
+        "SafeLine",
     ] {
         assert!(
             waf_names.contains(expected),
@@ -645,4 +648,34 @@ fn test_parse_waf_type_from_rule_named_and_fallback() {
         parse_waf_type_from_rule(""),
         WafType::Unknown(String::new()),
     );
+}
+
+#[test]
+fn test_wallarm_detection_by_header() {
+    let headers = make_headers(&[("server", "nginx-wallarm")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Wallarm));
+    assert!(result.primary().unwrap().confidence >= 0.9);
+}
+
+#[test]
+fn test_naxsi_detection_by_header() {
+    let headers = make_headers(&[("x-data-origin", "naxsi")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::Naxsi));
+}
+
+#[test]
+fn test_naxsi_detection_by_body() {
+    let headers = make_headers(&[]);
+    let body = "Request blocked by naxsi";
+    let result = fingerprint_from_response(&headers, Some(body), 403);
+    assert!(result.waf_types().contains(&&WafType::Naxsi));
+}
+
+#[test]
+fn test_safeline_detection_by_cookie() {
+    let headers = make_headers(&[("set-cookie", "sl-session=abc123; Path=/; Secure")]);
+    let result = fingerprint_from_response(&headers, None, 200);
+    assert!(result.waf_types().contains(&&WafType::SafeLine));
 }


### PR DESCRIPTION
## Summary

Adds fingerprinting support for three additional WAFs:

* **Wallarm** — detected via `Server: nginx-wallarm`
* **NAXSI** — detected via `X-Data-Origin: naxsi` and `blocked by naxsi` body text
* **SafeLine** — detected via the `sl-session=` cookie

### Changes

* Added `Wallarm`, `Naxsi`, and `SafeLine` variants to `WafType`
* Added their `Display` implementations and rule-name parsing
* Added header/body fingerprint rules to `src/waf/rules.toml`
* Added detection tests for all three WAFs, including both NAXSI signatures
* Updated the WAF bypass strategy match to handle the new WAF variants using the existing conservative generic strategy until WAF-specific bypass behavior is validated
* Updated the WAF family coverage test

### Validation

* `cargo fmt --check`
* `cargo build --lib`
* `cargo test --lib waf` — **144 passed, 0 failed**
* `cargo clippy --lib -- -D warnings`
* `git diff --check`

Closes #1326
