### PR TITLE
feat: add completion subcommand (#1325)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -332,6 +332,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "clap_complete"
+version = "4.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3be2ad0423bdbbb0e25bc89add796f3559706d4a95e1bc98e4d9662a957b6a19"
+dependencies = [
+ "clap",
+]
+
+[[package]]
 name = "clap_derive"
 version = "4.6.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -546,6 +555,7 @@ dependencies = [
  "base64 0.23.1",
  "chrono",
  "clap",
+ "clap_complete",
  "clap_mangen",
  "console",
  "ctr",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,6 +69,7 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
 sha2_oaep = { package = "sha2", version = "0.10" }
 clap_mangen = "0.3"
+clap_complete = "4.6.9"
 
 [profile.release]
 lto = true

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -17,6 +17,7 @@ dalfox [SUBCOMMAND] [TARGET] [FLAGS]
 | `server` | Run a REST API server |
 | `payload` | List or fetch built-in/remote payloads |
 | `mcp` | Run a Model Context Protocol stdio server |
+| `completion` | Generate a shell completion script |
 | `help` | Print help for any subcommand |
 
 ## Global flags
@@ -267,6 +268,29 @@ dalfox mcp
 No additional flags. See [MCP Server](../../integrations/mcp/) for tool definitions.
 
 ---
+
+## `dalfox completion`
+
+Generate a shell completion script and print it to stdout.
+
+```bash
+dalfox completion <SHELL>
+```
+
+Supported shells: `bash`, `zsh`, `fish`, `powershell`, `elvish`.
+
+```bash
+# bash
+dalfox completion bash > /etc/bash_completion.d/dalfox
+
+# zsh
+dalfox completion zsh > "${fpath[1]}/_dalfox"
+
+# fish
+dalfox completion fish > ~/.config/fish/completions/dalfox.fish
+```
+
+Nothing else is written to stdout, so the output can always be safely redirected to a file.
 
 ## See also
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -4,7 +4,7 @@ Happy hacking :D
 */
 
 use clap::{CommandFactory, FromArgMatches, Parser, Subcommand};
-
+use clap_complete::{Shell, generate};
 use dalfox::cmd::scan::ScanOutcome;
 use dalfox::{DEBUG, cmd, config, mcp, server, utils};
 
@@ -64,6 +64,11 @@ enum Commands {
     Payload(cmd::payload::PayloadArgs),
     /// Run MCP stdio server (Model Context Protocol) exposing Dalfox tools
     Mcp,
+    /// Generate shell completion scripts
+    Completion {
+        /// Shell to generate completions for
+        shell: Shell,
+    },
     /// Generate a roff man page and print it to stdout
     #[clap(hide = true)]
     Man,
@@ -185,9 +190,19 @@ async fn main() {
 
     // Keep man-page output as pure roff by handling it before the
     // banner/config machinery writes anything else to stdout.
-    if let Some(Commands::Man) = &cli.command {
-        print_man_page();
-        return;
+    if let Some(command) = &cli.command {
+        match command {
+            Commands::Man => {
+                print_man_page();
+                return;
+            }
+            Commands::Completion { shell } => {
+                let mut cmd = Cli::command();
+                generate(*shell, &mut cmd, "dalfox", &mut std::io::stdout());
+                return;
+            }
+            _ => {}
+        }
     }
 
     // Set global debug toggle for downstream modules
@@ -440,6 +455,8 @@ async fn main() {
                 }
                 outcome = ScanOutcome::Clean;
             }
+
+            Commands::Completion { .. } => unreachable!(),
 
             // `dalfox man` is handled immediately after parsing so this arm
             // should never execute. It exists only for match exhaustiveness.


### PR DESCRIPTION
 

**Closes #1325**

### Summary

Adds a `dalfox completion <shell>` subcommand that prints a shell completion script to stdout, using `clap_complete`.

### Changes

- Added `clap_complete = "4.6.9"` to `Cargo.toml`
- Added `Commands::Completion { shell: Shell }` to the CLI's subcommand enum in `src/main.rs`
- Handled before the config/banner machinery runs (same pattern as the existing `man` subcommand), so `dalfox completion <shell>` writes only the generated script to stdout — nothing else
- Documented the new subcommand in `docs/content/reference/cli.md` (subcommand table + a `## dalfox completion` reference section)

### Usage

```bash
dalfox completion bash > /etc/bash_completion.d/dalfox
dalfox completion zsh > "${fpath[1]}/_dalfox"
dalfox completion fish > ~/.config/fish/completions/dalfox.fish
dalfox completion powershell > dalfox.ps1
dalfox completion elvish > dalfox.elv
```

Supported shells (from `clap_complete::Shell`): `bash`, `elvish`, `fish`, `powershell`, `zsh`.

### Testing

- `cargo build` — clean
- Verified all five shells produce valid completion scripts with no extraneous output on stdout:
```bash
  for s in bash zsh fish powershell elvish; do
    dalfox completion "$s" | head -5
  done
```