### PR TITLE
feat(packaging): install shell completions wherever the man page is installed

### DIFF
--- a/.github/workflows/cd-homebrew-tap.yml
+++ b/.github/workflows/cd-homebrew-tap.yml
@@ -19,14 +19,18 @@ jobs:
           commit_email: hahwul@gmail.com
           depends_on: |
             "rust"
-          # The man page is rendered by the binary we just built (`dalfox man`)
-          # instead of shipping a generated .1 in the source tree, so it can
-          # never drift from the CLI definition.
+          # The man page and the shell completions are rendered by the binary we
+          # just built (`dalfox man`, `dalfox completion <shell>`) instead of
+          # shipping generated copies in the source tree, so neither can drift
+          # from the CLI definition. `generate_completions_from_executable`
+          # passes the shell as a positional argument by default, which is
+          # exactly the `dalfox completion <shell>` form.
           install: |
             system "cargo build --release"
             (buildpath/"dalfox.1").write Utils.safe_popen_read("#{buildpath}/target/release/dalfox", "man")
             bin.install "target/release/dalfox"
             man1.install "dalfox.1"
+            generate_completions_from_executable(bin/"dalfox", "completion")
           test: system "#{bin}/dalfox", "-V"
           update_readme_table: false
           skip_commit: false

--- a/.github/workflows/cd-release.yml
+++ b/.github/workflows/cd-release.yml
@@ -168,22 +168,27 @@ jobs:
           mkdir -p target/release
           cp "target/${{ matrix.target }}/release/dalfox" target/release/dalfox
 
-      # Render the man page from the binary we just built rather than from a
-      # committed .1 file, so it can never drift from the CLI definition. Both
-      # packaging targets build natively (x86_64 on ubuntu-latest, aarch64 on
-      # ubuntu-24.04-arm), so the binary is runnable here. `set -o pipefail`
-      # plus the size check keeps a failed render from shipping an empty page.
-      - name: Render man page for packaging
+      # Render the man page and the shell completions from the binary we just
+      # built rather than from committed copies, so they can never drift from
+      # the CLI definition. Both packaging targets build natively (x86_64 on
+      # ubuntu-latest, aarch64 on ubuntu-24.04-arm), so the binary is runnable
+      # here. `set -o pipefail` plus the size checks keep a failed render from
+      # shipping an empty file.
+      - name: Render man page and shell completions for packaging
         if: |
           matrix.target == 'x86_64-unknown-linux-gnu' ||
           matrix.target == 'aarch64-unknown-linux-gnu'
         shell: bash
         run: |
           set -euo pipefail
-          mkdir -p target/man
+          mkdir -p target/man target/completions
           target/release/dalfox man > target/man/dalfox.1
           test -s target/man/dalfox.1
           head -n 5 target/man/dalfox.1
+          for shell in bash zsh fish; do
+            target/release/dalfox completion "$shell" > "target/completions/dalfox.$shell"
+            test -s "target/completions/dalfox.$shell"
+          done
 
       - name: Build Debian package
         if: |
@@ -191,9 +196,17 @@ jobs:
           matrix.target == 'aarch64-unknown-linux-gnu'
         run: |
           cargo deb --no-build
-          # The man page is a generated asset, so a path change would drop it
-          # silently. Fail here instead (matches `.1` and `.1.gz`).
-          dpkg-deb -c "$(find target/debian -name '*.deb' | head -n1)" | grep -q 'man1/dalfox\.1'
+          # The man page and completions are generated assets, so a path change
+          # would drop them silently. Fail here instead (the man entry matches
+          # both `.1` and `.1.gz`).
+          deb="$(find target/debian -name '*.deb' | head -n1)"
+          for entry in \
+            'man1/dalfox\.1' \
+            'bash-completion/completions/dalfox' \
+            'zsh/site-functions/_dalfox' \
+            'fish/vendor_completions\.d/dalfox\.fish'; do
+            dpkg-deb -c "$deb" | grep -q "$entry"
+          done
 
       - name: Build RPM package
         if: |

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,13 +85,16 @@ It supports reflected, stored, and DOM-based XSS discovery with AST-backed verif
 depends = ["ca-certificates"]
 section = "utils"
 priority = "optional"
-# `target/man/dalfox.1` is rendered by the release workflow (`dalfox man`)
-# right before packaging — it is generated, never committed. Keep it out of
-# the `target/release/` prefix, which cargo-deb rewrites to the real target
-# dir when cross-building.
+# `target/man/dalfox.1` and `target/completions/*` are rendered by the release
+# workflow (`dalfox man` / `dalfox completion <shell>`) right before packaging —
+# they are generated, never committed. Keep them out of the `target/release/`
+# prefix, which cargo-deb rewrites to the real target dir when cross-building.
 assets = [
     { source = "target/release/dalfox", dest = "/usr/bin/dalfox", mode = "755" },
     { source = "target/man/dalfox.1", dest = "/usr/share/man/man1/dalfox.1", mode = "644" },
+    { source = "target/completions/dalfox.bash", dest = "/usr/share/bash-completion/completions/dalfox", mode = "644" },
+    { source = "target/completions/dalfox.zsh", dest = "/usr/share/zsh/site-functions/_dalfox", mode = "644" },
+    { source = "target/completions/dalfox.fish", dest = "/usr/share/fish/vendor_completions.d/dalfox.fish", mode = "644" },
 ]
 
 [package.metadata.generate-rpm]
@@ -103,8 +106,11 @@ description = """Dalfox is a powerful open-source XSS scanner and automation uti
 It supports reflected, stored, and DOM-based XSS discovery with AST-backed verification."""
 # See the note above the `[package.metadata.deb]` assets: cargo-generate-rpm
 # rewrites `target/release/` too when `--target` is passed, so the generated
-# man page lives outside that prefix.
+# man page and completions live outside that prefix.
 assets = [
     { source = "target/release/dalfox", dest = "/usr/bin/dalfox", mode = "755" },
     { source = "target/man/dalfox.1", dest = "/usr/share/man/man1/dalfox.1", mode = "644" },
+    { source = "target/completions/dalfox.bash", dest = "/usr/share/bash-completion/completions/dalfox", mode = "644" },
+    { source = "target/completions/dalfox.zsh", dest = "/usr/share/zsh/site-functions/_dalfox", mode = "644" },
+    { source = "target/completions/dalfox.fish", dest = "/usr/share/fish/vendor_completions.d/dalfox.fish", mode = "644" },
 ]

--- a/aur/PKGBUILD
+++ b/aur/PKGBUILD
@@ -38,8 +38,15 @@ package() {
     install -Dm0755 -t "$pkgdir/usr/bin/" "target/release/$pkgname"
     install -Dm0644 -t "$pkgdir/usr/share/licenses/$pkgname/" LICENSE.txt
     install -Dm0644 -t "$pkgdir/usr/share/doc/$pkgname/" README.md
-    # The man page is rendered by the binary we just built (`dalfox man`)
-    # instead of shipping a generated .1 in the source tree.
+    # The man page and the shell completions are rendered by the binary we just
+    # built (`dalfox man`, `dalfox completion <shell>`) instead of shipping
+    # generated copies in the source tree.
     "target/release/$pkgname" man > "$pkgname.1"
     install -Dm0644 "$pkgname.1" "$pkgdir/usr/share/man/man1/$pkgname.1"
+    "target/release/$pkgname" completion bash > "$pkgname.bash"
+    "target/release/$pkgname" completion zsh > "_$pkgname"
+    "target/release/$pkgname" completion fish > "$pkgname.fish"
+    install -Dm0644 "$pkgname.bash" "$pkgdir/usr/share/bash-completion/completions/$pkgname"
+    install -Dm0644 "_$pkgname" "$pkgdir/usr/share/zsh/site-functions/_$pkgname"
+    install -Dm0644 "$pkgname.fish" "$pkgdir/usr/share/fish/vendor_completions.d/$pkgname.fish"
 }

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -97,6 +97,20 @@ dalfox --version
 
 `dalfox 3.1.2` 같은 버전 정보와 함께 Dalfox 배너가 보이면 됩니다.
 
+## 셸 자동완성
+
+Homebrew, AUR 패키지, `.deb` / `.rpm` 패키지, Nix 플레이크로 설치하면 bash·zsh·fish 자동완성이 함께 설치되므로 따로 할 일이 없습니다.
+
+Cargo, 릴리스 아카이브, 소스 빌드처럼 다른 방법으로 설치했다면 직접 생성하면 됩니다.
+
+```bash
+dalfox completion bash > /etc/bash_completion.d/dalfox
+dalfox completion zsh > "${fpath[1]}/_dalfox"
+dalfox completion fish > ~/.config/fish/completions/dalfox.fish
+```
+
+`powershell`과 `elvish`도 지원합니다. 자세한 내용은 [CLI 레퍼런스](../../reference/cli/)를 참조하세요.
+
 ## 도움말 보기
 
 Dalfox는 [clap](https://github.com/clap-rs/clap)을 쓰기 때문에 도움말을 언제든 볼 수 있습니다.

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -97,6 +97,20 @@ dalfox --version
 
 You should see something like `dalfox 3.2.1` along with the Dalfox banner.
 
+## Shell completions
+
+Homebrew, the AUR package, the `.deb` / `.rpm` packages and the Nix flake install bash, zsh and fish completions for you — nothing else to do.
+
+Installed another way (Cargo, a release archive, a source build)? Generate them yourself:
+
+```bash
+dalfox completion bash > /etc/bash_completion.d/dalfox
+dalfox completion zsh > "${fpath[1]}/_dalfox"
+dalfox completion fish > ~/.config/fish/completions/dalfox.fish
+```
+
+`powershell` and `elvish` are supported too — see the [CLI reference](../../reference/cli/).
+
 ## Getting help
 
 Dalfox uses [clap](https://github.com/clap-rs/clap), so help is always accessible:

--- a/flake.nix
+++ b/flake.nix
@@ -57,14 +57,22 @@
             lockFile = ./Cargo.lock;
           };
 
-          inherit nativeBuildInputs buildInputs;
+          # `installShellFiles` is package-only (it provides
+          # `installShellCompletion` below); the dev shell has no use for it.
+          nativeBuildInputs = nativeBuildInputs ++ [ pkgs.installShellFiles ];
+          inherit buildInputs;
 
-          # Render the man page with the binary that was just installed rather
-          # than shipping a generated .1 in the source tree. This runs the
-          # built binary, so it applies to native builds only.
+          # Render the man page and the shell completions with the binary that
+          # was just installed rather than shipping generated copies in the
+          # source tree. This runs the built binary, so it applies to native
+          # builds only.
           postInstall = ''
             mkdir -p $out/share/man/man1
             $out/bin/dalfox man > $out/share/man/man1/dalfox.1
+            installShellCompletion --cmd dalfox \
+              --bash <($out/bin/dalfox completion bash) \
+              --zsh <($out/bin/dalfox completion zsh) \
+              --fish <($out/bin/dalfox completion fish)
           '';
 
           meta = with pkgs.lib; {


### PR DESCRIPTION
Post-merge follow-up to #1374, after #1377.

## Problem

#1374 added `dalfox completion <shell>`, but nothing ships it. The man page has the opposite treatment — rendered from the freshly built binary at package time, on every packaging surface, with a `dpkg-deb -c` guard so a path change fails the release instead of silently dropping the file. Completions had none of that: every install path left the user to run the command and redirect it themselves.

So this PR walks the same five places the man page is rendered and does the same thing for completions.

## Changes

| Surface | What it now installs |
|---|---|
| `.deb` / `.rpm` (`Cargo.toml` + `cd-release.yml`) | `/usr/share/bash-completion/completions/dalfox`, `/usr/share/zsh/site-functions/_dalfox`, `/usr/share/fish/vendor_completions.d/dalfox.fish` |
| Homebrew (`cd-homebrew-tap.yml`) | `generate_completions_from_executable(bin/"dalfox", "completion")` — bash, zsh, fish |
| AUR (`aur/PKGBUILD`) | same three paths, in `package()` |
| Nix (`flake.nix`) | `installShellCompletion` in `postInstall` |

The completions are rendered into `target/completions/` — outside `target/release/`, which both cargo-deb and cargo-generate-rpm rewrite when `--target` is passed, the same reason `target/man/` sits where it does. The existing `dpkg-deb -c` guard grows from one entry to all four generated ones.

Docs: `installation.md` / `installation.ko.md` get a **Shell completions** section saying which install methods hand you completions and how to generate them otherwise.

## Deliberately out of scope

- **Snap** — its completion mechanism is a bash-only `completer:` entry needing an `override-build`; different enough to be its own change.
- **Release archives / `cargo install`** — one matrix target (`macos-x86_64`) is cross-built on an arm runner, so the binary can't be run to render completions for every archive. Users on those paths run `dalfox completion <shell>` themselves, which the docs now spell out.

## Verification

The release workflow doesn't run on PRs, so this was validated locally with real packages on macOS:

- `cargo deb --no-build` → the extracted `data.tar` contains all three completion paths plus `man1/dalfox.1.gz`, and all four CI grep patterns match its listing.
- `cargo generate-rpm` → the RPM header carries the same four dirname/basename pairs.
- Nix: `nix eval .#default.drvPath` evaluates (so `pkgs.installShellFiles` resolves). A full `nix build .#default` could **not** validate `postInstall`, because the flake does not build at all on its pinned toolchain right now — on clean `main` it fails with `rustc 1.92.0 is not supported ... dalfox@3.2.1 requires rustc 1.93` (the `rust-overlay` pin in `flake.lock` predates the oxc bump). Pre-existing and unrelated to this PR, but worth a separate `nix flake update`.
- `crystal run scripts/docs_lint.cr` — 25/25, EN/KO pairing included.
- YAML parse + `bash -n` on the modified workflow snippets and the PKGBUILD.

