### PR TITLE
feat(payload): add `javascript` selector; fix encoder doc mismatches

### DIFF
--- a/src/cmd/payload.rs
+++ b/src/cmd/payload.rs
@@ -4,6 +4,7 @@ use serde::Serialize;
 use crate::cmd::scan::ScanOutcome;
 
 const KNOWN_SELECTORS: &[&str] = &[
+    "javascript",
     "event-handlers",
     "useful-tags",
     "payloadbox",
@@ -63,13 +64,13 @@ fn closest_selector(input: &str) -> Option<&'static str> {
 #[derive(Args, Debug, Clone)]
 #[command(
     about = "Manage or inspect payloads",
-    long_about = "Selectors:\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
+    long_about = "Selectors:\n  - javascript: print the canonical JavaScript execution payloads used in JS-string / script contexts (alert(1), backtick and keyword-split variants, ...)\n  - event-handlers: list all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: list useful HTML tag names often used in XSS contexts (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
 )]
 pub struct PayloadArgs {
     #[arg(
         value_name = "SELECTOR",
-        help = "Payload selector\nAvailable selectors:\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme\n  - special-chars\n  - functions\n  - awesome-alert\n  - dom-clobbering\n  - mxss\n  - blind\n  - all",
-        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
+        help = "Payload selector\nAvailable selectors:\n  - javascript\n  - event-handlers\n  - useful-tags\n  - payloadbox\n  - portswigger\n  - uri-scheme\n  - special-chars\n  - functions\n  - awesome-alert\n  - dom-clobbering\n  - mxss\n  - blind\n  - all",
+        long_help = "Selector to enumerate payload resources.\nSupported selectors:\n  - javascript: print the canonical JavaScript execution payloads used in JS-string / script contexts (alert(1), backtick and keyword-split variants, ...)\n  - event-handlers: print all DOM event handler attribute names (e.g., onclick, onmouseover)\n  - useful-tags: print useful HTML tag names used for XSS payloads (e.g., script, img, svg)\n  - payloadbox: fetch and print remote XSS payloads from PayloadBox\n  - portswigger: fetch and print remote XSS payloads from PortSwigger\n  - uri-scheme: print scheme-based XSS payloads (javascript:, data:, etc.)\n  - special-chars: print special characters (and encoded variants) for context probing / breakout\n  - functions: print visibly-confirmable sinks with filter-surviving variants (alert, prompt, ...)\n  - awesome-alert: print polished alert PoCs for clean screenshots/demos (alert(document.domain), ...)\n  - dom-clobbering: print DOM clobbering payloads\n  - mxss: print mutation-XSS / sanitizer-bypass payloads\n  - blind: print blind-XSS skeletons ({} = your OOB callback URL)\n  - all: print every local selector above in one pass, each under a '# name' header (no network fetch)"
     )]
     pub selector: Option<String>,
 
@@ -252,6 +253,10 @@ impl SelectorLines {
 fn static_selector_groups() -> Vec<(&'static str, SelectorLines)> {
     vec![
         (
+            "javascript",
+            SelectorLines::Static(crate::payload::XSS_JAVASCRIPT_PAYLOADS),
+        ),
+        (
             "event-handlers",
             SelectorLines::Static(crate::payload::xss_event::common_event_handler_names()),
         ),
@@ -296,10 +301,6 @@ fn static_selector_counts() -> Vec<(&'static str, usize)> {
 /// without capturing stdout.
 fn summary_block() -> String {
     let mut out = String::from("Summary:\n");
-    out.push_str(&format!(
-        "- Canonical JavaScript payloads: {}\n",
-        crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
-    ));
     for (selector, count) in static_selector_counts() {
         out.push_str(&format!("- {}: {}\n", selector, count));
     }
@@ -310,6 +311,7 @@ fn print_summary() {
     println!("Dalfox payload");
     println!("----------------");
     println!("Provide a selector to list payloads. Examples:");
+    println!("  dalfox payload javascript");
     println!("  dalfox payload event-handlers");
     println!("  dalfox payload useful-tags");
     println!("  dalfox payload payloadbox");
@@ -413,6 +415,11 @@ pub fn run_payload(args: PayloadArgs) -> ScanOutcome {
     };
 
     match args.selector.as_deref() {
+        Some("javascript") => print_outcome(print_lines(
+            "javascript",
+            crate::payload::XSS_JAVASCRIPT_PAYLOADS,
+            args.json,
+        )),
         Some("event-handlers") => print_outcome(print_lines(
             "event-handlers",
             crate::payload::xss_event::common_event_handler_names(),

--- a/src/cmd/payload/tests.rs
+++ b/src/cmd/payload/tests.rs
@@ -57,6 +57,7 @@ fn test_curated_selector_lists_are_nonempty_and_clean() {
 #[test]
 fn test_run_payload_known_selectors_return_clean() {
     for selector in [
+        "javascript",
         "event-handlers",
         "useful-tags",
         "uri-scheme",
@@ -188,6 +189,10 @@ fn test_static_selector_counts_match_the_lists_they_describe() {
     };
 
     assert_eq!(
+        count_of("javascript"),
+        crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
+    );
+    assert_eq!(
         count_of("event-handlers"),
         crate::payload::xss_event::common_event_handler_names().len()
     );
@@ -216,8 +221,11 @@ fn test_summary_block_renders_a_line_per_static_selector() {
     let rendered = summary_block();
 
     assert!(rendered.starts_with("Summary:\n"));
+    // The canonical JavaScript payloads are now a first-class `javascript`
+    // selector, so they render through the shared static-selector loop below
+    // rather than a bespoke line.
     assert!(rendered.contains(&format!(
-        "- Canonical JavaScript payloads: {}\n",
+        "- javascript: {}\n",
         crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
     )));
     for (selector, count) in static_selector_counts() {

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -7,7 +7,7 @@ use base64::{Engine, engine::general_purpose::STANDARD};
 /// Policy:
 /// - If encoders contains "none", return only the original payloads (deduplicated), no variants.
 /// - Otherwise, include original payload and, for each encoder present, append its variant(s).
-/// - Encoder application order is fixed to: url, html, 2url, 3url, 4url, base64
+/// - Encoder application order is fixed to: url, html, htmlpad, 2url, 3url, 4url, base64, unicode, zwsp
 /// - Results are de-duplicated while preserving the first occurrence order.
 pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String]) -> Vec<String> {
     // Dedup base first while preserving order
@@ -149,7 +149,7 @@ pub fn unicode_fullwidth_encode(payload: &str) -> String {
 
 /// HTML entity encoding with zero-padded hex codes.
 /// Bypasses WAF regex patterns that expect exactly `&#xNN;` format.
-/// Example: "<" becomes "&#x0000003c;" (with extra leading zeros)
+/// Example: "<" becomes "&#x000003c;" (7-digit zero-padded hex)
 pub fn html_entity_zero_padded_encode(payload: &str) -> String {
     use std::fmt::Write;
     let mut out = String::with_capacity(payload.len() * 12);


### PR DESCRIPTION
## Summary

While auditing the payload feature for bugs and unexpected behavior, I found one concrete UX inconsistency and two stale doc comments.

**Main fix — `dalfox payload` advertised a payload category it couldn't list.**
The summary printed `- Canonical JavaScript payloads: N`, but:
- there was no selector to actually print them — `dalfox payload javascript` returned `Unknown selector`, and
- `dalfox payload all`, documented as *"print every local selector … in one pass"*, silently omitted them.

This promotes the canonical JS payloads to a first-class **`javascript`** selector:
- listable via `dalfox payload javascript [--json]`
- included in `dalfox payload all` (under a `# javascript` header)
- counted in the summary through the shared `static_selector_groups` source of truth

The bespoke `summary_block` line is dropped in favor of the shared loop, so the selector, the `all` dump, and the summary count can no longer drift apart. Wired into `KNOWN_SELECTORS`, the `run_payload` match arm, and the help/long-help text.

**Doc fixes in `src/encoding/mod.rs`:**
- `apply_encoders_to_payloads` order comment now matches the actual `prio` array (adds `htmlpad`, `unicode`, `zwsp`).
- `html_entity_zero_padded_encode` example now matches the code's 7-digit `{:07x}` output (`&#x000003c;`, not `&#x0000003c;`).

## Testing
- `cargo test --lib` — all pass (payload + encoding tests updated to cover the new selector).
- `cargo clippy --lib` — clean.
- `/code-review` on the diff — no findings.

The rest of the payload module (synthesis, js_breakout, remote, pipeline/pre-encoding, csp_bypass, gadget_db, mining) was reviewed and found to be well-hardened; no correctness changes were needed.