### PR TITLE
docs(cli): document `completion` on the Korean page and fix the subcommand count

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,8 +44,12 @@ Top-level commands:
 - `server`
 - `payload`
 - `mcp`
+- `completion` (writes a `clap_complete` shell script to stdout; `bash`, `zsh`, `fish`, `powershell`, `elvish`)
 - hidden compatibility commands: `url`, `file`, `pipe`
 - hidden packaging helper: `man` (renders the roff man page to stdout)
+
+Both `man` and `completion` are dispatched immediately after parsing, before the
+banner/config machinery writes anything, so stdout stays a pure artifact.
 
 Behavioral default:
 - No subcommand => defaults to `scan` in `src/main.rs`.

--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -5,7 +5,7 @@ weight = 1
 toc = true
 +++
 
-Dalfox는 네 개의 서브커맨드와 기본 제공 `help`로 구성되어 있습니다. 기본값(대상만 전달했을 때)은 `scan`입니다.
+Dalfox는 다섯 개의 서브커맨드와 기본 제공 `help`로 구성되어 있습니다. 기본값(대상만 전달했을 때)은 `scan`입니다.
 
 ```
 dalfox [SUBCOMMAND] [TARGET] [FLAGS]
@@ -17,6 +17,7 @@ dalfox [SUBCOMMAND] [TARGET] [FLAGS]
 | `server` | REST API 서버를 실행합니다 |
 | `payload` | 내장/원격 페이로드를 나열하거나 가져옵니다 |
 | `mcp` | Model Context Protocol stdio 서버를 실행합니다 |
+| `completion` | 셸 자동완성 스크립트를 생성합니다 |
 | `help` | 서브커맨드별 도움말을 출력합니다 |
 
 ## 전역 플래그
@@ -262,6 +263,33 @@ dalfox mcp
 ```
 
 추가 플래그는 없습니다. 도구 정의는 [MCP Server](../../integrations/mcp/)를 참조하세요.
+
+---
+
+## `dalfox completion`
+
+셸 자동완성 스크립트를 생성해 stdout으로 출력합니다.
+
+```bash
+dalfox completion <SHELL>
+```
+
+지원하는 셸: `bash`, `zsh`, `fish`, `powershell`, `elvish`.
+
+```bash
+# bash
+dalfox completion bash > /etc/bash_completion.d/dalfox
+
+# zsh
+dalfox completion zsh > "${fpath[1]}/_dalfox"
+
+# fish
+dalfox completion fish > ~/.config/fish/completions/dalfox.fish
+```
+
+stdout에는 스크립트 외에 아무것도 출력되지 않으므로, 출력을 그대로 파일로 리다이렉트해도 안전합니다.
+
+숨김 서브커맨드(구버전 호환용 `url` / `file` / `pipe`와 패키징 헬퍼 `man`)는 `--help`에서와 마찬가지로 생성된 스크립트에도 포함되지 않습니다.
 
 ---
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -5,7 +5,7 @@ weight = 1
 toc = true
 +++
 
-Dalfox is organised into four subcommands, plus the built-in `help`. The default (when you just pass a target) is `scan`.
+Dalfox is organised into five subcommands, plus the built-in `help`. The default (when you just pass a target) is `scan`.
 
 ```
 dalfox [SUBCOMMAND] [TARGET] [FLAGS]


### PR DESCRIPTION
Post-merge follow-up to #1374.

## What was missing

`docs/content/reference/cli.md` and `cli.ko.md` are language twins, but #1374 only touched the English one. The Korean page listed four subcommands and had no `dalfox completion` section at all.

Both pages also still opened with *"Dalfox is organised into four subcommands"* while the table below listed five.

## Changes

- `cli.ko.md` — `completion` row in the subcommand table + a full `## dalfox completion` section mirroring the English one (usage, supported shells, per-shell install examples, the stdout-purity note).
- `cli.md` / `cli.ko.md` — "four subcommands" → "five".
- `AGENTS.md` — `completion` added to the top-level command list, with a note on why it and `man` are dispatched before the banner/config machinery.

Verified with `crystal run scripts/docs_lint.cr` (25/25 passed, EN/KO pairing included) and a full `hwaro build` (46 pages, `/ko/reference/cli/` renders the new section).

> Depends on #1377 for the "hidden subcommands are left out of the generated scripts" sentence on the Korean page — merge that one first.