### PR TITLE
refactor(scan): break the four giant scan-path functions into named stages

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -140,679 +140,857 @@ pub(crate) async fn run_preflight_and_analysis(
             let target_mutation_stats_outer = target_mutation_stats.clone();
             let session_baselines_outer = session_baselines.clone();
             let session_lost_outer = session_lost.clone();
-            local.run_until(async move {
-                let mut handles = vec![];
+            local
+                .run_until(async move {
+                    let mut handles = vec![];
 
-                for mut target in drained {
-            // Kept outside the task so a panicking task can still be reported
-            // against its target instead of vanishing (see the collector).
-            let panic_target_url = target.url.to_string();
-            let args_clone = args_outer.clone();
-            let sem = pre_analyze_semaphore_outer.clone();
-            let preflight_idx_clone = preflight_idx_outer.clone();
-            let analyze_idx_clone = analyze_idx_outer.clone();
-            let total_targets_copy = total_targets_outer;
-            let multi_pb_clone = multi_pb_outer.clone();
-            let results_clone = results_outer.clone();
-            let findings_count_clone = findings_count_outer.clone();
-            let skipped_targets_clone = skipped_targets_outer.clone();
-            let target_meta_clone = target_meta_outer.clone();
-            let target_mutation_stats_clone = target_mutation_stats_outer.clone();
-            let session_baselines_clone = session_baselines_outer.clone();
-            let session_lost_clone = session_lost_outer.clone();
+                    for target in drained {
+                        // Kept outside the task so a panicking task can still be reported
+                        // against its target instead of vanishing (see the collector).
+                        let panic_target_url = target.url.to_string();
+                        let ctx = TargetTaskCtx {
+                            args_clone: args_outer.clone(),
+                            sem: pre_analyze_semaphore_outer.clone(),
+                            preflight_idx_clone: preflight_idx_outer.clone(),
+                            analyze_idx_clone: analyze_idx_outer.clone(),
+                            total_targets_copy: total_targets_outer,
+                            spinner_allowed,
+                            multi_pb_clone: multi_pb_outer.clone(),
+                            results_clone: results_outer.clone(),
+                            findings_count_clone: findings_count_outer.clone(),
+                            skipped_targets_clone: skipped_targets_outer.clone(),
+                            target_meta_clone: target_meta_outer.clone(),
+                            target_mutation_stats_clone: target_mutation_stats_outer.clone(),
+                            session_baselines_clone: session_baselines_outer.clone(),
+                            session_lost_clone: session_lost_outer.clone(),
+                        };
 
-            handles.push((panic_target_url, tokio::task::spawn_local(async move {
-                // Bound concurrency across targets for preflight + analysis
-                let Ok(_permit) = sem.acquire_owned().await else {
-                    return None;
-                };
-                let mut __preflight_csp_present = false;
-                let mut __preflight_csp_header: Option<(String, String)> = None;
-                let mut preflight_response_body: Option<String> = None;
-
-                // Preflight probe: fetch the landing page for content-type, CSP,
-                // WAF, and tech detection, and capture the body (which feeds the
-                // initial AST DOM-XSS pass and outdated-lib detection below).
-                // This runs for EVERY scan, including `--deep-scan`. `--deep-scan`
-                // only lifts the per-parameter payload cap and the content-type
-                // *denylist skip* (gated below) — it must NOT skip the preflight
-                // itself. Wrapping the whole probe in `if !deep_scan` silently
-                // disabled WAF fingerprinting/bypass, CSP-bypass, tech detection,
-                // and the initial-response AST DOM analysis under `--deep-scan`,
-                // making the "more thorough" mode strictly weaker.
-                {
-                    let current = preflight_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
-                    // Print an ephemeral spinner and auto-clear when finished
-                    let label = if total_targets_copy > 1 {
-                        format!(
-                            "[{}/{}] preflight: {}",
-                            current, total_targets_copy, target.url
-                        )
-                    } else {
-                        format!("preflight: {}", target.url)
-                    };
-                    let __preflight_spinner = if total_targets_copy == 1 { start_spinner(spinner_allowed, !args_clone.silence, label) } else { None };
-
-                    let __preflight_info = preflight_content_type(&target, &args_clone).await;
-                    if let Some((tx, done_rx)) = __preflight_spinner {
-                        let _ = tx.send(());
-                        let _ = done_rx.await;
+                        handles.push((
+                            panic_target_url,
+                            tokio::task::spawn_local(preflight_and_analyze_target(target, ctx)),
+                        ));
                     }
 
-                    let __preflight_info = match __preflight_info {
-                        PreflightOutcome::Unreachable(code) => {
-                            // Hard reachability failure (DNS, TCP refused,
-                            // TLS handshake timeout). preflight_content_type
-                            // already surfaced the UNREACHABLE diagnostic.
-                            // Mark the target as skipped with the *specific*
-                            // error_code we classified — DNS_RESOLUTION_FAILED
-                            // vs TLS_HANDSHAKE_FAILED vs REQUEST_TIMEOUT vs
-                            // CONNECTION_FAILED — so target_summary tells
-                            // ops *which* layer broke instead of lumping.
-                            skipped_targets_clone
-                                .lock()
-                                .await
-                                .insert(target.url.to_string(), code);
-                            return None;
-                        }
-                        // NoContentType (e.g. GET preflight on a POST-only
-                        // endpoint that 405s without a Content-Type header)
-                        // — keep scanning, just skip the preflight metadata
-                        // population below. Preserves the v3.0 behavior
-                        // that body-param scans of /post-only endpoints
-                        // still work. The session baseline is the one piece
-                        // that must survive: the target still gets scanned, so
-                        // it still has a session that can die mid-run.
-                        PreflightOutcome::NoContentType(baseline) => {
-                            if let Some(baseline) = baseline {
-                                record_session_baseline(
-                                    &args_clone,
-                                    &target,
-                                    baseline,
-                                    &session_baselines_clone,
-                                    &session_lost_clone,
-                                )
-                                .await;
-                            }
-                            None
-                        }
-                        PreflightOutcome::WithContentType(r) => Some(r),
-                    };
-
-                    if let Some(preflight) = __preflight_info {
-                        preflight_response_body = preflight.response_body;
-                        // Authenticated-state fingerprint for mid-scan
-                        // session-loss detection. Present only when the target
-                        // carries credentials (or the operator asked for a
-                        // check explicitly).
-                        if let Some(baseline) = preflight.session_baseline {
-                            record_session_baseline(
-                                &args_clone,
-                                &target,
-                                baseline,
-                                &session_baselines_clone,
-                                &session_lost_clone,
-                            )
-                            .await;
-                        }
-                        if let Some((hn, hv)) = preflight.csp_header {
-                            __preflight_csp_present = true;
-                            // Analyze CSP and store on target for bypass payload generation
-                            let mut csp = crate::payload::xss_csp_bypass::analyze_csp(&hv);
-                            // A report-only CSP enforces nothing — it only emits
-                            // violation reports — so `require-trusted-types-for`
-                            // there must not drive Trusted Types suppression in
-                            // the AST analyzer (that would be a false negative).
-                            // Bypass-payload fields stay as parsed.
-                            if !hn.eq_ignore_ascii_case("content-security-policy") {
-                                csp.report_only = true;
-                                csp.require_trusted_types_for = false;
-                            }
-                            if crate::DEBUG.load(Ordering::Relaxed) {
-                                let class = if csp.is_hardened() {
-                                    "hardened (nonce/hash-only)"
-                                } else if csp.is_gadget_bypassable() {
-                                    "gadget-bypassable"
-                                } else {
-                                    "no script-execution bypass surface"
-                                };
-                                crate::ceprintln!(
-                                    "[csp] {} classified {} (strict-dynamic={}, nonces={}, trusted-types-enforced={})",
-                                    hn,
-                                    class,
-                                    csp.has_strict_dynamic,
-                                    csp.nonce_values.len(),
-                                    csp.require_trusted_types_for
+                    // Collect processed targets (skipping those filtered by preflight)
+                    let mut processed: Vec<Target> = Vec::new();
+                    for (target_url, handle) in handles {
+                        match handle.await {
+                            Ok(Some(t)) => processed.push(t),
+                            // Preflight deliberately dropped this target; it has
+                            // already recorded its own `skipped_targets` entry.
+                            Ok(None) => {}
+                            // A panic in here used to be swallowed whole: the
+                            // target silently disappeared from `processed`, never
+                            // reached the injection stage, and the run finished
+                            // `0 XSS` with exit 0 — a scanner reporting "clean" for
+                            // a target it crashed on. Surface it and record the
+                            // target as skipped so `target_summary` says
+                            // INTERNAL_ERROR instead of clean. The injection
+                            // stage in `scan_loop.rs` does the same.
+                            Err(e) => {
+                                // Sanitized: a `JoinError`'s Display carries the
+                                // panic message, and panic messages quote the data
+                                // that caused them — a slice-boundary panic embeds
+                                // bytes straight from the scanned response. A raw
+                                // CR/LF there would let a target forge log lines.
+                                eprintln!(
+                                    "[scan] preflight/analysis task failed for {}: {}",
+                                    crate::utils::log::sanitize_log_message(&target_url),
+                                    crate::utils::log::sanitize_log_message(&e.to_string())
                                 );
-                            }
-                            target.csp_analysis = Some(csp);
-                            __preflight_csp_header = Some((hn, hv));
-                        }
-                        // Store WAF detection result on target
-                        if !preflight.waf_result.is_empty() {
-                            target.waf_info = Some(preflight.waf_result);
-                            // Allocate per-target effectiveness counters when
-                            // bypass is going to run; the scanning loop and
-                            // check_reflection both update this Arc, and the
-                            // target_mutation_stats side-map keeps it alive
-                            // until target_summary is built.
-                            if args_clone.waf_bypass != "off" {
-                                let stats = std::sync::Arc::new(
-                                    crate::waf::bypass::MutationStats::default(),
-                                );
-                                target.mutation_stats = Some(stats.clone());
-                                target_mutation_stats_clone
+                                skipped_targets_outer
                                     .lock()
                                     .await
-                                    .insert(target.url.to_string(), stats);
-                            }
-
-                            // Snapshot WAF + applied bypass for target_summary
-                            // (JSON/JSONL output). Plain mode logs the same
-                            // info to the console below; JSON consumers
-                            // would otherwise have no visibility.
-                            let mut detected_waf_extra_delay_ms = 0u64;
-                            if let Some(ref waf_info) = target.waf_info {
-                                let detected_json: Vec<serde_json::Value> = waf_info
-                                    .detected
-                                    .iter()
-                                    .map(|fp| {
-                                        serde_json::json!({
-                                            "type": fp.waf_type.to_string(),
-                                            "confidence": fp.confidence,
-                                            "evidence": fp.evidence,
-                                        })
-                                    })
-                                    .collect();
-                                let mut meta_json = serde_json::json!({
-                                    "detected": detected_json,
-                                });
-                                if args_clone.waf_bypass != "off" {
-                                    let waf_types: Vec<&crate::waf::WafType> =
-                                        waf_info.waf_types();
-                                    let strategy =
-                                        crate::waf::bypass::merge_strategies(&waf_types);
-                                    // Carry the per-WAF pacing hint onto the target so the
-                                    // injection paths actually slow down for rate-limiting
-                                    // WAFs — previously this only landed in JSON meta.
-                                    detected_waf_extra_delay_ms = strategy.extra_delay_hint_ms;
-                                    meta_json["bypass"] = serde_json::json!({
-                                        "encoders": strategy.extra_encoders,
-                                        "mutation_count": strategy.mutations.len(),
-                                        "extra_delay_hint_ms": strategy.extra_delay_hint_ms,
-                                    });
-                                }
-                                target_meta_clone
-                                    .lock()
-                                    .await
-                                    .insert(target.url.to_string(), meta_json);
-                            }
-
-                            // Apply the WAF pacing hint so detected rate-limiting
-                            // WAFs slow the injection cadence even without
-                            // --waf-evasion (0 when no WAF / --waf-bypass off).
-                            target.waf_extra_delay_ms = detected_waf_extra_delay_ms;
-
-                            // Adaptive WAF evasion: randomized inter-request jitter
-                            // plus an escalating cooldown on block clusters, applied
-                            // in the injection paths via `args.waf_evasion` and
-                            // `target.waf_extra_delay_ms`. This replaces the old blunt
-                            // workers=1 / delay=3000 preset, which throttled far harder
-                            // than necessary and was trivially fingerprintable.
-                            if args_clone.waf_evasion && !args_clone.silence {
-                                let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-                                crate::cprintln!(
-                                    "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m evasion activated: adaptive jitter + cooldown",
-                                    ts
-                                );
-                            }
-                        }
-                        // Store technology detection result on target
-                        if !preflight.tech_result.is_empty() {
-                            target.tech_info = Some(preflight.tech_result);
-                        }
-                        // Content-type denylist skip stays gated on !deep_scan:
-                        // `--deep-scan` deliberately scans every content type,
-                        // whereas a normal scan drops denylisted types (images,
-                        // fonts, etc.) that can't carry reflected/DOM XSS.
-                        if !args_clone.deep_scan
-                            && !is_allowed_content_type(&preflight.content_type)
-                        {
-                            // Skip this target early
-                            skipped_targets_clone.lock().await.insert(
-                                target.url.to_string(),
-                                crate::cmd::error_codes::CONTENT_TYPE_MISMATCH,
-                            );
-                            return None;
-                        }
-                    }
-                }
-
-                // Pretty start log per target (plain only)
-                if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
-                    if total_targets_copy > 1 {
-                        let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(
-                            target.url.as_ref(),
-                        ));
-                        let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-                        crate::cprintln!(
-                            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} start scan to {}",
-                            ts, sid, target.url
-                        );
-                    } else {
-                        let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-                        crate::cprintln!(
-                            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m start scan to {}",
-                            ts, target.url
-                        );
-                        if __preflight_csp_present {
-                            crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m CSP: enabled", ts);
-                            if let Some((hn, hv)) = &__preflight_csp_header {
-                                crate::cprintln!("  \x1b[90m└──\x1b[0m \x1b[38;5;247m{}:\x1b[0m \x1b[38;5;247m{}\x1b[0m", hn, hv);
-                            }
-                        }
-                        // Log WAF detection
-                        if let Some(ref waf_info) = target.waf_info {
-                            for fp in &waf_info.detected {
-                                crate::cprintln!(
-                                    "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m {} detected (confidence: {:.0}%, evidence: {})",
-                                    ts, fp.waf_type, fp.confidence * 100.0, fp.evidence
-                                );
-                            }
-                            if args_clone.waf_bypass != "off" {
-                                let waf_types: Vec<&crate::waf::WafType> = waf_info.waf_types();
-                                let strategy = crate::waf::bypass::merge_strategies(&waf_types);
-                                if !strategy.extra_encoders.is_empty() {
-                                    crate::cprintln!(
-                                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass encoders: {}\x1b[0m",
-                                        strategy.extra_encoders.join(", ")
-                                    );
-                                }
-                                if !strategy.mutations.is_empty() {
-                                    crate::cprintln!(
-                                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass mutations: {} types\x1b[0m",
-                                        strategy.mutations.len()
-                                    );
-                                }
-                            }
-                        }
-                        // Log detected technologies
-                        if let Some(ref tech_info) = target.tech_info {
-                            let tech_names: Vec<String> = tech_info.detected.iter().map(|d| format!("{}", d.tech)).collect();
-                            if !tech_names.is_empty() {
-                                crate::cprintln!(
-                                    "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m tech: {}",
-                                    ts, tech_names.join(", ")
-                                );
+                                    .insert(target_url, crate::cmd::error_codes::INTERNAL_ERROR);
                             }
                         }
                     }
-                }
-
-                // Silence parameter analysis logs and progress; show spinner for single-target runs.
-                // When multi_pb_clone is active, analyze_parameters renders its own indicatif
-                // spinner via that MultiProgress — skip the stdout spinner so we don't double up.
-                let current = analyze_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
-                let __analyze_spinner = if total_targets_copy == 1 && multi_pb_clone.is_none() {
-                    start_spinner(
-                        spinner_allowed,
-                        !args_clone.silence,
-                        if total_targets_copy > 1 {
-                            format!("[{}/{}] analyzing: {}", current, total_targets_copy, target.url)
-                        } else {
-                            format!("analyzing: {}", target.url)
-                        },
-                    )
-                } else {
-                    None
-                };
-                let mut __analysis_args = args_clone.clone();
-                __analysis_args.silence = true;
-                if let Some(ref marker) = args_clone.inject_marker {
-                    // Custom injection marker mode: skip normal discovery/mining
-                    // and create params from marker positions in URL/headers/body
-                    use crate::parameter_analysis::{Location, Param};
-                    let mut marker_params = Vec::new();
-
-                    // Check URL query params
-                    for (k, v) in target.url.query_pairs() {
-                        if v.contains(marker.as_str()) {
-                            marker_params.push(Param {
-                                name: k.to_string(),
-                                value: v.to_string(),
-                                location: Location::Query,
-                                injection_context: None,
-                                valid_specials: None,
-                                invalid_specials: None,
-                                pre_encoding: None,
-                                pre_encoding_pipeline: None,
-                                wire_name: None,
-                                form_action_url: None,
-                                form_origin_url: None,
-                                framework_sink: None,
-                                escaped_specials: None,
-                                js_breakout: None,
-                            });
-                        }
-                    }
-
-                    // Check body params
-                    if let Some(ref data) = target.data {
-                        if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(data) {
-                            if let Some(obj) = json_val.as_object() {
-                                for (k, v) in obj {
-                                    if let Some(s) = v.as_str()
-                                        && s.contains(marker.as_str())
-                                    {
-                                        marker_params.push(Param {
-                                            name: k.clone(),
-                                            value: s.to_string(),
-                                            location: Location::JsonBody,
-                                            injection_context: None,
-                                            valid_specials: None,
-                                            invalid_specials: None,
-                                            pre_encoding: None,
-                                            pre_encoding_pipeline: None,
-                                            wire_name: None,
-                                            form_action_url: None,
-                                            form_origin_url: None,
-                                            framework_sink: None,
-                                            escaped_specials: None,
-                                            js_breakout: None,
-                                        });
-                                    }
-                                }
-                            }
-                        } else {
-                            for pair in data.split('&') {
-                                if let Some((k, v)) = pair.split_once('=')
-                                    && v.contains(marker.as_str())
-                                {
-                                    marker_params.push(Param {
-                                        name: k.to_string(),
-                                        value: v.to_string(),
-                                        location: Location::Body,
-                                        injection_context: None,
-                                        valid_specials: None,
-                                        invalid_specials: None,
-                                        pre_encoding: None,
-                                        pre_encoding_pipeline: None,
-                                        wire_name: None,
-                                        form_action_url: None,
-                                        form_origin_url: None,
-                                        framework_sink: None,
-                                        escaped_specials: None,
-                                        js_breakout: None,
-                                    });
-                                }
-                            }
-                        }
-                    }
-
-                    // Check headers
-                    for (k, v) in &target.headers {
-                        if v.contains(marker.as_str()) {
-                            marker_params.push(Param {
-                                name: k.clone(),
-                                value: v.clone(),
-                                location: Location::Header,
-                                injection_context: None,
-                                valid_specials: None,
-                                invalid_specials: None,
-                                pre_encoding: None,
-                                pre_encoding_pipeline: None,
-                                wire_name: None,
-                                form_action_url: None,
-                                form_origin_url: None,
-                                framework_sink: None,
-                                escaped_specials: None,
-                                js_breakout: None,
-                            });
-                        }
-                    }
-
-                    // Check cookies
-                    for (k, v) in &target.cookies {
-                        if v.contains(marker.as_str()) {
-                            marker_params.push(Param {
-                                name: k.clone(),
-                                value: v.clone(),
-                                location: Location::Header,
-                                injection_context: None,
-                                valid_specials: None,
-                                invalid_specials: None,
-                                pre_encoding: None,
-                                pre_encoding_pipeline: None,
-                                wire_name: None,
-                                form_action_url: None,
-                                form_origin_url: None,
-                                framework_sink: None,
-                                escaped_specials: None,
-                                js_breakout: None,
-                            });
-                        }
-                    }
-
-                    target.reflection_params = marker_params;
-                } else {
-                    analyze_parameters(&mut target, &__analysis_args, multi_pb_clone).await;
-                }
-                if let Some((tx, done_rx)) = __analyze_spinner {
-                    let _ = tx.send(());
-                    let _ = done_rx.await;
-                }
-
-                // Outdated / known-vulnerable JS library detection (issue #1074).
-                // OPT-IN (`--detect-outdated-libs`, default off): dalfox's default
-                // output is verified XSS, so this informational (CWE-1104) add-on
-                // is gated behind a flag. Emits once per target from the initial
-                // response; borrows the body so the AST block below can still use it.
-                if args_clone.detect_outdated_libs
-                    && let Some(body) = preflight_response_body.as_deref()
-                {
-                    let lib_findings = crate::scanning::vuln_libs::library_findings(
-                        crate::scanning::vuln_libs::detect_vulnerable_libraries(body),
-                        target.url.as_str(),
-                        &target.method,
-                    );
-                    if !lib_findings.is_empty() {
-                        // Count only findings matching --limit-result-type so a
-                        // CWE-1104 (informational) batch can't trip --limit when
-                        // the user is limiting on a different result type.
-                        let added = crate::scanning::count_matching_results(
-                            &lib_findings,
-                            &args_clone.limit_result_type.to_uppercase(),
-                        );
-                        let mut guard = results_clone.lock().await;
-                        guard.extend(lib_findings);
-                        findings_count_clone.fetch_add(added, Ordering::Relaxed);
-                    }
-                }
-
-                // Run AST-based DOM XSS analysis on the initial response
-                // (enabled by default). The helper is shared with the
-                // server (`dalfox server`) and MCP (`scan_with_dalfox`)
-                // paths so all three surfaces produce the same DOM-XSS
-                // findings for an identical target.
-                if !args_clone.skip_ast_analysis
-                    && let Some(response_text) = preflight_response_body
-                {
-                    let ast_batch =
-                        crate::scanning::ast_integration::run_initial_ast_dom_analysis(
-                            &response_text,
-                            target.url.as_str(),
-                            &target.method,
-                            crate::scanning::ast_integration::PageSecurityPosture::from_target(
-                                &target,
-                            ),
-                        );
-                    if !ast_batch.is_empty() {
-                        let added = crate::scanning::count_matching_results(
-                            &ast_batch,
-                            &args_clone.limit_result_type.to_uppercase(),
-                        );
-                        let mut guard = results_clone.lock().await;
-                        guard.extend(ast_batch);
-                        findings_count_clone.fetch_add(added, Ordering::Relaxed);
-                    }
-                    if args_clone.analyze_external_js {
-                        let ext_client = target.build_client_or_default();
-                        let ext_batch = crate::scanning::fetch_and_analyze_external_js(
-                            &ext_client,
-                            &target,
-                            &response_text,
-                            &args_clone,
-                        )
-                        .await;
-                        crate::scanning::accumulate_findings(
-                            &results_clone,
-                            &findings_count_clone,
-                            ext_batch,
-                            &args_clone.limit_result_type.to_uppercase(),
-                        )
-                        .await;
-                    }
-                }
-
-                // Pretty reflection summary (plain only)
-                if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
-                    let n = target.reflection_params.len();
-                    let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-                    if total_targets_copy > 1 {
-                        let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(
-                            target.url.as_ref(),
-                        ));
-                        crate::cprintln!(
-                            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} found reflected \x1b[33m{}\x1b[0m params",
-                            ts, sid, n
-                        );
-                    } else {
-                        crate::cprintln!(
-                            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m found reflected \x1b[33m{}\x1b[0m params",
-                            ts, n
-                        );
-                    }
-                    for (i, p) in target.reflection_params.iter().enumerate() {
-                        let bullet = if i + 1 == n { "└──" } else { "├──" };
-                        let valid = p
-                            .valid_specials
-                            .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
-                        let invalid = p
-                            .invalid_specials
-                            .as_ref().map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
-                        crate::cprintln!(
-                            "  \x1b[90m{}\x1b[0m \x1b[38;5;247m{}\x1b[0m \x1b[38;5;247mvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\" \x1b[38;5;247minvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\"",
-                            bullet, p.name, valid, invalid
-                        );
-                    }
-                    // Debug: estimate total test cases (requests) to be run during scanning
-                    if crate::DEBUG.load(Ordering::Relaxed) && args_clone.format == "plain" && !args_clone.silence {
-                        // encoder expansion factor
-                        let enc_factor = if args_clone.encoders.iter().any(|e| e == "none") {
-                            1
-                        } else {
-                            let mut f = 1;
-                            for e in ["url", "html", "2url", "3url", "4url", "base64"] {
-                                if args_clone.encoders.iter().any(|x| x == e) {
-                                    f += 1;
-                                }
-                            }
-                            f
-                        };
-                        // Match the scan-time effective cap so the preflight
-                        // request estimate reflects the built-in safety cap.
-                        let cap = crate::scanning::effective_payload_cap(
-                            args_clone.max_payloads_per_param,
-                            args_clone.deep_scan,
-                        );
-                        let apply_cap = |n: usize| -> usize {
-                            if cap == 0 { n } else { n.min(cap) }
-                        };
-                        let mut total: usize = 0;
-                        for p in &target.reflection_params {
-                            let refl_len = if let Some(ctx) = &p.injection_context {
-                                crate::scanning::xss_common::get_dynamic_payloads(ctx, &args_clone)
-                                    .unwrap_or_else(|_| vec![])
-                                    .len()
-                            } else {
-                                // Fallback estimate: HTML dynamic payloads + JS payloads (with encoders), excluding remote payloads
-                                let html_base_len = crate::payload::get_dynamic_xss_html_payloads().len();
-                                let html_len = html_base_len * enc_factor;
-                                let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                                html_len + js_len
-                            };
-                            let dom_len = match &p.injection_context {
-                                Some(crate::parameter_analysis::InjectionContext::Javascript(_)) => 0,
-                                Some(ctx) => {
-                                    // Use locally generated payloads and apply encoder factor; exclude remote payloads
-                                    let base = crate::scanning::xss_common::generate_dynamic_payloads(ctx);
-                                    base.len() * enc_factor
-                                }
-                                None => {
-                                    // Unknown context: use HTML + Attribute payloads without remote, apply encoder factor
-                                    let html = crate::payload::get_dynamic_xss_html_payloads();
-                                    let attr = crate::payload::get_dynamic_xss_attribute_payloads();
-                                    (html.len() + attr.len()) * enc_factor
-                                }
-                            };
-                            // Scan loop is additive (one reflection request + one DOM request
-                            // per payload), not cartesian. Mirrors the `total_tasks` calculation
-                            // in src/scanning/mod.rs that drives the progress bar / ETA.
-                            // WAF mutation/encoder expansion isn't reflected here yet, so this
-                            // remains a lower bound.
-                            total = total.saturating_add(
-                                apply_cap(refl_len).saturating_add(apply_cap(dom_len)),
-                            );
-                        }
-                        if args_clone.format == "plain" && !args_clone.silence {
-                            crate::dbg_log!("{} test cases (reqs) estimated", total);
-                        }
-                    }
-                }
-
-                Some(target)
-            })));
-        }
-
-        // Collect processed targets (skipping those filtered by preflight)
-                let mut processed: Vec<Target> = Vec::new();
-                for (target_url, handle) in handles {
-                    match handle.await {
-                        Ok(Some(t)) => processed.push(t),
-                        // Preflight deliberately dropped this target; it has
-                        // already recorded its own `skipped_targets` entry.
-                        Ok(None) => {}
-                        // A panic in here used to be swallowed whole: the
-                        // target silently disappeared from `processed`, never
-                        // reached the injection stage, and the run finished
-                        // `0 XSS` with exit 0 — a scanner reporting "clean" for
-                        // a target it crashed on. Surface it and record the
-                        // target as skipped so `target_summary` says
-                        // INTERNAL_ERROR instead of clean. The injection
-                        // stage in `scan_loop.rs` does the same.
-                        Err(e) => {
-                            // Sanitized: a `JoinError`'s Display carries the
-                            // panic message, and panic messages quote the data
-                            // that caused them — a slice-boundary panic embeds
-                            // bytes straight from the scanned response. A raw
-                            // CR/LF there would let a target forge log lines.
-                            eprintln!(
-                                "[scan] preflight/analysis task failed for {}: {}",
-                                crate::utils::log::sanitize_log_message(&target_url),
-                                crate::utils::log::sanitize_log_message(&e.to_string())
-                            );
-                            skipped_targets_outer
-                                .lock()
-                                .await
-                                .insert(target_url, crate::cmd::error_codes::INTERNAL_ERROR);
-                        }
-                    }
-                }
-                processed
-            }).await
+                    processed
+                })
+                .await
         };
 
         // Replace group with processed targets
         *group = processed;
+    }
+}
+
+/// The per-target handles the preflight/analysis task needs.
+///
+/// Bundled rather than passed positionally: the task body used to capture
+/// fourteen separately-cloned locals, and every new one meant another
+/// `let x_clone = x_outer.clone();` line at the spawn site. `Clone` here is a
+/// handful of refcount bumps, the same cost as before.
+#[derive(Clone)]
+pub(crate) struct TargetTaskCtx {
+    pub(crate) args_clone: ScanArgs,
+    pub(crate) sem: Arc<tokio::sync::Semaphore>,
+    pub(crate) preflight_idx_clone: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) analyze_idx_clone: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) total_targets_copy: usize,
+    pub(crate) spinner_allowed: bool,
+    pub(crate) multi_pb_clone: Option<Arc<indicatif::MultiProgress>>,
+    pub(crate) results_clone: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+    pub(crate) findings_count_clone: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) skipped_targets_clone: Arc<Mutex<HashMap<String, &'static str>>>,
+    pub(crate) target_meta_clone: Arc<Mutex<HashMap<String, serde_json::Value>>>,
+    pub(crate) target_mutation_stats_clone:
+        Arc<Mutex<HashMap<String, Arc<crate::waf::bypass::MutationStats>>>>,
+    pub(crate) session_baselines_clone: Arc<Mutex<HashMap<String, SessionBaseline>>>,
+    pub(crate) session_lost_clone: Arc<Mutex<HashMap<String, String>>>,
+}
+
+/// Preflight one target and analyze its parameters, returning it enriched — or
+/// `None` when preflight dropped it (unreachable, content-type mismatch, …),
+/// in which case the reason has been recorded in `skipped_targets`.
+pub(crate) async fn preflight_and_analyze_target(
+    mut target: Target,
+    ctx: TargetTaskCtx,
+) -> Option<Target> {
+    let TargetTaskCtx {
+        args_clone,
+        sem,
+        preflight_idx_clone,
+        analyze_idx_clone,
+        total_targets_copy,
+        spinner_allowed,
+        multi_pb_clone,
+        results_clone,
+        findings_count_clone,
+        skipped_targets_clone,
+        target_meta_clone,
+        target_mutation_stats_clone,
+        session_baselines_clone,
+        session_lost_clone,
+    } = ctx;
+    // Bound concurrency across targets for preflight + analysis
+    let Ok(_permit) = sem.acquire_owned().await else {
+        return None;
+    };
+    let PreflightCapture {
+        csp_present: __preflight_csp_present,
+        csp_header: __preflight_csp_header,
+        response_body: preflight_response_body,
+    } = run_target_preflight(
+        &mut target,
+        &args_clone,
+        &preflight_idx_clone,
+        total_targets_copy,
+        spinner_allowed,
+        &skipped_targets_clone,
+        &target_meta_clone,
+        &target_mutation_stats_clone,
+        &session_baselines_clone,
+        &session_lost_clone,
+    )
+    .await?;
+
+    // Pretty start log per target (plain only)
+    if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
+        if total_targets_copy > 1 {
+            let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(target.url.as_ref()));
+            let ts = chrono::Local::now().format("%-I:%M%p").to_string();
+            crate::cprintln!(
+                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} start scan to {}",
+                ts,
+                sid,
+                target.url
+            );
+        } else {
+            let ts = chrono::Local::now().format("%-I:%M%p").to_string();
+            crate::cprintln!(
+                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m start scan to {}",
+                ts,
+                target.url
+            );
+            if __preflight_csp_present {
+                crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m CSP: enabled", ts);
+                if let Some((hn, hv)) = &__preflight_csp_header {
+                    crate::cprintln!(
+                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247m{}:\x1b[0m \x1b[38;5;247m{}\x1b[0m",
+                        hn,
+                        hv
+                    );
+                }
+            }
+            // Log WAF detection
+            if let Some(ref waf_info) = target.waf_info {
+                for fp in &waf_info.detected {
+                    crate::cprintln!(
+                        "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m {} detected (confidence: {:.0}%, evidence: {})",
+                        ts,
+                        fp.waf_type,
+                        fp.confidence * 100.0,
+                        fp.evidence
+                    );
+                }
+                if args_clone.waf_bypass != "off" {
+                    let waf_types: Vec<&crate::waf::WafType> = waf_info.waf_types();
+                    let strategy = crate::waf::bypass::merge_strategies(&waf_types);
+                    if !strategy.extra_encoders.is_empty() {
+                        crate::cprintln!(
+                            "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass encoders: {}\x1b[0m",
+                            strategy.extra_encoders.join(", ")
+                        );
+                    }
+                    if !strategy.mutations.is_empty() {
+                        crate::cprintln!(
+                            "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass mutations: {} types\x1b[0m",
+                            strategy.mutations.len()
+                        );
+                    }
+                }
+            }
+            // Log detected technologies
+            if let Some(ref tech_info) = target.tech_info {
+                let tech_names: Vec<String> = tech_info
+                    .detected
+                    .iter()
+                    .map(|d| format!("{}", d.tech))
+                    .collect();
+                if !tech_names.is_empty() {
+                    crate::cprintln!(
+                        "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m tech: {}",
+                        ts,
+                        tech_names.join(", ")
+                    );
+                }
+            }
+        }
+    }
+
+    // Silence parameter analysis logs and progress; show spinner for single-target runs.
+    // When multi_pb_clone is active, analyze_parameters renders its own indicatif
+    // spinner via that MultiProgress — skip the stdout spinner so we don't double up.
+    let current = analyze_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
+    let __analyze_spinner = if total_targets_copy == 1 && multi_pb_clone.is_none() {
+        start_spinner(
+            spinner_allowed,
+            !args_clone.silence,
+            if total_targets_copy > 1 {
+                format!(
+                    "[{}/{}] analyzing: {}",
+                    current, total_targets_copy, target.url
+                )
+            } else {
+                format!("analyzing: {}", target.url)
+            },
+        )
+    } else {
+        None
+    };
+    let mut __analysis_args = args_clone.clone();
+    __analysis_args.silence = true;
+    if let Some(ref marker) = args_clone.inject_marker {
+        // Custom injection marker mode: skip normal discovery/mining
+        // and create params from marker positions in URL/headers/body
+        use crate::parameter_analysis::{Location, Param};
+        let mut marker_params = Vec::new();
+
+        // Check URL query params
+        for (k, v) in target.url.query_pairs() {
+            if v.contains(marker.as_str()) {
+                marker_params.push(Param {
+                    name: k.to_string(),
+                    value: v.to_string(),
+                    location: Location::Query,
+                    injection_context: None,
+                    valid_specials: None,
+                    invalid_specials: None,
+                    pre_encoding: None,
+                    pre_encoding_pipeline: None,
+                    wire_name: None,
+                    form_action_url: None,
+                    form_origin_url: None,
+                    framework_sink: None,
+                    escaped_specials: None,
+                    js_breakout: None,
+                });
+            }
+        }
+
+        // Check body params
+        if let Some(ref data) = target.data {
+            if let Ok(json_val) = serde_json::from_str::<serde_json::Value>(data) {
+                if let Some(obj) = json_val.as_object() {
+                    for (k, v) in obj {
+                        if let Some(s) = v.as_str()
+                            && s.contains(marker.as_str())
+                        {
+                            marker_params.push(Param {
+                                name: k.clone(),
+                                value: s.to_string(),
+                                location: Location::JsonBody,
+                                injection_context: None,
+                                valid_specials: None,
+                                invalid_specials: None,
+                                pre_encoding: None,
+                                pre_encoding_pipeline: None,
+                                wire_name: None,
+                                form_action_url: None,
+                                form_origin_url: None,
+                                framework_sink: None,
+                                escaped_specials: None,
+                                js_breakout: None,
+                            });
+                        }
+                    }
+                }
+            } else {
+                for pair in data.split('&') {
+                    if let Some((k, v)) = pair.split_once('=')
+                        && v.contains(marker.as_str())
+                    {
+                        marker_params.push(Param {
+                            name: k.to_string(),
+                            value: v.to_string(),
+                            location: Location::Body,
+                            injection_context: None,
+                            valid_specials: None,
+                            invalid_specials: None,
+                            pre_encoding: None,
+                            pre_encoding_pipeline: None,
+                            wire_name: None,
+                            form_action_url: None,
+                            form_origin_url: None,
+                            framework_sink: None,
+                            escaped_specials: None,
+                            js_breakout: None,
+                        });
+                    }
+                }
+            }
+        }
+
+        // Check headers
+        for (k, v) in &target.headers {
+            if v.contains(marker.as_str()) {
+                marker_params.push(Param {
+                    name: k.clone(),
+                    value: v.clone(),
+                    location: Location::Header,
+                    injection_context: None,
+                    valid_specials: None,
+                    invalid_specials: None,
+                    pre_encoding: None,
+                    pre_encoding_pipeline: None,
+                    wire_name: None,
+                    form_action_url: None,
+                    form_origin_url: None,
+                    framework_sink: None,
+                    escaped_specials: None,
+                    js_breakout: None,
+                });
+            }
+        }
+
+        // Check cookies
+        for (k, v) in &target.cookies {
+            if v.contains(marker.as_str()) {
+                marker_params.push(Param {
+                    name: k.clone(),
+                    value: v.clone(),
+                    location: Location::Header,
+                    injection_context: None,
+                    valid_specials: None,
+                    invalid_specials: None,
+                    pre_encoding: None,
+                    pre_encoding_pipeline: None,
+                    wire_name: None,
+                    form_action_url: None,
+                    form_origin_url: None,
+                    framework_sink: None,
+                    escaped_specials: None,
+                    js_breakout: None,
+                });
+            }
+        }
+
+        target.reflection_params = marker_params;
+    } else {
+        analyze_parameters(&mut target, &__analysis_args, multi_pb_clone).await;
+    }
+    if let Some((tx, done_rx)) = __analyze_spinner {
+        let _ = tx.send(());
+        let _ = done_rx.await;
+    }
+
+    detect_outdated_libs(
+        &target,
+        &args_clone,
+        preflight_response_body.as_ref(),
+        &results_clone,
+        &findings_count_clone,
+    )
+    .await;
+
+    run_initial_ast_pass(
+        &target,
+        &args_clone,
+        preflight_response_body.as_ref(),
+        &results_clone,
+        &findings_count_clone,
+    )
+    .await;
+
+    // Pretty reflection summary (plain only)
+    if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
+        let n = target.reflection_params.len();
+        let ts = chrono::Local::now().format("%-I:%M%p").to_string();
+        if total_targets_copy > 1 {
+            let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(target.url.as_ref()));
+            crate::cprintln!(
+                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} found reflected \x1b[33m{}\x1b[0m params",
+                ts,
+                sid,
+                n
+            );
+        } else {
+            crate::cprintln!(
+                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m found reflected \x1b[33m{}\x1b[0m params",
+                ts,
+                n
+            );
+        }
+        for (i, p) in target.reflection_params.iter().enumerate() {
+            let bullet = if i + 1 == n { "└──" } else { "├──" };
+            let valid = p
+                .valid_specials
+                .as_ref()
+                .map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
+            let invalid = p
+                .invalid_specials
+                .as_ref()
+                .map_or_else(|| "-".to_string(), |v| v.iter().collect::<String>());
+            crate::cprintln!(
+                "  \x1b[90m{}\x1b[0m \x1b[38;5;247m{}\x1b[0m \x1b[38;5;247mvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\" \x1b[38;5;247minvalid_specials=\x1b[0m\"\x1b[38;5;247m{}\x1b[0m\"",
+                bullet,
+                p.name,
+                valid,
+                invalid
+            );
+        }
+        // Debug: estimate total test cases (requests) to be run during scanning
+        if crate::DEBUG.load(Ordering::Relaxed)
+            && args_clone.format == "plain"
+            && !args_clone.silence
+        {
+            // encoder expansion factor
+            let enc_factor = if args_clone.encoders.iter().any(|e| e == "none") {
+                1
+            } else {
+                let mut f = 1;
+                for e in ["url", "html", "2url", "3url", "4url", "base64"] {
+                    if args_clone.encoders.iter().any(|x| x == e) {
+                        f += 1;
+                    }
+                }
+                f
+            };
+            // Match the scan-time effective cap so the preflight
+            // request estimate reflects the built-in safety cap.
+            let cap = crate::scanning::effective_payload_cap(
+                args_clone.max_payloads_per_param,
+                args_clone.deep_scan,
+            );
+            let apply_cap = |n: usize| -> usize { if cap == 0 { n } else { n.min(cap) } };
+            let mut total: usize = 0;
+            for p in &target.reflection_params {
+                let refl_len = if let Some(ctx) = &p.injection_context {
+                    crate::scanning::xss_common::get_dynamic_payloads(ctx, &args_clone)
+                        .unwrap_or_else(|_| vec![])
+                        .len()
+                } else {
+                    // Fallback estimate: HTML dynamic payloads + JS payloads (with encoders), excluding remote payloads
+                    let html_base_len = crate::payload::get_dynamic_xss_html_payloads().len();
+                    let html_len = html_base_len * enc_factor;
+                    let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
+                    html_len + js_len
+                };
+                let dom_len = match &p.injection_context {
+                    Some(crate::parameter_analysis::InjectionContext::Javascript(_)) => 0,
+                    Some(ctx) => {
+                        // Use locally generated payloads and apply encoder factor; exclude remote payloads
+                        let base = crate::scanning::xss_common::generate_dynamic_payloads(ctx);
+                        base.len() * enc_factor
+                    }
+                    None => {
+                        // Unknown context: use HTML + Attribute payloads without remote, apply encoder factor
+                        let html = crate::payload::get_dynamic_xss_html_payloads();
+                        let attr = crate::payload::get_dynamic_xss_attribute_payloads();
+                        (html.len() + attr.len()) * enc_factor
+                    }
+                };
+                // Scan loop is additive (one reflection request + one DOM request
+                // per payload), not cartesian. Mirrors the `total_tasks` calculation
+                // in src/scanning/mod.rs that drives the progress bar / ETA.
+                // WAF mutation/encoder expansion isn't reflected here yet, so this
+                // remains a lower bound.
+                total =
+                    total.saturating_add(apply_cap(refl_len).saturating_add(apply_cap(dom_len)));
+            }
+            if args_clone.format == "plain" && !args_clone.silence {
+                crate::dbg_log!("{} test cases (reqs) estimated", total);
+            }
+        }
+    }
+
+    Some(target)
+}
+
+/// What the preflight probe captured for one target, beyond the enrichment it
+/// writes straight onto the `Target` (WAF, CSP, tech, mutation stats).
+pub(crate) struct PreflightCapture {
+    /// A CSP was present on the response (header or `<meta>`).
+    pub(crate) csp_present: bool,
+    /// The CSP the response carried, as `(header-name, value)` — *not*
+    /// necessarily an enforcing one. `preflight` fills this from
+    /// `content-security-policy-report-only` too, and synthesizes a name for a
+    /// `<meta>`-sourced policy. The consumer re-checks the name for exactly
+    /// that reason: treating a report-only `require-trusted-types-for` as
+    /// enforcing would suppress Trusted Types findings that do fire.
+    pub(crate) csp_header: Option<(String, String)>,
+    /// The landing-page body, reused by the AST DOM pass so it is fetched once.
+    pub(crate) response_body: Option<String>,
+}
+
+/// Fetch the landing page once and derive everything the later phases need from
+/// it: content-type gating, CSP, WAF fingerprint, and technology detection.
+///
+/// `None` means this target is out — unreachable, or a content type the scan
+/// does not apply to — and the reason has already been recorded in
+/// `skipped_targets`. Runs for every scan, `--deep-scan` included.
+#[allow(clippy::too_many_arguments)]
+async fn run_target_preflight(
+    target: &mut Target,
+    args_clone: &ScanArgs,
+    preflight_idx_clone: &Arc<std::sync::atomic::AtomicUsize>,
+    total_targets_copy: usize,
+    spinner_allowed: bool,
+    skipped_targets_clone: &Arc<Mutex<HashMap<String, &'static str>>>,
+    target_meta_clone: &Arc<Mutex<HashMap<String, serde_json::Value>>>,
+    target_mutation_stats_clone: &Arc<
+        Mutex<HashMap<String, Arc<crate::waf::bypass::MutationStats>>>,
+    >,
+    session_baselines_clone: &Arc<Mutex<HashMap<String, SessionBaseline>>>,
+    session_lost_clone: &Arc<Mutex<HashMap<String, String>>>,
+) -> Option<PreflightCapture> {
+    let mut __preflight_csp_present = false;
+    let mut __preflight_csp_header: Option<(String, String)> = None;
+    let mut preflight_response_body: Option<String> = None;
+    // Preflight probe: fetch the landing page for content-type, CSP,
+    // WAF, and tech detection, and capture the body (which feeds the
+    // initial AST DOM-XSS pass and outdated-lib detection below).
+    // This runs for EVERY scan, including `--deep-scan`. `--deep-scan`
+    // only lifts the per-parameter payload cap and the content-type
+    // *denylist skip* (gated below) — it must NOT skip the preflight
+    // itself. Wrapping the whole probe in `if !deep_scan` silently
+    // disabled WAF fingerprinting/bypass, CSP-bypass, tech detection,
+    // and the initial-response AST DOM analysis under `--deep-scan`,
+    // making the "more thorough" mode strictly weaker.
+    {
+        let current = preflight_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
+        // Print an ephemeral spinner and auto-clear when finished
+        let label = if total_targets_copy > 1 {
+            format!(
+                "[{}/{}] preflight: {}",
+                current, total_targets_copy, target.url
+            )
+        } else {
+            format!("preflight: {}", target.url)
+        };
+        let __preflight_spinner = if total_targets_copy == 1 {
+            start_spinner(spinner_allowed, !args_clone.silence, label)
+        } else {
+            None
+        };
+
+        let __preflight_info = preflight_content_type(target, args_clone).await;
+        if let Some((tx, done_rx)) = __preflight_spinner {
+            let _ = tx.send(());
+            let _ = done_rx.await;
+        }
+
+        let __preflight_info = match __preflight_info {
+            PreflightOutcome::Unreachable(code) => {
+                // Hard reachability failure (DNS, TCP refused,
+                // TLS handshake timeout). preflight_content_type
+                // already surfaced the UNREACHABLE diagnostic.
+                // Mark the target as skipped with the *specific*
+                // error_code we classified — DNS_RESOLUTION_FAILED
+                // vs TLS_HANDSHAKE_FAILED vs REQUEST_TIMEOUT vs
+                // CONNECTION_FAILED — so target_summary tells
+                // ops *which* layer broke instead of lumping.
+                skipped_targets_clone
+                    .lock()
+                    .await
+                    .insert(target.url.to_string(), code);
+                return None;
+            }
+            // NoContentType (e.g. GET preflight on a POST-only
+            // endpoint that 405s without a Content-Type header)
+            // — keep scanning, just skip the preflight metadata
+            // population below. Preserves the v3.0 behavior
+            // that body-param scans of /post-only endpoints
+            // still work. The session baseline is the one piece
+            // that must survive: the target still gets scanned, so
+            // it still has a session that can die mid-run.
+            PreflightOutcome::NoContentType(baseline) => {
+                if let Some(baseline) = baseline {
+                    record_session_baseline(
+                        args_clone,
+                        target,
+                        baseline,
+                        session_baselines_clone,
+                        session_lost_clone,
+                    )
+                    .await;
+                }
+                None
+            }
+            PreflightOutcome::WithContentType(r) => Some(r),
+        };
+
+        if let Some(preflight) = __preflight_info {
+            preflight_response_body = preflight.response_body;
+            // Authenticated-state fingerprint for mid-scan
+            // session-loss detection. Present only when the target
+            // carries credentials (or the operator asked for a
+            // check explicitly).
+            if let Some(baseline) = preflight.session_baseline {
+                record_session_baseline(
+                    args_clone,
+                    target,
+                    baseline,
+                    session_baselines_clone,
+                    session_lost_clone,
+                )
+                .await;
+            }
+            if let Some((hn, hv)) = preflight.csp_header {
+                __preflight_csp_present = true;
+                // Analyze CSP and store on target for bypass payload generation
+                let mut csp = crate::payload::xss_csp_bypass::analyze_csp(&hv);
+                // A report-only CSP enforces nothing — it only emits
+                // violation reports — so `require-trusted-types-for`
+                // there must not drive Trusted Types suppression in
+                // the AST analyzer (that would be a false negative).
+                // Bypass-payload fields stay as parsed.
+                if !hn.eq_ignore_ascii_case("content-security-policy") {
+                    csp.report_only = true;
+                    csp.require_trusted_types_for = false;
+                }
+                if crate::DEBUG.load(Ordering::Relaxed) {
+                    let class = if csp.is_hardened() {
+                        "hardened (nonce/hash-only)"
+                    } else if csp.is_gadget_bypassable() {
+                        "gadget-bypassable"
+                    } else {
+                        "no script-execution bypass surface"
+                    };
+                    crate::ceprintln!(
+                        "[csp] {} classified {} (strict-dynamic={}, nonces={}, trusted-types-enforced={})",
+                        hn,
+                        class,
+                        csp.has_strict_dynamic,
+                        csp.nonce_values.len(),
+                        csp.require_trusted_types_for
+                    );
+                }
+                target.csp_analysis = Some(csp);
+                __preflight_csp_header = Some((hn, hv));
+            }
+            // Store WAF detection result on target
+            if !preflight.waf_result.is_empty() {
+                target.waf_info = Some(preflight.waf_result);
+                // Allocate per-target effectiveness counters when
+                // bypass is going to run; the scanning loop and
+                // check_reflection both update this Arc, and the
+                // target_mutation_stats side-map keeps it alive
+                // until target_summary is built.
+                if args_clone.waf_bypass != "off" {
+                    let stats = std::sync::Arc::new(crate::waf::bypass::MutationStats::default());
+                    target.mutation_stats = Some(stats.clone());
+                    target_mutation_stats_clone
+                        .lock()
+                        .await
+                        .insert(target.url.to_string(), stats);
+                }
+
+                // Snapshot WAF + applied bypass for target_summary
+                // (JSON/JSONL output). Plain mode logs the same
+                // info to the console below; JSON consumers
+                // would otherwise have no visibility.
+                let mut detected_waf_extra_delay_ms = 0u64;
+                if let Some(ref waf_info) = target.waf_info {
+                    let detected_json: Vec<serde_json::Value> = waf_info
+                        .detected
+                        .iter()
+                        .map(|fp| {
+                            serde_json::json!({
+                                "type": fp.waf_type.to_string(),
+                                "confidence": fp.confidence,
+                                "evidence": fp.evidence,
+                            })
+                        })
+                        .collect();
+                    let mut meta_json = serde_json::json!({
+                        "detected": detected_json,
+                    });
+                    if args_clone.waf_bypass != "off" {
+                        let waf_types: Vec<&crate::waf::WafType> = waf_info.waf_types();
+                        let strategy = crate::waf::bypass::merge_strategies(&waf_types);
+                        // Carry the per-WAF pacing hint onto the target so the
+                        // injection paths actually slow down for rate-limiting
+                        // WAFs — previously this only landed in JSON meta.
+                        detected_waf_extra_delay_ms = strategy.extra_delay_hint_ms;
+                        meta_json["bypass"] = serde_json::json!({
+                            "encoders": strategy.extra_encoders,
+                            "mutation_count": strategy.mutations.len(),
+                            "extra_delay_hint_ms": strategy.extra_delay_hint_ms,
+                        });
+                    }
+                    target_meta_clone
+                        .lock()
+                        .await
+                        .insert(target.url.to_string(), meta_json);
+                }
+
+                // Apply the WAF pacing hint so detected rate-limiting
+                // WAFs slow the injection cadence even without
+                // --waf-evasion (0 when no WAF / --waf-bypass off).
+                target.waf_extra_delay_ms = detected_waf_extra_delay_ms;
+
+                // Adaptive WAF evasion: randomized inter-request jitter
+                // plus an escalating cooldown on block clusters, applied
+                // in the injection paths via `args.waf_evasion` and
+                // `target.waf_extra_delay_ms`. This replaces the old blunt
+                // workers=1 / delay=3000 preset, which throttled far harder
+                // than necessary and was trivially fingerprintable.
+                if args_clone.waf_evasion && !args_clone.silence {
+                    let ts = chrono::Local::now().format("%-I:%M%p").to_string();
+                    crate::cprintln!(
+                        "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m evasion activated: adaptive jitter + cooldown",
+                        ts
+                    );
+                }
+            }
+            // Store technology detection result on target
+            if !preflight.tech_result.is_empty() {
+                target.tech_info = Some(preflight.tech_result);
+            }
+            // Content-type denylist skip stays gated on !deep_scan:
+            // `--deep-scan` deliberately scans every content type,
+            // whereas a normal scan drops denylisted types (images,
+            // fonts, etc.) that can't carry reflected/DOM XSS.
+            if !args_clone.deep_scan && !is_allowed_content_type(&preflight.content_type) {
+                // Skip this target early
+                skipped_targets_clone.lock().await.insert(
+                    target.url.to_string(),
+                    crate::cmd::error_codes::CONTENT_TYPE_MISMATCH,
+                );
+                return None;
+            }
+        }
+    }
+
+    Some(PreflightCapture {
+        csp_present: __preflight_csp_present,
+        csp_header: __preflight_csp_header,
+        response_body: preflight_response_body,
+    })
+}
+
+/// `--detect-outdated-libs` (opt-in): flag known-vulnerable JS libraries on the
+/// landing page as informational (CWE-1104) findings.
+async fn detect_outdated_libs(
+    target: &Target,
+    args_clone: &ScanArgs,
+    preflight_response_body: Option<&String>,
+    results_clone: &Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+    findings_count_clone: &Arc<std::sync::atomic::AtomicUsize>,
+) {
+    // Outdated / known-vulnerable JS library detection (issue #1074).
+    // OPT-IN (`--detect-outdated-libs`, default off): dalfox's default
+    // output is verified XSS, so this informational (CWE-1104) add-on
+    // is gated behind a flag. Emits once per target from the initial
+    // response; borrows the body so the AST block below can still use it.
+    if args_clone.detect_outdated_libs
+        && let Some(body) = preflight_response_body
+    {
+        let lib_findings = crate::scanning::vuln_libs::library_findings(
+            crate::scanning::vuln_libs::detect_vulnerable_libraries(body),
+            target.url.as_str(),
+            &target.method,
+        );
+        if !lib_findings.is_empty() {
+            // Count only findings matching --limit-result-type so a
+            // CWE-1104 (informational) batch can't trip --limit when
+            // the user is limiting on a different result type.
+            let added = crate::scanning::count_matching_results(
+                &lib_findings,
+                &args_clone.limit_result_type.to_uppercase(),
+            );
+            let mut guard = results_clone.lock().await;
+            guard.extend(lib_findings);
+            findings_count_clone.fetch_add(added, Ordering::Relaxed);
+        }
+    }
+}
+
+/// Run the AST DOM-XSS pass over the landing page captured by preflight.
+///
+/// CLI-only. The analyzer it calls
+/// (`scanning::ast_integration::run_initial_ast_dom_analysis`) is what the
+/// `server` and MCP paths share, so all three surfaces report the same DOM-XSS
+/// findings for the same page — but editing *this* wrapper moves the CLI alone.
+/// Security posture comes from the `Target`, which preflight already enriched.
+async fn run_initial_ast_pass(
+    target: &Target,
+    args_clone: &ScanArgs,
+    preflight_response_body: Option<&String>,
+    results_clone: &Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+    findings_count_clone: &Arc<std::sync::atomic::AtomicUsize>,
+) {
+    // Run AST-based DOM XSS analysis on the initial response
+    // (enabled by default). The helper is shared with the
+    // server (`dalfox server`) and MCP (`scan_with_dalfox`)
+    // paths so all three surfaces produce the same DOM-XSS
+    // findings for an identical target.
+    if !args_clone.skip_ast_analysis
+        && let Some(response_text) = preflight_response_body
+    {
+        let ast_batch = crate::scanning::ast_integration::run_initial_ast_dom_analysis(
+            response_text,
+            target.url.as_str(),
+            &target.method,
+            crate::scanning::ast_integration::PageSecurityPosture::from_target(target),
+        );
+        if !ast_batch.is_empty() {
+            let added = crate::scanning::count_matching_results(
+                &ast_batch,
+                &args_clone.limit_result_type.to_uppercase(),
+            );
+            let mut guard = results_clone.lock().await;
+            guard.extend(ast_batch);
+            findings_count_clone.fetch_add(added, Ordering::Relaxed);
+        }
+        if args_clone.analyze_external_js {
+            let ext_client = target.build_client_or_default();
+            let ext_batch = crate::scanning::fetch_and_analyze_external_js(
+                &ext_client,
+                target,
+                response_text,
+                args_clone,
+            )
+            .await;
+            crate::scanning::accumulate_findings(
+                results_clone,
+                findings_count_clone,
+                ext_batch,
+                &args_clone.limit_result_type.to_uppercase(),
+            )
+            .await;
+        }
     }
 }

--- a/src/cmd/scan/baseline.rs
+++ b/src/cmd/scan/baseline.rs
@@ -387,3 +387,48 @@ fn parse_report(
 
 #[cfg(test)]
 mod tests;
+
+/// Load `--baseline` before any request goes out.
+///
+/// Up front on purpose: a stale or malformed baseline path is exactly what a
+/// pipeline gets wrong, and finding out after a 20-minute scan is too late.
+/// The warnings go to stderr for every format (stdout stays a clean machine
+/// payload) rather than through `log_warn`, which only speaks in `plain`.
+pub(crate) fn load_from_args(args: &super::args::ScanArgs) -> Option<Baseline> {
+    args.baseline.as_ref().map(|path| {
+        // `--output` pointed at the baseline overwrites it with this run's
+        // report. Under the default `filter` mode that report holds only the
+        // NEW findings, so the recorded backlog is destroyed and the next run
+        // re-reports all of it. Refreshing a baseline means re-running WITHOUT
+        // `--baseline`; warn rather than refuse, since `annotate` mode writes a
+        // complete report and is a legitimate way to do it.
+        if args.output.as_deref() == Some(path.as_str()) {
+            eprintln!(
+                "Warning: --output and --baseline are the same path ('{}'); under --baseline-mode filter this overwrites the baseline with new findings only. Re-run without --baseline to refresh it.",
+                path
+            );
+        }
+        // `--limit` stops the scan once N findings accrue, and that count is
+        // taken before the baseline diff runs. A target whose first N findings
+        // are all already known therefore halts early and reports zero new
+        // findings without having tested the rest of its parameters.
+        if args.limit.is_some() {
+            eprintln!(
+                "Warning: --limit counts findings before the --baseline diff, so a run whose first {} findings are all in the baseline stops early and reports 0 new. Drop --limit when gating on new findings.",
+                args.limit.unwrap_or(0)
+            );
+        }
+        let loaded = load(path, args.baseline_mode());
+        match &loaded.warning {
+            Some(w) => eprintln!("Warning: {} — baseline diff disabled", w),
+            None => super::logging::log_info(
+                args,
+                &format!(
+                    "baseline loaded: {} known findings from {}",
+                    loaded.entries, path
+                ),
+            ),
+        }
+        loaded
+    })
+}

--- a/src/cmd/scan/blind.rs
+++ b/src/cmd/scan/blind.rs
@@ -1,0 +1,96 @@
+//! Blind-XSS arming and dispatch: the static `-b/--blind` callback and the
+//! OOB/OAST (interactsh) channel.
+//!
+//! Split out of `run_scan` because the gating is subtle and easy to get wrong
+//! in either direction — these are *stored* attack payloads, so a run that was
+//! told not to attack must not send them, while a registration outage must not
+//! abort a scan that would otherwise proceed.
+
+use std::collections::BTreeMap;
+use std::sync::Arc;
+
+use super::args::ScanArgs;
+use super::logging::{log_info, log_warn};
+use crate::target_parser::Target;
+
+/// Arm the configured blind-XSS channels and inject over them, returning the
+/// OOB session (if one registered) for the poller to drain later.
+pub(crate) async fn arm_and_dispatch(
+    args: &ScanArgs,
+    host_groups: &BTreeMap<String, Vec<Target>>,
+) -> Option<Arc<crate::oob::OobSession>> {
+    // Blind XSS: the static `-b/--blind` callback and/or OOB/OAST (interactsh)
+    // callbacks. Skipped in preview-only modes — `--dry-run` (which advertises
+    // "without sending attack payloads") and `--only-discovery` — because blind
+    // payloads are real attack traffic and OOB registration is an outbound side
+    // effect to a third-party server.
+    //
+    // Start an OOB session first — it fails soft (warn + continue), so a
+    // registration outage never aborts the scan. Injection then runs over
+    // whichever channel(s) are configured; the OOB poller is spawned once
+    // `stream_findings_enabled` is known (below) and drained before rendering.
+    // `--skip-xss-scanning` means "send no attack payloads". Blind XSS payloads
+    // are attack payloads — stored ones, at that: they persist in the target
+    // after the run. Only the per-target injection stage used to honour the
+    // flag (scan_loop.rs), so `--skip-xss-scanning -b <callback>` (with `-b`
+    // commonly living in a shared config file) still wrote live stored-XSS
+    // payloads into every parameter and form of a production system the
+    // operator had explicitly asked not to attack. This also skips OOB session
+    // registration, which is correct: there is nothing left to call back.
+    let blind_active = !args.dry_run && !args.only_discovery && !args.skip_xss_scanning;
+    let oob_session: Option<Arc<crate::oob::OobSession>> =
+        if blind_active && args.blind_oob_enabled() {
+            match crate::oob::OobSession::start(&args.oob_config()).await {
+                Ok(session) => {
+                    log_info(
+                        args,
+                        &format!(
+                            "OOB blind XSS armed via interactsh server: {}",
+                            session.server_domain()
+                        ),
+                    );
+                    Some(Arc::new(session))
+                }
+                Err(e) => {
+                    log_warn(
+                        args,
+                        &format!("--blind-oob disabled (could not register with any server): {e}"),
+                    );
+                    None
+                }
+            }
+        } else {
+            None
+        };
+
+    if blind_active && (args.blind_callback_url.is_some() || oob_session.is_some()) {
+        if let Some(callback_url) = &args.blind_callback_url {
+            log_info(
+                args,
+                &format!(
+                    "Performing blind XSS scanning with callback URL: {}",
+                    callback_url
+                ),
+            );
+        }
+        let custom = args.custom_blind_xss_payload.as_deref();
+        for group in host_groups.values() {
+            for target in group {
+                let source = match (&args.blind_callback_url, &oob_session) {
+                    (Some(url), Some(session)) => crate::scanning::CallbackSource::Both {
+                        url: url.as_str(),
+                        session: session.as_ref(),
+                    },
+                    (Some(url), None) => crate::scanning::CallbackSource::Static(url.as_str()),
+                    (None, Some(session)) => crate::scanning::CallbackSource::Oob(session.as_ref()),
+                    // Guarded by the enclosing `if`: at least one is Some.
+                    (None, None) => continue,
+                };
+                crate::scanning::blind_scanning_with(target, source, custom).await;
+                crate::scanning::blind_scan_forms_with(target, source, custom).await;
+            }
+        }
+    }
+
+    oob_session
+}

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -47,27 +47,28 @@ pub(crate) struct ResolvedTargets {
     pub(crate) dedup: DedupStats,
 }
 
+// Byte budget for any path that slurps a file or stdin into memory.
+// 256 MiB lands well above realistic URL lists (≈5 M URLs at ~50 B
+// each) while still cutting `/dev/zero`, runaway pipes, and
+// gigabyte misclassified blobs to a fast, clear error instead of
+// OOM-ing the process. The matching `read_bounded` / `read_stdin_
+// bounded` enforce the cap during the read itself, so a pseudo-
+// file that lies about its size (`/dev/zero` reports 0 bytes via
+// metadata) is still stopped.
+const MAX_TARGET_LIST_BYTES: u64 = crate::utils::fs::MAX_FILE_READ_BYTES;
+
+// Prefix budget for content sniffing during auto-detection. A raw HTTP
+// request is identified by its first line and a HAR by its leading
+// `{ … "log" … "entries"` preamble, so 8 KiB is enough to classify the
+// input without reading a (possibly huge) file in full — only the
+// committed input mode reads the whole file. Real HARs place `entries`
+// within the first few hundred bytes; the rare capture that buries it past
+// the budget can still be forced with `--input-type har`.
+const SNIFF_PREFIX_BYTES: u64 = 8 * 1024;
+
 pub(crate) async fn resolve_targets(
     args: &ScanArgs,
 ) -> std::result::Result<ResolvedTargets, ScanOutcome> {
-    // Byte budget for any path that slurps a file or stdin into memory.
-    // 256 MiB lands well above realistic URL lists (≈5 M URLs at ~50 B
-    // each) while still cutting `/dev/zero`, runaway pipes, and
-    // gigabyte misclassified blobs to a fast, clear error instead of
-    // OOM-ing the process. The matching `read_bounded` / `read_stdin_
-    // bounded` enforce the cap during the read itself, so a pseudo-
-    // file that lies about its size (`/dev/zero` reports 0 bytes via
-    // metadata) is still stopped.
-    const MAX_TARGET_LIST_BYTES: u64 = crate::utils::fs::MAX_FILE_READ_BYTES;
-    // Prefix budget for content sniffing during auto-detection. A raw HTTP
-    // request is identified by its first line and a HAR by its leading
-    // `{ … "log" … "entries"` preamble, so 8 KiB is enough to classify the
-    // input without reading a (possibly huge) file in full — only the
-    // committed input mode reads the whole file. Real HARs place `entries`
-    // within the first few hundred bytes; the rare capture that buries it past
-    // the budget can still be forced with `--input-type har`.
-    const SNIFF_PREFIX_BYTES: u64 = 8 * 1024;
-
     // stdin can only be read once. When auto-detection needs to peek at a
     // piped stream (to tell a HAR document apart from a line-based URL list),
     // it buffers the whole stream here so the parsing phase reuses the same
@@ -90,91 +91,7 @@ pub(crate) async fn resolve_targets(
         }
     };
 
-    let input_type = if args.input_type == "auto" {
-        if args.targets.is_empty() {
-            // No positional targets: only honour stdin if it's actually
-            // piped — never block waiting for terminal input.
-            if stdin_is_piped {
-                // Buffer stdin once, then auto-detect: a HAR document piped in
-                // (`cat capture.har | dalfox scan`) parses as `har`; anything
-                // else is treated as a line-based pipe from the same bytes.
-                match crate::utils::fs::read_stdin_bounded(MAX_TARGET_LIST_BYTES, "stdin pipe") {
-                    Ok(buf) => {
-                        let detected = if crate::target_parser::is_har_content(&buf) {
-                            "har"
-                        } else {
-                            "pipe"
-                        };
-                        buffered_stdin = Some(buf);
-                        detected.to_string()
-                    }
-                    Err(e) => {
-                        if !args.silence {
-                            emit_error(
-                                &args.format,
-                                crate::cmd::error_codes::STDIN_ERROR,
-                                &format!("Error reading from stdin: {}", e),
-                            );
-                        }
-                        return Err(ScanOutcome::Error);
-                    }
-                }
-            } else {
-                if !args.silence {
-                    emit_error(
-                        &args.format,
-                        crate::cmd::error_codes::NO_TARGETS,
-                        "No targets specified",
-                    );
-                }
-                return Err(ScanOutcome::Error);
-            }
-        } else {
-            // Classify the positional file args by sniffing a bounded *prefix*
-            // of each rather than slurping it in full: `is_raw_http_request`
-            // only inspects the first line and `is_har_content` only the
-            // leading `{ … "log" … "entries"` markers, so the first few KiB
-            // decide it. The committed input mode reads each file completely
-            // later. Raw HTTP pasted directly on the CLI is matched as a
-            // literal (it is not a path on disk). Both flags accumulate with
-            // AND, so a single non-match rules a type out.
-            let mut all_raw_http = true;
-            let mut all_har = true;
-            for t in &args.targets {
-                if crate::target_parser::is_raw_http_request(t) {
-                    all_har = false; // a raw-http literal is never a HAR
-                    continue;
-                }
-                match crate::utils::fs::read_prefix_lossy(
-                    std::path::Path::new(t),
-                    SNIFF_PREFIX_BYTES,
-                ) {
-                    Ok(prefix) => {
-                        all_raw_http &= crate::target_parser::is_raw_http_request(&prefix);
-                        all_har &= crate::target_parser::is_har_content(&prefix);
-                    }
-                    // Not a readable file (a bare URL/host literal, or an
-                    // unreadable path): neither a raw-http nor a HAR file.
-                    Err(_) => {
-                        all_raw_http = false;
-                        all_har = false;
-                    }
-                }
-                if !all_raw_http && !all_har {
-                    break; // neither type is still possible — stop sniffing
-                }
-            }
-            if all_raw_http {
-                "raw-http".to_string()
-            } else if all_har {
-                "har".to_string()
-            } else {
-                "auto".to_string()
-            }
-        }
-    } else {
-        args.input_type.clone()
-    };
+    let input_type = detect_input_type(args, stdin_is_piped, &mut buffered_stdin)?;
 
     let mut target_strings = Vec::new();
 
@@ -613,114 +530,9 @@ pub(crate) async fn resolve_targets(
         }
     }
 
-    // Apply URL scope filtering (--include-url / --exclude-url)
-    {
-        // Invalid scope patterns must always surface on stderr, even when
-        // `--silence` is on: silently discarding the user's filter means
-        // every target gets scanned anyway, which is exactly the opposite
-        // of what the operator asked for. stderr stays out of the stdout
-        // payload that scripts parse, so a noise-sensitive caller can
-        // still redirect `2>/dev/null` if they really want it gone.
-        let include_patterns: Vec<regex::Regex> = args
-            .include_url
-            .iter()
-            .filter_map(|p| match regex::Regex::new(p) {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    eprintln!(
-                        "Warning: invalid --include-url regex '{}': {} (hint: --include-url takes a regex like '.*/api/.*', not a shell glob)",
-                        p, e
-                    );
-                    None
-                }
-            })
-            .collect();
-        let exclude_patterns: Vec<regex::Regex> = args
-            .exclude_url
-            .iter()
-            .filter_map(|p| match regex::Regex::new(p) {
-                Ok(r) => Some(r),
-                Err(e) => {
-                    eprintln!(
-                        "Warning: invalid --exclude-url regex '{}': {} (hint: --exclude-url takes a regex like '.*/admin.*', not a shell glob)",
-                        p, e
-                    );
-                    None
-                }
-            })
-            .collect();
+    apply_url_scope_filters(args, &mut parsed_targets);
 
-        if !include_patterns.is_empty() || !exclude_patterns.is_empty() {
-            let before = parsed_targets.len();
-            parsed_targets.retain(|t| {
-                let url_str = t.url.as_str();
-                // If include patterns are set, URL must match at least one
-                if !include_patterns.is_empty()
-                    && !include_patterns.iter().any(|r| r.is_match(url_str))
-                {
-                    return false;
-                }
-                // If exclude patterns are set, URL must not match any
-                if exclude_patterns.iter().any(|r| r.is_match(url_str)) {
-                    return false;
-                }
-                true
-            });
-            let filtered = before - parsed_targets.len();
-            if filtered > 0 {
-                log_info(
-                    args,
-                    &format!("scope filter: {} target(s) excluded", filtered),
-                );
-            }
-        }
-    }
-
-    // Apply out-of-scope domain filtering (--out-of-scope / --out-of-scope-file)
-    {
-        let mut oos_domains: Vec<String> = args.out_of_scope.clone();
-        if let Some(ref path) = args.out_of_scope_file {
-            match crate::utils::fs::read_bounded(
-                std::path::Path::new(path),
-                MAX_TARGET_LIST_BYTES,
-                "out-of-scope domain file",
-            ) {
-                Ok(contents) => {
-                    for line in contents.lines() {
-                        let trimmed = line.trim();
-                        if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                            oos_domains.push(trimmed.to_string());
-                        }
-                    }
-                }
-                Err(e) => {
-                    log_warn(
-                        args,
-                        &format!("failed to read --out-of-scope-file '{}': {}", path, e),
-                    );
-                }
-            }
-        }
-        if !oos_domains.is_empty() {
-            let before = parsed_targets.len();
-            parsed_targets.retain(|t| {
-                let host = match t.url.host_str() {
-                    Some(h) => h,
-                    None => return true,
-                };
-                !oos_domains
-                    .iter()
-                    .any(|pattern| domain_matches_pattern(host, pattern))
-            });
-            let filtered = before - parsed_targets.len();
-            if filtered > 0 {
-                log_info(
-                    args,
-                    &format!("out-of-scope filter: {} target(s) excluded", filtered),
-                );
-            }
-        }
-    }
+    apply_out_of_scope_filter(args, &mut parsed_targets);
 
     // Deduplicate targets per `--dedup-urls` (exact / signature / off) to avoid
     // redundant scans (e.g. pipe input with duplicates, or a `gau`/`katana`
@@ -776,40 +588,7 @@ pub(crate) async fn resolve_targets(
         return Err(ScanOutcome::Error);
     }
 
-    // Load cookies from raw HTTP request file if specified
-    if let Some(path) = &args.cookie_from_raw {
-        match crate::utils::fs::read_bounded(
-            std::path::Path::new(path),
-            MAX_TARGET_LIST_BYTES,
-            "raw cookie file",
-        ) {
-            Ok(content) => {
-                let mut cookies_from_raw: Vec<(String, String)> = Vec::new();
-                for line in content.lines() {
-                    // HTTP header names are case-insensitive (RFC 7230 §3.2;
-                    // HTTP/2 mandates lowercase), so match `Cookie`/`cookie`/
-                    // `COOKIE` alike and tolerate arbitrary spacing after the
-                    // colon. Delegate value splitting to the shared
-                    // `split_cookie_pairs` so this parses identically to the
-                    // server / preflight cookie paths.
-                    if let Some((name, value)) = line.split_once(':')
-                        && name.trim().eq_ignore_ascii_case("cookie")
-                    {
-                        cookies_from_raw.extend(crate::job::split_cookie_pairs(value));
-                    }
-                }
-                if !cookies_from_raw.is_empty() {
-                    for target in &mut parsed_targets {
-                        target.cookies.extend(cookies_from_raw.iter().cloned());
-                    }
-                }
-            }
-            Err(e) if !args.silence => {
-                eprintln!("Error reading cookie file {}: {}", path, e);
-            }
-            Err(_) => {}
-        }
-    }
+    load_cookies_from_raw_http(args, &mut parsed_targets);
 
     Ok(ResolvedTargets {
         targets: parsed_targets,
@@ -1135,3 +914,270 @@ fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
 
 #[cfg(test)]
 mod tests;
+
+/// Drop targets excluded by `--include-url` / `--exclude-url`.
+///
+/// Runs before the out-of-scope domain filter and before dedup, so a URL the
+/// operator scoped out never reaches either.
+pub(crate) fn apply_url_scope_filters(args: &ScanArgs, parsed_targets: &mut Vec<Target>) {
+    // Apply URL scope filtering (--include-url / --exclude-url)
+    {
+        // Invalid scope patterns must always surface on stderr, even when
+        // `--silence` is on: silently discarding the user's filter means
+        // every target gets scanned anyway, which is exactly the opposite
+        // of what the operator asked for. stderr stays out of the stdout
+        // payload that scripts parse, so a noise-sensitive caller can
+        // still redirect `2>/dev/null` if they really want it gone.
+        let include_patterns: Vec<regex::Regex> = args
+            .include_url
+            .iter()
+            .filter_map(|p| match regex::Regex::new(p) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: invalid --include-url regex '{}': {} (hint: --include-url takes a regex like '.*/api/.*', not a shell glob)",
+                        p, e
+                    );
+                    None
+                }
+            })
+            .collect();
+        let exclude_patterns: Vec<regex::Regex> = args
+            .exclude_url
+            .iter()
+            .filter_map(|p| match regex::Regex::new(p) {
+                Ok(r) => Some(r),
+                Err(e) => {
+                    eprintln!(
+                        "Warning: invalid --exclude-url regex '{}': {} (hint: --exclude-url takes a regex like '.*/admin.*', not a shell glob)",
+                        p, e
+                    );
+                    None
+                }
+            })
+            .collect();
+
+        if !include_patterns.is_empty() || !exclude_patterns.is_empty() {
+            let before = parsed_targets.len();
+            parsed_targets.retain(|t| {
+                let url_str = t.url.as_str();
+                // If include patterns are set, URL must match at least one
+                if !include_patterns.is_empty()
+                    && !include_patterns.iter().any(|r| r.is_match(url_str))
+                {
+                    return false;
+                }
+                // If exclude patterns are set, URL must not match any
+                if exclude_patterns.iter().any(|r| r.is_match(url_str)) {
+                    return false;
+                }
+                true
+            });
+            let filtered = before - parsed_targets.len();
+            if filtered > 0 {
+                log_info(
+                    args,
+                    &format!("scope filter: {} target(s) excluded", filtered),
+                );
+            }
+        }
+    }
+}
+
+/// Drop targets whose host matches `--out-of-scope` / `--out-of-scope-file`.
+pub(crate) fn apply_out_of_scope_filter(args: &ScanArgs, parsed_targets: &mut Vec<Target>) {
+    // Apply out-of-scope domain filtering (--out-of-scope / --out-of-scope-file)
+    {
+        let mut oos_domains: Vec<String> = args.out_of_scope.clone();
+        if let Some(ref path) = args.out_of_scope_file {
+            match crate::utils::fs::read_bounded(
+                std::path::Path::new(path),
+                MAX_TARGET_LIST_BYTES,
+                "out-of-scope domain file",
+            ) {
+                Ok(contents) => {
+                    for line in contents.lines() {
+                        let trimmed = line.trim();
+                        if !trimmed.is_empty() && !trimmed.starts_with('#') {
+                            oos_domains.push(trimmed.to_string());
+                        }
+                    }
+                }
+                Err(e) => {
+                    log_warn(
+                        args,
+                        &format!("failed to read --out-of-scope-file '{}': {}", path, e),
+                    );
+                }
+            }
+        }
+        if !oos_domains.is_empty() {
+            let before = parsed_targets.len();
+            parsed_targets.retain(|t| {
+                let host = match t.url.host_str() {
+                    Some(h) => h,
+                    None => return true,
+                };
+                !oos_domains
+                    .iter()
+                    .any(|pattern| domain_matches_pattern(host, pattern))
+            });
+            let filtered = before - parsed_targets.len();
+            if filtered > 0 {
+                log_info(
+                    args,
+                    &format!("out-of-scope filter: {} target(s) excluded", filtered),
+                );
+            }
+        }
+    }
+}
+
+/// Apply `--cookie-from-raw`: lift the `Cookie` header out of a saved raw HTTP
+/// request and attach it to every resolved target.
+///
+/// Non-fatal by design as it stands: an unreadable file prints to stderr (and
+/// says nothing at all under `--silence`), then the scan proceeds *without the
+/// cookies* — i.e. logged out, which typically reports `0 XSS` and exits 0. A
+/// CI gate cannot tell that apart from a clean target. Preserved here because
+/// changing it changes exit codes; worth revisiting on its own.
+fn load_cookies_from_raw_http(args: &ScanArgs, parsed_targets: &mut [Target]) {
+    // Load cookies from raw HTTP request file if specified
+    if let Some(path) = &args.cookie_from_raw {
+        match crate::utils::fs::read_bounded(
+            std::path::Path::new(path),
+            MAX_TARGET_LIST_BYTES,
+            "raw cookie file",
+        ) {
+            Ok(content) => {
+                let mut cookies_from_raw: Vec<(String, String)> = Vec::new();
+                for line in content.lines() {
+                    // HTTP header names are case-insensitive (RFC 7230 §3.2;
+                    // HTTP/2 mandates lowercase), so match `Cookie`/`cookie`/
+                    // `COOKIE` alike and tolerate arbitrary spacing after the
+                    // colon. Delegate value splitting to the shared
+                    // `split_cookie_pairs` so this parses identically to the
+                    // server / preflight cookie paths.
+                    if let Some((name, value)) = line.split_once(':')
+                        && name.trim().eq_ignore_ascii_case("cookie")
+                    {
+                        cookies_from_raw.extend(crate::job::split_cookie_pairs(value));
+                    }
+                }
+                if !cookies_from_raw.is_empty() {
+                    for target in parsed_targets.iter_mut() {
+                        target.cookies.extend(cookies_from_raw.iter().cloned());
+                    }
+                }
+            }
+            Err(e) if !args.silence => {
+                eprintln!("Error reading cookie file {}: {}", path, e);
+            }
+            Err(_) => {}
+        }
+    }
+}
+
+/// Decide which input mode a bare `dalfox scan …` is really asking for.
+///
+/// `--input-type` other than `auto` is taken at its word. Otherwise the shape
+/// of the arguments and of stdin decides: no positional targets plus a piped
+/// stdin means a list (or a HAR) is arriving on the pipe; a single argument
+/// that looks like a path is sniffed to tell a raw HTTP request and a HAR
+/// document apart from a line-based URL list.
+///
+/// `buffered_stdin` is an out-parameter on purpose: stdin can be read only
+/// once, so when detection has to peek at the stream it hands the bytes back
+/// for the parsing phase to reuse rather than reading an already-drained fd.
+fn detect_input_type(
+    args: &ScanArgs,
+    stdin_is_piped: bool,
+    buffered_stdin: &mut Option<String>,
+) -> Result<String, ScanOutcome> {
+    let input_type = if args.input_type == "auto" {
+        if args.targets.is_empty() {
+            // No positional targets: only honour stdin if it's actually
+            // piped — never block waiting for terminal input.
+            if stdin_is_piped {
+                // Buffer stdin once, then auto-detect: a HAR document piped in
+                // (`cat capture.har | dalfox scan`) parses as `har`; anything
+                // else is treated as a line-based pipe from the same bytes.
+                match crate::utils::fs::read_stdin_bounded(MAX_TARGET_LIST_BYTES, "stdin pipe") {
+                    Ok(buf) => {
+                        let detected = if crate::target_parser::is_har_content(&buf) {
+                            "har"
+                        } else {
+                            "pipe"
+                        };
+                        *buffered_stdin = Some(buf);
+                        detected.to_string()
+                    }
+                    Err(e) => {
+                        if !args.silence {
+                            emit_error(
+                                &args.format,
+                                crate::cmd::error_codes::STDIN_ERROR,
+                                &format!("Error reading from stdin: {}", e),
+                            );
+                        }
+                        return Err(ScanOutcome::Error);
+                    }
+                }
+            } else {
+                if !args.silence {
+                    emit_error(
+                        &args.format,
+                        crate::cmd::error_codes::NO_TARGETS,
+                        "No targets specified",
+                    );
+                }
+                return Err(ScanOutcome::Error);
+            }
+        } else {
+            // Classify the positional file args by sniffing a bounded *prefix*
+            // of each rather than slurping it in full: `is_raw_http_request`
+            // only inspects the first line and `is_har_content` only the
+            // leading `{ … "log" … "entries"` markers, so the first few KiB
+            // decide it. The committed input mode reads each file completely
+            // later. Raw HTTP pasted directly on the CLI is matched as a
+            // literal (it is not a path on disk). Both flags accumulate with
+            // AND, so a single non-match rules a type out.
+            let mut all_raw_http = true;
+            let mut all_har = true;
+            for t in &args.targets {
+                if crate::target_parser::is_raw_http_request(t) {
+                    all_har = false; // a raw-http literal is never a HAR
+                    continue;
+                }
+                match crate::utils::fs::read_prefix_lossy(
+                    std::path::Path::new(t),
+                    SNIFF_PREFIX_BYTES,
+                ) {
+                    Ok(prefix) => {
+                        all_raw_http &= crate::target_parser::is_raw_http_request(&prefix);
+                        all_har &= crate::target_parser::is_har_content(&prefix);
+                    }
+                    // Not a readable file (a bare URL/host literal, or an
+                    // unreadable path): neither a raw-http nor a HAR file.
+                    Err(_) => {
+                        all_raw_http = false;
+                        all_har = false;
+                    }
+                }
+                if !all_raw_http && !all_har {
+                    break; // neither type is still possible — stop sniffing
+                }
+            }
+            if all_raw_http {
+                "raw-http".to_string()
+            } else if all_har {
+                "har".to_string()
+            } else {
+                "auto".to_string()
+            }
+        }
+    } else {
+        args.input_type.clone()
+    };
+    Ok(input_type)
+}

--- a/src/cmd/scan/logging.rs
+++ b/src/cmd/scan/logging.rs
@@ -4,6 +4,8 @@
 
 use super::args::ScanArgs;
 use std::io::{self, Write};
+use std::sync::Arc;
+use std::sync::atomic::{AtomicUsize, Ordering};
 use std::time::Duration;
 use tokio::sync::oneshot;
 
@@ -83,4 +85,69 @@ pub(crate) fn start_spinner(
         }
     });
     Some((tx, done_rx))
+}
+
+/// The single "overall N/M targets · P% · F findings" line that shimmers at the
+/// bottom of a multi-target plain-format run.
+///
+/// Returns the shutdown channel pair, or `None` when the line must not render
+/// at all: another format owns stdout, `--silence` is set, there is only one
+/// target, or stdout is not a TTY — a redraw frame every `FRAME_MS` is garbage
+/// in a log file.
+pub(crate) fn start_overall_ticker(
+    args: &ScanArgs,
+    total_targets: usize,
+    findings_count: &Arc<AtomicUsize>,
+    overall_done: &Arc<AtomicUsize>,
+) -> Option<(oneshot::Sender<()>, oneshot::Receiver<()>)> {
+    // Start global overall progress ticker when multiple targets; runs across preflight, analysis, and scanning.
+    // Suppressed when stdout isn't a TTY — cursor-redraw frames look like garbage in logs.
+    if args.format == "plain"
+        && !args.silence
+        && total_targets > 1
+        && crate::utils::term::stdout_is_tty()
+    {
+        let findings_count_clone = findings_count.clone();
+        let overall_done_clone = overall_done.clone();
+        let total_targets_copy = total_targets;
+        let (tx, mut rx) = oneshot::channel::<()>();
+        let (done_tx, done_rx) = oneshot::channel::<()>();
+        tokio::spawn(async move {
+            use crate::utils::shimmer;
+            let mut phase = 0usize;
+            loop {
+                let done = overall_done_clone.load(Ordering::Relaxed);
+                let percent = (done * 100) / std::cmp::max(1, total_targets_copy);
+                let findings = findings_count_clone.load(Ordering::Relaxed);
+                let text = format!(
+                    "overall  {done}/{total_targets_copy} targets · {percent}% · {findings} findings"
+                );
+                // Truncate to the terminal width (reserving the glyph + space)
+                // and clear to EOL so the metallic line never wraps onto a
+                // second row, which would desync the `\r` redraw.
+                let budget = crate::utils::term::term_cols().saturating_sub(2).max(8);
+                let visible = console::truncate_str(&text, budget, "…");
+                crate::cprint!(
+                    "\r{} {}\x1b[K",
+                    shimmer::spin_glyph(phase),
+                    shimmer::shimmer(visible.as_ref(), phase)
+                );
+                let _ = io::stdout().flush();
+                tokio::select! {
+                    _ = tokio::time::sleep(Duration::from_millis(shimmer::FRAME_MS as u64)) => {},
+                    _ = &mut rx => {
+                        // clear the line and exit
+                        crate::cprint!("\r\x1b[2K\r");
+                        let _ = io::stdout().flush();
+                        let _ = done_tx.send(());
+                        break;
+                    }
+                }
+                phase = phase.wrapping_add(1);
+            }
+        });
+        Some((tx, done_rx))
+    } else {
+        None
+    }
 }

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -16,15 +16,13 @@
 
 use indicatif::MultiProgress;
 use std::collections::HashMap;
-use std::fs;
-use std::io::{self, Write};
 use std::sync::Arc;
 use std::sync::{
     OnceLock,
     atomic::{AtomicUsize, Ordering},
 };
 use std::time::Duration;
-use tokio::sync::{Mutex, oneshot};
+use tokio::sync::Mutex;
 
 use crate::scanning::result::Result;
 use crate::target_parser::*;
@@ -32,6 +30,7 @@ use crate::target_parser::*;
 mod analysis;
 mod args;
 mod baseline;
+mod blind;
 mod input;
 mod logging;
 mod output;
@@ -40,6 +39,7 @@ mod postprocess;
 mod preflight;
 mod scan_loop;
 pub(crate) mod session;
+mod startup;
 mod state_file;
 mod validation;
 
@@ -55,8 +55,7 @@ pub use args::{
     WAF_BYPASS_VALUES, format_is_machine,
 };
 pub(crate) use args::{parse_force_waf_arg, parse_http_method_arg};
-pub(crate) use logging::{log_info, log_warn};
-pub(crate) use validation::validate_numeric_args;
+pub(crate) use logging::log_info;
 
 static GLOBAL_ENCODERS: OnceLock<Vec<String>> = OnceLock::new();
 
@@ -241,228 +240,16 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     if GLOBAL_ENCODERS.get().is_none() {
         let _ = GLOBAL_ENCODERS.set(args.encoders.clone());
     }
-    // Validate numeric args up front so misconfigurations (workers: 0,
-    // max_targets_per_host: 0, absurd timeouts) fail fast with a clear
-    // message instead of producing cryptic mid-scan failures.
-    if let Err((code, msg)) = validate_numeric_args(args) {
-        if !args.silence {
-            emit_error(&args.format, code, &msg);
-        }
-        return ScanOutcome::Error;
+    // Startup gate: numeric ranges, session-check inputs, the custom-payload
+    // file, and the process-wide rate limiter. Each failure it catches would
+    // otherwise surface mid-scan as a result rather than a mistake.
+    if let Err(outcome) = startup::prepare_and_validate(args) {
+        return outcome;
     }
 
-    // Install the process-wide request rate limiter (`--rate-limit`, req/sec;
-    // 0 = unlimited). Shared across every worker and target so the aggregate
-    // outbound rate stays bounded regardless of fan-out. Done before any
-    // requests go out (preflight included). Idempotent across CLI invocations.
-    crate::install_rate_limiter(args.rate_limit);
+    let baseline = baseline::load_from_args(args);
 
-    // `--limit-result-type` only affects which finding types count
-    // toward `--limit`; without `--limit` it is a no-op. Dogfood
-    // showed operators conflating it with `--only-poc`, which IS the
-    // output filter, so emit a one-line nudge on stderr when used
-    // alone. stderr stays out of the stdout payload that scripts
-    // parse.
-    if !args.limit_result_type.eq_ignore_ascii_case("all") && args.limit.is_none() {
-        eprintln!(
-            "Hint: --limit-result-type only affects counting toward --limit; for output filtering use --only-poc {}",
-            args.limit_result_type.to_uppercase()
-        );
-    }
-
-    // Validate the session-check inputs up front. Both are consulted only when
-    // a probe fires — potentially an hour into the scan — so a bad regex or a
-    // malformed probe URL must fail here, not there.
-    if let Err(e) = session::compile_session_check(args) {
-        emit_error(
-            &args.format,
-            crate::cmd::error_codes::PARSE_ERROR,
-            &format!("--session-check is not a valid regex: {e}"),
-        );
-        return ScanOutcome::Error;
-    }
-    if let Some(u) = &args.session_check_url
-        && url::Url::parse(u).is_err()
-    {
-        emit_error(
-            &args.format,
-            crate::cmd::error_codes::PARSE_ERROR,
-            &format!("--session-check-url is not a valid absolute URL: {u}"),
-        );
-        return ScanOutcome::Error;
-    }
-
-    // `--only-custom-payload` with no `--custom-payload` at all is the same
-    // catastrophe as an unreadable file — `get_dynamic_payloads` takes the
-    // only-custom branch, finds no file to read, and returns an empty vec, so
-    // the reflection phase sends *zero* attack payloads and the run prints
-    // `0 XSS` and exits 0. That is indistinguishable from a clean target, which
-    // is exactly what a CI gate keys on. The check below only runs inside
-    // `if let Some(path)`, so this pairing has to be rejected before it.
-    // Reachable from a config file too (`only_custom_payload = true`), which is
-    // why `Config::normalize_and_validate` carries the same rule.
-    if args.only_custom_payload && args.custom_payload.is_none() {
-        emit_error(
-            &args.format,
-            crate::cmd::error_codes::INVALID_INPUT_TYPE,
-            "--only-custom-payload requires --custom-payload <FILE>",
-        );
-        return ScanOutcome::Error;
-    }
-
-    // Validate --custom-payload up front. Without this check, a missing or
-    // unreadable file silently produces zero custom payloads mid-scan. With
-    // --only-custom-payload that's catastrophic (no payloads at all, scan
-    // reports clean), so fail fast. In additive mode it just degrades
-    // detection, so warn and continue.
-    if let Some(path) = &args.custom_payload {
-        match fs::metadata(path) {
-            Ok(m) if !m.is_file() => {
-                if args.only_custom_payload {
-                    emit_error(
-                        &args.format,
-                        crate::cmd::error_codes::FILE_READ_ERROR,
-                        &format!("--custom-payload is not a regular file: {}", path),
-                    );
-                    return ScanOutcome::Error;
-                }
-                log_warn(
-                    args,
-                    &format!(
-                        "--custom-payload is not a regular file ({}) — built-in payloads only",
-                        path
-                    ),
-                );
-            }
-            Err(e) => {
-                if args.only_custom_payload {
-                    emit_error(
-                        &args.format,
-                        crate::cmd::error_codes::FILE_READ_ERROR,
-                        &format!("--custom-payload not readable ({}): {}", path, e),
-                    );
-                    return ScanOutcome::Error;
-                }
-                log_warn(
-                    args,
-                    &format!(
-                        "--custom-payload not readable ({}: {}) — built-in payloads only",
-                        path, e
-                    ),
-                );
-            }
-            Ok(_) => {
-                // The stat above only proves a regular file exists. An empty,
-                // comment-only, non-UTF-8, or over-budget file passes it yet
-                // yields zero usable payloads — load_custom_payloads rejects
-                // those, but the scan driver swallows that error via
-                // `.unwrap_or_else(|_| vec![])`, so --only-custom-payload would
-                // "succeed" having scanned nothing. Validate the content here
-                // (this also warms the shared cache the scan reuses): fatal
-                // under --only-custom-payload, a warning in additive mode.
-                if let Err(e) = crate::scanning::xss_common::load_custom_payloads(path) {
-                    if args.only_custom_payload {
-                        emit_error(
-                            &args.format,
-                            crate::cmd::error_codes::FILE_READ_ERROR,
-                            &e.to_string(),
-                        );
-                        return ScanOutcome::Error;
-                    }
-                    log_warn(args, &format!("{} — built-in payloads only", e));
-                }
-            }
-        }
-    }
-
-    // Load `--baseline` before any request goes out. A stale or malformed
-    // baseline path is exactly the thing a pipeline gets wrong, and finding
-    // out after a 20-minute scan is too late — so the warning lands here, on
-    // stderr (every format; stdout stays a clean machine payload) rather than
-    // through log_warn, which only speaks in `plain`.
-    let baseline = args.baseline.as_ref().map(|path| {
-        // `--output` pointed at the baseline overwrites it with this run's
-        // report. Under the default `filter` mode that report holds only the
-        // NEW findings, so the recorded backlog is destroyed and the next run
-        // re-reports all of it. Refreshing a baseline means re-running WITHOUT
-        // `--baseline`; warn rather than refuse, since `annotate` mode writes a
-        // complete report and is a legitimate way to do it.
-        if args.output.as_deref() == Some(path.as_str()) {
-            eprintln!(
-                "Warning: --output and --baseline are the same path ('{}'); under --baseline-mode filter this overwrites the baseline with new findings only. Re-run without --baseline to refresh it.",
-                path
-            );
-        }
-        // `--limit` stops the scan once N findings accrue, and that count is
-        // taken before the baseline diff runs. A target whose first N findings
-        // are all already known therefore halts early and reports zero new
-        // findings without having tested the rest of its parameters.
-        if args.limit.is_some() {
-            eprintln!(
-                "Warning: --limit counts findings before the --baseline diff, so a run whose first {} findings are all in the baseline stops early and reports 0 new. Drop --limit when gating on new findings.",
-                args.limit.unwrap_or(0)
-            );
-        }
-        let loaded = baseline::load(path, args.baseline_mode());
-        match &loaded.warning {
-            Some(w) => eprintln!("Warning: {} — baseline diff disabled", w),
-            None => log_info(
-                args,
-                &format!(
-                    "baseline loaded: {} known findings from {}",
-                    loaded.entries, path
-                ),
-            ),
-        }
-        loaded
-    });
-
-    // Warn loudly about unknown remote-provider names *before* the init
-    // call swallows them as silent no-ops. Previously a typo like
-    // `--remote-payloads payloadboxx` would just not fetch anything and
-    // the user would never know.
-    if !args.remote_payloads.is_empty() {
-        let known: std::collections::HashSet<String> = crate::payload::list_payload_providers()
-            .into_iter()
-            .collect();
-        for p in &args.remote_payloads {
-            if !known.contains(&p.to_ascii_lowercase()) {
-                eprintln!(
-                    "Warning: unknown --remote-payloads provider '{}' (known: {})",
-                    p,
-                    crate::payload::list_payload_providers().join(", ")
-                );
-            }
-        }
-    }
-    if !args.remote_wordlists.is_empty() {
-        let known: std::collections::HashSet<String> = crate::payload::list_wordlist_providers()
-            .into_iter()
-            .collect();
-        for p in &args.remote_wordlists {
-            if !known.contains(&p.to_ascii_lowercase()) {
-                eprintln!(
-                    "Warning: unknown --remote-wordlists provider '{}' (known: {})",
-                    p,
-                    crate::payload::list_wordlist_providers().join(", ")
-                );
-            }
-        }
-    }
-
-    // Initialize remote payloads/wordlists if requested (honor timeout/proxy)
-    if (!args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty())
-        && let Err(e) = crate::utils::init_remote_resources_with_options(
-            &args.remote_payloads,
-            &args.remote_wordlists,
-            Some(args.timeout),
-            args.proxy.clone(),
-        )
-        .await
-        && !args.silence
-    {
-        eprintln!("Error initializing remote resources: {}", e);
-    }
+    startup::init_remote_providers(args).await;
     // Resolve targets: input-type detection, file/stdin/raw-HTTP parsing,
     // dedup, scope + out-of-scope filtering, and --cookie-from-raw. Emits the
     // structured error itself on failure and returns Err for us to propagate.
@@ -671,56 +458,8 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     let scan_idx = Arc::new(AtomicUsize::new(0));
     let overall_done = Arc::new(AtomicUsize::new(0));
 
-    // Start global overall progress ticker when multiple targets; runs across preflight, analysis, and scanning.
-    // Suppressed when stdout isn't a TTY — cursor-redraw frames look like garbage in logs.
-    let overall_ticker = if args.format == "plain"
-        && !args.silence
-        && total_targets > 1
-        && crate::utils::term::stdout_is_tty()
-    {
-        let findings_count_clone = findings_count.clone();
-        let overall_done_clone = overall_done.clone();
-        let total_targets_copy = total_targets;
-        let (tx, mut rx) = oneshot::channel::<()>();
-        let (done_tx, done_rx) = oneshot::channel::<()>();
-        tokio::spawn(async move {
-            use crate::utils::shimmer;
-            let mut phase = 0usize;
-            loop {
-                let done = overall_done_clone.load(Ordering::Relaxed);
-                let percent = (done * 100) / std::cmp::max(1, total_targets_copy);
-                let findings = findings_count_clone.load(Ordering::Relaxed);
-                let text = format!(
-                    "overall  {done}/{total_targets_copy} targets · {percent}% · {findings} findings"
-                );
-                // Truncate to the terminal width (reserving the glyph + space)
-                // and clear to EOL so the metallic line never wraps onto a
-                // second row, which would desync the `\r` redraw.
-                let budget = crate::utils::term::term_cols().saturating_sub(2).max(8);
-                let visible = console::truncate_str(&text, budget, "…");
-                crate::cprint!(
-                    "\r{} {}\x1b[K",
-                    shimmer::spin_glyph(phase),
-                    shimmer::shimmer(visible.as_ref(), phase)
-                );
-                let _ = io::stdout().flush();
-                tokio::select! {
-                    _ = tokio::time::sleep(Duration::from_millis(shimmer::FRAME_MS as u64)) => {},
-                    _ = &mut rx => {
-                        // clear the line and exit
-                        crate::cprint!("\r\x1b[2K\r");
-                        let _ = io::stdout().flush();
-                        let _ = done_tx.send(());
-                        break;
-                    }
-                }
-                phase = phase.wrapping_add(1);
-            }
-        });
-        Some((tx, done_rx))
-    } else {
-        None
-    };
+    let overall_ticker =
+        logging::start_overall_ticker(args, total_targets, &findings_count, &overall_done);
 
     // Bundle the cross-task handles for the preflight/analysis loop, the
     // scanning loop, and result rendering. `host_groups`, `all_target_urls`,
@@ -747,78 +486,7 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         resumed_skipped,
     };
 
-    // Blind XSS: the static `-b/--blind` callback and/or OOB/OAST (interactsh)
-    // callbacks. Skipped in preview-only modes — `--dry-run` (which advertises
-    // "without sending attack payloads") and `--only-discovery` — because blind
-    // payloads are real attack traffic and OOB registration is an outbound side
-    // effect to a third-party server.
-    //
-    // Start an OOB session first — it fails soft (warn + continue), so a
-    // registration outage never aborts the scan. Injection then runs over
-    // whichever channel(s) are configured; the OOB poller is spawned once
-    // `stream_findings_enabled` is known (below) and drained before rendering.
-    // `--skip-xss-scanning` means "send no attack payloads". Blind XSS payloads
-    // are attack payloads — stored ones, at that: they persist in the target
-    // after the run. Only the per-target injection stage used to honour the
-    // flag (scan_loop.rs), so `--skip-xss-scanning -b <callback>` (with `-b`
-    // commonly living in a shared config file) still wrote live stored-XSS
-    // payloads into every parameter and form of a production system the
-    // operator had explicitly asked not to attack. This also skips OOB session
-    // registration, which is correct: there is nothing left to call back.
-    let blind_active = !args.dry_run && !args.only_discovery && !args.skip_xss_scanning;
-    let oob_session: Option<Arc<crate::oob::OobSession>> =
-        if blind_active && args.blind_oob_enabled() {
-            match crate::oob::OobSession::start(&args.oob_config()).await {
-                Ok(session) => {
-                    log_info(
-                        args,
-                        &format!(
-                            "OOB blind XSS armed via interactsh server: {}",
-                            session.server_domain()
-                        ),
-                    );
-                    Some(Arc::new(session))
-                }
-                Err(e) => {
-                    log_warn(
-                        args,
-                        &format!("--blind-oob disabled (could not register with any server): {e}"),
-                    );
-                    None
-                }
-            }
-        } else {
-            None
-        };
-
-    if blind_active && (args.blind_callback_url.is_some() || oob_session.is_some()) {
-        if let Some(callback_url) = &args.blind_callback_url {
-            log_info(
-                args,
-                &format!(
-                    "Performing blind XSS scanning with callback URL: {}",
-                    callback_url
-                ),
-            );
-        }
-        let custom = args.custom_blind_xss_payload.as_deref();
-        for group in host_groups.values() {
-            for target in group {
-                let source = match (&args.blind_callback_url, &oob_session) {
-                    (Some(url), Some(session)) => crate::scanning::CallbackSource::Both {
-                        url: url.as_str(),
-                        session: session.as_ref(),
-                    },
-                    (Some(url), None) => crate::scanning::CallbackSource::Static(url.as_str()),
-                    (None, Some(session)) => crate::scanning::CallbackSource::Oob(session.as_ref()),
-                    // Guarded by the enclosing `if`: at least one is Some.
-                    (None, None) => continue,
-                };
-                crate::scanning::blind_scanning_with(target, source, custom).await;
-                crate::scanning::blind_scan_forms_with(target, source, custom).await;
-            }
-        }
-    }
+    let oob_session = blind::arm_and_dispatch(args, &host_groups).await;
 
     // Targets entering preflight, so the ones it drops can be told apart from
     // the ones that go on to be scanned. Only materialized when `--state-file`
@@ -947,57 +615,14 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
         );
     }
 
-    // A scan where every supplied target failed reachability checks
-    // (DNS lookup failure, connection refused, content-type mismatch,
-    // etc.) used to fall through to `ScanOutcome::Clean` here — same
-    // exit code 0 as "scanned and found nothing." That silently masked
-    // hard failures from scripts like
-    //   `dalfox scan https://target && echo "no XSS found"`,
-    // so the operator could read a downed server or typo'd host as a
-    // clean pass. Treat the all-skipped case as an error instead; if
-    // even one target produced any scan activity (even with zero
-    // findings) the outcome falls through to Clean as before.
-    let all_unreachable = !all_target_urls.is_empty() && {
-        let skipped = state.skipped_targets.lock().await;
-        !skipped.is_empty() && all_target_urls.iter().all(|u| skipped.contains_key(u))
-    };
-    if all_unreachable {
-        return ScanOutcome::Error;
-    }
-
-    // An empty report after a dead session must not exit 0 — `dalfox scan ... &&
-    // echo "no XSS found"` is exactly the script this issue is about. Under
-    // `--on-session-loss continue` the operator has said the detection may be
-    // misfiring on their target and asked to keep going, so the exit code is
-    // left alone; the `incomplete` meta flag and the per-target SESSION_LOST
-    // entries still record what happened either way.
-    //
-    // Gated on there being no findings: a run that confirmed a `V` and *then*
-    // lost its session should exit 1 (vulnerabilities found), not 2 (hard
-    // error). CI that separates those two — a distinction the output guide
-    // documents — would otherwise read a successful detection as an
-    // infrastructure failure. `meta.incomplete` carries the incompleteness for
-    // both codes.
-    if final_results.is_empty()
-        && session::aborts_on_loss(args)
-        && !state.session_lost.lock().await.is_empty()
-    {
-        return ScanOutcome::Error;
-    }
-
-    // A requested `--output` file that couldn't be written is a hard failure,
-    // same as an all-unreachable run: the operator asked for results on disk and
-    // didn't get them. Report it via the exit code so scripts don't read it as a
-    // clean/successful pass.
-    if output_write_failed {
-        return ScanOutcome::Error;
-    }
-
-    if final_results.is_empty() {
-        ScanOutcome::Clean
-    } else {
-        ScanOutcome::Findings
-    }
+    output::derive_outcome(
+        args,
+        &all_target_urls,
+        &state,
+        &final_results,
+        output_write_failed,
+    )
+    .await
 }
 
 #[cfg(test)]

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -756,3 +756,70 @@ fn write_output_or_stdout(args: &ScanArgs, output_content: &str) -> bool {
     }
     output_write_failed
 }
+
+/// Decide the process exit code from what the scan actually produced.
+///
+/// Every branch here exists because a real script read the wrong thing from a
+/// zero exit: `dalfox scan https://target && echo "no XSS found"` must not
+/// print that when the host was down, when the session died, or when the
+/// `--output` file could not be written. Only "we looked and found nothing"
+/// is Clean.
+pub(crate) async fn derive_outcome(
+    args: &ScanArgs,
+    all_target_urls: &[String],
+    state: &ScanState,
+    final_results: &[Result],
+    output_write_failed: bool,
+) -> ScanOutcome {
+    // A scan where every supplied target failed reachability checks
+    // (DNS lookup failure, connection refused, content-type mismatch,
+    // etc.) used to fall through to `ScanOutcome::Clean` here — same
+    // exit code 0 as "scanned and found nothing." That silently masked
+    // hard failures from scripts like
+    //   `dalfox scan https://target && echo "no XSS found"`,
+    // so the operator could read a downed server or typo'd host as a
+    // clean pass. Treat the all-skipped case as an error instead; if
+    // even one target produced any scan activity (even with zero
+    // findings) the outcome falls through to Clean as before.
+    let all_unreachable = !all_target_urls.is_empty() && {
+        let skipped = state.skipped_targets.lock().await;
+        !skipped.is_empty() && all_target_urls.iter().all(|u| skipped.contains_key(u))
+    };
+    if all_unreachable {
+        return ScanOutcome::Error;
+    }
+
+    // An empty report after a dead session must not exit 0 — `dalfox scan ... &&
+    // echo "no XSS found"` is exactly the script this issue is about. Under
+    // `--on-session-loss continue` the operator has said the detection may be
+    // misfiring on their target and asked to keep going, so the exit code is
+    // left alone; the `incomplete` meta flag and the per-target SESSION_LOST
+    // entries still record what happened either way.
+    //
+    // Gated on there being no findings: a run that confirmed a `V` and *then*
+    // lost its session should exit 1 (vulnerabilities found), not 2 (hard
+    // error). CI that separates those two — a distinction the output guide
+    // documents — would otherwise read a successful detection as an
+    // infrastructure failure. `meta.incomplete` carries the incompleteness for
+    // both codes.
+    if final_results.is_empty()
+        && super::session::aborts_on_loss(args)
+        && !state.session_lost.lock().await.is_empty()
+    {
+        return ScanOutcome::Error;
+    }
+
+    // A requested `--output` file that couldn't be written is a hard failure,
+    // same as an all-unreachable run: the operator asked for results on disk and
+    // didn't get them. Report it via the exit code so scripts don't read it as a
+    // clean/successful pass.
+    if output_write_failed {
+        return ScanOutcome::Error;
+    }
+
+    if final_results.is_empty() {
+        ScanOutcome::Clean
+    } else {
+        ScanOutcome::Findings
+    }
+}

--- a/src/cmd/scan/scan_loop.rs
+++ b/src/cmd/scan/scan_loop.rs
@@ -11,9 +11,11 @@ use super::poc::render_finding_block;
 use super::session::{ProbePhase, SessionMonitor};
 use crate::target_parser::Target;
 use crate::utils::semaphore_permits;
+use std::collections::HashMap;
 use std::sync::Arc;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::time::Duration;
+use tokio::sync::Mutex;
 
 /// Host-group slots per configured concurrent target. Groups are cheap
 /// relative to targets and spend part of their life holding no target permit,
@@ -270,347 +272,26 @@ pub(crate) async fn run_scan_loop(
         // session; a dead session on one of them says nothing about a
         // different host in the same run.
         let session_lost_group = Arc::new(AtomicBool::new(false));
-        group_handles.spawn(async move {
-            // Released when this group finishes, admitting the next one.
-            let _group_permit = group_permit;
-            // Skip the (expensive) payload-counting loop entirely when no
-            // overall progress bar will be drawn — generating ~10k payloads
-            // per param twice (here and again inside run_scanning) added a
-            // measurable CPU tax for every --silence / non-TTY scan.
-            let overall_pb: Option<Arc<indicatif::ProgressBar>> = if let Some(ref mp) =
-                multi_pb_clone
-            {
-                // Calculate total overall tasks for this group. Must mirror what
-                // run_scanning actually increments — one tick per reflection
-                // payload, one per DOM payload — otherwise the overall bar rolls
-                // past 100% (the previous reflection-only count was the cause).
-                let mut total_overall_tasks = 0u64;
-                for target in &group {
-                    for param in &target.reflection_params {
-                        let reflection_payloads = if let Some(context) = &param.injection_context {
-                            crate::scanning::xss_common::get_dynamic_payloads(context, &args_arc)
-                                .unwrap_or_else(|_| vec![])
-                        } else {
-                            crate::scanning::xss_common::get_dynamic_payloads(
-                                &crate::parameter_analysis::InjectionContext::Html(None),
-                                &args_arc,
-                            )
-                            .unwrap_or_else(|_| vec![])
-                        };
-                        let dom_payloads = crate::scanning::get_dom_payloads(param, &args_arc)
-                            .unwrap_or_else(|_| vec![]);
-                        total_overall_tasks +=
-                            reflection_payloads.len() as u64 + dom_payloads.len() as u64;
-                    }
-                }
-                let pb = mp.add(indicatif::ProgressBar::new(total_overall_tasks));
-                // See `crate::scanning::req_per_sec_tracker` for why we
-                // replace `{per_sec}` (pb-position rate, inflated by
-                // skipped-payload `inc(1)` calls) with a `REQUEST_COUNT`-delta
-                // tracker.
-                let req_start = crate::REQUEST_COUNT.load(Ordering::Relaxed);
-                pb.set_style(
-                    indicatif::ProgressStyle::default_bar()
-                        .template("{spinner:.cyan} [{elapsed_precise}] [{bar:28.45/238}] {pos:>5}/{len:5} · {req_per_sec} · {wave}")
-                        .expect("valid progress bar template")
-                        .tick_chars(crate::utils::shimmer::TICK_CHARS)
-                        .with_key(
-                            "req_per_sec",
-                            crate::scanning::req_per_sec_tracker(req_start),
-                        )
-                        .with_key(
-                            "wave",
-                            crate::utils::shimmer::wave_tracker(
-                                "Overall scanning".to_string(),
-                                crate::utils::shimmer::BAR_WAVE_RESERVE,
-                            ),
-                        )
-                        .progress_chars("█▉▊▋▌▍▎▏░"),
-                );
-                pb.enable_steady_tick(Duration::from_millis(
-                    crate::utils::shimmer::FRAME_MS as u64,
-                ));
-                Some(Arc::new(pb))
-            } else {
-                None
-            };
-
-            // Also a `JoinSet`: when the run stops early under `--limit` the
-            // group task itself is aborted, and a `Vec<JoinHandle>` would let
-            // its in-flight targets detach and keep issuing requests. A
-            // `JoinSet` aborts them when it drops.
-            let mut target_handles = tokio::task::JoinSet::new();
-            // task id -> target URL, so a panicking task can be attributed to
-            // the target it was scanning (a `JoinError` carries only the id).
-            let mut panicked_target_of: std::collections::HashMap<tokio::task::Id, String> =
-                std::collections::HashMap::new();
-
-            for target in group {
-                if let Some(lim) = args_arc.limit
-                    && findings_count_group.load(Ordering::Relaxed) >= lim
-                {
-                    break;
-                }
-                // SIGINT bail-out at the per-target dispatch boundary —
-                // skip queuing any more targets once the user pressed
-                // Ctrl-C, even if some are still pending.
-                if cancel_flag_group.load(std::sync::atomic::Ordering::Relaxed) {
-                    break;
-                }
-                let Ok(permit) = global_semaphore_clone.clone().acquire_owned().await else {
-                    break;
-                };
-                // Session-loss bail-out at the same boundary. Once the shared
-                // session for this host is gone, every remaining target would
-                // be scanned against a login page — the exact silent
-                // false-negative run this exists to prevent. Record each one as
-                // SESSION_LOST rather than letting target_summary call them
-                // clean.
-                //
-                // Checked *after* acquiring the permit, not before: at
-                // `--max-concurrent-targets 1` the sibling that discovers the
-                // dead session is still holding the permit when this iteration
-                // begins, so a pre-acquire check would read a stale `false` and
-                // dispatch the target anyway. Targets already in flight are not
-                // recalled — their own post-scan probe covers them.
-                if session_lost_group.load(Ordering::Relaxed) {
-                    skipped_targets_group.lock().await.insert(
-                        target.url.to_string(),
-                        crate::cmd::error_codes::SESSION_LOST,
-                    );
-                    // `cancelled`, not `completed`: this target was never
-                    // tested, so a later run must pick it up again.
-                    if let Some(sf) = &state_file_group {
-                        sf.record(
-                            target.url.as_str(),
-                            &target.method,
-                            super::state_file::TargetOutcome::Cancelled,
-                        );
-                    }
-                    drop(permit);
-                    continue;
-                }
-                let args_clone = args_arc.clone();
-                let results_clone_inner = results_clone.clone();
-                let multi_pb_clone_inner = multi_pb_clone.clone();
-                let overall_pb_clone = overall_pb.clone();
-                let scan_idx_clone = scan_idx.clone();
-                let total_targets_copy = total_targets;
-                let findings_count_target = findings_count_group.clone();
-                let finding_tx_target = finding_tx_group.clone();
-                let cancel_flag_inner = cancel_flag_group.clone();
-                let session_monitor_target = session_monitor_group.clone();
-                let session_lost_target = session_lost_group.clone();
-                let skipped_targets_target = skipped_targets_group.clone();
-                let state_file_target = state_file_group.clone();
-
-                let multi_pb_active = multi_pb_clone_inner.is_some();
-                let panic_target_url = target.url.to_string();
-                let spawned = target_handles.spawn(async move {
-                    if !args_clone.skip_xss_scanning && !args_clone.only_discovery {
-                        // Re-validate the session before spending this target's
-                        // request budget. Throttled: on a short run the preflight
-                        // baseline is seconds old and re-probing proves nothing
-                        // (see `session::pre_dispatch_probe_due`).
-                        if let Some(monitor) = &session_monitor_target
-                            && monitor
-                                .check(&target, ProbePhase::PreDispatch)
-                                .await
-                                .is_some()
-                            && monitor.abort_on_loss
-                        {
-                            session_lost_target.store(true, Ordering::Relaxed);
-                            skipped_targets_target.lock().await.insert(
-                                target.url.to_string(),
-                                crate::cmd::error_codes::SESSION_LOST,
-                            );
-                            if let Some(sf) = &state_file_target {
-                                sf.record(
-                                    target.url.as_str(),
-                                    &target.method,
-                                    super::state_file::TargetOutcome::Cancelled,
-                                );
-                            }
-                            drop(permit);
-                            return;
-                        }
-                        let __scan_spinner = {
-                            // When the indicatif bar is active, run_scanning renders a
-                            // per-target progress bar with rate/ETA — suppress the stdout
-                            // spinner so we don't show two competing scan indicators.
-                            let enabled =
-                                !args_clone.silence && total_targets_copy == 1 && !multi_pb_active;
-                            let current = scan_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
-                            start_spinner(
-                                spinner_allowed,
-                                enabled,
-                                if total_targets_copy > 1 {
-                                    format!(
-                                        "[{}/{}] scanning: {}",
-                                        current, total_targets_copy, target.url
-                                    )
-                                } else {
-                                    format!("scanning: {}", target.url)
-                                },
-                            )
-                        };
-                        // Per-target cancellation flag. With a `--scan-timeout`
-                        // set, hand `run_scanning` a fresh per-target flag
-                        // (seeded from the real Ctrl-C flag) so the cap cancels
-                        // only this target — never the shared SIGINT flag, which
-                        // would abort every sibling and skip all pending targets
-                        // (see `run_target_capped`). With no cap, pass the shared
-                        // flag straight through so the common path keeps its
-                        // zero-overhead direct wiring.
-                        let timeout_set = args_clone.scan_timeout > 0;
-                        let target_cancel = if timeout_set {
-                            Arc::new(AtomicBool::new(cancel_flag_inner.load(Ordering::Relaxed)))
-                        } else {
-                            cancel_flag_inner.clone()
-                        };
-                        let scan_fut = crate::scanning::run_scanning(
-                            &target,
-                            args_clone.clone(),
-                            // No `params_done`: the CLI renders its own
-                            // indicatif progress bar instead.
-                            crate::scanning::ScanRunHandles::new(
-                                results_clone_inner,
-                                findings_count_target,
-                            )
-                            .with_progress(multi_pb_clone_inner, overall_pb_clone)
-                            .with_cancel(target_cancel.clone())
-                            .with_finding_tx(finding_tx_target),
-                        );
-                        // Honor --scan-timeout as a hard wall-clock cap per
-                        // target. When a slow endpoint streams a partial body
-                        // and pins every phase at the per-request `--timeout`,
-                        // the per-target scan would otherwise serialize each
-                        // phase × per-request timeout and run far longer than
-                        // the user expects. Setting the cap to 0 disables it.
-                        let (timed_out, scan_report) = if timeout_set {
-                            run_target_capped(
-                                scan_fut,
-                                args_clone.scan_timeout,
-                                &cancel_flag_inner,
-                                &target_cancel,
-                            )
-                            .await
-                        } else {
-                            (false, scan_fut.await)
-                        };
-                        if timed_out && !args_clone.silence {
-                            eprintln!(
-                                "[scan] {} exceeded --scan-timeout ({}s); cancelling target (stops at next checkpoint)",
-                                target.url, args_clone.scan_timeout,
-                            );
-                        }
-                        if let Some((tx, done_rx)) = __scan_spinner {
-                            let _ = tx.send(());
-                            let _ = done_rx.await;
-                        }
-                        // Post-scan re-validation — the probe that actually
-                        // catches the reported failure: a session that survived
-                        // preflight and died an hour into the injection stage,
-                        // leaving every request after that answered by a login
-                        // page. Never throttled, and skipped only when the run
-                        // was cut short anyway (Ctrl-C / --scan-timeout), where
-                        // "incomplete" is already established and a login-page
-                        // probe would just be noise.
-                        let mut session_died = false;
-                        if let Some(monitor) = &session_monitor_target
-                            && !timed_out
-                            && !cancel_flag_inner.load(Ordering::Relaxed)
-                            && monitor.check(&target, ProbePhase::PostScan).await.is_some()
-                        {
-                            session_died = true;
-                            if monitor.abort_on_loss {
-                                // Nothing left to abort for *this* target, but
-                                // the rest of the host group is still ahead of
-                                // us.
-                                session_lost_target.store(true, Ordering::Relaxed);
-                            }
-                        }
-
-                        // Terminal state for `--state-file`. Only a target that
-                        // ran to the end under a live session is `completed`
-                        // and therefore skippable next run; a Ctrl-C, a
-                        // `--scan-timeout` expiry, a session that died
-                        // mid-scan, or a `--limit` cap that cut the dispatch
-                        // loop short all leave coverage unknown, so they are
-                        // recorded `cancelled` and retried. `--limit` matters
-                        // as much as the others even though the run "succeeded":
-                        // `limit` is part of the config hash, so re-running the
-                        // identical command would skip this target forever with
-                        // most of its parameters never tested.
-                        if let Some(sf) = &state_file_target {
-                            let outcome = if timed_out
-                                || cancel_flag_inner.load(Ordering::Relaxed)
-                                || session_died
-                                || scan_report.limit_stopped
-                            {
-                                super::state_file::TargetOutcome::Cancelled
-                            } else {
-                                super::state_file::TargetOutcome::Completed
-                            };
-                            sf.record(target.url.as_str(), &target.method, outcome);
-                        }
-                    } else if let Some(sf) = &state_file_target {
-                        // `--skip-xss-scanning`: the injection stage is off, but
-                        // preflight, discovery, and mining already ran for this
-                        // target and that is the whole run. Recording it means a
-                        // resumed discovery-only campaign makes progress instead
-                        // of redoing every target while looking resumable. Safe
-                        // because `skip_xss_scanning` is part of the config hash:
-                        // a later run that does scan does not reuse these.
-                        sf.record(
-                            target.url.as_str(),
-                            &target.method,
-                            super::state_file::TargetOutcome::Completed,
-                        );
-                    }
-                    drop(permit);
-                });
-                panicked_target_of.insert(spawned.id(), panic_target_url);
-            }
-
-            while let Some(joined) = target_handles.join_next().await {
-                // Surface panics from per-target scan tasks instead of letting
-                // them disappear silently — a panic here points to a bug in
-                // the scanning pipeline and operators need a chance to see it.
-                if let Err(e) = joined
-                    && e.is_panic()
-                {
-                    // Sanitized: a panic message quotes the data that caused
-                    // it, which for this pipeline can be bytes straight from a
-                    // scanned response — raw CR/LF there forges log lines.
-                    eprintln!(
-                        "[scan] target task panicked: {}",
-                        crate::utils::log::sanitize_log_message(&e.to_string())
-                    );
-                    // Logging alone still left the target reported `clean`:
-                    // it produced no findings and nothing marked it otherwise,
-                    // which for a scanner is the worst possible outcome. Record
-                    // it the same way the preflight/analysis stage does.
-                    if let Some(url) = panicked_target_of.get(&e.id()) {
-                        skipped_targets_group
-                            .lock()
-                            .await
-                            .insert(url.clone(), crate::cmd::error_codes::INTERNAL_ERROR);
-                    }
-                }
-                // Update global overall progress line when multiple targets
-                overall_done_clone.fetch_add(1, Ordering::Relaxed);
-                // overall ticker handles rendering globally
-            }
-
-            if let Some(pb) = overall_pb {
-                crate::scanning::finish_scan_bar(
-                    &pb,
-                    console::style("✓").green().to_string(),
-                    format!("All scanning completed for {}", host),
-                );
-            }
-        });
+        group_handles.spawn(scan_host_group(HostGroupCtx {
+            host,
+            group,
+            group_permit,
+            global_semaphore_clone,
+            multi_pb_clone,
+            args_arc,
+            results_clone,
+            findings_count_group,
+            finding_tx_group,
+            scan_idx,
+            overall_done_clone,
+            cancel_flag_group,
+            session_monitor_group,
+            skipped_targets_group,
+            state_file_group,
+            session_lost_group,
+            total_targets,
+            spinner_allowed,
+        }));
     }
 
     while let Some(joined) = group_handles.join_next().await {
@@ -651,6 +332,394 @@ pub(crate) async fn run_scan_loop(
         && e.is_panic()
     {
         eprintln!("[scan] finding printer task panicked: {}", e);
+    }
+}
+
+/// The handles one host group's scan task needs.
+///
+/// Bundled rather than captured one by one: the task body took fifteen
+/// separately-cloned locals, so adding a handle meant editing two places that
+/// had to stay in step. Cloning this is the same set of refcount bumps the
+/// individual `let … = ….clone();` lines performed.
+pub(crate) struct HostGroupCtx {
+    pub(crate) host: String,
+    pub(crate) group: Vec<Target>,
+    pub(crate) group_permit: tokio::sync::OwnedSemaphorePermit,
+    pub(crate) global_semaphore_clone: Arc<tokio::sync::Semaphore>,
+    pub(crate) multi_pb_clone: Option<Arc<indicatif::MultiProgress>>,
+    pub(crate) args_arc: Arc<ScanArgs>,
+    pub(crate) results_clone: Arc<Mutex<Vec<crate::scanning::result::Result>>>,
+    pub(crate) findings_count_group: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) finding_tx_group:
+        Option<tokio::sync::mpsc::UnboundedSender<crate::scanning::result::Result>>,
+    pub(crate) scan_idx: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) overall_done_clone: Arc<std::sync::atomic::AtomicUsize>,
+    pub(crate) cancel_flag_group: Arc<AtomicBool>,
+    pub(crate) session_monitor_group: Option<Arc<SessionMonitor>>,
+    pub(crate) skipped_targets_group: Arc<Mutex<HashMap<String, &'static str>>>,
+    pub(crate) state_file_group: Option<Arc<super::state_file::StateFile>>,
+    pub(crate) session_lost_group: Arc<AtomicBool>,
+    pub(crate) total_targets: usize,
+    pub(crate) spinner_allowed: bool,
+}
+
+/// Scan every target in one host group, under the global concurrency permit.
+pub(crate) async fn scan_host_group(ctx: HostGroupCtx) {
+    let HostGroupCtx {
+        host,
+        group,
+        group_permit,
+        global_semaphore_clone,
+        multi_pb_clone,
+        args_arc,
+        results_clone,
+        findings_count_group,
+        finding_tx_group,
+        scan_idx,
+        overall_done_clone,
+        cancel_flag_group,
+        session_monitor_group,
+        skipped_targets_group,
+        state_file_group,
+        session_lost_group,
+        total_targets,
+        spinner_allowed,
+    } = ctx;
+    // Released when this group finishes, admitting the next one.
+    let _group_permit = group_permit;
+    // Skip the (expensive) payload-counting loop entirely when no
+    // overall progress bar will be drawn — generating ~10k payloads
+    // per param twice (here and again inside run_scanning) added a
+    // measurable CPU tax for every --silence / non-TTY scan.
+    let overall_pb: Option<Arc<indicatif::ProgressBar>> = if let Some(ref mp) = multi_pb_clone {
+        // Calculate total overall tasks for this group. Must mirror what
+        // run_scanning actually increments — one tick per reflection
+        // payload, one per DOM payload — otherwise the overall bar rolls
+        // past 100% (the previous reflection-only count was the cause).
+        let mut total_overall_tasks = 0u64;
+        for target in &group {
+            for param in &target.reflection_params {
+                let reflection_payloads = if let Some(context) = &param.injection_context {
+                    crate::scanning::xss_common::get_dynamic_payloads(context, &args_arc)
+                        .unwrap_or_else(|_| vec![])
+                } else {
+                    crate::scanning::xss_common::get_dynamic_payloads(
+                        &crate::parameter_analysis::InjectionContext::Html(None),
+                        &args_arc,
+                    )
+                    .unwrap_or_else(|_| vec![])
+                };
+                let dom_payloads =
+                    crate::scanning::get_dom_payloads(param, &args_arc).unwrap_or_else(|_| vec![]);
+                total_overall_tasks += reflection_payloads.len() as u64 + dom_payloads.len() as u64;
+            }
+        }
+        let pb = mp.add(indicatif::ProgressBar::new(total_overall_tasks));
+        // See `crate::scanning::req_per_sec_tracker` for why we
+        // replace `{per_sec}` (pb-position rate, inflated by
+        // skipped-payload `inc(1)` calls) with a `REQUEST_COUNT`-delta
+        // tracker.
+        let req_start = crate::REQUEST_COUNT.load(Ordering::Relaxed);
+        pb.set_style(
+                indicatif::ProgressStyle::default_bar()
+                    .template("{spinner:.cyan} [{elapsed_precise}] [{bar:28.45/238}] {pos:>5}/{len:5} · {req_per_sec} · {wave}")
+                    .expect("valid progress bar template")
+                    .tick_chars(crate::utils::shimmer::TICK_CHARS)
+                    .with_key(
+                        "req_per_sec",
+                        crate::scanning::req_per_sec_tracker(req_start),
+                    )
+                    .with_key(
+                        "wave",
+                        crate::utils::shimmer::wave_tracker(
+                            "Overall scanning".to_string(),
+                            crate::utils::shimmer::BAR_WAVE_RESERVE,
+                        ),
+                    )
+                    .progress_chars("█▉▊▋▌▍▎▏░"),
+            );
+        pb.enable_steady_tick(Duration::from_millis(
+            crate::utils::shimmer::FRAME_MS as u64,
+        ));
+        Some(Arc::new(pb))
+    } else {
+        None
+    };
+
+    // Also a `JoinSet`: when the run stops early under `--limit` the
+    // group task itself is aborted, and a `Vec<JoinHandle>` would let
+    // its in-flight targets detach and keep issuing requests. A
+    // `JoinSet` aborts them when it drops.
+    let mut target_handles = tokio::task::JoinSet::new();
+    // task id -> target URL, so a panicking task can be attributed to
+    // the target it was scanning (a `JoinError` carries only the id).
+    let mut panicked_target_of: std::collections::HashMap<tokio::task::Id, String> =
+        std::collections::HashMap::new();
+
+    for target in group {
+        if let Some(lim) = args_arc.limit
+            && findings_count_group.load(Ordering::Relaxed) >= lim
+        {
+            break;
+        }
+        // SIGINT bail-out at the per-target dispatch boundary —
+        // skip queuing any more targets once the user pressed
+        // Ctrl-C, even if some are still pending.
+        if cancel_flag_group.load(std::sync::atomic::Ordering::Relaxed) {
+            break;
+        }
+        let Ok(permit) = global_semaphore_clone.clone().acquire_owned().await else {
+            break;
+        };
+        // Session-loss bail-out at the same boundary. Once the shared
+        // session for this host is gone, every remaining target would
+        // be scanned against a login page — the exact silent
+        // false-negative run this exists to prevent. Record each one as
+        // SESSION_LOST rather than letting target_summary call them
+        // clean.
+        //
+        // Checked *after* acquiring the permit, not before: at
+        // `--max-concurrent-targets 1` the sibling that discovers the
+        // dead session is still holding the permit when this iteration
+        // begins, so a pre-acquire check would read a stale `false` and
+        // dispatch the target anyway. Targets already in flight are not
+        // recalled — their own post-scan probe covers them.
+        if session_lost_group.load(Ordering::Relaxed) {
+            skipped_targets_group.lock().await.insert(
+                target.url.to_string(),
+                crate::cmd::error_codes::SESSION_LOST,
+            );
+            // `cancelled`, not `completed`: this target was never
+            // tested, so a later run must pick it up again.
+            if let Some(sf) = &state_file_group {
+                sf.record(
+                    target.url.as_str(),
+                    &target.method,
+                    super::state_file::TargetOutcome::Cancelled,
+                );
+            }
+            drop(permit);
+            continue;
+        }
+        let args_clone = args_arc.clone();
+        let results_clone_inner = results_clone.clone();
+        let multi_pb_clone_inner = multi_pb_clone.clone();
+        let overall_pb_clone = overall_pb.clone();
+        let scan_idx_clone = scan_idx.clone();
+        let total_targets_copy = total_targets;
+        let findings_count_target = findings_count_group.clone();
+        let finding_tx_target = finding_tx_group.clone();
+        let cancel_flag_inner = cancel_flag_group.clone();
+        let session_monitor_target = session_monitor_group.clone();
+        let session_lost_target = session_lost_group.clone();
+        let skipped_targets_target = skipped_targets_group.clone();
+        let state_file_target = state_file_group.clone();
+
+        let multi_pb_active = multi_pb_clone_inner.is_some();
+        let panic_target_url = target.url.to_string();
+        let spawned = target_handles.spawn(async move {
+                if !args_clone.skip_xss_scanning && !args_clone.only_discovery {
+                    // Re-validate the session before spending this target's
+                    // request budget. Throttled: on a short run the preflight
+                    // baseline is seconds old and re-probing proves nothing
+                    // (see `session::pre_dispatch_probe_due`).
+                    if let Some(monitor) = &session_monitor_target
+                        && monitor
+                            .check(&target, ProbePhase::PreDispatch)
+                            .await
+                            .is_some()
+                        && monitor.abort_on_loss
+                    {
+                        session_lost_target.store(true, Ordering::Relaxed);
+                        skipped_targets_target.lock().await.insert(
+                            target.url.to_string(),
+                            crate::cmd::error_codes::SESSION_LOST,
+                        );
+                        if let Some(sf) = &state_file_target {
+                            sf.record(
+                                target.url.as_str(),
+                                &target.method,
+                                super::state_file::TargetOutcome::Cancelled,
+                            );
+                        }
+                        drop(permit);
+                        return;
+                    }
+                    let __scan_spinner = {
+                        // When the indicatif bar is active, run_scanning renders a
+                        // per-target progress bar with rate/ETA — suppress the stdout
+                        // spinner so we don't show two competing scan indicators.
+                        let enabled =
+                            !args_clone.silence && total_targets_copy == 1 && !multi_pb_active;
+                        let current = scan_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
+                        start_spinner(
+                            spinner_allowed,
+                            enabled,
+                            if total_targets_copy > 1 {
+                                format!(
+                                    "[{}/{}] scanning: {}",
+                                    current, total_targets_copy, target.url
+                                )
+                            } else {
+                                format!("scanning: {}", target.url)
+                            },
+                        )
+                    };
+                    // Per-target cancellation flag. With a `--scan-timeout`
+                    // set, hand `run_scanning` a fresh per-target flag
+                    // (seeded from the real Ctrl-C flag) so the cap cancels
+                    // only this target — never the shared SIGINT flag, which
+                    // would abort every sibling and skip all pending targets
+                    // (see `run_target_capped`). With no cap, pass the shared
+                    // flag straight through so the common path keeps its
+                    // zero-overhead direct wiring.
+                    let timeout_set = args_clone.scan_timeout > 0;
+                    let target_cancel = if timeout_set {
+                        Arc::new(AtomicBool::new(cancel_flag_inner.load(Ordering::Relaxed)))
+                    } else {
+                        cancel_flag_inner.clone()
+                    };
+                    let scan_fut = crate::scanning::run_scanning(
+                        &target,
+                        args_clone.clone(),
+                        // No `params_done`: the CLI renders its own
+                        // indicatif progress bar instead.
+                        crate::scanning::ScanRunHandles::new(
+                            results_clone_inner,
+                            findings_count_target,
+                        )
+                        .with_progress(multi_pb_clone_inner, overall_pb_clone)
+                        .with_cancel(target_cancel.clone())
+                        .with_finding_tx(finding_tx_target),
+                    );
+                    // Honor --scan-timeout as a hard wall-clock cap per
+                    // target. When a slow endpoint streams a partial body
+                    // and pins every phase at the per-request `--timeout`,
+                    // the per-target scan would otherwise serialize each
+                    // phase × per-request timeout and run far longer than
+                    // the user expects. Setting the cap to 0 disables it.
+                    let (timed_out, scan_report) = if timeout_set {
+                        run_target_capped(
+                            scan_fut,
+                            args_clone.scan_timeout,
+                            &cancel_flag_inner,
+                            &target_cancel,
+                        )
+                        .await
+                    } else {
+                        (false, scan_fut.await)
+                    };
+                    if timed_out && !args_clone.silence {
+                        eprintln!(
+                            "[scan] {} exceeded --scan-timeout ({}s); cancelling target (stops at next checkpoint)",
+                            target.url, args_clone.scan_timeout,
+                        );
+                    }
+                    if let Some((tx, done_rx)) = __scan_spinner {
+                        let _ = tx.send(());
+                        let _ = done_rx.await;
+                    }
+                    // Post-scan re-validation — the probe that actually
+                    // catches the reported failure: a session that survived
+                    // preflight and died an hour into the injection stage,
+                    // leaving every request after that answered by a login
+                    // page. Never throttled, and skipped only when the run
+                    // was cut short anyway (Ctrl-C / --scan-timeout), where
+                    // "incomplete" is already established and a login-page
+                    // probe would just be noise.
+                    let mut session_died = false;
+                    if let Some(monitor) = &session_monitor_target
+                        && !timed_out
+                        && !cancel_flag_inner.load(Ordering::Relaxed)
+                        && monitor.check(&target, ProbePhase::PostScan).await.is_some()
+                    {
+                        session_died = true;
+                        if monitor.abort_on_loss {
+                            // Nothing left to abort for *this* target, but
+                            // the rest of the host group is still ahead of
+                            // us.
+                            session_lost_target.store(true, Ordering::Relaxed);
+                        }
+                    }
+
+                    // Terminal state for `--state-file`. Only a target that
+                    // ran to the end under a live session is `completed`
+                    // and therefore skippable next run; a Ctrl-C, a
+                    // `--scan-timeout` expiry, a session that died
+                    // mid-scan, or a `--limit` cap that cut the dispatch
+                    // loop short all leave coverage unknown, so they are
+                    // recorded `cancelled` and retried. `--limit` matters
+                    // as much as the others even though the run "succeeded":
+                    // `limit` is part of the config hash, so re-running the
+                    // identical command would skip this target forever with
+                    // most of its parameters never tested.
+                    if let Some(sf) = &state_file_target {
+                        let outcome = if timed_out
+                            || cancel_flag_inner.load(Ordering::Relaxed)
+                            || session_died
+                            || scan_report.limit_stopped
+                        {
+                            super::state_file::TargetOutcome::Cancelled
+                        } else {
+                            super::state_file::TargetOutcome::Completed
+                        };
+                        sf.record(target.url.as_str(), &target.method, outcome);
+                    }
+                } else if let Some(sf) = &state_file_target {
+                    // `--skip-xss-scanning`: the injection stage is off, but
+                    // preflight, discovery, and mining already ran for this
+                    // target and that is the whole run. Recording it means a
+                    // resumed discovery-only campaign makes progress instead
+                    // of redoing every target while looking resumable. Safe
+                    // because `skip_xss_scanning` is part of the config hash:
+                    // a later run that does scan does not reuse these.
+                    sf.record(
+                        target.url.as_str(),
+                        &target.method,
+                        super::state_file::TargetOutcome::Completed,
+                    );
+                }
+                drop(permit);
+            });
+        panicked_target_of.insert(spawned.id(), panic_target_url);
+    }
+
+    while let Some(joined) = target_handles.join_next().await {
+        // Surface panics from per-target scan tasks instead of letting
+        // them disappear silently — a panic here points to a bug in
+        // the scanning pipeline and operators need a chance to see it.
+        if let Err(e) = joined
+            && e.is_panic()
+        {
+            // Sanitized: a panic message quotes the data that caused
+            // it, which for this pipeline can be bytes straight from a
+            // scanned response — raw CR/LF there forges log lines.
+            eprintln!(
+                "[scan] target task panicked: {}",
+                crate::utils::log::sanitize_log_message(&e.to_string())
+            );
+            // Logging alone still left the target reported `clean`:
+            // it produced no findings and nothing marked it otherwise,
+            // which for a scanner is the worst possible outcome. Record
+            // it the same way the preflight/analysis stage does.
+            if let Some(url) = panicked_target_of.get(&e.id()) {
+                skipped_targets_group
+                    .lock()
+                    .await
+                    .insert(url.clone(), crate::cmd::error_codes::INTERNAL_ERROR);
+            }
+        }
+        // Update global overall progress line when multiple targets
+        overall_done_clone.fetch_add(1, Ordering::Relaxed);
+        // overall ticker handles rendering globally
+    }
+
+    if let Some(pb) = overall_pb {
+        crate::scanning::finish_scan_bar(
+            &pb,
+            console::style("✓").green().to_string(),
+            format!("All scanning completed for {}", host),
+        );
     }
 }
 

--- a/src/cmd/scan/startup.rs
+++ b/src/cmd/scan/startup.rs
@@ -1,0 +1,221 @@
+//! Everything `run_scan` does before the first target is resolved: the
+//! startup validation gate, and remote payload/wordlist provider setup.
+//!
+//! These share a deadline rather than a topic — each one has to happen before
+//! any request goes out, because each failure it catches is otherwise
+//! discovered mid-scan, where it reads as a *result* rather than a mistake.
+
+use std::fs;
+
+use super::args::ScanArgs;
+use super::logging::log_warn;
+use super::validation::validate_numeric_args;
+use super::{ScanOutcome, emit_error, session};
+
+/// Everything that must hold — and be installed — before the first request
+/// goes out: numeric ranges, the session-check inputs, and the custom-payload
+/// file, plus the process-wide rate limiter.
+///
+/// These are grouped because they share one property: each failure they catch
+/// is otherwise discovered *mid-scan*, where it reads as a result rather than a
+/// mistake. An unreadable `--custom-payload` under `--only-custom-payload`
+/// sends zero attack payloads and prints `0 XSS`, which is exactly what a CI
+/// gate treats as a clean target; a bad `--session-check` regex only fires when
+/// a probe does, potentially an hour in.
+///
+/// `Err` carries the outcome `run_scan` returns; the error text has already
+/// been emitted. Warnings (additive-mode payload problems) are emitted here and
+/// do not stop the scan. The order of the checks is load-bearing for what
+/// reaches stderr first, so it is preserved exactly as it ran inline.
+pub(crate) fn prepare_and_validate(args: &ScanArgs) -> Result<(), super::ScanOutcome> {
+    // Validate numeric args up front so misconfigurations (workers: 0,
+    // max_targets_per_host: 0, absurd timeouts) fail fast with a clear
+    // message instead of producing cryptic mid-scan failures.
+    if let Err((code, msg)) = validate_numeric_args(args) {
+        if !args.silence {
+            emit_error(&args.format, code, &msg);
+        }
+        return Err(ScanOutcome::Error);
+    }
+
+    // Install the process-wide request rate limiter (`--rate-limit`, req/sec;
+    // 0 = unlimited). Shared across every worker and target so the aggregate
+    // outbound rate stays bounded regardless of fan-out. Done before any
+    // requests go out (preflight included). Idempotent across CLI invocations.
+    crate::install_rate_limiter(args.rate_limit);
+
+    // `--limit-result-type` only affects which finding types count
+    // toward `--limit`; without `--limit` it is a no-op. Dogfood
+    // showed operators conflating it with `--only-poc`, which IS the
+    // output filter, so emit a one-line nudge on stderr when used
+    // alone. stderr stays out of the stdout payload that scripts
+    // parse.
+    if !args.limit_result_type.eq_ignore_ascii_case("all") && args.limit.is_none() {
+        eprintln!(
+            "Hint: --limit-result-type only affects counting toward --limit; for output filtering use --only-poc {}",
+            args.limit_result_type.to_uppercase()
+        );
+    }
+
+    // Validate the session-check inputs up front. Both are consulted only when
+    // a probe fires — potentially an hour into the scan — so a bad regex or a
+    // malformed probe URL must fail here, not there.
+    if let Err(e) = session::compile_session_check(args) {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::PARSE_ERROR,
+            &format!("--session-check is not a valid regex: {e}"),
+        );
+        return Err(ScanOutcome::Error);
+    }
+    if let Some(u) = &args.session_check_url
+        && url::Url::parse(u).is_err()
+    {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::PARSE_ERROR,
+            &format!("--session-check-url is not a valid absolute URL: {u}"),
+        );
+        return Err(ScanOutcome::Error);
+    }
+
+    // `--only-custom-payload` with no `--custom-payload` at all is the same
+    // catastrophe as an unreadable file — `get_dynamic_payloads` takes the
+    // only-custom branch, finds no file to read, and returns an empty vec, so
+    // the reflection phase sends *zero* attack payloads and the run prints
+    // `0 XSS` and exits 0. That is indistinguishable from a clean target, which
+    // is exactly what a CI gate keys on. The check below only runs inside
+    // `if let Some(path)`, so this pairing has to be rejected before it.
+    // Reachable from a config file too (`only_custom_payload = true`), which is
+    // why `Config::normalize_and_validate` carries the same rule.
+    if args.only_custom_payload && args.custom_payload.is_none() {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::INVALID_INPUT_TYPE,
+            "--only-custom-payload requires --custom-payload <FILE>",
+        );
+        return Err(ScanOutcome::Error);
+    }
+
+    // Validate --custom-payload up front. Without this check, a missing or
+    // unreadable file silently produces zero custom payloads mid-scan. With
+    // --only-custom-payload that's catastrophic (no payloads at all, scan
+    // reports clean), so fail fast. In additive mode it just degrades
+    // detection, so warn and continue.
+    if let Some(path) = &args.custom_payload {
+        match fs::metadata(path) {
+            Ok(m) if !m.is_file() => {
+                if args.only_custom_payload {
+                    emit_error(
+                        &args.format,
+                        crate::cmd::error_codes::FILE_READ_ERROR,
+                        &format!("--custom-payload is not a regular file: {}", path),
+                    );
+                    return Err(ScanOutcome::Error);
+                }
+                log_warn(
+                    args,
+                    &format!(
+                        "--custom-payload is not a regular file ({}) — built-in payloads only",
+                        path
+                    ),
+                );
+            }
+            Err(e) => {
+                if args.only_custom_payload {
+                    emit_error(
+                        &args.format,
+                        crate::cmd::error_codes::FILE_READ_ERROR,
+                        &format!("--custom-payload not readable ({}): {}", path, e),
+                    );
+                    return Err(ScanOutcome::Error);
+                }
+                log_warn(
+                    args,
+                    &format!(
+                        "--custom-payload not readable ({}: {}) — built-in payloads only",
+                        path, e
+                    ),
+                );
+            }
+            Ok(_) => {
+                // The stat above only proves a regular file exists. An empty,
+                // comment-only, non-UTF-8, or over-budget file passes it yet
+                // yields zero usable payloads — load_custom_payloads rejects
+                // those, but the scan driver swallows that error via
+                // `.unwrap_or_else(|_| vec![])`, so --only-custom-payload would
+                // "succeed" having scanned nothing. Validate the content here
+                // (this also warms the shared cache the scan reuses): fatal
+                // under --only-custom-payload, a warning in additive mode.
+                if let Err(e) = crate::scanning::xss_common::load_custom_payloads(path) {
+                    if args.only_custom_payload {
+                        emit_error(
+                            &args.format,
+                            crate::cmd::error_codes::FILE_READ_ERROR,
+                            &e.to_string(),
+                        );
+                        return Err(ScanOutcome::Error);
+                    }
+                    log_warn(args, &format!("{} — built-in payloads only", e));
+                }
+            }
+        }
+    }
+    Ok(())
+}
+
+/// Fetch the remote payload / wordlist providers named by `--remote-payloads`
+/// and `--remote-wordlists`.
+///
+/// Unknown provider names are warned about *first*, separately: the init call
+/// treats them as silent no-ops, so a typo like `payloadboxx` used to fetch
+/// nothing and say nothing. A fetch failure is likewise only a warning — the
+/// scan continues on built-in payloads.
+pub(crate) async fn init_remote_providers(args: &ScanArgs) {
+    // Warn loudly about unknown remote-provider names *before* the init
+    // call swallows them as silent no-ops. Previously a typo like
+    // `--remote-payloads payloadboxx` would just not fetch anything and
+    // the user would never know.
+    if !args.remote_payloads.is_empty() {
+        let known: std::collections::HashSet<String> = crate::payload::list_payload_providers()
+            .into_iter()
+            .collect();
+        for p in &args.remote_payloads {
+            if !known.contains(&p.to_ascii_lowercase()) {
+                eprintln!(
+                    "Warning: unknown --remote-payloads provider '{}' (known: {})",
+                    p,
+                    crate::payload::list_payload_providers().join(", ")
+                );
+            }
+        }
+    }
+    if !args.remote_wordlists.is_empty() {
+        let known: std::collections::HashSet<String> = crate::payload::list_wordlist_providers()
+            .into_iter()
+            .collect();
+        for p in &args.remote_wordlists {
+            if !known.contains(&p.to_ascii_lowercase()) {
+                eprintln!(
+                    "Warning: unknown --remote-wordlists provider '{}' (known: {})",
+                    p,
+                    crate::payload::list_wordlist_providers().join(", ")
+                );
+            }
+        }
+    }
+
+    // Initialize remote payloads/wordlists if requested (honor timeout/proxy)
+    if (!args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty())
+        && let Err(e) = crate::utils::init_remote_resources_with_options(
+            &args.remote_payloads,
+            &args.remote_wordlists,
+            Some(args.timeout),
+            args.proxy.clone(),
+        )
+        .await
+        && !args.silence
+    {
+        eprintln!("Error initializing remote resources: {}", e);
+    }
+}

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -5,10 +5,11 @@ use super::output::{
 use super::poc::{build_ast_dom_message, generate_poc, render_finding_block};
 use super::postprocess::{dedupe_ast_results, extract_context};
 use super::preflight::{PreflightOutcome, is_allowed_content_type, preflight_content_type};
+use super::validation::validate_numeric_args;
 use super::{
     CLI_MAX_DELAY_MS, CLI_MAX_RATE_LIMIT, CLI_MAX_RETRIES, CLI_MAX_RETRY_DELAY_MS,
     CLI_MAX_TIMEOUT_SECS, CLI_MAX_WORKERS, DEFAULT_DELAY_MS, ScanArgs, ScanOutcome, ScanState,
-    finalize_scan_args, validate_numeric_args,
+    finalize_scan_args,
 };
 use crate::parameter_analysis::{InjectionContext, Location, Param};
 use crate::scanning::result::{FindingType, Result as ScanResult};


### PR DESCRIPTION
## What was wrong

Four functions on the scan path had grown past the point where they can be read:

| function | lines |
|---|---:|
| `cmd/scan/mod.rs::run_scan` | 817 |
| `cmd/scan/input.rs::resolve_targets` | 769 |
| `cmd/scan/analysis.rs::run_preflight_and_analysis` | 750 |
| `cmd/scan/scan_loop.rs::run_scan_loop` | 555 |

Two of them were not really long functions at all — they were a short loop
wrapped around a single **anonymous task body** of 609 and 339 lines, which
captured thirteen and fifteen separately-cloned handles:

```rust
let args_clone = args_outer.clone();
let sem = pre_analyze_semaphore_outer.clone();
let preflight_idx_clone = preflight_idx_outer.clone();
// … ten more …
handles.push((panic_target_url, tokio::task::spawn_local(async move { /* 609 lines */ })));
```

Adding one handle meant editing two places that had to stay in step, with no
compiler help if they drifted.

## What changed

Thirteen named stages extracted, and the two anonymous bodies replaced by named
functions taking an explicit context struct (`TargetTaskCtx`, `HostGroupCtx`):

- new `startup.rs` — the startup validation gate and remote provider setup
- new `blind.rs` — blind-XSS arming and dispatch
- `baseline::load_from_args`, `logging::start_overall_ticker`,
  `output::derive_outcome`
- `input::{detect_input_type, apply_url_scope_filters, apply_out_of_scope_filter,
  load_cookies_from_raw_http}`
- `analysis::{preflight_and_analyze_target, run_target_preflight,
  run_initial_ast_pass, detect_outdated_libs}`
- `scan_loop::scan_host_group`

| | before | after |
|---|---:|---:|
| longest function in `cmd/scan` | 817 | **529** |
| combined size of the 300+ line functions | 2891 | **1726** |

**Being straight about the limit:** the *count* of 300+ line functions in
`cmd/scan` is still four, because two of the extracted task bodies are
themselves long (`preflight_and_analyze_target` 396, `scan_host_group` 358).
The worst case dropped 35% and the bulk 40%, but this did not get everything
under 300. `resolve_targets` (529) is the remaining outlier; most of what is
left is a per-input-type `match` whose arms parse genuinely different things,
so splitting further is its own change.

## Verification

This is a pure decomposition, so the bar is "provably nothing moved":

- **Labelled corpus identical to the pre-refactor baseline**, captured before
  the first edit and re-checked after each stage: tp 738 / fp 2 / fn 24,
  recall 96.85, precision 99.73 — every individual count, not just the summary.
- `cargo test` green; `cargo fmt --check` and `clippy --all-targets
  --all-features -D warnings` clean.
- Gates: `replay_corpus` (false-positive oracle), `output_conformance`,
  `surface_parity`, `docs_lint` all pass.
- Statement order and stderr ordering preserved. Where preserving it constrained
  the split it won: the startup block interleaves `install_rate_limiter` and a
  `--limit-result-type` hint between validation checks, so it moved as one piece
  under an honestly-named `prepare_and_validate` rather than being split into
  tidier parts that would reorder what a failing run prints.

## Review follow-ups included

Four defects the split itself introduced, all caught in review:

- `run_initial_ast_pass` took two parameters it never read. Both began with `_`,
  so the unused-variable lint stayed quiet and the signature implied the AST
  pass was already CSP-aware. Removed.
- `PreflightCapture::csp_header` was documented as "the enforcing CSP header",
  but it also carries report-only and `<meta>`-sourced policies. The consumer
  re-checks the header name for exactly that reason; anyone trusting the doc and
  deleting that check would let a report-only `require-trusted-types-for`
  suppress Trusted Types findings. Documented properly.
- `run_initial_ast_pass`'s doc claimed it was shared with server/MCP. The inner
  analyzer is; the wrapper is CLI-only.
- `load_cookies_from_raw_http` documented an `Err` path it does not have.

That last one surfaced a pre-existing behaviour worth a separate look, left
unchanged here because fixing it changes exit codes: an unreadable
`--cookie-from-raw` file prints one stderr line (nothing under `--silence`) and
the scan continues **logged out**, typically reporting `0 XSS` and exiting 0 —
which a CI gate cannot distinguish from a clean target. The doc now says so.
