### PR TITLE
fix(scan): make a failed --cookie-from-raw stop the scan

### DIFF
--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -89,7 +89,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--cookies` | — | — | 쿠키 (반복 지정 가능) |
 | `--method` | `-X` | `GET` | HTTP 메서드 재정의 (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY` / RFC 10008) |
 | `--user-agent` | — | — | 사용자 지정 User-Agent |
-| `--cookie-from-raw` | — | — | raw HTTP 요청 파일에서 쿠키를 불러옵니다 |
+| `--cookie-from-raw` | — | — | raw HTTP 요청 파일에서 쿠키를 불러옵니다. 파일을 읽을 수 없거나 `Cookie:` 헤더가 없으면 종료 코드 `2`로 중단합니다 — 그대로 진행하면 로그아웃 상태로 스캔해 `0 XSS`를 보고하기 때문입니다 |
 
 ### 세션
 

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -89,7 +89,7 @@ See [Baselines](../../guide/output/#baselines-reporting-only-what-is-new) for th
 | `--cookies` | — | — | Cookie (repeatable) |
 | `--method` | `-X` | `GET` | HTTP method override (`GET`, `POST`, `PUT`, `DELETE`, `HEAD`, `OPTIONS`, `PATCH`, `QUERY` / RFC 10008) |
 | `--user-agent` | — | — | Custom User-Agent |
-| `--cookie-from-raw` | — | — | Load cookies from a raw HTTP request file |
+| `--cookie-from-raw` | — | — | Load cookies from a raw HTTP request file. Fatal (exit `2`) if the file cannot be read or carries no `Cookie:` header — continuing would scan logged out and report `0 XSS` |
 
 ### Session
 

--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -588,7 +588,7 @@ pub(crate) async fn resolve_targets(
         return Err(ScanOutcome::Error);
     }
 
-    load_cookies_from_raw_http(args, &mut parsed_targets);
+    load_cookies_from_raw_http(args, &mut parsed_targets)?;
 
     Ok(ResolvedTargets {
         targets: parsed_targets,
@@ -1036,46 +1036,63 @@ pub(crate) fn apply_out_of_scope_filter(args: &ScanArgs, parsed_targets: &mut Ve
 /// Apply `--cookie-from-raw`: lift the `Cookie` header out of a saved raw HTTP
 /// request and attach it to every resolved target.
 ///
-/// Non-fatal by design as it stands: an unreadable file prints to stderr (and
-/// says nothing at all under `--silence`), then the scan proceeds *without the
-/// cookies* — i.e. logged out, which typically reports `0 XSS` and exits 0. A
-/// CI gate cannot tell that apart from a clean target. Preserved here because
-/// changing it changes exit codes; worth revisiting on its own.
-fn load_cookies_from_raw_http(args: &ScanArgs, parsed_targets: &mut [Target]) {
-    // Load cookies from raw HTTP request file if specified
-    if let Some(path) = &args.cookie_from_raw {
-        match crate::utils::fs::read_bounded(
-            std::path::Path::new(path),
-            MAX_TARGET_LIST_BYTES,
-            "raw cookie file",
-        ) {
-            Ok(content) => {
-                let mut cookies_from_raw: Vec<(String, String)> = Vec::new();
-                for line in content.lines() {
-                    // HTTP header names are case-insensitive (RFC 7230 §3.2;
-                    // HTTP/2 mandates lowercase), so match `Cookie`/`cookie`/
-                    // `COOKIE` alike and tolerate arbitrary spacing after the
-                    // colon. Delegate value splitting to the shared
-                    // `split_cookie_pairs` so this parses identically to the
-                    // server / preflight cookie paths.
-                    if let Some((name, value)) = line.split_once(':')
-                        && name.trim().eq_ignore_ascii_case("cookie")
-                    {
-                        cookies_from_raw.extend(crate::job::split_cookie_pairs(value));
-                    }
-                }
-                if !cookies_from_raw.is_empty() {
-                    for target in parsed_targets.iter_mut() {
-                        target.cookies.extend(cookies_from_raw.iter().cloned());
-                    }
-                }
-            }
-            Err(e) if !args.silence => {
-                eprintln!("Error reading cookie file {}: {}", path, e);
-            }
-            Err(_) => {}
+/// Both failure modes are fatal, because neither is recoverable in a way the
+/// operator would want: continuing means scanning *logged out*, which reports
+/// `0 XSS` and exits 0 — indistinguishable from a clean target to the CI gate
+/// that asked for the credentials in the first place. Previously an unreadable
+/// file only warned (and said nothing at all under `--silence`), while a file
+/// carrying no `Cookie:` header was silent even at full verbosity.
+fn load_cookies_from_raw_http(
+    args: &ScanArgs,
+    parsed_targets: &mut [Target],
+) -> std::result::Result<(), ScanOutcome> {
+    let Some(path) = &args.cookie_from_raw else {
+        return Ok(());
+    };
+
+    let content = match crate::utils::fs::read_bounded(
+        std::path::Path::new(path),
+        MAX_TARGET_LIST_BYTES,
+        "raw cookie file",
+    ) {
+        Ok(content) => content,
+        Err(e) => {
+            emit_error(
+                &args.format,
+                crate::cmd::error_codes::FILE_READ_ERROR,
+                &format!("--cookie-from-raw could not be read ({}): {}", path, e),
+            );
+            return Err(ScanOutcome::Error);
+        }
+    };
+
+    let mut cookies_from_raw: Vec<(String, String)> = Vec::new();
+    for line in content.lines() {
+        // HTTP header names are case-insensitive (RFC 7230 §3.2; HTTP/2
+        // mandates lowercase), so match `Cookie`/`cookie`/`COOKIE` alike and
+        // tolerate arbitrary spacing after the colon. Delegate value splitting
+        // to the shared `split_cookie_pairs` so this parses identically to the
+        // server / preflight cookie paths.
+        if let Some((name, value)) = line.split_once(':')
+            && name.trim().eq_ignore_ascii_case("cookie")
+        {
+            cookies_from_raw.extend(crate::job::split_cookie_pairs(value));
         }
     }
+
+    if cookies_from_raw.is_empty() {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::PARSE_ERROR,
+            &format!("--cookie-from-raw found no `Cookie:` header in {}", path),
+        );
+        return Err(ScanOutcome::Error);
+    }
+
+    for target in parsed_targets.iter_mut() {
+        target.cookies.extend(cookies_from_raw.iter().cloned());
+    }
+    Ok(())
 }
 
 /// Decide which input mode a bare `dalfox scan …` is really asking for.

--- a/src/cmd/scan/input/tests.rs
+++ b/src/cmd/scan/input/tests.rs
@@ -333,6 +333,52 @@ async fn cookie_from_raw_appends_cookies_to_targets() {
     assert!(cookies.iter().any(|(k, v)| k == "b" && v == "2"));
 }
 
+/// A `--cookie-from-raw` the operator supplied but that cannot be read must
+/// stop the run. Continuing means scanning *logged out*: the scan reports
+/// `0 XSS` and exits 0, which the CI gate that asked for the credentials
+/// cannot tell apart from a clean target. Note `-S` (silence) is set here —
+/// this used to print nothing at all in that mode.
+#[tokio::test]
+async fn cookie_from_raw_unreadable_file_is_fatal() {
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--cookie-from-raw",
+        "/nonexistent/dalfox-cookie-file",
+        "https://example.com/",
+    ]);
+    assert!(
+        resolve(&args).await.is_err(),
+        "an unreadable --cookie-from-raw must not fall through to a logged-out scan"
+    );
+}
+
+/// The quieter half of the same failure: the file reads fine but carries no
+/// `Cookie:` header, so zero cookies are attached. That produced no message at
+/// any verbosity and scanned logged out.
+#[tokio::test]
+async fn cookie_from_raw_without_cookie_header_is_fatal() {
+    let p = tmp_file(
+        "nocookie",
+        "GET / HTTP/1.1\r\nHost: x\r\nAccept: */*\r\n\r\n",
+    );
+    let args = args_from(&[
+        "-i",
+        "url",
+        "-S",
+        "--cookie-from-raw",
+        p.to_str().unwrap(),
+        "https://example.com/",
+    ]);
+    let outcome = resolve(&args).await;
+    let _ = std::fs::remove_file(&p);
+    assert!(
+        outcome.is_err(),
+        "a --cookie-from-raw file with no Cookie: header must not scan logged out"
+    );
+}
+
 // ── load_request_source ─────────────────────────────────────────────
 
 #[test]


### PR DESCRIPTION
## The bug

`--cookie-from-raw` had two failure modes and both were silent:

| failure | before |
|---|---|
| file cannot be read | one stderr line — **nothing at all** under `--silence` |
| file reads fine, no `Cookie:` header in it | **nothing, at any verbosity** |

In both cases the scan continued *without the cookies* — logged out — and
finished `0 XSS`, exit 0.

That is indistinguishable from a clean target to the thing that asked for the
credentials. A CI gate running

```sh
dalfox scan --cookie-from-raw ./session.txt https://app.internal && echo "no XSS"
```

prints "no XSS" when the file path is wrong, when a volume did not mount, or
when someone saved a request that had no `Cookie:` header — having scanned the
logged-out surface the whole time.

## The fix

Both now emit a structured error and exit `2`:

```console
$ dalfox scan -S --cookie-from-raw /nope/x https://example.com/ ; echo "exit=$?"
exit=2

$ dalfox scan -f json --cookie-from-raw /nope/x https://example.com/
{
  "code": "FILE_READ_ERROR",
  "error": true,
  "message": "--cookie-from-raw could not be read (/nope/x): No such file or directory (os error 2)"
}
```

`FILE_READ_ERROR` for the unreadable file, `PARSE_ERROR` for the file with no
`Cookie:` header — through `emit_error`, so JSON/JSONL consumers get it in the
envelope rather than only on stderr.

## Note on compatibility

This changes the exit code for a run that previously "succeeded" — deliberately.
That success was the bug. A pipeline that today passes `--cookie-from-raw` with
a path that does not resolve will start failing; it was scanning logged out and
reporting clean.

## Verification

- Two regression tests, one per failure mode, both **mutation-tested**: reverting
  either branch to its old non-fatal form makes the matching test fail. The
  unreadable-file test deliberately runs under `-S`, which is the mode that used
  to print nothing.
- End-to-end confirmed on the real binary: exit 2 for both, and the JSON error
  envelope above.
- `cargo test` green (2277); `fmt --check` and `clippy --all-targets
  --all-features -D warnings` clean; `docs_lint` passes.
- CLI reference updated in **both** EN and KO, since the flag's contract changed.
