### PR TITLE
refactor(job): one scan-execution core for the REST server and MCP

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -17,6 +17,8 @@ use serde::{Deserialize, Serialize};
 use crate::scanning::result::SanitizedResult;
 use crate::target_parser::Target;
 
+pub(crate) mod runner;
+
 /// Status of an asynchronous scan job (used by both REST server and MCP).
 #[derive(Debug, Clone, PartialEq, Eq, Serialize, Deserialize)]
 #[serde(rename_all = "lowercase")]
@@ -455,7 +457,7 @@ pub async fn send_reachability_probe(target: &Target) -> bool {
             .join("; ");
         req = req.header("Cookie", cookie_header);
     }
-    if let Some(ua) = target.user_agent.as_deref().filter(|s| !s.is_empty()) {
+    if let Some(ua) = target.effective_user_agent() {
         req = req.header("User-Agent", ua);
     }
     if let Some(body) = &target.data {

--- a/src/job/runner.rs
+++ b/src/job/runner.rs
@@ -1,0 +1,395 @@
+//! The scan-execution core shared by the REST server and the MCP runtime.
+//!
+//! Both interfaces used to carry their own copy of this: ~280 lines that were
+//! character-for-character identical apart from one log call, kept in step by
+//! comments telling each side to mirror the other. That worked until it did
+//! not — a run of parity fixes (blind-XSS dispatch, the initial AST pass,
+//! session-loss detection, per-job WAF backoff) each had to be applied twice,
+//! and each was reported because one side had been missed.
+//!
+//! What genuinely differs between the two stays with them: how a job record is
+//! claimed and stored (the REST server holds jobs behind a `tokio::sync::Mutex`,
+//! MCP behind a `std::sync::Mutex`), how options become a `ScanArgs`, and the
+//! REST-only completion webhook. Everything from "hydrate the target" to
+//! "the scan finished and here is what it left behind" lives here.
+
+use std::sync::Arc;
+use std::sync::atomic::AtomicBool;
+
+use tokio::sync::Mutex;
+
+use super::{AbortOnDrop, JobProgress, cap_reflection_params, run_within_scan_budget};
+use crate::cmd::scan::ScanArgs;
+use crate::parameter_analysis::analyze_parameters;
+use crate::scanning::result::Result as ScanResult;
+use crate::target_parser::{Target, parse_target};
+
+/// Ceiling on parameters carried into the scan phase, named in the warning
+/// below. Defined one level up in `job`; the REST server only re-exports it.
+use super::MAX_DISCOVERED_PARAMS;
+
+/// Build the `Target` a job scans from its `ScanArgs`.
+///
+/// `Err` carries the operator-facing message; the caller decides how its own
+/// job store records the failure.
+///
+/// `user_agent` is normalized to `Some("")` when none was supplied, which is
+/// this codebase's sentinel for "no override" — the CLI sets it the same way
+/// (`cmd::scan::input`). Consumers must empty-check before putting it on the
+/// wire; `utils::http::apply_headers_ua_cookies` does.
+pub(crate) fn hydrate_target(url: &str, args: &ScanArgs) -> Result<Target, String> {
+    let mut t = parse_target(url).map_err(|e| format!("parse_target failed: {}", e))?;
+    t.method = args.method.clone();
+    t.timeout = args.timeout;
+    t.delay = args.delay;
+    t.proxy = args.proxy.clone();
+    t.insecure = args.insecure.unwrap_or(true);
+    t.follow_redirects = args.follow_redirects;
+    t.ignore_return = args.ignore_return.clone();
+    t.workers = args.workers;
+    t.data = args.data.clone();
+    t.headers = args
+        .headers
+        .iter()
+        .filter_map(|h| crate::utils::http::parse_header_line(h))
+        .collect();
+    // A supplied User-Agent is also pushed as a header so the header-reflection
+    // probe exercises it even on blanket-echo targets, where the common header
+    // sweep is suppressed. An empty value means "no override", so it must not
+    // become a literal `User-Agent:` on every request.
+    if let Some(ua) = args.user_agent.as_deref().filter(|s| !s.is_empty()) {
+        t.headers.push(("User-Agent".to_string(), ua.to_string()));
+        t.user_agent = Some(ua.to_string());
+    } else {
+        t.user_agent = Some(String::new());
+    }
+    t.cookies = args
+        .cookies
+        .iter()
+        .flat_map(|c| super::split_cookie_pairs(c))
+        .collect();
+    Ok(t)
+}
+
+/// What a finished scan left behind, for the caller to record in its own job
+/// store. `results` is the live accumulator the scan wrote into.
+pub(crate) struct ScanRun {
+    pub(crate) results: Arc<Mutex<Vec<ScanResult>>>,
+    /// The whole-scan wall-clock budget expired (`scan_timeout`).
+    pub(crate) timed_out: bool,
+    /// The cancellation flag was set — by the caller, or by the budget above.
+    pub(crate) was_cancelled: bool,
+    /// A worker task panicked, so at least one parameter is unfinished. Never
+    /// set together with `was_cancelled`, which is partial by design and wins.
+    pub(crate) panicked: bool,
+    /// How many worker tasks panicked, for the operator-facing message.
+    pub(crate) worker_panics: usize,
+    /// The authenticated session was gone, with the signal that fired.
+    pub(crate) session_lost: Option<String>,
+}
+
+impl ScanRun {
+    /// The scan completed but its findings cannot be trusted, so it must not
+    /// settle as a clean `done`. Cancellation still takes precedence.
+    pub(crate) fn lost_session(&self) -> bool {
+        !self.was_cancelled && self.session_lost.is_some()
+    }
+}
+
+/// Run one job's scan to completion and report what it left behind.
+///
+/// `warn` receives operator-facing warnings so each interface can route them
+/// through its own logger — the single line that differed between the two
+/// copies this replaces.
+pub(crate) async fn execute_scan(
+    target: &mut Target,
+    args: &Arc<ScanArgs>,
+    progress: &JobProgress,
+    cancel_flag: &Arc<AtomicBool>,
+    warn: &(dyn Fn(&str) + Send + Sync),
+) -> ScanRun {
+    let args = args.clone();
+    let cancel_flag = cancel_flag.clone();
+    let results = Arc::new(Mutex::new(Vec::<ScanResult>::new()));
+    // Per-job WAF consecutive-block counter so one scan's WAF backoff doesn't
+    // throttle an unrelated scan.
+    //
+    // For the request counter, we scope `progress.requests_sent` directly
+    // instead of a private local atomic — every `crate::tick_request_count()`
+    // call then writes through to the publicly visible progress field, so
+    // GET /scan/{id} returns a live `requests_sent` value during the scan
+    // instead of `0` until completion.
+    let job_waf_consecutive = Arc::new(std::sync::atomic::AtomicU32::new(0));
+    // `run_scanning`'s 6th argument is the running findings tally, not a
+    // parameter counter (see scanning/mod.rs:findings_count). Older code
+    // here called it `param_counter` and stored it into `params_tested`,
+    // which conflated two unrelated metrics.
+    let findings_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+
+    // Mirror the in-flight findings tally into `progress.findings_so_far`
+    // periodically so pollers see a non-zero value before the scan finishes.
+    // The types differ (`AtomicUsize` inside scanning, `AtomicU64` in the
+    // public progress struct), which is why a copying task is needed.
+    let progress_findings = progress.findings_so_far.clone();
+    let findings_count_for_updater = findings_count.clone();
+    // RAII abort — covers the panic path too, not just the manual abort below.
+    let findings_updater = AbortOnDrop(tokio::spawn(async move {
+        let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
+        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
+        loop {
+            tick.tick().await;
+            progress_findings.store(
+                findings_count_for_updater.load(std::sync::atomic::Ordering::Relaxed) as u64,
+                std::sync::atomic::Ordering::Relaxed,
+            );
+        }
+    }));
+
+    // Captured from inside the scoped/async blocks below so worker-panic count
+    // survives past the scan; assigned by the run_scanning call.
+    let mut scan_report = crate::scanning::ScanRunReport::default();
+    // Set (from inside the scoped block below) when this job's authenticated
+    // session was gone — either before the scan began or by the time it ended.
+    // Carries the signal that fired, verbatim into `error_message`.
+    let mut session_lost: Option<String> = None;
+    let scan_fut = crate::with_job_rate_limiter(
+        args.rate_limit,
+        crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
+            crate::WAF_CONSECUTIVE_BLOCKS_JOB
+                .scope(job_waf_consecutive.clone(), async {
+                    if let Some(callback_url) = &args.blind_callback_url {
+                        crate::scanning::blind_scanning(
+                            target,
+                            callback_url,
+                            args.custom_blind_xss_payload.as_deref(),
+                        )
+                        .await;
+                    }
+
+                    // Session-loss detection (issue #1273), the server half.
+                    // A `dalfox server` job carrying credentials has exactly
+                    // the CLI's exposure: the session dies mid-scan, every
+                    // later request is answered by a login page, nothing
+                    // reflects, and the job settles `done` with zero findings —
+                    // indistinguishable from a clean target. Off, and free,
+                    // when no credentials were supplied.
+                    let monitor_session =
+                        crate::cmd::scan::session::monitoring_enabled(&args, target);
+                    let session_check_re =
+                        crate::cmd::scan::session::compile_session_check(&args)
+                            .ok()
+                            .flatten();
+                    let mut session_baseline = None;
+
+                    // Initial AST DOM-XSS pass on the GET response, mirroring
+                    // the CLI flow. Server used to skip this because it
+                    // didn't run preflight, so identical targets reported
+                    // 0 findings via API even when CLI saw multiple
+                    // DOM-XSS sinks (e.g. xss-game level3 with
+                    // location.hash → html). Best-effort fetch — if it
+                    // fails the regular scan path below still runs.
+                    if !args.skip_ast_analysis {
+                        let client = target.build_client_or_default();
+                        // Mirror the CLI preflight: carry the target's
+                        // headers/cookies/User-Agent (so auth/header/UA-gated
+                        // SPAs are analyzed logged-in, matching CLI findings —
+                        // a bare GET dropped them and analyzed the logged-out
+                        // page) and cap the body with `Range: 0-8191` so a large
+                        // response can't buffer unbounded into server memory.
+                        let preflight = crate::utils::build_preflight_request(
+                            &client,
+                            target,
+                            false,
+                            Some(8192),
+                        );
+                        // Count + rate-limit the preflight GET like the CLI
+                        // (record_outbound_request), so it isn't missing from the
+                        // job's requests_sent tally.
+                        crate::record_outbound_request().await;
+                        if let Ok(resp) = preflight.send().await {
+                            // Clone the headers before `read_body` consumes the
+                            // response: the posture needs both them and the
+                            // document (a page can declare its CSP with
+                            // `<meta http-equiv>`), so Trusted Types awareness
+                            // and the confidence grading's CSP signal match what
+                            // the CLI derives from preflight.
+                            let resp_headers = resp.headers().clone();
+                            // Captured before `read_body` consumes the response.
+                            // Under `follow_redirects` this is where the chain
+                            // actually ended, which is the only thing a session
+                            // baseline can meaningfully compare against.
+                            let resp_status = resp.status().as_u16();
+                            let resp_final_url = resp.url().clone();
+                            if let Ok(body) = crate::utils::http::read_body(resp).await {
+                                // Authenticated-state fingerprint, derived from
+                                // this same response so monitoring costs the
+                                // job no extra request (mirrors the CLI).
+                                // `--session-check-url` is the exception: its
+                                // baseline has to come from that endpoint, so
+                                // it falls through to the capture below.
+                                if monitor_session && args.session_check_url.is_none() {
+                                    session_baseline =
+                                        Some(crate::cmd::scan::session::baseline_from_preflight(
+                                            &target.url,
+                                            &resp_final_url,
+                                            resp_status,
+                                            &resp_headers,
+                                            &body,
+                                            session_check_re.as_ref(),
+                                        ));
+                                }
+                                let posture =
+                                    crate::scanning::ast_integration::PageSecurityPosture::from_response(
+                                        &resp_headers,
+                                        &body,
+                                    );
+                                let ast_batch =
+                                    crate::scanning::ast_integration::run_initial_ast_dom_analysis(
+                                        &body,
+                                        target.url.as_str(),
+                                        &target.method,
+                                        posture,
+                                    );
+                                if !ast_batch.is_empty() {
+                                    let added = crate::scanning::count_matching_results(
+                                        &ast_batch,
+                                        &args.limit_result_type.to_uppercase(),
+                                    );
+                                    let mut guard = results.lock().await;
+                                    guard.extend(ast_batch);
+                                    findings_count
+                                        .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
+                                }
+                                let ext_batch = crate::scanning::fetch_and_analyze_external_js(
+                                    &client,
+                                    target,
+                                    &body,
+                                    args.as_ref(),
+                                )
+                                .await;
+                                crate::scanning::accumulate_findings(
+                                    &results,
+                                    &findings_count,
+                                    ext_batch,
+                                    &args.limit_result_type.to_uppercase(),
+                                )
+                                .await;
+                            }
+                        }
+                    }
+
+                    // The AST pass above is skipped entirely under
+                    // `skip_ast_analysis`, and `--session-check-url` needs its
+                    // baseline from that endpoint rather than from the target.
+                    // Either way there is no response to reuse, so pay for one
+                    // request — but only for a job that actually has a session.
+                    if monitor_session && session_baseline.is_none() {
+                        session_baseline =
+                            crate::cmd::scan::session::capture_baseline(target, &args).await;
+                    }
+                    // Credentials that were already dead when the job started:
+                    // no later probe can detect a *change* from that baseline,
+                    // so it is recorded now rather than settling as `done`.
+                    session_lost = session_baseline
+                        .as_ref()
+                        .and_then(crate::cmd::scan::session::baseline_warning);
+
+                    // `args.silence` is already `true` (set at construction), and
+                    // `analyze_parameters` takes `&ScanArgs`, so pass the shared
+                    // Arc directly instead of deep-cloning it just to re-set a
+                    // field that already holds the desired value.
+                    analyze_parameters(target, args.as_ref(), None).await;
+
+                    // Bound the per-scan fan-out: a sprawling/hostile target can
+                    // expose thousands of params, and scanning spawns O(params ×
+                    // payloads) workers. Truncate with a warning past the cap.
+                    let dropped = cap_reflection_params(target);
+                    if dropped > 0 {
+                        warn(&format!(
+                            "discovered params capped to {} (dropped {})",
+                            MAX_DISCOVERED_PARAMS, dropped
+                        ));
+                    }
+
+                    // Count only the params the HTTP scan phase will actually
+                    // test (Fragment params are client-side only and spawn no
+                    // worker), so `params_total` matches the per-parameter
+                    // workers and `estimated_completion_pct` stays honest.
+                    progress.params_total.store(
+                        crate::scanning::http_scannable_param_count(target) as u32,
+                        std::sync::atomic::Ordering::Relaxed,
+                    );
+
+                    scan_report = crate::scanning::run_scanning(
+                        target,
+                        args.clone(),
+                        crate::scanning::ScanRunHandles::new(
+                            results.clone(),
+                            findings_count.clone(),
+                        )
+                        .with_cancel(cancel_flag.clone())
+                        // Feed the live per-parameter completion counter so
+                        // GET /scan/{id} reports `params_tested` climbing
+                        // during the scan instead of staying at 0 until done.
+                        .with_params_done(progress.params_tested.clone()),
+                    )
+                    .await;
+
+                    // The probe that catches the reported failure: a session
+                    // that survived the job's start and died during the
+                    // injection stage. Skipped when the run was cut short
+                    // anyway (cancel / scan_timeout), where a login-page probe
+                    // would only add noise to an already-partial result.
+                    if session_lost.is_none()
+                        && !cancel_flag.load(std::sync::atomic::Ordering::Relaxed)
+                        && let Some(baseline) = &session_baseline
+                    {
+                        session_lost = crate::cmd::scan::session::session_lost_after_scan(
+                            target, baseline, &args,
+                        )
+                        .await;
+                    }
+                })
+                .await;
+        }),
+    );
+
+    // Enforce the whole-scan wall-clock budget. On expiry the cancel flag is
+    // tripped so any in-flight workers wind down at their next checkpoint, and
+    // the job settles as `cancelled` with whatever partial results it gathered
+    // (plus an explanatory error_message) — the same shape as a user cancel.
+    let timed_out = run_within_scan_budget(args.scan_timeout, &cancel_flag, scan_fut).await;
+
+    drop(findings_updater);
+
+    let was_cancelled = cancel_flag.load(std::sync::atomic::Ordering::Relaxed);
+    // A worker-task panic means at least one parameter's findings are
+    // incomplete. Surface that as `error` (with the partial results still
+    // attached) so a poller can't mistake a crashed scan for a clean `done`.
+    // Cancellation takes precedence (it's already a partial-by-design state).
+    let panicked = !was_cancelled && scan_report.worker_panics > 0;
+
+    if !was_cancelled && !panicked {
+        // After a clean, complete run every discovered parameter was processed
+        // by `run_scanning`, so pin `params_tested` to `params_total` (exactly
+        // 100%). Skip this on cancellation AND on a worker panic: both stop
+        // short of finishing every parameter — a panicked worker never bumps
+        // the live counter — so promoting to params_total would report
+        // estimated_completion_pct = 100 for a job whose status is
+        // cancelled/error, making a partial scan read as a clean finish.
+        progress.params_tested.store(
+            progress
+                .params_total
+                .load(std::sync::atomic::Ordering::Relaxed),
+            std::sync::atomic::Ordering::Relaxed,
+        );
+    }
+    ScanRun {
+        results,
+        worker_panics: scan_report.worker_panics,
+        timed_out,
+        was_cancelled,
+        panicked,
+        session_lost,
+    }
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -29,7 +29,6 @@ use std::sync::{Arc, Mutex as StdMutex};
 
 use rmcp::schemars::JsonSchema;
 use serde::{Deserialize, Serialize};
-use tokio::sync::Mutex;
 
 use rmcp::{
     ErrorData,
@@ -41,14 +40,14 @@ use rmcp::{
 use crate::{
     cmd::scan::ScanArgs,
     job::{
-        AbortOnDrop, JOB_RETENTION_SECS, Job, JobStatus, MAX_ACTIVE_SCANS_MCP, MAX_DELAY_MS,
-        MAX_DISCOVERED_PARAMS, MAX_RETAINED_SCANS_MCP, MAX_SCAN_TIMEOUT_SECS, MAX_TIMEOUT_SECS,
-        MAX_WORKERS, cap_reflection_params, has_http_scheme, now_ms, parse_job_status,
-        purge_expired_jobs as purge_jobs_map, run_within_scan_budget, send_reachability_probe,
-        split_cookie_pairs, unreachable_error_message,
+        JOB_RETENTION_SECS, Job, JobStatus, MAX_ACTIVE_SCANS_MCP, MAX_DELAY_MS,
+        MAX_RETAINED_SCANS_MCP, MAX_SCAN_TIMEOUT_SECS, MAX_TIMEOUT_SECS, MAX_WORKERS,
+        cap_reflection_params, has_http_scheme, now_ms, parse_job_status,
+        purge_expired_jobs as purge_jobs_map, send_reachability_probe, split_cookie_pairs,
+        unreachable_error_message,
     },
     parameter_analysis::analyze_parameters,
-    scanning::result::{Result as ScanResult, SanitizedResult},
+    scanning::result::SanitizedResult,
     target_parser::parse_target,
 };
 
@@ -294,49 +293,10 @@ impl DalfoxMcp {
         let include_request = scan_args.include_request;
         let include_response = scan_args.include_response;
 
-        // Parse and hydrate a single target
-        let mut target = match parse_target(url) {
-            Ok(mut t) => {
-                t.method = scan_args.method.clone();
-                t.timeout = scan_args.timeout;
-                t.delay = scan_args.delay;
-                t.proxy = scan_args.proxy.clone();
-                t.insecure = scan_args.insecure.unwrap_or(true);
-                t.follow_redirects = scan_args.follow_redirects;
-                t.ignore_return = scan_args.ignore_return.clone();
-                t.workers = scan_args.workers;
-                t.user_agent = scan_args.user_agent.clone();
-                // Parse via the shared helpers so MCP matches the REST server:
-                // empty header names are rejected, and each cookie entry is
-                // `;`-split + trimmed (a bare split_once would keep whitespace
-                // and fold `a=b; c=d` into one value).
-                t.headers = scan_args
-                    .headers
-                    .iter()
-                    .filter_map(|h| crate::utils::http::parse_header_line(h))
-                    .collect();
-                // Also expose a supplied User-Agent as a header so the
-                // header-reflection probe tests it even on blanket-echo targets:
-                // user-supplied headers are always probed, whereas the common
-                // header sweep (which includes User-Agent) is suppressed when the
-                // target echoes every header. Without this, a User-Agent
-                // reflection is missed — an MCP-only false negative for identical
-                // input. Mirrors the CLI and REST server, which set both fields;
-                // like them, the scan path's `apply_headers_ua_cookies` then sends
-                // both this header entry and `target.user_agent`.
-                if let Some(ua) = scan_args.user_agent.as_deref().filter(|s| !s.is_empty()) {
-                    t.headers.push(("User-Agent".to_string(), ua.to_string()));
-                }
-                t.cookies = scan_args
-                    .cookies
-                    .iter()
-                    .flat_map(|c| split_cookie_pairs(c))
-                    .collect();
-                t.data = scan_args.data.clone();
-                t
-            }
-            Err(e) => {
-                let msg = format!("parse_target failed: {}", e);
+        // Parse and hydrate a single target (shared with the REST server).
+        let mut target = match crate::job::runner::hydrate_target(url, &scan_args) {
+            Ok(t) => t,
+            Err(msg) => {
                 Self::log("ERR", &msg);
                 // Route through the `!is_terminal()`-gated helper (as the
                 // unreachable path below and the REST server's parse-error
@@ -376,297 +336,24 @@ impl DalfoxMcp {
             return;
         }
 
-        // Per-job WAF consecutive-block counter so one scan's WAF backoff
-        // doesn't throttle an unrelated scan. The request counter is the
-        // public `progress.requests_sent` field itself — scoping it directly
-        // lets `crate::tick_request_count()` write through to the visible
-        // progress, so pollers see a live `requests_sent` value instead of 0.
-        let job_waf_consecutive = Arc::new(std::sync::atomic::AtomicU32::new(0));
-        let results_arc = Arc::new(Mutex::new(Vec::<ScanResult>::new()));
-        // `run_scanning`'s 6th argument is the running findings tally, not a
-        // parameter counter. Older code stored this into `params_tested`,
-        // which conflated two different metrics.
-        let findings_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+        // The scan itself — shared verbatim with the REST server; only the
+        // warning sink differs, so the scan id is bound into it here.
+        let run = crate::job::runner::execute_scan(
+            &mut target,
+            &scan_args,
+            &progress,
+            &cancel_flag,
+            &|msg: &str| Self::log("WRN", &format!("scan_id={} {}", scan_id, msg)),
+        )
+        .await;
 
-        // Mirror the in-flight findings tally into `progress.findings_so_far`
-        // so MCP pollers see progress before the scan finishes. The atomic
-        // types differ (`AtomicUsize` inside scanning, `AtomicU64` here),
-        // hence the copying task.
-        let progress_findings = progress.findings_so_far.clone();
-        let findings_count_for_updater = findings_count.clone();
-        // RAII abort — covers the panic path too, not just the manual drop below.
-        let findings_updater = AbortOnDrop(tokio::spawn(async move {
-            let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
-            tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-            loop {
-                tick.tick().await;
-                progress_findings.store(
-                    findings_count_for_updater.load(std::sync::atomic::Ordering::Relaxed) as u64,
-                    std::sync::atomic::Ordering::Relaxed,
-                );
-            }
-        }));
-
-        // Captured from inside the scoped/async blocks below so the worker-panic
-        // count survives past the scan; assigned by the run_scanning call.
-        let mut scan_report = crate::scanning::ScanRunReport::default();
-        // Set from inside the scoped block below when this scan's authenticated
-        // session was gone — before it began, or by the time it ended. Carries
-        // the signal that fired, verbatim into the job's `error_message`.
-        let mut session_lost: Option<String> = None;
-        let scan_fut = crate::with_job_rate_limiter(
-            scan_args.rate_limit,
-            crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
-                crate::WAF_CONSECUTIVE_BLOCKS_JOB
-                    .scope(job_waf_consecutive.clone(), async {
-                        // Dispatch blind-XSS probes when a callback URL was
-                        // supplied. MCP exposes `blind_callback_url` in its
-                        // scan schema and wires it into ScanArgs, but the
-                        // execution path never invoked blind_scanning — so the
-                        // documented option was a silent no-op, diverging from
-                        // both the CLI and the REST server (which call this
-                        // here). run_scanning does not cover blind scanning.
-                        if let Some(callback_url) = &scan_args.blind_callback_url {
-                            crate::scanning::blind_scanning(
-                                &target,
-                                callback_url,
-                                scan_args.custom_blind_xss_payload.as_deref(),
-                            )
-                            .await;
-                        }
-
-                        // Session-loss detection (issue #1273), the MCP half.
-                        // An MCP scan carrying credentials has exactly the
-                        // CLI's exposure: the session dies mid-scan, every
-                        // later request is answered by a login page, nothing
-                        // reflects, and the tool reports zero findings —
-                        // indistinguishable from a clean target. Off, and free,
-                        // when no credentials were supplied.
-                        let monitor_session =
-                            crate::cmd::scan::session::monitoring_enabled(&scan_args, &target);
-                        let session_check_re =
-                            crate::cmd::scan::session::compile_session_check(&scan_args)
-                                .ok()
-                                .flatten();
-                        let mut session_baseline = None;
-
-                        // Initial AST DOM-XSS pass on the GET response so MCP
-                        // scans match CLI for targets where the vulnerability
-                        // lives entirely in JS (location.hash → innerHTML
-                        // etc.). MCP previously skipped this because the
-                        // scan path didn't run preflight; same divergence
-                        // hit the REST server, now fixed in both places.
-                        if !scan_args.skip_ast_analysis {
-                            let client = target.build_client_or_default();
-                            // Mirror the CLI preflight: carry the target's
-                            // headers/cookies/User-Agent (so auth/header/UA-gated
-                            // SPAs are analyzed logged-in, matching CLI findings)
-                            // and cap the body with `Range: 0-8191` so a large
-                            // response can't buffer unbounded into memory.
-                            let preflight = crate::utils::build_preflight_request(
-                                &client,
-                                &target,
-                                false,
-                                Some(8192),
-                            );
-                            // Count + rate-limit the preflight GET like the CLI
-                            // (record_outbound_request), so it isn't missing from
-                            // the job's requests_sent tally.
-                            crate::record_outbound_request().await;
-                            if let Ok(resp) = preflight.send().await {
-                                // Clone the headers before `read_body` consumes
-                                // the response: the posture needs both them and
-                                // the document (a page can declare its CSP with
-                                // `<meta http-equiv>`), so Trusted Types
-                                // awareness and the confidence grading's CSP
-                                // signal match what the CLI derives from
-                                // preflight.
-                                let resp_headers = resp.headers().clone();
-                                // Captured before `read_body` consumes the
-                                // response: under `follow_redirects` this is
-                                // where the chain actually ended, the only
-                                // landing a baseline can compare against.
-                                let resp_status = resp.status().as_u16();
-                                let resp_final_url = resp.url().clone();
-                                if let Ok(body) = crate::utils::http::read_body(resp).await {
-                                    // Authenticated-state fingerprint from this
-                                    // same response, so monitoring costs no
-                                    // extra request. `session_check_url` is the
-                                    // exception — its baseline must come from
-                                    // that endpoint, handled below.
-                                    if monitor_session && scan_args.session_check_url.is_none() {
-                                        session_baseline = Some(
-                                            crate::cmd::scan::session::baseline_from_preflight(
-                                                &target.url,
-                                                &resp_final_url,
-                                                resp_status,
-                                                &resp_headers,
-                                                &body,
-                                                session_check_re.as_ref(),
-                                            ),
-                                        );
-                                    }
-                                    let posture =
-                                    crate::scanning::ast_integration::PageSecurityPosture::from_response(
-                                        &resp_headers,
-                                        &body,
-                                    );
-                                    let ast_batch =
-                                    crate::scanning::ast_integration::run_initial_ast_dom_analysis(
-                                        &body,
-                                        target.url.as_str(),
-                                        &target.method,
-                                        posture,
-                                    );
-                                    if !ast_batch.is_empty() {
-                                        let added = crate::scanning::count_matching_results(
-                                            &ast_batch,
-                                            &scan_args.limit_result_type.to_uppercase(),
-                                        );
-                                        let mut guard = results_arc.lock().await;
-                                        guard.extend(ast_batch);
-                                        findings_count
-                                            .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
-                                    }
-                                    let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                                        &client,
-                                        &target,
-                                        &body,
-                                        scan_args.as_ref(),
-                                    )
-                                    .await;
-                                    crate::scanning::accumulate_findings(
-                                        &results_arc,
-                                        &findings_count,
-                                        ext_batch,
-                                        &scan_args.limit_result_type.to_uppercase(),
-                                    )
-                                    .await;
-                                }
-                            }
-                        }
-
-                        // Parameter discovery / mining
-                        // No response to reuse under `skip_ast_analysis`, and
-                        // `session_check_url` needs its baseline from that
-                        // endpoint anyway — pay one request, only for a scan
-                        // that actually has a session.
-                        if monitor_session && session_baseline.is_none() {
-                            session_baseline =
-                                crate::cmd::scan::session::capture_baseline(&target, &scan_args)
-                                    .await;
-                        }
-                        // Credentials already dead when the scan began: no later
-                        // probe can detect a *change* from that baseline, so it
-                        // is recorded now instead of reporting a clean run.
-                        session_lost = session_baseline
-                            .as_ref()
-                            .and_then(crate::cmd::scan::session::baseline_warning);
-
-                        analyze_parameters(&mut target, scan_args.as_ref(), None).await;
-
-                        // Bound the per-scan fan-out: a sprawling/hostile target
-                        // can expose thousands of params, and scanning spawns
-                        // O(params × payloads) workers. Truncate past the cap.
-                        let dropped = cap_reflection_params(&mut target);
-                        if dropped > 0 {
-                            Self::log(
-                                "WRN",
-                                &format!(
-                                    "scan_id={} discovered params capped to {} (dropped {})",
-                                    scan_id, MAX_DISCOVERED_PARAMS, dropped
-                                ),
-                            );
-                        }
-
-                        // Record the count of params the HTTP scan phase will
-                        // actually test (Fragment params are client-side only and
-                        // spawn no worker), so params_total matches the
-                        // per-parameter workers and estimated_completion_pct
-                        // stays honest. Mirrors the REST server.
-                        progress.params_total.store(
-                            crate::scanning::http_scannable_param_count(&target) as u32,
-                            std::sync::atomic::Ordering::Relaxed,
-                        );
-
-                        scan_report = crate::scanning::run_scanning(
-                            &target,
-                            scan_args.clone(),
-                            crate::scanning::ScanRunHandles::new(
-                                results_arc.clone(),
-                                findings_count.clone(),
-                            )
-                            .with_cancel(cancel_flag.clone())
-                            // Feed the live per-parameter completion counter
-                            // so get_results_dalfox reports `params_tested`
-                            // (and estimated_completion_pct) advancing during
-                            // the scan instead of staying at 0 until done.
-                            .with_params_done(progress.params_tested.clone()),
-                        )
-                        .await;
-
-                        // The probe that catches the reported failure: a
-                        // session that survived the scan's start and died
-                        // during the injection stage. Skipped when the run was
-                        // cut short anyway (cancel / scan_timeout), where a
-                        // login-page probe only adds noise to a partial result.
-                        if session_lost.is_none()
-                            && !cancel_flag.load(std::sync::atomic::Ordering::Relaxed)
-                            && let Some(baseline) = &session_baseline
-                        {
-                            session_lost = crate::cmd::scan::session::session_lost_after_scan(
-                                &target,
-                                baseline,
-                                &scan_args,
-                            )
-                            .await;
-                        }
-                    })
-                    .await;
-            }),
-        );
-
-        // Enforce the whole-scan wall-clock budget. On expiry the cancel flag is
-        // tripped so in-flight workers wind down at their next checkpoint and
-        // the job settles as `cancelled` with partial results, mirroring a user
-        // cancel — plus an error_message below so a timeout stays distinguishable.
-        let timed_out =
-            run_within_scan_budget(scan_args.scan_timeout, &cancel_flag, scan_fut).await;
-
-        drop(findings_updater);
-
-        // Check if cancelled during scanning. Read this BEFORE rewriting
-        // `params_tested` — a cancelled scan exited early and almost
-        // certainly did not finish every discovered parameter, so promoting
-        // `params_tested` to `params_total` would lie about completion
-        // (the client would compute estimated_completion_pct = 100 even
-        // though the scan stopped at, say, 10/50 params).
-        let was_cancelled = cancel_flag.load(std::sync::atomic::Ordering::Relaxed);
-        // A worker-task panic means a parameter's findings are incomplete;
-        // surface it as `error` (partial results still attached) so a poller
-        // can't mistake a crashed scan for a clean finish. Cancellation wins.
-        let panicked = !was_cancelled && scan_report.worker_panics > 0;
-        // Same reasoning as `panicked`: the scan ran to completion but its
-        // results cannot be trusted, so it must not settle as a clean `done`.
-        // Cancellation still wins — it is partial by design and says so.
-        let lost_session = !was_cancelled && session_lost.is_some();
-
-        if !was_cancelled && !panicked {
-            // Only a clean, complete run pins `params_tested` to `params_total`
-            // (exactly 100%). Skip on cancellation AND on a worker panic: both
-            // stop short of finishing every discovered parameter — a panicked
-            // worker never bumps the live per-param counter fed to
-            // `run_scanning` at line ~540 — so promoting to params_total would
-            // make get_results_dalfox report estimated_completion_pct = 100 for
-            // a job whose status is cancelled/error, a partial scan reading as a
-            // clean finish.
-            progress.params_tested.store(
-                progress
-                    .params_total
-                    .load(std::sync::atomic::Ordering::Relaxed),
-                std::sync::atomic::Ordering::Relaxed,
-            );
-        }
+        let results_arc = run.results.clone();
+        let timed_out = run.timed_out;
+        let was_cancelled = run.was_cancelled;
+        let panicked = run.panicked;
+        let lost_session = run.lost_session();
+        let session_lost = run.session_lost.clone();
+        let worker_panics = run.worker_panics;
 
         let sanitized = {
             let locked = results_arc.lock().await;
@@ -711,7 +398,7 @@ impl DalfoxMcp {
                 } else if panicked && j.error_message.is_none() {
                     j.error_message = Some(format!(
                         "{} scan worker task(s) panicked; results are partial",
-                        scan_report.worker_panics
+                        worker_panics
                     ));
                 } else if timed_out && j.error_message.is_none() {
                     j.error_message = Some(format!(
@@ -1840,7 +1527,9 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                 t.proxy = params.proxy.clone();
                 t.insecure = params.insecure;
                 t.follow_redirects = params.follow_redirects;
-                t.user_agent = params.user_agent.clone();
+                // Normalized like the scan path (`job::runner::hydrate_target`)
+                // so MCP carries one User-Agent convention, not two.
+                t.user_agent = Some(params.user_agent.clone().unwrap_or_default());
                 // Shared parsers: reject empty header names and `;`-split +
                 // trim each cookie, matching the scan path and the REST server.
                 t.headers = params

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -251,7 +251,10 @@ async fn send_probe_request_for_param(
     let url_original = target.url.clone();
     let headers = target.headers.clone();
     let cookies = target.cookies.clone();
-    let user_agent = target.user_agent.clone();
+    // `effective_user_agent`, not the raw field: `Some("")` is the "no
+    // override" sentinel every entry point sets when none was supplied, and
+    // sending it verbatim put a literal blank `User-Agent:` on every probe.
+    let user_agent = target.effective_user_agent().map(str::to_string);
     let data = target.data.clone();
     let param_name = param.name.clone();
     let wire_name = param.effective_wire_name().to_string();

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1773,3 +1773,59 @@ fn test_transport_invalid_chars_marks_semicolon_for_cookies() {
         transport_invalid_chars(&target, &probe_test_param(Location::Query, "session")).is_empty()
     );
 }
+
+/// The stage-3 probe is the highest-volume request a scan makes, and it read
+/// `target.user_agent` raw. `Some("")` is the "no override" sentinel every
+/// entry point normalizes to when the operator supplied none, so every probe
+/// went out carrying a literal blank `User-Agent:` — a fingerprint no ordinary
+/// client sends, on the requests meant to look ordinary. Reached here through
+/// a reflecting param so the probe actually runs; the REST regression test for
+/// the same sentinel uses a non-reflecting target and never gets this far.
+#[tokio::test]
+async fn active_probe_omits_user_agent_for_the_no_override_sentinel() {
+    use axum::{Router, extract::State, http::HeaderMap, response::Html};
+    use std::net::Ipv4Addr;
+    use tokio::time::{Duration, sleep};
+
+    type Seen = std::sync::Arc<std::sync::Mutex<Vec<Option<String>>>>;
+
+    async fn echo(State(seen): State<Seen>, headers: HeaderMap) -> Html<String> {
+        seen.lock().expect("record ua").push(
+            headers
+                .get("user-agent")
+                .and_then(|v| v.to_str().ok())
+                .map(str::to_string),
+        );
+        Html("<div>ok</div>".to_string())
+    }
+
+    let seen: Seen = std::sync::Arc::new(std::sync::Mutex::new(Vec::new()));
+    let app = Router::new()
+        .route("/probe", axum::routing::get(echo))
+        .with_state(seen.clone());
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let mut target = parse_target(&format!("http://{addr}/probe?q=seed")).unwrap();
+    target.user_agent = Some(String::new());
+
+    let _ = active_probe_param(
+        &target,
+        probe_param("q", Location::Query),
+        Arc::new(Semaphore::new(8)),
+    )
+    .await;
+
+    let uas = seen.lock().expect("uas").clone();
+    assert!(!uas.is_empty(), "the probe must have reached the server");
+    assert!(
+        !uas.iter().any(|ua| ua.as_deref() == Some("")),
+        "the empty sentinel must not become a blank User-Agent header; saw {uas:?}"
+    );
+}

--- a/src/scanning/xss_blind.rs
+++ b/src/scanning/xss_blind.rs
@@ -314,7 +314,9 @@ async fn send_blind_request(target: &Target, param_name: &str, payload: &str, pa
     for (k, v) in &headers {
         request = request.header(k, v);
     }
-    if let Some(ua) = &target.user_agent {
+    // Through `effective_user_agent` so the `Some("")` "no override" sentinel
+    // never reaches the wire as a literal `User-Agent:`.
+    if let Some(ua) = target.effective_user_agent() {
         request = request.header("User-Agent", ua);
     }
     let mut cookie_header = String::new();
@@ -406,7 +408,7 @@ pub async fn blind_scan_forms_with(
     for (k, v) in &target.headers {
         fetch = fetch.header(k, v);
     }
-    if let Some(ua) = &target.user_agent {
+    if let Some(ua) = target.effective_user_agent() {
         fetch = fetch.header("User-Agent", ua);
     }
     if let Some(ref h) = cookie_header {
@@ -525,7 +527,7 @@ pub async fn blind_scan_forms_with(
                 }
                 // Set Content-Type last to guarantee it wins.
                 request = request.header("Content-Type", "application/x-www-form-urlencoded");
-                if let Some(ua) = &target.user_agent {
+                if let Some(ua) = target.effective_user_agent() {
                     request = request.header("User-Agent", ua);
                 }
                 if let Some(ref h) = cookie_header {

--- a/src/scanning/xss_blind/tests.rs
+++ b/src/scanning/xss_blind/tests.rs
@@ -624,3 +624,26 @@ fn build_blind_templates_falls_back_when_file_unreadable() {
     );
     assert!(templates.iter().all(|t| t.contains("{}")));
 }
+
+/// `Some("")` is the "no UA override" sentinel every entry point sets when the
+/// operator supplied none (`job::runner::hydrate_target`, `cmd::scan::input`).
+/// `apply_headers_ua_cookies` has always empty-checked it; the blind-XSS
+/// requests were the one path that did not, so they put a literal blank
+/// `User-Agent:` on the wire — a fingerprint no ordinary client sends, on
+/// exactly the requests meant to look ordinary.
+#[tokio::test]
+async fn test_send_blind_request_omits_user_agent_for_the_no_override_sentinel() {
+    let (addr, state) = start_capture_server().await;
+    let mut target = make_target(addr, "/?q=seed");
+    target.user_agent = Some(String::new());
+
+    send_blind_request(&target, "q", "PAYLOAD", "query").await;
+
+    let records = state.lock().await.clone();
+    assert_eq!(records.len(), 1);
+    let ua = records[0].headers.get("user-agent").map(String::as_str);
+    assert!(
+        ua != Some(""),
+        "the empty sentinel must not become a blank User-Agent header; saw {ua:?}"
+    );
+}

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -377,59 +377,14 @@ pub(crate) async fn run_scan_job(
             ),
         );
     }
-    let results = Arc::new(Mutex::new(Vec::<ScanResult>::new()));
-
-    let mut target = match parse_target(&url) {
-        Ok(mut t) => {
-            t.data = args.data.clone();
-            t.headers = args
-                .headers
-                .iter()
-                .filter_map(|h| {
-                    let mut parts = h.splitn(2, ':');
-                    let name = parts.next()?.trim();
-                    let value = parts.next()?.trim();
-                    if name.is_empty() {
-                        return None;
-                    }
-                    Some((name.to_string(), value.to_string()))
-                })
-                .collect();
-            t.method = args.method.clone();
-            if let Some(ua) = &args.user_agent {
-                // Skip the header push for an explicitly-empty user_agent:
-                // `apply_headers_ua_cookies` copies `t.headers` verbatim, so an
-                // empty entry put a literal `User-Agent:` on every request,
-                // while `t.user_agent` (which it *does* empty-check) sent none.
-                // MCP already filters this; align so both behave the same.
-                if !ua.is_empty() {
-                    t.headers.push(("User-Agent".to_string(), ua.clone()));
-                }
-                t.user_agent = Some(ua.clone());
-            } else {
-                t.user_agent = Some("".to_string());
-            }
-            t.cookies = args
-                .cookies
-                .iter()
-                .flat_map(|c| split_cookie_pairs(c))
-                .collect();
-            t.timeout = args.timeout;
-            t.delay = args.delay;
-            t.proxy = args.proxy.clone();
-            t.insecure = args.insecure.unwrap_or(true);
-            t.follow_redirects = args.follow_redirects;
-            t.ignore_return = args.ignore_return.clone();
-            t.workers = args.workers;
-            t
-        }
-        Err(e) => {
+    let mut target = match crate::job::runner::hydrate_target(&url, &args) {
+        Ok(t) => t,
+        Err(msg) => {
             // Webhook subscribers expect a terminal callback for every scan;
             // before, this branch transitioned the job to Error but never
             // fired the webhook, so a malformed URL silently left the
             // subscriber waiting indefinitely. mark_job_error now handles
             // both the status update and the webhook dispatch.
-            let msg = format!("parse_target failed: {}", e);
             mark_job_error(&state, &job_id, &url, msg, None).await;
             return;
         }
@@ -475,287 +430,24 @@ pub(crate) async fn run_scan_job(
         return;
     }
 
-    // Per-job WAF consecutive-block counter so one scan's WAF backoff doesn't
-    // throttle an unrelated scan.
-    //
-    // For the request counter, we scope `progress.requests_sent` directly
-    // instead of a private local atomic — every `crate::tick_request_count()`
-    // call then writes through to the publicly visible progress field, so
-    // GET /scan/{id} returns a live `requests_sent` value during the scan
-    // instead of `0` until completion.
-    let job_waf_consecutive = Arc::new(std::sync::atomic::AtomicU32::new(0));
-    // `run_scanning`'s 6th argument is the running findings tally, not a
-    // parameter counter (see scanning/mod.rs:findings_count). Older code
-    // here called it `param_counter` and stored it into `params_tested`,
-    // which conflated two unrelated metrics.
-    let findings_count = Arc::new(std::sync::atomic::AtomicUsize::new(0));
+    // The scan itself — shared verbatim with the MCP runtime; only the warning
+    // sink differs, so the job id is bound into it here.
+    let run = crate::job::runner::execute_scan(
+        &mut target,
+        &args,
+        &progress,
+        &cancel_flag,
+        &|msg: &str| log(&state, "WRN", &format!("id={} {}", job_id, msg)),
+    )
+    .await;
 
-    // Mirror the in-flight findings tally into `progress.findings_so_far`
-    // periodically so pollers see a non-zero value before the scan finishes.
-    // The types differ (`AtomicUsize` inside scanning, `AtomicU64` in the
-    // public progress struct), which is why a copying task is needed.
-    let progress_findings = progress.findings_so_far.clone();
-    let findings_count_for_updater = findings_count.clone();
-    // RAII abort — covers the panic path too, not just the manual abort below.
-    let findings_updater = AbortOnDrop(tokio::spawn(async move {
-        let mut tick = tokio::time::interval(std::time::Duration::from_millis(250));
-        tick.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Skip);
-        loop {
-            tick.tick().await;
-            progress_findings.store(
-                findings_count_for_updater.load(std::sync::atomic::Ordering::Relaxed) as u64,
-                std::sync::atomic::Ordering::Relaxed,
-            );
-        }
-    }));
-
-    // Captured from inside the scoped/async blocks below so worker-panic count
-    // survives past the scan; assigned by the run_scanning call.
-    let mut scan_report = crate::scanning::ScanRunReport::default();
-    // Set (from inside the scoped block below) when this job's authenticated
-    // session was gone — either before the scan began or by the time it ended.
-    // Carries the signal that fired, verbatim into `error_message`.
-    let mut session_lost: Option<String> = None;
-    let scan_fut = crate::with_job_rate_limiter(
-        args.rate_limit,
-        crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
-            crate::WAF_CONSECUTIVE_BLOCKS_JOB
-                .scope(job_waf_consecutive.clone(), async {
-                    if let Some(callback_url) = &args.blind_callback_url {
-                        crate::scanning::blind_scanning(
-                            &target,
-                            callback_url,
-                            args.custom_blind_xss_payload.as_deref(),
-                        )
-                        .await;
-                    }
-
-                    // Session-loss detection (issue #1273), the server half.
-                    // A `dalfox server` job carrying credentials has exactly
-                    // the CLI's exposure: the session dies mid-scan, every
-                    // later request is answered by a login page, nothing
-                    // reflects, and the job settles `done` with zero findings —
-                    // indistinguishable from a clean target. Off, and free,
-                    // when no credentials were supplied.
-                    let monitor_session =
-                        crate::cmd::scan::session::monitoring_enabled(&args, &target);
-                    let session_check_re =
-                        crate::cmd::scan::session::compile_session_check(&args)
-                            .ok()
-                            .flatten();
-                    let mut session_baseline = None;
-
-                    // Initial AST DOM-XSS pass on the GET response, mirroring
-                    // the CLI flow. Server used to skip this because it
-                    // didn't run preflight, so identical targets reported
-                    // 0 findings via API even when CLI saw multiple
-                    // DOM-XSS sinks (e.g. xss-game level3 with
-                    // location.hash → html). Best-effort fetch — if it
-                    // fails the regular scan path below still runs.
-                    if !args.skip_ast_analysis {
-                        let client = target.build_client_or_default();
-                        // Mirror the CLI preflight: carry the target's
-                        // headers/cookies/User-Agent (so auth/header/UA-gated
-                        // SPAs are analyzed logged-in, matching CLI findings —
-                        // a bare GET dropped them and analyzed the logged-out
-                        // page) and cap the body with `Range: 0-8191` so a large
-                        // response can't buffer unbounded into server memory.
-                        let preflight = crate::utils::build_preflight_request(
-                            &client,
-                            &target,
-                            false,
-                            Some(8192),
-                        );
-                        // Count + rate-limit the preflight GET like the CLI
-                        // (record_outbound_request), so it isn't missing from the
-                        // job's requests_sent tally.
-                        crate::record_outbound_request().await;
-                        if let Ok(resp) = preflight.send().await {
-                            // Clone the headers before `read_body` consumes the
-                            // response: the posture needs both them and the
-                            // document (a page can declare its CSP with
-                            // `<meta http-equiv>`), so Trusted Types awareness
-                            // and the confidence grading's CSP signal match what
-                            // the CLI derives from preflight.
-                            let resp_headers = resp.headers().clone();
-                            // Captured before `read_body` consumes the response.
-                            // Under `follow_redirects` this is where the chain
-                            // actually ended, which is the only thing a session
-                            // baseline can meaningfully compare against.
-                            let resp_status = resp.status().as_u16();
-                            let resp_final_url = resp.url().clone();
-                            if let Ok(body) = crate::utils::http::read_body(resp).await {
-                                // Authenticated-state fingerprint, derived from
-                                // this same response so monitoring costs the
-                                // job no extra request (mirrors the CLI).
-                                // `--session-check-url` is the exception: its
-                                // baseline has to come from that endpoint, so
-                                // it falls through to the capture below.
-                                if monitor_session && args.session_check_url.is_none() {
-                                    session_baseline =
-                                        Some(crate::cmd::scan::session::baseline_from_preflight(
-                                            &target.url,
-                                            &resp_final_url,
-                                            resp_status,
-                                            &resp_headers,
-                                            &body,
-                                            session_check_re.as_ref(),
-                                        ));
-                                }
-                                let posture =
-                                    crate::scanning::ast_integration::PageSecurityPosture::from_response(
-                                        &resp_headers,
-                                        &body,
-                                    );
-                                let ast_batch =
-                                    crate::scanning::ast_integration::run_initial_ast_dom_analysis(
-                                        &body,
-                                        target.url.as_str(),
-                                        &target.method,
-                                        posture,
-                                    );
-                                if !ast_batch.is_empty() {
-                                    let added = crate::scanning::count_matching_results(
-                                        &ast_batch,
-                                        &args.limit_result_type.to_uppercase(),
-                                    );
-                                    let mut guard = results.lock().await;
-                                    guard.extend(ast_batch);
-                                    findings_count
-                                        .fetch_add(added, std::sync::atomic::Ordering::Relaxed);
-                                }
-                                let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                                    &client,
-                                    &target,
-                                    &body,
-                                    args.as_ref(),
-                                )
-                                .await;
-                                crate::scanning::accumulate_findings(
-                                    &results,
-                                    &findings_count,
-                                    ext_batch,
-                                    &args.limit_result_type.to_uppercase(),
-                                )
-                                .await;
-                            }
-                        }
-                    }
-
-                    // The AST pass above is skipped entirely under
-                    // `skip_ast_analysis`, and `--session-check-url` needs its
-                    // baseline from that endpoint rather than from the target.
-                    // Either way there is no response to reuse, so pay for one
-                    // request — but only for a job that actually has a session.
-                    if monitor_session && session_baseline.is_none() {
-                        session_baseline =
-                            crate::cmd::scan::session::capture_baseline(&target, &args).await;
-                    }
-                    // Credentials that were already dead when the job started:
-                    // no later probe can detect a *change* from that baseline,
-                    // so it is recorded now rather than settling as `done`.
-                    session_lost = session_baseline
-                        .as_ref()
-                        .and_then(crate::cmd::scan::session::baseline_warning);
-
-                    // `args.silence` is already `true` (set at construction), and
-                    // `analyze_parameters` takes `&ScanArgs`, so pass the shared
-                    // Arc directly instead of deep-cloning it just to re-set a
-                    // field that already holds the desired value.
-                    analyze_parameters(&mut target, args.as_ref(), None).await;
-
-                    // Bound the per-scan fan-out: a sprawling/hostile target can
-                    // expose thousands of params, and scanning spawns O(params ×
-                    // payloads) workers. Truncate with a warning past the cap.
-                    let dropped = cap_reflection_params(&mut target);
-                    if dropped > 0 {
-                        log(
-                            &state,
-                            "WRN",
-                            &format!(
-                                "id={} discovered params capped to {} (dropped {})",
-                                job_id, MAX_DISCOVERED_PARAMS, dropped
-                            ),
-                        );
-                    }
-
-                    // Count only the params the HTTP scan phase will actually
-                    // test (Fragment params are client-side only and spawn no
-                    // worker), so `params_total` matches the per-parameter
-                    // workers and `estimated_completion_pct` stays honest.
-                    progress.params_total.store(
-                        crate::scanning::http_scannable_param_count(&target) as u32,
-                        std::sync::atomic::Ordering::Relaxed,
-                    );
-
-                    scan_report = crate::scanning::run_scanning(
-                        &target,
-                        args.clone(),
-                        crate::scanning::ScanRunHandles::new(
-                            results.clone(),
-                            findings_count.clone(),
-                        )
-                        .with_cancel(cancel_flag.clone())
-                        // Feed the live per-parameter completion counter so
-                        // GET /scan/{id} reports `params_tested` climbing
-                        // during the scan instead of staying at 0 until done.
-                        .with_params_done(progress.params_tested.clone()),
-                    )
-                    .await;
-
-                    // The probe that catches the reported failure: a session
-                    // that survived the job's start and died during the
-                    // injection stage. Skipped when the run was cut short
-                    // anyway (cancel / scan_timeout), where a login-page probe
-                    // would only add noise to an already-partial result.
-                    if session_lost.is_none()
-                        && !cancel_flag.load(std::sync::atomic::Ordering::Relaxed)
-                        && let Some(baseline) = &session_baseline
-                    {
-                        session_lost = crate::cmd::scan::session::session_lost_after_scan(
-                            &target, baseline, &args,
-                        )
-                        .await;
-                    }
-                })
-                .await;
-        }),
-    );
-
-    // Enforce the whole-scan wall-clock budget. On expiry the cancel flag is
-    // tripped so any in-flight workers wind down at their next checkpoint, and
-    // the job settles as `cancelled` with whatever partial results it gathered
-    // (plus an explanatory error_message) — the same shape as a user cancel.
-    let timed_out = run_within_scan_budget(args.scan_timeout, &cancel_flag, scan_fut).await;
-
-    drop(findings_updater);
-
-    let was_cancelled = cancel_flag.load(std::sync::atomic::Ordering::Relaxed);
-    // A worker-task panic means at least one parameter's findings are
-    // incomplete. Surface that as `error` (with the partial results still
-    // attached) so a poller can't mistake a crashed scan for a clean `done`.
-    // Cancellation takes precedence (it's already a partial-by-design state).
-    let panicked = !was_cancelled && scan_report.worker_panics > 0;
-    // Same reasoning as `panicked`: the scan ran to completion but its results
-    // cannot be trusted, so it must not settle as a clean `done`. Cancellation
-    // still takes precedence — it is partial by design and says so.
-    let lost_session = !was_cancelled && session_lost.is_some();
-
-    if !was_cancelled && !panicked {
-        // After a clean, complete run every discovered parameter was processed
-        // by `run_scanning`, so pin `params_tested` to `params_total` (exactly
-        // 100%). Skip this on cancellation AND on a worker panic: both stop
-        // short of finishing every parameter — a panicked worker never bumps
-        // the live counter — so promoting to params_total would report
-        // estimated_completion_pct = 100 for a job whose status is
-        // cancelled/error, making a partial scan read as a clean finish.
-        progress.params_tested.store(
-            progress
-                .params_total
-                .load(std::sync::atomic::Ordering::Relaxed),
-            std::sync::atomic::Ordering::Relaxed,
-        );
-    }
+    let results = run.results.clone();
+    let timed_out = run.timed_out;
+    let was_cancelled = run.was_cancelled;
+    let panicked = run.panicked;
+    let lost_session = run.lost_session();
+    let session_lost = run.session_lost.clone();
+    let worker_panics = run.worker_panics;
 
     let final_results = {
         let locked = results.lock().await;
@@ -800,7 +492,7 @@ pub(crate) async fn run_scan_job(
             } else if panicked && job.error_message.is_none() {
                 job.error_message = Some(format!(
                     "{} scan worker task(s) panicked; results are partial",
-                    scan_report.worker_panics
+                    worker_panics
                 ));
             } else if timed_out && job.error_message.is_none() {
                 job.error_message = Some(format!(

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -35,14 +35,14 @@ pub(crate) use serde::{Deserialize, Serialize};
 
 pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
-    AbortOnDrop, JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS,
-    MAX_DISCOVERED_PARAMS, MAX_SCAN_TIMEOUT_SECS, MAX_TIMEOUT_SECS, MAX_WORKERS,
-    cap_reflection_params, effective_rate_limit, effective_scan_timeout, enforce_retention_cap,
-    has_http_scheme, now_ms, parse_job_status, purge_expired_jobs as purge_jobs_map,
-    run_within_scan_budget, send_reachability_probe, split_cookie_pairs, unreachable_error_message,
+    JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_SCAN_TIMEOUT_SECS,
+    MAX_TIMEOUT_SECS, MAX_WORKERS, cap_reflection_params, effective_rate_limit,
+    effective_scan_timeout, enforce_retention_cap, has_http_scheme, now_ms, parse_job_status,
+    purge_expired_jobs as purge_jobs_map, send_reachability_probe, split_cookie_pairs,
+    unreachable_error_message,
 };
 pub(crate) use crate::parameter_analysis::analyze_parameters;
-pub(crate) use crate::scanning::result::{Result as ScanResult, SanitizedResult};
+pub(crate) use crate::scanning::result::SanitizedResult;
 pub(crate) use crate::target_parser::parse_target;
 
 mod auth;

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -64,6 +64,20 @@ pub struct Target {
 }
 
 impl Target {
+    /// The `User-Agent` to actually put on the wire, or `None` for "leave it
+    /// to the HTTP client".
+    ///
+    /// `user_agent` carries two spellings of the same thing: `None`, and the
+    /// `Some("")` sentinel that every entry point normalizes to when the
+    /// operator supplied no override (`job::runner::hydrate_target`,
+    /// `cmd::scan::input`). Reading the field directly means remembering to
+    /// empty-check, and three of the four call sites that did so forgot —
+    /// putting a literal blank `User-Agent:` on probe and blind-XSS requests,
+    /// a fingerprint no ordinary client sends. Go through here instead.
+    pub fn effective_user_agent(&self) -> Option<&str> {
+        self.user_agent.as_deref().filter(|ua| !ua.is_empty())
+    }
+
     /// Construct a `Target` for `url` with empty request fields (method `GET`,
     /// no data/headers/cookies) and scan-context fields at their parse-time
     /// defaults. `resolve_targets` overwrites timeout/delay/proxy/workers/etc.

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -103,9 +103,7 @@ pub fn apply_headers_ua_cookies(
     }
 
     // Apply UA (override any existing UA header)
-    if let Some(ua) = &target.user_agent
-        && !ua.is_empty()
-    {
+    if let Some(ua) = target.effective_user_agent() {
         rb = rb.header("User-Agent", ua);
     }
 


### PR DESCRIPTION
## The duplication

`server::job_runner::run_scan_job` (670 lines) and `mcp::run_job` (489 lines)
each carried their own copy of the scan-execution core. Normalizing identifiers
and comments away, ~280 of those lines were **character-for-character
identical** — the only difference was one log call.

Parity between them was maintained by comments telling each side to mirror the
other, and it kept failing: blind-XSS dispatch, the initial AST pass,
session-loss detection and per-job WAF backoff were each fixed twice, and each
was reported because one side had been missed the first time.

This moves target hydration and the scan itself into `job::runner`. What
genuinely differs stays with each interface: how a job record is claimed and
stored (REST holds jobs behind a `tokio::sync::Mutex`, MCP behind a
`std::sync::Mutex`), how options become a `ScanArgs`, and the REST-only
completion webhook. The warning sink is the single divergence, so it is passed
in as a closure.

| file | before | after |
|---|---:|---:|
| `server/job_runner.rs` | 950 | 642 |
| `mcp/mod.rs` | 2140 | 1827 |
| `job/runner.rs` (new) | — | 395 |

`run_scanning` now has two callers instead of three: the CLI scan loop, and
this shared core.

## The behaviour difference it forced a choice on

The two copies disagreed on exactly one field. When the caller supplied no
user agent, MCP left `target.user_agent` as `None`; the CLI and REST normalize
it to `Some("")` — this codebase's "no override" sentinel.

Adopting the sentinel (the majority, and what `cmd::scan::input` sets) exposed
that **three of its four consumers never empty-checked it**:

- `parameter_analysis` — every stage-3 special-character probe, the
  highest-volume request a scan makes
- `scanning::xss_blind` — all three blind-XSS request builders
- `utils::http::apply_headers_ua_cookies` — the one that got it right

So probe and blind-XSS requests have been going out with a literal blank
`User-Agent:` header — a fingerprint no ordinary client sends, on exactly the
requests meant to look ordinary. Verified on the wire, not just in review: the
new tests fail with `saw [Some(""), Some(""), None, None]` when the fix is
reverted.

Rather than empty-check in three more places, the sentinel is now read through
one accessor, `Target::effective_user_agent()`, and all six consumers go through
it. `mcp::preflight_dalfox` also stopped using a second UA convention of its own.

## Verification

- `cargo test` green (2274); `cargo fmt --check` and `clippy --all-targets
  --all-features -D warnings` clean.
- Harness gates: `replay_corpus` (the false-positive oracle), `surface_parity`,
  `output_conformance`, `docs_lint` all pass. `server_mcp_smoke` is 43/44 — the
  one failure is the pre-existing rmcp `isError`-vs-JSON-RPC-channel defect that
  `ci-extended.yml` already marks `continue-on-error` with a comment.
- The extraction was checked mechanically, not by eye: the two removed bodies
  were normalized and diffed against each other first, which is how the single
  `user_agent` divergence was found rather than silently resolved.
- Both new UA tests are mutation-tested. The stage-3 one deliberately uses a
  *reflecting* param, because the existing REST regression test for this
  sentinel uses a non-reflecting target and never reaches the probe.
