### PR TITLE
fix(cli): keep hidden subcommands out of shell completions

### DIFF
--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -292,6 +292,10 @@ dalfox completion fish > ~/.config/fish/completions/dalfox.fish
 
 Nothing else is written to stdout, so the output can always be safely redirected to a file.
 
+The deprecated `url` / `file` / `pipe` compat commands and the packaging helper `man` are hidden from `--help`, and the generated scripts leave them out too.
+
+---
+
 ## See also
 
 - [Config File reference](../config/)

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,8 +8,12 @@ use clap_complete::{Shell, generate};
 use dalfox::cmd::scan::ScanOutcome;
 use dalfox::{DEBUG, cmd, config, mcp, server, utils};
 
+/// Binary name, shared by the clap definition, the completion command tree and
+/// the `bin_name` the generated scripts key off, so the three cannot drift.
+const BIN_NAME: &str = "dalfox";
+
 #[derive(Parser)]
-#[command(name = "dalfox")]
+#[command(name = BIN_NAME)]
 #[command(about = "Powerful open-source XSS scanner")]
 #[command(version, short_flag = 'V')]
 #[command(
@@ -107,6 +111,40 @@ fn print_man_page() {
     }
 }
 
+/// The command tree the shell-completion scripts are generated from: `Cli`
+/// minus every `hide = true` subcommand.
+///
+/// `clap_mangen` drops hidden subcommands on its own, but `clap_complete`'s
+/// generators walk `Command::get_subcommands()` unfiltered, so `dalfox <TAB>`
+/// would offer the deprecated compat commands (`url` / `file` / `pipe`) and the
+/// packaging helper (`man`) that `--help` and the man page both hide — and
+/// carry four copies of the flattened `ScanArgs` while doing it.
+///
+/// `clap::Command` has no `remove_subcommand`, so the root is re-assembled from
+/// the real definition's own arguments and its visible subcommands instead. No
+/// part of the CLI surface is restated here — the flags and subcommands are
+/// `Cli`'s own — and the two root fields that are come from the same constants
+/// the derive reads. Only cosmetic root settings the completion scripts never
+/// render (usage string, help template) are left behind.
+///
+/// The subcommand tree is one level deep, so filtering the root's children is
+/// the whole job; a nested hidden subcommand would need this to recurse.
+fn completion_command() -> clap::Command {
+    let full = Cli::command();
+    let mut cmd = clap::Command::new(BIN_NAME)
+        .version(env!("CARGO_PKG_VERSION"))
+        .args(full.get_arguments().cloned())
+        .subcommands(
+            full.get_subcommands()
+                .filter(|sc| !sc.is_hide_set())
+                .cloned(),
+        );
+    if let Some(about) = full.get_about() {
+        cmd = cmd.about(about.clone());
+    }
+    cmd
+}
+
 /// Which of `name`'s flags the operator actually typed, for the scan-bearing
 /// subcommands (`scan`, and the compat `url` / `file` / `pipe`, which all carry
 /// a flattened `ScanArgs`).
@@ -197,8 +235,8 @@ async fn main() {
                 return;
             }
             Commands::Completion { shell } => {
-                let mut cmd = Cli::command();
-                generate(*shell, &mut cmd, "dalfox", &mut std::io::stdout());
+                let mut cmd = completion_command();
+                generate(*shell, &mut cmd, BIN_NAME, &mut std::io::stdout());
                 return;
             }
             _ => {}

--- a/tests/e2e/cli_smoke_test.rs
+++ b/tests/e2e/cli_smoke_test.rs
@@ -537,3 +537,94 @@ fn test_e2e_non_regular_file_rejected() {
         stderr
     );
 }
+
+/// Every shell `dalfox completion` accepts (i.e. every `clap_complete::Shell`).
+const COMPLETION_SHELLS: [&str; 5] = ["bash", "zsh", "fish", "powershell", "elvish"];
+
+/// How each shell's generator declares one subcommand, with `{}` standing in
+/// for its name. Asserting a *visible* subcommand matches keeps these patterns
+/// honest: if a `clap_complete` upgrade changes the emitted shape, the
+/// visible-subcommand half fails instead of the hidden-subcommand half quietly
+/// passing against a pattern that can no longer match anything.
+const SUBCOMMAND_DECLARATION: [(&str, &str); 5] = [
+    ("bash", "dalfox,{})"),
+    // zsh indents the first `case` arm and no others, so the pattern anchors on
+    // the trailing newline only.
+    ("zsh", "({})\n"),
+    ("fish", "__fish_dalfox_using_subcommand {}"),
+    ("powershell", "'dalfox;{}'"),
+    ("elvish", "&'dalfox;{}'="),
+];
+
+fn completion_script(shell: &str) -> String {
+    let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .args(["completion", shell])
+        .output()
+        .unwrap_or_else(|e| panic!("failed to execute dalfox completion {shell}: {e}"));
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "dalfox completion {shell} should exit 0, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "dalfox completion {shell} should write nothing to stderr, got:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    String::from_utf8(output.stdout)
+        .unwrap_or_else(|e| panic!("dalfox completion {shell} emitted non-UTF-8: {e}"))
+}
+
+/// The subcommand returns before the banner/config machinery runs, so the
+/// script is the *only* thing on stdout. Users redirect this straight into
+/// `/etc/bash_completion.d/dalfox`, so a stray banner line is a broken shell,
+/// not cosmetic noise.
+#[test]
+fn test_completion_writes_only_the_script_to_stdout() {
+    for shell in COMPLETION_SHELLS {
+        let script = completion_script(shell);
+
+        assert!(
+            script.contains("only-poc"),
+            "dalfox completion {shell} should carry the scan subtree's flags"
+        );
+        assert!(
+            script.contains("completion"),
+            "dalfox completion {shell} should carry the completion subcommand itself"
+        );
+        // `█` is unique to the ASCII-art banner, which must never reach stdout
+        // on this path.
+        assert!(
+            !script.contains('█'),
+            "dalfox completion {shell} leaked the banner into the script"
+        );
+    }
+}
+
+/// `clap_complete`'s generators walk `Command::get_subcommands()` without
+/// filtering `hide = true` entries — unlike `clap_mangen`, which drops them —
+/// so the completion scripts are the one surface where the deprecated compat
+/// commands (`url` / `file` / `pipe`) and the packaging helper (`man`) can be
+/// advertised to users. `completion_command()` in `src/main.rs` filters them.
+#[test]
+fn test_completion_omits_hidden_subcommands() {
+    for (shell, declaration) in SUBCOMMAND_DECLARATION {
+        let script = completion_script(shell);
+
+        for visible in ["scan", "server", "payload", "mcp", "completion"] {
+            assert!(
+                script.contains(&declaration.replace("{}", visible)),
+                "dalfox completion {shell} should declare the `{visible}` subcommand"
+            );
+        }
+
+        for hidden in ["man", "url", "file", "pipe"] {
+            assert!(
+                !script.contains(&declaration.replace("{}", hidden)),
+                "dalfox completion {shell} advertises the hidden `{hidden}` subcommand"
+            );
+        }
+    }
+}


### PR DESCRIPTION
Post-merge follow-up to #1374.

## Problem

`clap_complete`'s generators walk `Command::get_subcommands()` without filtering `hide = true` entries — unlike `clap_mangen`, which drops them — so all five generated scripts advertised the subcommands the CLI deliberately hides:

```
# before, bash
opts="… scan server payload mcp completion man url file pipe help"
```

`dalfox <TAB>` offered the deprecated compat commands (`url` / `file` / `pipe`) and the packaging helper (`man`), i.e. exactly what `--help` and the man page hide. Confirmed on every shell: bash `dalfox,man)`, zsh `(man)`, fish `__fish_dalfox_using_subcommand man`, powershell/elvish `'dalfox;man'`.

## Fix

`clap::Command` has no `remove_subcommand`, so `completion_command()` re-assembles the root from `Cli`'s own arguments and its **visible** subcommands. No part of the CLI surface is restated in it, so it cannot drift from `Cli`; only cosmetic root settings completions never render (usage string, help template) are left behind.

Side effect: dropping the three compat commands drops their three extra copies of the flattened `ScanArgs`.

| shell | before | after |
|---|---|---|
| bash | 62K | 23K |
| zsh | 78K | 26K |
| fish | 86K | 28K |
| powershell | 110K | 36K |
| elvish | 71K | 23K |

## Tests

Two e2e tests in `tests/e2e/cli_smoke_test.rs`, table-driven over all five shells:

- `test_completion_omits_hidden_subcommands` — asserts each shell's subcommand-declaration syntax matches for `scan`/`server`/`payload`/`mcp`/`completion` and does **not** for `man`/`url`/`file`/`pipe`. The visible half keeps the patterns honest: a `clap_complete` upgrade that changes the emitted shape fails loudly instead of turning the hidden half into a silent no-op.
- `test_completion_writes_only_the_script_to_stdout` — exit 0, empty stderr, no banner. That contract had no coverage before.

Mutation-checked: reverting `completion_command()` back to `Cli::command()` fails `test_completion_omits_hidden_subcommands` on the first shell.

Verified locally: `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, full `cargo test` (2273 + 210 e2e, all green), plus `dalfox --help` / `dalfox man` / `dalfox url --help` unchanged.