### PR TITLE
chore(cli): render generated artifacts to a buffer before writing stdout

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,7 +69,7 @@ rand = "0.8"
 uuid = { version = "1", features = ["v4"] }
 sha2_oaep = { package = "sha2", version = "0.10" }
 clap_mangen = "0.3"
-clap_complete = "4.6.9"
+clap_complete = "4"
 
 [profile.release]
 lto = true

--- a/src/main.rs
+++ b/src/main.rs
@@ -92,10 +92,32 @@ enum Commands {
 // byte budget — is identical).
 use dalfox::utils::fs::read_bounded;
 
-/// Render the top-level `dalfox` man page from the Clap command definition.
-fn print_man_page() {
+/// Hand a fully rendered artifact (man page, completion script) to stdout.
+///
+/// Rendering into a buffer first and writing it here keeps the generators off
+/// the real stdout handle: `clap_complete::generate` writes with `expect`, so
+/// pointing it at stdout turns any write failure — a full disk, a closed pipe —
+/// into a panic from inside the crate. A `Vec<u8>` cannot fail, which leaves
+/// exactly one place to report a write error, the way `dalfox man` already did.
+fn write_to_stdout(artifact: &str, bytes: &[u8]) {
     use std::io::Write;
 
+    let mut out = std::io::stdout().lock();
+    if let Err(e) = out.write_all(bytes).and_then(|()| out.flush()) {
+        // A downstream `head` closing the pipe is not a failure — the panic
+        // hook installed in `main` already treats `Broken pipe` as a clean exit
+        // for the scanning paths, and these one-shot generators get the same
+        // treatment rather than a diagnostic nobody can act on.
+        if e.kind() == std::io::ErrorKind::BrokenPipe {
+            return;
+        }
+        eprintln!("dalfox: failed to write {artifact}: {e}");
+        std::process::exit(2);
+    }
+}
+
+/// Render the top-level `dalfox` man page from the Clap command definition.
+fn print_man_page() {
     let cmd = Cli::command();
     let man = clap_mangen::Man::new(cmd);
     let mut buf = Vec::new();
@@ -105,10 +127,17 @@ fn print_man_page() {
         std::process::exit(2);
     }
 
-    if let Err(e) = std::io::stdout().write_all(&buf) {
-        eprintln!("dalfox: failed to write man page: {e}");
-        std::process::exit(2);
-    }
+    write_to_stdout("man page", &buf);
+}
+
+/// Render the completion script for `shell` from the completion command tree.
+fn print_completion_script(shell: Shell) {
+    let mut cmd = completion_command();
+    let mut buf = Vec::new();
+
+    generate(shell, &mut cmd, BIN_NAME, &mut buf);
+
+    write_to_stdout("completion script", &buf);
 }
 
 /// The command tree the shell-completion scripts are generated from: `Cli`
@@ -226,21 +255,20 @@ async fn main() {
     let cli =
         Cli::from_arg_matches(&matches).unwrap_or_else(|e| e.format(&mut Cli::command()).exit());
 
-    // Keep man-page output as pure roff by handling it before the
-    // banner/config machinery writes anything else to stdout.
-    if let Some(command) = &cli.command {
-        match command {
-            Commands::Man => {
-                print_man_page();
-                return;
-            }
-            Commands::Completion { shell } => {
-                let mut cmd = completion_command();
-                generate(*shell, &mut cmd, BIN_NAME, &mut std::io::stdout());
-                return;
-            }
-            _ => {}
+    // `man` and `completion` each write one generated artifact to stdout and
+    // nothing else — the roff has to stay pure roff, the completion script has
+    // to stay sourceable — so both are dispatched here, before the
+    // banner/config machinery gets a chance to add to that stream.
+    match &cli.command {
+        Some(Commands::Man) => {
+            print_man_page();
+            return;
         }
+        Some(Commands::Completion { shell }) => {
+            print_completion_script(*shell);
+            return;
+        }
+        _ => {}
     }
 
     // Set global debug toggle for downstream modules

--- a/tests/e2e/cli_smoke_test.rs
+++ b/tests/e2e/cli_smoke_test.rs
@@ -628,3 +628,58 @@ fn test_completion_omits_hidden_subcommands() {
         }
     }
 }
+
+/// `dalfox man` shares the completion path's stdout contract: one generated
+/// artifact and nothing else. Every packaging surface pipes it straight into
+/// `dalfox.1`, so a banner line here ships a corrupt man page — and unlike the
+/// completion scripts, it also has to stay *pure roff*.
+#[test]
+fn test_man_writes_only_roff_to_stdout() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .arg("man")
+        .output()
+        .expect("failed to execute dalfox man");
+
+    assert_eq!(
+        output.status.code(),
+        Some(0),
+        "dalfox man should exit 0, stderr:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+    assert!(
+        output.stderr.is_empty(),
+        "dalfox man should write nothing to stderr, got:\n{}",
+        String::from_utf8_lossy(&output.stderr)
+    );
+
+    let page = String::from_utf8(output.stdout).expect("dalfox man emitted non-UTF-8");
+
+    // roff from the first byte: a leading banner would push the `.ie` escape
+    // off line 1 and troff would render it as text.
+    assert!(
+        page.starts_with(".ie "),
+        "dalfox man should open with roff, got: {:?}",
+        page.chars().take(40).collect::<String>()
+    );
+    assert!(
+        page.contains(".TH dalfox 1"),
+        "dalfox man should carry the title header"
+    );
+    // The hidden subcommands stay out of the man page too — `clap_mangen`
+    // filters them on its own, unlike `clap_complete`; see
+    // `completion_command()` in `src/main.rs`. As in
+    // `test_completion_omits_hidden_subcommands`, asserting the visible half
+    // against the same `dalfox\-<name>(1)` shape keeps the pattern honest.
+    for visible in ["scan", "server", "payload", "mcp", "completion"] {
+        assert!(
+            page.contains(&format!("dalfox\\-{visible}(1)")),
+            "dalfox man should document the `{visible}` subcommand"
+        );
+    }
+    for hidden in ["man", "url", "file", "pipe"] {
+        assert!(
+            !page.contains(&format!("dalfox\\-{hidden}(1)")),
+            "dalfox man should not document the hidden `{hidden}` subcommand"
+        );
+    }
+}


### PR DESCRIPTION
Last of the #1374 follow-ups (after #1377, #1378, #1380). Small, no behaviour change.

## Why

`clap_complete::generate` writes with `expect`, so pointing it at the real stdout handle turns any write failure into a panic from inside the crate. The neighbouring `dalfox man` reports the same class of failure properly — diagnostic on stderr, exit 2 — so the two halves of the same dispatch block disagreed on what a failed write means.

Rendering into a `Vec<u8>` first (writes to which cannot fail) leaves exactly one place that touches stdout, shared by both subcommands, and takes an `expect` out of a runtime path — which AGENTS.md asks for.

Broken pipe returns cleanly there rather than reporting an error, matching the policy `main`'s panic hook already applies to the scanning paths.

**Honest scope note:** this is hardening, not a fixed bug report. I could not produce a write failure on either path locally — the completion scripts are all ≤36K, so `| head -1` never fills a 64K pipe buffer, and the panic is only reachable on a genuinely failing stdout (full disk, closed fd). There is no portable way to force that from the e2e suite, so the error branch stays uncovered; the success path is covered.

## Test added

`dalfox man` had **no test at all** — which is what the red `codecov/patch` was really pointing at, since this PR moves its stdout write into the shared helper. `test_man_writes_only_roff_to_stdout` asserts exit 0, empty stderr, roff from the first byte, and that `clap_mangen` documents the visible subcommands while leaving the hidden ones out. Built the same way as `test_completion_omits_hidden_subcommands`: the visible half holds the `dalfox\-<name>(1)` pattern honest. Both halves mutation-checked.

## Also in here

- `clap_complete = "4.6.9"` → `"4"`, matching how every other dependency in this file is specified (`clap = "4.0"`, `clap_mangen = "0.3"`, `uuid = "1"`). Same resolved version, no `Cargo.lock` change.
- The dispatch comment still said "Keep man-page output as pure roff" after #1374 added a second arm to it.
- `if let Some(command) = … { match command { … } }` flattened to one `match`.

## Verification

All five completion scripts and the man page are byte-identical before and after (22694 / 26452 / 27901 / 36099 / 22526 / 1266 bytes). `cargo fmt --check`, `cargo clippy --all-targets --all-features -D warnings`, full `cargo test` green.
