### PR TITLE
fix(server,mcp): stop silently discarding proxy/callback_url and correct the preflight estimate

### DIFF
--- a/docs/content/integrations/mcp.ko.md
+++ b/docs/content/integrations/mcp.ko.md
@@ -310,7 +310,9 @@ WAF 관련 다섯 개 필드는 CLI의 WAF 플래그와 대응됩니다. `waf_by
 
 도달 가능 여부, 발견된 파라미터, 예상 요청 수를 반환합니다.
 
-`encoders`, `max_payloads_per_param`, `deep_scan`는 그 자체로 요청을 보내지 않습니다. 뒤이어 실행할 `scan_with_dalfox` 호출을 설명하는 값이며, `estimated_total_requests`가 그 스캔의 확장 폭을 반영하도록 합니다. 실제로 스캔할 때 쓸 값을 그대로 넘기세요. 추정치는 스캔이 적용하는 파라미터당 페이로드 상한까지 함께 반영합니다.
+`encoders`, `max_payloads_per_param`, `deep_scan`는 그 자체로 요청을 보내지 않습니다. 뒤이어 실행할 `scan_with_dalfox` 호출을 설명하는 값이며, `estimated_total_requests`가 그 스캔의 확장 폭을 반영하도록 합니다. 실제로 스캔할 때 쓸 값을 그대로 넘기세요.
+
+추정치는 스캔이 파라미터마다 실행하는 두 단계(리플렉션, DOM 검증)를 모두 세며, 각 단계를 파라미터당 페이로드 상한으로 자릅니다. `--dry-run`과 동일한 계산입니다. 다만 하한값입니다: WAF 변형/인코더 확장과 상한 적용 이후 덧붙는 공용 CSP/tech 페이로드는 세지 않습니다.
 
 ## 일반적인 에이전트 흐름
 

--- a/docs/content/integrations/mcp.ko.md
+++ b/docs/content/integrations/mcp.ko.md
@@ -301,11 +301,16 @@ WAF 관련 다섯 개 필드는 CLI의 WAF 플래그와 대응됩니다. `waf_by
   "target": "https://example.com",
   "method": "GET",
   "skip_discovery": false,
-  "skip_mining": false
+  "skip_mining": false,
+  "encoders": ["url", "html"],
+  "max_payloads_per_param": 0,
+  "deep_scan": false
 }
 ```
 
 도달 가능 여부, 발견된 파라미터, 예상 요청 수를 반환합니다.
+
+`encoders`, `max_payloads_per_param`, `deep_scan`는 그 자체로 요청을 보내지 않습니다. 뒤이어 실행할 `scan_with_dalfox` 호출을 설명하는 값이며, `estimated_total_requests`가 그 스캔의 확장 폭을 반영하도록 합니다. 실제로 스캔할 때 쓸 값을 그대로 넘기세요. 추정치는 스캔이 적용하는 파라미터당 페이로드 상한까지 함께 반영합니다.
 
 ## 일반적인 에이전트 흐름
 

--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -308,7 +308,9 @@ Analyse a target **without** sending payloads. Useful for scoping before committ
 
 Returns reachability, discovered parameters, and an estimated request count.
 
-`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves — they describe the `scan_with_dalfox` call you are sizing, so `estimated_total_requests` reflects that scan's fan-out. Pass the same values you intend to scan with; the estimate honours the per-parameter payload cap the scan enforces.
+`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves — they describe the `scan_with_dalfox` call you are sizing, so `estimated_total_requests` reflects that scan's fan-out. Pass the same values you intend to scan with.
+
+The estimate counts both phases the scan runs per parameter — reflection and DOM verification — each truncated to the per-parameter payload cap, matching `--dry-run`. It remains a lower bound: WAF mutation/encoder expansion and the shared CSP/tech payloads appended after the cap are not counted.
 
 ## Typical agent flow
 

--- a/docs/content/integrations/mcp.md
+++ b/docs/content/integrations/mcp.md
@@ -299,11 +299,16 @@ Analyse a target **without** sending payloads. Useful for scoping before committ
   "target": "https://example.com",
   "method": "GET",
   "skip_discovery": false,
-  "skip_mining": false
+  "skip_mining": false,
+  "encoders": ["url", "html"],
+  "max_payloads_per_param": 0,
+  "deep_scan": false
 }
 ```
 
 Returns reachability, discovered parameters, and an estimated request count.
+
+`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves — they describe the `scan_with_dalfox` call you are sizing, so `estimated_total_requests` reflects that scan's fan-out. Pass the same values you intend to scan with; the estimate honours the per-parameter payload cap the scan enforces.
 
 ## Typical agent flow
 

--- a/docs/content/integrations/server.ko.md
+++ b/docs/content/integrations/server.ko.md
@@ -249,6 +249,12 @@ curl http://127.0.0.1:6664/health
 건너뜁니다). 인증서 검증을 강제하려면 `"insecure": false` (또는 `GET /scan`에서
 `?insecure=false`)를 보내세요.
 
+`proxy`와 `callback_url`은 요청을 받는 시점에 검증하며, 사용할 수 없는 값이면 조용히
+버리는 대신 `400`으로 거절합니다. 사용할 수 없는 `proxy`는 그냥 "프록시 없음"으로
+해석되어 스캔이 요청한 터널을 우회한 채 대상에 **직접** 연결되고도 `done`으로
+보고되며, `http(s)` 이외 스킴의 `callback_url`은 아예 호출되지 않아 웹훅 구독자가
+영원히 기다리게 됩니다.
+
 `analyze_external_js`는 옵트인 방식입니다 (기본값 `false`). `true`로 설정하면
 프리플라이트 시점에 동일 출처의 `<script src>` 번들을 가져와 DOM XSS를 위한 AST
 분석을 수행합니다. 싱크(sink) 로직이 전부 외부 번들에 들어 있는 SPA에 유용합니다.

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -250,6 +250,13 @@ outdated / known-vulnerable JS libraries as informational `[I]` findings
 the CLI scanner default); send `"insecure": false` (or `?insecure=false` on
 `GET /scan`) to enforce certificate validation.
 
+`proxy` and `callback_url` are validated at submission and rejected with `400`
+when unusable, rather than being accepted and then silently discarded. An
+unusable `proxy` would otherwise resolve away to *no proxy*, so the scan would
+connect **directly** to the target — bypassing the tunnel you asked for — and
+still report `done`; a `callback_url` with a scheme other than `http(s)` would
+never be dialed, leaving your webhook subscriber waiting forever.
+
 `analyze_external_js` is opt-in (default `false`): set it `true` to fetch
 same-origin `<script src>` bundles at preflight time and AST-analyze them for
 DOM XSS. Useful for SPAs whose sink logic lives entirely in external bundles.

--- a/skills/dalfox/references/mcp.md
+++ b/skills/dalfox/references/mcp.md
@@ -80,12 +80,12 @@ Terminal jobs auto-purge after 1 hour.
 
 ## preflight_dalfox — Parameters
 
-Fewer options (no encoders, no `include_*`, no blind, no deep scan, no workers — it only does discovery).
+Fewer options (no `include_*`, no blind, no workers — it only does discovery).
 
 ```json
 {
   "target": "...",
-  "param": [...],
+  "param": [...],                    // accepted for symmetry, NOT applied
   "method": "GET",
   "data": "...",
   "headers": [...],
@@ -94,10 +94,16 @@ Fewer options (no encoders, no `include_*`, no blind, no deep scan, no workers �
   "timeout": 10,
   "proxy": "...",
   "follow_redirects": false,
+  "insecure": true,
   "skip_mining": false,
-  "skip_discovery": false
+  "skip_discovery": false,
+  "encoders": ["url", "html"],       // sizing only — see below
+  "max_payloads_per_param": 0,       // sizing only
+  "deep_scan": false                 // sizing only
 }
 ```
+
+`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves: they describe the `scan_with_dalfox` call you are about to size, so `estimated_total_requests` matches that scan's fan-out. Pass the same values you intend to scan with, otherwise the estimate answers a different question than the one you are asking. The estimate honours the per-parameter payload cap the scan enforces, so it never quotes volume the scan would not send.
 
 Use this before expensive scans when the user is concerned about request volume.
 

--- a/skills/dalfox/references/mcp.md
+++ b/skills/dalfox/references/mcp.md
@@ -103,7 +103,9 @@ Fewer options (no `include_*`, no blind, no workers — it only does discovery).
 }
 ```
 
-`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves: they describe the `scan_with_dalfox` call you are about to size, so `estimated_total_requests` matches that scan's fan-out. Pass the same values you intend to scan with, otherwise the estimate answers a different question than the one you are asking. The estimate honours the per-parameter payload cap the scan enforces, so it never quotes volume the scan would not send.
+`encoders`, `max_payloads_per_param` and `deep_scan` send nothing themselves: they describe the `scan_with_dalfox` call you are about to size, so `estimated_total_requests` matches that scan's fan-out. Pass the same values you intend to scan with, otherwise the estimate answers a different question than the one you are asking.
+
+The estimate counts both phases the scan runs per parameter — reflection and DOM verification — each truncated to the per-parameter payload cap, the same arithmetic `--dry-run` uses. Treat it as a lower bound: WAF mutation/encoder expansion and the shared CSP/tech payloads appended after the cap are not counted.
 
 Use this before expensive scans when the user is concerned about request volume.
 

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -575,18 +575,9 @@ pub(crate) async fn preflight_and_analyze_target(
             && args_clone.format == "plain"
             && !args_clone.silence
         {
-            // encoder expansion factor
-            let enc_factor = if args_clone.encoders.iter().any(|e| e == "none") {
-                1
-            } else {
-                let mut f = 1;
-                for e in ["url", "html", "2url", "3url", "4url", "base64"] {
-                    if args_clone.encoders.iter().any(|x| x == e) {
-                        f += 1;
-                    }
-                }
-                f
-            };
+            // Encoder expansion factor, taken from the encoder pipeline so it
+            // can't drift from the expansion the scan actually performs.
+            let enc_factor = crate::encoding::encoder_expansion_factor(&args_clone.encoders);
             // Match the scan-time effective cap so the preflight
             // request estimate reflects the built-in safety cap.
             let cap = crate::scanning::effective_payload_cap(

--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -587,38 +587,19 @@ pub(crate) async fn preflight_and_analyze_target(
             let apply_cap = |n: usize| -> usize { if cap == 0 { n } else { n.min(cap) } };
             let mut total: usize = 0;
             for p in &target.reflection_params {
-                let refl_len = if let Some(ctx) = &p.injection_context {
-                    crate::scanning::xss_common::get_dynamic_payloads(ctx, &args_clone)
-                        .unwrap_or_else(|_| vec![])
-                        .len()
-                } else {
-                    // Fallback estimate: HTML dynamic payloads + JS payloads (with encoders), excluding remote payloads
-                    let html_base_len = crate::payload::get_dynamic_xss_html_payloads().len();
-                    let html_len = html_base_len * enc_factor;
-                    let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                    html_len + js_len
-                };
-                let dom_len = match &p.injection_context {
-                    Some(crate::parameter_analysis::InjectionContext::Javascript(_)) => 0,
-                    Some(ctx) => {
-                        // Use locally generated payloads and apply encoder factor; exclude remote payloads
-                        let base = crate::scanning::xss_common::generate_dynamic_payloads(ctx);
-                        base.len() * enc_factor
-                    }
-                    None => {
-                        // Unknown context: use HTML + Attribute payloads without remote, apply encoder factor
-                        let html = crate::payload::get_dynamic_xss_html_payloads();
-                        let attr = crate::payload::get_dynamic_xss_attribute_payloads();
-                        (html.len() + attr.len()) * enc_factor
-                    }
-                };
                 // Scan loop is additive (one reflection request + one DOM request
-                // per payload), not cartesian. Mirrors the `total_tasks` calculation
-                // in src/scanning/mod.rs that drives the progress bar / ETA.
-                // WAF mutation/encoder expansion isn't reflected here yet, so this
-                // remains a lower bound.
-                total =
-                    total.saturating_add(apply_cap(refl_len).saturating_add(apply_cap(dom_len)));
+                // per payload), not cartesian, and each half is capped
+                // separately — mirrored by the shared estimator, which the REST
+                // `/preflight` endpoint and the MCP preflight tool also use so
+                // the three can't quote different numbers for the same target.
+                // WAF mutation/encoder expansion isn't reflected there yet, so
+                // this remains a lower bound.
+                total = total.saturating_add(crate::scanning::estimate_param_requests(
+                    p,
+                    &args_clone,
+                    enc_factor,
+                    &apply_cap,
+                ));
             }
             if args_clone.format == "plain" && !args_clone.silence {
                 crate::dbg_log!("{} test cases (reqs) estimated", total);

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -56,9 +56,10 @@ pub use args::{
 };
 pub(crate) use args::{parse_force_waf_arg, parse_http_method_arg};
 pub(crate) use logging::log_info;
-// Shared with the server/MCP option validator so all three entry points refuse
-// the same unroutable proxy values.
-pub(crate) use validation::validate_proxy_url;
+// Shared with `job::normalize_proxy` so REST/MCP refuse the same unroutable
+// proxy values the CLI startup gate does. The CLI wrapper that also rejects
+// empty lives in `validation::validate_proxy_url`.
+pub(crate) use validation::check_routable_proxy;
 
 static GLOBAL_ENCODERS: OnceLock<Vec<String>> = OnceLock::new();
 

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -24,18 +24,10 @@ pub(crate) async fn render_dry_run(
     for group in host_groups.values() {
         for target in group {
             let param_count = target.reflection_params.len();
-            // Estimate request count per target using encoder expansion
-            let enc_factor = if args.encoders.iter().any(|e| e == "none") {
-                1usize
-            } else {
-                let mut f = 1usize;
-                for e in ["url", "html", "2url", "3url", "4url", "base64"] {
-                    if args.encoders.iter().any(|x| x == e) {
-                        f += 1;
-                    }
-                }
-                f
-            };
+            // Estimate request count per target using encoder expansion. The
+            // factor comes from the encoder pipeline so it can't drift from the
+            // expansion the scan actually performs.
+            let enc_factor = crate::encoding::encoder_expansion_factor(&args.encoders);
             // Mirror the scan-time effective cap (built-in safety cap unless
             // --deep-scan / explicit --max-payloads-per-param). This is a
             // LOWER-BOUND estimate: it counts the capped base reflection set only,

--- a/src/cmd/scan/validation.rs
+++ b/src/cmd/scan/validation.rs
@@ -165,45 +165,57 @@ pub(crate) fn validate_numeric_args(
 pub(crate) const SUPPORTED_PROXY_SCHEMES: &[&str] =
     &["http", "https", "socks4", "socks4a", "socks5", "socks5h"];
 
-/// Validate a `--proxy` value the way the scan will actually use it: non-empty,
-/// a scheme reqwest routes through, and accepted by the same
-/// `reqwest::Proxy::all` the shared client builder
-/// ([`crate::target_parser::Target::build_client`]) calls.
+/// Shape + routability check for a proxy URL that is already trimmed and
+/// non-empty. Shared by the CLI (`validate_proxy_url`, empty is an error) and
+/// the REST/MCP normalizer (`normalize_proxy`, empty means "no proxy").
 ///
-/// Deliberately self-contained: the returned message never echoes the value, so
-/// a proxy carrying embedded credentials (`http://user:pass@host`) can't leak
-/// into stderr/CI logs and a value with a stray newline can't forge a log line.
-/// Returns `Err(message)` on failure; `String` so the server/MCP validator
-/// ([`crate::server::util::validate_scan_options`]) can reuse it verbatim.
-pub(crate) fn validate_proxy_url(value: &str) -> Result<(), String> {
-    let trimmed = value.trim();
-    if trimmed.is_empty() {
-        // Empty (a blank config field, or `--proxy "$UNSET"` from the shell) is
-        // rejected rather than tolerated: silently running DIRECT is the exact
-        // hazard this check exists to close. Omit the flag for no proxy.
-        return Err(
-            "--proxy is empty (omit the flag entirely to scan without a proxy)".to_string(),
-        );
-    }
-    let scheme = match url::Url::parse(trimmed) {
+/// `name` is the option as the caller knows it (`--proxy` on the CLI, `proxy`
+/// on REST/MCP) so the message names the field without echoing the value —
+/// a proxy carrying embedded credentials (`http://user:pass@host`) must not
+/// leak into stderr/CI logs, and a value with a stray newline must not forge
+/// a log line.
+pub(crate) fn check_routable_proxy(value: &str, name: &str) -> Result<(), String> {
+    let scheme = match url::Url::parse(value) {
         Ok(u) => u.scheme().to_ascii_lowercase(),
-        Err(_) => return Err(PROXY_SHAPE_HINT.to_string()),
+        Err(_) => return Err(proxy_shape_hint(name)),
     };
     if !SUPPORTED_PROXY_SCHEMES.contains(&scheme.as_str()) {
         return Err(format!(
-            "--proxy scheme '{scheme}' is not routable — reqwest silently drops it and would scan DIRECT; use one of: {}",
+            "{name} scheme '{scheme}' is not routable — reqwest silently drops it and would scan DIRECT; use one of: {}",
             SUPPORTED_PROXY_SCHEMES.join(", ")
         ));
     }
     // Belt-and-suspenders: reject anything `reqwest::Proxy::all` itself won't
     // accept, so whatever passes here is exactly what the client will use.
-    if reqwest::Proxy::all(trimmed).is_err() {
-        return Err(PROXY_SHAPE_HINT.to_string());
+    if reqwest::Proxy::all(value).is_err() {
+        return Err(proxy_shape_hint(name));
     }
     Ok(())
 }
 
-const PROXY_SHAPE_HINT: &str = "--proxy is not a usable proxy URL (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:9050)";
+fn proxy_shape_hint(name: &str) -> String {
+    format!(
+        "{name} is not a usable proxy URL (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:9050)"
+    )
+}
+
+/// Validate a `--proxy` value the way the scan will actually use it: non-empty,
+/// a scheme reqwest routes through, and accepted by the same
+/// `reqwest::Proxy::all` the shared client builder
+/// ([`crate::target_parser::Target::build_client`]) calls.
+///
+/// Empty is an error here because a blank CLI flag / config field is how the
+/// operator asked for a proxy and would otherwise scan DIRECT. REST/MCP treat
+/// empty as absent instead — see [`crate::job::normalize_proxy`].
+pub(crate) fn validate_proxy_url(value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(
+            "--proxy is empty (omit the flag entirely to scan without a proxy)".to_string(),
+        );
+    }
+    check_routable_proxy(trimmed, "--proxy")
+}
 
 /// Validate an HTTP(S) URL flag (`--sxss-url`, `--session-check-url`): non-empty,
 /// absolute, and an `http`/`https` scheme.

--- a/src/encoding/encoder_policy_tests.rs
+++ b/src/encoding/encoder_policy_tests.rs
@@ -67,3 +67,75 @@ fn test_expand_single_payload() {
     assert!(out.contains(&triple_url_encode("<")));
     assert!(out.contains(&base64_encode("<")));
 }
+
+// ---------------------------------------------------------------------------
+// `encoder_expansion_factor` — the multiplier every request-count estimate
+// (`--dry-run`, the debug preflight estimate, REST `/preflight`, MCP
+// `preflight_dalfox`) uses to size a scan before running it.
+//
+// All four call sites used to re-derive it from a hand-written literal list
+// that had silently drifted out of step with the expansion below: it named only
+// url/html/2url/3url/4url/base64, so `htmlpad`, `unicode` and `zwsp` — all
+// accepted by `--encoders` and all genuinely expanded — contributed nothing to
+// the estimate. A caller asking for them was quoted a request budget well under
+// what the scan would actually send. These tests pin the helper to the real
+// expansion so the two can't drift again.
+// ---------------------------------------------------------------------------
+
+/// The factor is not an independent guess: it must equal the width the real
+/// expansion produces. Uses a base payload whose variants are all distinct
+/// under every encoder, so nothing is de-duplicated away and the row width is
+/// exactly `1 + active encoders`.
+#[test]
+fn test_encoder_expansion_factor_matches_the_real_expansion() {
+    let bases = vec!["<a href=\"x\">".to_string()];
+    for encs in [
+        vec![],
+        vec!["url".to_string()],
+        vec!["url".to_string(), "html".to_string()],
+        // The three the old hand-rolled list forgot.
+        vec!["htmlpad".to_string()],
+        vec!["unicode".to_string()],
+        vec!["zwsp".to_string()],
+        vec!["url".to_string(), "html".to_string(), "htmlpad".to_string()],
+        crate::cmd::scan::ENCODER_VALUES
+            .iter()
+            .filter(|e| **e != "none")
+            .map(ToString::to_string)
+            .collect::<Vec<_>>(),
+    ] {
+        let expanded = apply_encoders_to_payloads(&bases, &encs);
+        assert_eq!(
+            encoder_expansion_factor(&encs),
+            expanded.len(),
+            "factor must match the expansion width for encoders {encs:?} (expanded: {expanded:?})"
+        );
+    }
+}
+
+/// Every value `--encoders` accepts (bar `none`) must add to the factor.
+/// Asserting the total against `ENCODER_VALUES` is what catches a newly
+/// supported encoder being wired into the expansion but not the estimate.
+#[test]
+fn test_encoder_expansion_factor_counts_every_supported_encoder() {
+    let all: Vec<String> = crate::cmd::scan::ENCODER_VALUES
+        .iter()
+        .filter(|e| **e != "none")
+        .map(ToString::to_string)
+        .collect();
+    assert_eq!(
+        encoder_expansion_factor(&all),
+        all.len() + 1,
+        "every non-`none` encoder must contribute one variant on top of the original"
+    );
+    // `none` wins outright: only the originals are sent, whatever else is listed.
+    assert_eq!(
+        encoder_expansion_factor(&["none".to_string(), "url".to_string()]),
+        1
+    );
+    // An unrecognised name contributes nothing (validation rejects it earlier).
+    assert_eq!(
+        encoder_expansion_factor(&["url".to_string(), "urlencode".to_string()]),
+        2
+    );
+}

--- a/src/encoding/mod.rs
+++ b/src/encoding/mod.rs
@@ -3,6 +3,39 @@ pub mod pre_encoding;
 
 use base64::{Engine, engine::general_purpose::STANDARD};
 
+/// Encoders applied to every base payload, in the fixed order the expansion
+/// emits them. Also the single source of truth for
+/// [`encoder_expansion_factor`], so a newly supported encoder can't be added
+/// to the expansion while the request-count estimate keeps ignoring it.
+const EXPANSION_ORDER: [&str; 9] = [
+    "url", "html", "htmlpad", "2url", "3url", "4url", "base64", "unicode", "zwsp",
+];
+
+/// How many payloads [`apply_encoders_to_payloads`] produces per distinct base
+/// payload: the original plus one variant per recognised encoder, or exactly
+/// `1` when `"none"` is selected.
+///
+/// This is the multiplier every request-count estimate needs (`--dry-run`, the
+/// debug preflight estimate, the REST `/preflight` endpoint and the MCP
+/// `preflight_dalfox` tool). All four used to re-derive it from a hand-written
+/// literal list that had drifted out of step with the expansion above: it
+/// omitted `htmlpad`, `unicode` and `zwsp`, so a caller asking for any of them
+/// was quoted an `estimated_total_requests` well below what the scan would
+/// actually send — on an estimate whose entire purpose is sizing scan impact.
+///
+/// The count is an upper bound per base payload: variants that collide with the
+/// original (or with each other) are de-duplicated away by the expansion, e.g.
+/// a payload with nothing to percent-encode.
+pub fn encoder_expansion_factor(encoders: &[String]) -> usize {
+    if encoders.iter().any(|e| e == "none") {
+        return 1;
+    }
+    1 + EXPANSION_ORDER
+        .iter()
+        .filter(|e| encoders.iter().any(|x| x == *e))
+        .count()
+}
+
 /// Apply encoder policy to a list of base payloads and return expanded, de-duplicated variants.
 /// Policy:
 /// - If encoders contains "none", return only the original payloads (deduplicated), no variants.
@@ -28,13 +61,8 @@ pub fn apply_encoders_to_payloads(base_payloads: &[String], encoders: &[String])
     let encoder_set: std::collections::HashSet<&str> =
         encoders.iter().map(String::as_str).collect();
 
-    // Expansion order
-    let prio = [
-        "url", "html", "htmlpad", "2url", "3url", "4url", "base64", "unicode", "zwsp",
-    ];
-
     // Pre-calculate active encoders using set lookup
-    let active_encoders: Vec<&str> = prio
+    let active_encoders: Vec<&str> = EXPANSION_ORDER
         .iter()
         .filter(|&&e| encoder_set.contains(e))
         .copied()

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -160,6 +160,32 @@ pub(crate) fn validate_header_list(headers: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Validate a caller-supplied proxy URL, rejecting anything reqwest cannot turn
+/// into a proxy.
+///
+/// This matters more than a normal input check because the failure is silent
+/// and inverts the caller's intent: `Target::build_client` resolves the proxy
+/// with `reqwest::Proxy::all(..).ok()` and falls back to *no proxy* when that
+/// fails. A submitted scan whose `proxy` was a typo therefore connected
+/// **directly** to the target — bypassing the intercept proxy / SOCKS tunnel
+/// the caller asked for, sending traffic down a path they did not intend — and
+/// still settled `done`, reporting a perfectly successful scan.
+///
+/// Shared by the REST server and MCP so both front ends refuse the same values.
+pub(crate) fn validate_proxy(proxy: &str) -> Result<(), String> {
+    let trimmed = proxy.trim();
+    if trimmed.is_empty() {
+        return Err("proxy must not be empty (omit the field for no proxy)".to_string());
+    }
+    reqwest::Proxy::all(trimmed).map(|_| ()).map_err(|e| {
+        format!(
+            "invalid proxy '{}': {} (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:1080)",
+            crate::utils::log::sanitize_log_message(trimmed),
+            e
+        )
+    })
+}
+
 /// Truncate a target's discovered parameter set to [`MAX_DISCOVERED_PARAMS`],
 /// returning how many were dropped (0 if already under the cap). Shared by the
 /// REST server, MCP, and both preflight paths so every async front-end bounds

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -161,8 +161,10 @@ pub(crate) fn validate_header_list(headers: &[String]) -> Result<(), String> {
 }
 
 /// Validate and normalize a caller-supplied proxy URL, rejecting anything
-/// reqwest cannot turn into a proxy. Returns the value to store: `None` when
-/// the field was empty (which already meant "no proxy"), else the trimmed URL.
+/// reqwest cannot actually route through (unparseable, or a scheme like
+/// `ftp://` / `socks6://` that `Proxy::all` accepts then silently drops).
+/// Returns the value to store: `None` when the field was empty (which already
+/// meant "no proxy"), else the trimmed URL.
 ///
 /// This matters more than a normal input check because the failure is silent
 /// and inverts the caller's intent: `Target::build_client` resolves the proxy
@@ -191,15 +193,13 @@ pub(crate) fn normalize_proxy(proxy: &str) -> Result<Option<String>, String> {
     if trimmed.is_empty() {
         return Ok(None);
     }
-    reqwest::Proxy::all(trimmed)
-        .map(|_| Some(trimmed.to_string()))
-        .map_err(|e| {
-            format!(
-                "invalid proxy '{}': {} (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:1080)",
-                crate::utils::log::sanitize_log_message(trimmed),
-                e
-            )
-        })
+    // Same scheme + `Proxy::all` gate the CLI uses. `reqwest::Proxy::all`
+    // accepts any URL-with-host, including `ftp://` / `socks6://`, which
+    // hyper-util then silently drops — the scan would go DIRECT. Empty was
+    // already handled above: on REST/MCP it means "no proxy", which is the
+    // opposite of the CLI (`--proxy ""` is an operator mistake).
+    crate::cmd::scan::check_routable_proxy(trimmed, "proxy")?;
+    Ok(Some(trimmed.to_string()))
 }
 
 /// Truncate a target's discovered parameter set to [`MAX_DISCOVERED_PARAMS`],

--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -160,8 +160,9 @@ pub(crate) fn validate_header_list(headers: &[String]) -> Result<(), String> {
     Ok(())
 }
 
-/// Validate a caller-supplied proxy URL, rejecting anything reqwest cannot turn
-/// into a proxy.
+/// Validate and normalize a caller-supplied proxy URL, rejecting anything
+/// reqwest cannot turn into a proxy. Returns the value to store: `None` when
+/// the field was empty (which already meant "no proxy"), else the trimmed URL.
 ///
 /// This matters more than a normal input check because the failure is silent
 /// and inverts the caller's intent: `Target::build_client` resolves the proxy
@@ -171,19 +172,34 @@ pub(crate) fn validate_header_list(headers: &[String]) -> Result<(), String> {
 /// the caller asked for, sending traffic down a path they did not intend — and
 /// still settled `done`, reporting a perfectly successful scan.
 ///
-/// Shared by the REST server and MCP so both front ends refuse the same values.
-pub(crate) fn validate_proxy(proxy: &str) -> Result<(), String> {
+/// Returning the normalized string rather than just `Ok(())` is load-bearing:
+/// the caller stores what `build_client` will later resolve, and the two must
+/// be the same bytes. `str::trim` strips all Unicode whitespace while
+/// `url::Url` strips only ASCII, so validating the trimmed form and storing the
+/// raw one would let `"\u{a0}http://127.0.0.1:8080"` — an ordinary
+/// copy-paste artifact — pass the check and still resolve away to no proxy,
+/// reopening the exact hole this function exists to close.
+///
+/// An empty value is normalized to `None` rather than refused: it carries no
+/// silent-bypass risk (nothing was asked for, nothing is skipped), and query
+/// strings are routinely templated with empty optional parameters
+/// (`?proxy=&callback_url=`), which used to scan fine.
+///
+/// Shared by the REST server and MCP so both front ends treat it identically.
+pub(crate) fn normalize_proxy(proxy: &str) -> Result<Option<String>, String> {
     let trimmed = proxy.trim();
     if trimmed.is_empty() {
-        return Err("proxy must not be empty (omit the field for no proxy)".to_string());
+        return Ok(None);
     }
-    reqwest::Proxy::all(trimmed).map(|_| ()).map_err(|e| {
-        format!(
-            "invalid proxy '{}': {} (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:1080)",
-            crate::utils::log::sanitize_log_message(trimmed),
-            e
-        )
-    })
+    reqwest::Proxy::all(trimmed)
+        .map(|_| Some(trimmed.to_string()))
+        .map_err(|e| {
+            format!(
+                "invalid proxy '{}': {} (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:1080)",
+                crate::utils::log::sanitize_log_message(trimmed),
+                e
+            )
+        })
 }
 
 /// Truncate a target's discovered parameter set to [`MAX_DISCOVERED_PARAMS`],

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -1,6 +1,44 @@
 use super::*;
 
 #[test]
+fn test_normalize_proxy_empty_is_absent_unroutable_is_error() {
+    // REST/MCP treat empty as "no proxy" (templated `?proxy=`). The CLI's
+    // `validate_proxy_url` rejects empty instead — that split is deliberate.
+    assert_eq!(normalize_proxy("").unwrap(), None);
+    assert_eq!(normalize_proxy("   ").unwrap(), None);
+
+    assert_eq!(
+        normalize_proxy("  http://127.0.0.1:8080  ")
+            .unwrap()
+            .as_deref(),
+        Some("http://127.0.0.1:8080")
+    );
+    assert_eq!(
+        normalize_proxy("\u{a0}socks5://127.0.0.1:1080")
+            .unwrap()
+            .as_deref(),
+        Some("socks5://127.0.0.1:1080")
+    );
+
+    // `ftp://` parses and passes `Proxy::all` but is not routed — must not
+    // survive as a stored proxy, or the scan goes DIRECT.
+    let err = normalize_proxy("ftp://127.0.0.1:8080").unwrap_err();
+    assert!(
+        err.contains("not routable"),
+        "unroutable scheme must be named, got: {err}"
+    );
+    assert!(
+        !err.contains("S3cr3t"),
+        "must not echo a proxy that could carry credentials"
+    );
+    let secret_err = normalize_proxy("ftp://user:S3cr3t@host:8080").unwrap_err();
+    assert!(
+        !secret_err.contains("S3cr3t"),
+        "error leaked credentials: {secret_err}"
+    );
+}
+
+#[test]
 fn test_has_http_scheme() {
     // Accepts http/https, case-insensitively, after trimming.
     for ok in [

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -915,12 +915,14 @@ browser execution; only detection_method=oob observes a real browser."
         // An unusable proxy is resolved away to "no proxy" when the scan's
         // client is built, so the scan silently went *direct* to the target
         // instead of through the tunnel the caller asked for, and still
-        // reported `done`. Same check the REST server runs.
-        if let Some(p) = proxy.as_deref()
-            && let Err(e) = crate::job::validate_proxy(p)
-        {
-            return Err(ErrorData::invalid_params(e, None));
-        }
+        // reported `done`. The normalized value is what flows into ScanArgs,
+        // because that is what the client builder later resolves. Same check
+        // the REST server runs.
+        let proxy = match proxy.as_deref().map(crate::job::normalize_proxy) {
+            Some(Ok(p)) => p,
+            Some(Err(e)) => return Err(ErrorData::invalid_params(e, None)),
+            None => None,
+        };
         if workers == 0 || workers > MAX_WORKERS {
             return Err(ErrorData::invalid_params(
                 format!(
@@ -1545,15 +1547,30 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
         // Same silent-fallback hazard as the scan tool: an unusable proxy would
         // make the reachability probe go direct and report the target reachable
         // through a path the caller never asked for.
-        if let Some(p) = params.proxy.as_deref() {
-            crate::job::validate_proxy(p).map_err(|e| ErrorData::invalid_params(e, None))?;
+        let proxy = match params.proxy.as_deref().map(crate::job::normalize_proxy) {
+            Some(Ok(p)) => p,
+            Some(Err(e)) => return Err(ErrorData::invalid_params(e, None)),
+            None => None,
+        };
+        // Bound it the same way `scan_with_dalfox` does. Preflight exists to
+        // size the scan you are about to run, so accepting a value the scan
+        // tool will reject would quote an estimate for a scan that cannot be
+        // started.
+        if params.max_payloads_per_param > MAX_PAYLOADS_PER_PARAM_MCP {
+            return Err(ErrorData::invalid_params(
+                format!(
+                    "max_payloads_per_param must be between 0 and {} (got {})",
+                    MAX_PAYLOADS_PER_PARAM_MCP, params.max_payloads_per_param
+                ),
+                None,
+            ));
         }
 
         let mut target = match parse_target(&target_url) {
             Ok(mut t) => {
                 t.method = method.clone();
                 t.timeout = params.timeout;
-                t.proxy = params.proxy.clone();
+                t.proxy = proxy.clone();
                 t.insecure = params.insecure;
                 t.follow_redirects = params.follow_redirects;
                 // Normalized like the scan path (`job::runner::hydrate_target`)
@@ -1595,7 +1612,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             cookies: params.cookies.clone(),
             user_agent: params.user_agent.clone(),
             timeout: params.timeout,
-            proxy: params.proxy.clone(),
+            proxy: proxy.clone(),
             insecure: params.insecure,
             follow_redirects: params.follow_redirects,
             skip_mining: params.skip_mining,
@@ -1681,21 +1698,15 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                                 // estimate must not bill any (still listed as
                                 // discovered). Mirrors the REST /preflight.
                                 0
-                            } else if let Some(ctx) = &p.injection_context {
-                                apply_cap(
-                                    crate::scanning::xss_common::get_dynamic_payloads(
-                                        ctx, &scan_args,
-                                    )
-                                    .unwrap_or_else(|_| vec![])
-                                    .len(),
-                                )
                             } else {
-                                let html_len = crate::payload::get_dynamic_xss_html_payloads()
-                                    .len()
-                                    * enc_factor;
-                                let js_len =
-                                    crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                                apply_cap(html_len + js_len)
+                                // Shared with the REST endpoint and the CLI's
+                                // --dry-run estimate so the three can't quote
+                                // different numbers for the same target —
+                                // including the DOM half of the fan-out, which
+                                // this estimate used to omit entirely.
+                                crate::scanning::estimate_param_requests(
+                                    p, &scan_args, enc_factor, &apply_cap,
+                                )
                             };
                             estimated_requests = estimated_requests.saturating_add(payload_count);
                             serde_json::json!({

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -784,11 +784,25 @@ pub(crate) struct PreflightDalfoxParams {
     pub skip_discovery: bool,
 
     /// Encoding strategies the subsequent scan will apply to payloads
-    /// (url, html, base64, 2url, 3url, 4url, none). Used only to make the
-    /// estimated_total_requests reflect that scan's fan-out; the default
-    /// matches scan_with_dalfox. Default: ["url", "html"]
+    /// (url, html, htmlpad, base64, 2url, 3url, 4url, unicode, zwsp, none).
+    /// Used only to make the estimated_total_requests reflect that scan's
+    /// fan-out; the default matches scan_with_dalfox. Default: ["url", "html"]
     #[serde(default = "default_encoders")]
     pub encoders: Vec<String>,
+
+    /// The `max_payloads_per_param` the subsequent scan will use. Like
+    /// `encoders`, this only shapes estimated_total_requests — preflight sends
+    /// no payloads. 0 (the default) means the built-in per-parameter safety
+    /// cap applies, which is what the estimate then reflects.
+    #[serde(default)]
+    pub max_payloads_per_param: usize,
+
+    /// Whether the subsequent scan will run with deep_scan. Only shapes
+    /// estimated_total_requests: deep_scan lifts the built-in per-parameter
+    /// payload safety cap, so the estimate is correspondingly larger.
+    /// Default: false
+    #[serde(default)]
+    pub deep_scan: bool,
 }
 
 /* ---------------------------
@@ -896,6 +910,15 @@ browser execution; only detection_method=oob observes a real browser."
         // reqwest fail on the builder for every request in the job, which
         // surfaces as the *target* being reported unreachable.
         if let Err(e) = crate::job::validate_header_list(&headers) {
+            return Err(ErrorData::invalid_params(e, None));
+        }
+        // An unusable proxy is resolved away to "no proxy" when the scan's
+        // client is built, so the scan silently went *direct* to the target
+        // instead of through the tunnel the caller asked for, and still
+        // reported `done`. Same check the REST server runs.
+        if let Some(p) = proxy.as_deref()
+            && let Err(e) = crate::job::validate_proxy(p)
+        {
             return Err(ErrorData::invalid_params(e, None));
         }
         if workers == 0 || workers > MAX_WORKERS {
@@ -1519,6 +1542,12 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             .map_err(|e| ErrorData::invalid_params(e, None))?;
         crate::job::validate_header_list(&params.headers)
             .map_err(|e| ErrorData::invalid_params(e, None))?;
+        // Same silent-fallback hazard as the scan tool: an unusable proxy would
+        // make the reachability probe go direct and report the target reachable
+        // through a path the caller never asked for.
+        if let Some(p) = params.proxy.as_deref() {
+            crate::job::validate_proxy(p).map_err(|e| ErrorData::invalid_params(e, None))?;
+        }
 
         let mut target = match parse_target(&target_url) {
             Ok(mut t) => {
@@ -1595,6 +1624,10 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                 ));
             }
         };
+        // Copied out before the blocking closure so it captures plain values
+        // rather than borrowing `params`.
+        let max_payloads_per_param = params.max_payloads_per_param;
+        let deep_scan = params.deep_scan;
         let target_url_for_err = target_url.clone();
         // Kept in the async-fn scope (not moved into the blocking closure) so
         // the outer JoinError branch below can still name the target when the
@@ -1627,18 +1660,16 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                     // so the estimate reflects what scanning actually fans out to.
                     cap_reflection_params(&mut target);
 
-                    // Estimate request count (encoder expansion factor)
-                    let enc_factor = if scan_args.encoders.iter().any(|e| e == "none") {
-                        1usize
-                    } else {
-                        let mut f = 1usize;
-                        for e in ["url", "html", "2url", "3url", "4url", "base64"] {
-                            if scan_args.encoders.iter().any(|x| x == e) {
-                                f += 1;
-                            }
-                        }
-                        f
-                    };
+                    // Estimate request count. The expansion factor comes from
+                    // the encoder pipeline itself so it can't drift from what
+                    // the scan applies (the hand-rolled list here used to omit
+                    // htmlpad/unicode/zwsp), and the per-parameter payload cap
+                    // `run_scanning` enforces is mirrored so the estimate never
+                    // quotes a volume the scan would not send.
+                    let enc_factor = crate::encoding::encoder_expansion_factor(&scan_args.encoders);
+                    let cap =
+                        crate::scanning::effective_payload_cap(max_payloads_per_param, deep_scan);
+                    let apply_cap = |n: usize| -> usize { if cap == 0 { n } else { n.min(cap) } };
                     let mut estimated_requests: usize = 0;
                     let discovered_params: Vec<serde_json::Value> = target
                         .reflection_params
@@ -1651,16 +1682,20 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
                                 // discovered). Mirrors the REST /preflight.
                                 0
                             } else if let Some(ctx) = &p.injection_context {
-                                crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
+                                apply_cap(
+                                    crate::scanning::xss_common::get_dynamic_payloads(
+                                        ctx, &scan_args,
+                                    )
                                     .unwrap_or_else(|_| vec![])
-                                    .len()
+                                    .len(),
+                                )
                             } else {
                                 let html_len = crate::payload::get_dynamic_xss_html_payloads()
                                     .len()
                                     * enc_factor;
                                 let js_len =
                                     crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                                html_len + js_len
+                                apply_cap(html_len + js_len)
                             };
                             estimated_requests = estimated_requests.saturating_add(payload_count);
                             serde_json::json!({

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1871,7 +1871,7 @@ async fn test_scan_with_dalfox_bounds_retained_finished_scans() {
 #[tokio::test]
 async fn test_scan_with_dalfox_rejects_unusable_proxy() {
     let mcp = DalfoxMcp::new();
-    for bad in ["not a url", "http://", "   "] {
+    for bad in ["not a url", "http://"] {
         let params = ScanWithDalfoxParams {
             proxy: Some(bad.to_string()),
             ..default_scan_params("http://127.0.0.1:1/")
@@ -1893,12 +1893,54 @@ async fn test_scan_with_dalfox_rejects_unusable_proxy() {
     );
 
     // A usable proxy spelling is still accepted (the scan then fails to reach
-    // the dead proxy, which is a visible `error`, not a silent direct connect).
-    let params = ScanWithDalfoxParams {
-        proxy: Some("socks5://127.0.0.1:1080".to_string()),
-        ..default_scan_params("http://127.0.0.1:1/")
-    };
-    assert!(mcp.scan_with_dalfox(Parameters(params)).await.is_ok());
+    // the dead proxy, which is a visible `error`, not a silent direct connect),
+    // and an empty one still means "no proxy" rather than a hard rejection.
+    for ok in ["socks5://127.0.0.1:1080", "  http://127.0.0.1:8080  ", ""] {
+        let params = ScanWithDalfoxParams {
+            proxy: Some(ok.to_string()),
+            ..default_scan_params("http://127.0.0.1:1/")
+        };
+        assert!(
+            mcp.scan_with_dalfox(Parameters(params)).await.is_ok(),
+            "'{ok}' must be accepted"
+        );
+    }
+}
+
+/// `preflight_dalfox` exists to size the `scan_with_dalfox` call you are about
+/// to make, so it must not accept a `max_payloads_per_param` the scan tool will
+/// reject — that quotes an estimate for a scan that cannot be started.
+#[tokio::test]
+async fn test_preflight_dalfox_bounds_max_payloads_like_the_scan_tool() {
+    let mcp = DalfoxMcp::new();
+    let over = crate::job::MAX_PAYLOADS_PER_PARAM + 1;
+    let err = mcp
+        .preflight_dalfox(Parameters(PreflightDalfoxParams {
+            target: "http://127.0.0.1:1/".to_string(),
+            param: vec![],
+            method: "GET".to_string(),
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            user_agent: None,
+            timeout: 1,
+            proxy: None,
+            follow_redirects: false,
+            insecure: true,
+            skip_mining: true,
+            skip_discovery: true,
+            encoders: vec!["none".to_string()],
+            max_payloads_per_param: over,
+            deep_scan: false,
+        }))
+        .await
+        .expect_err("a cap the scan tool refuses must not be accepted for sizing");
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("max_payloads_per_param"),
+        "got: {}",
+        err.message
+    );
 }
 
 #[tokio::test]

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1871,7 +1871,7 @@ async fn test_scan_with_dalfox_bounds_retained_finished_scans() {
 #[tokio::test]
 async fn test_scan_with_dalfox_rejects_unusable_proxy() {
     let mcp = DalfoxMcp::new();
-    for bad in ["not a url", "http://"] {
+    for bad in ["not a url", "http://", "ftp://127.0.0.1:8080"] {
         let params = ScanWithDalfoxParams {
             proxy: Some(bad.to_string()),
             ..default_scan_params("http://127.0.0.1:1/")
@@ -1956,7 +1956,7 @@ async fn test_preflight_dalfox_rejects_unusable_proxy() {
             cookies: vec![],
             user_agent: None,
             timeout: 1,
-            proxy: Some("not a url".to_string()),
+            proxy: Some("ftp://127.0.0.1:8080".to_string()),
             follow_redirects: false,
             insecure: true,
             skip_mining: true,

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -1974,3 +1974,148 @@ async fn test_preflight_dalfox_rejects_unusable_proxy() {
         err.message
     );
 }
+
+/// The strongest statement of what the proxy fix buys: point preflight at a
+/// **live** target through a proxy that is not listening. If the proxy is
+/// honoured the probe fails and the tool reports `reachable: false`; if it were
+/// silently resolved away — the old behaviour — the probe would reach the target
+/// directly and report `reachable: true`, i.e. an answer about a network path
+/// the caller never asked about.
+#[tokio::test]
+async fn test_preflight_dalfox_honours_the_proxy_instead_of_going_direct() {
+    use axum::{Router, response::Html, routing::any};
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    async fn ok() -> Html<&'static str> {
+        Html("<html><body>ok</body></html>")
+    }
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind preflight listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let app = Router::new().route("/{*rest}", any(ok));
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    // A port nothing is listening on: bound, read, then released.
+    let dead = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind throwaway listener");
+    let dead_addr: SocketAddr = dead.local_addr().expect("dead addr");
+    drop(dead);
+
+    let mcp = DalfoxMcp::new();
+    let res = mcp
+        .preflight_dalfox(Parameters(PreflightDalfoxParams {
+            target: format!("http://{addr}/page?q=a"),
+            param: vec![],
+            method: "GET".to_string(),
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            user_agent: None,
+            timeout: 5,
+            proxy: Some(format!("http://{dead_addr}")),
+            follow_redirects: false,
+            insecure: true,
+            skip_mining: true,
+            skip_discovery: true,
+            encoders: vec!["none".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
+        }))
+        .await
+        .expect("a well-formed proxy must be accepted");
+
+    let parsed = parse_result_json(&res);
+    assert_eq!(
+        parsed["reachable"],
+        serde_json::json!(false),
+        "the probe must go through the configured (dead) proxy, not around it: {parsed}"
+    );
+}
+
+/// Exercises the estimate path on a target that actually reflects, so the shared
+/// `estimate_param_requests` runs on the MCP side too, and pins the per-param
+/// figures against the total the tool reports.
+#[tokio::test]
+async fn test_preflight_dalfox_estimate_sums_the_per_param_figures() {
+    use axum::{Router, extract::Query as AxQuery, response::Html, routing::any};
+    use std::collections::HashMap as StdMap;
+    use std::net::{Ipv4Addr, SocketAddr};
+
+    async fn reflect(AxQuery(q): AxQuery<StdMap<String, String>>) -> Html<String> {
+        let mut body = String::from("<html><body>");
+        for (k, v) in &q {
+            body.push_str(&format!("<div>{k}={v}</div>"));
+        }
+        body.push_str("</body></html>");
+        Html(body)
+    }
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind reflecting listener");
+    let addr: SocketAddr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        let app = Router::new().route("/{*rest}", any(reflect));
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+
+    let mcp = DalfoxMcp::new();
+    let res = mcp
+        .preflight_dalfox(Parameters(PreflightDalfoxParams {
+            target: format!("http://{addr}/page?q=a"),
+            param: vec![],
+            method: "GET".to_string(),
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            user_agent: None,
+            timeout: 5,
+            proxy: None,
+            follow_redirects: false,
+            insecure: true,
+            skip_mining: true,
+            skip_discovery: false,
+            encoders: vec!["url".to_string(), "html".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
+        }))
+        .await
+        .expect("reachable target must preflight");
+
+    let parsed = parse_result_json(&res);
+    assert_eq!(parsed["reachable"], serde_json::json!(true));
+    let params = parsed["params"].as_array().expect("params array");
+    assert!(
+        !params.is_empty(),
+        "reflecting target must discover a param"
+    );
+
+    let cap = crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP as u64;
+    let summed: u64 = params
+        .iter()
+        .map(|p| p["estimated_requests"].as_u64().unwrap_or(0))
+        .sum();
+    assert_eq!(
+        parsed["estimated_total_requests"].as_u64().expect("total"),
+        summed,
+        "the total must be the sum of the per-param estimates: {parsed}"
+    );
+    for p in params {
+        let est = p["estimated_requests"]
+            .as_u64()
+            .expect("per-param estimate");
+        // Reflection and DOM are capped separately, so a scannable param costs
+        // more than one cap and at most two. Counting only reflection (the old
+        // behaviour) lands at or below `cap` and fails the lower bound.
+        assert!(
+            est > cap && est <= 2 * cap,
+            "expected a two-phase estimate in ({cap}, {}], got {est} for {p}",
+            2 * cap
+        );
+    }
+}

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -878,6 +878,8 @@ async fn test_preflight_rejects_empty_target() {
         skip_mining: false,
         skip_discovery: false,
         encoders: vec!["url".to_string(), "html".to_string()],
+        max_payloads_per_param: 0,
+        deep_scan: false,
     };
     let err = mcp
         .preflight_dalfox(Parameters(params))
@@ -905,6 +907,8 @@ async fn test_preflight_rejects_non_http_target() {
         skip_mining: false,
         skip_discovery: false,
         encoders: vec!["url".to_string(), "html".to_string()],
+        max_payloads_per_param: 0,
+        deep_scan: false,
     };
     let err = mcp
         .preflight_dalfox(Parameters(params))
@@ -932,6 +936,8 @@ async fn test_preflight_unreachable_target_returns_reachable_false() {
         skip_mining: true,
         skip_discovery: true,
         encoders: vec!["url".to_string(), "html".to_string()],
+        max_payloads_per_param: 0,
+        deep_scan: false,
     };
     let resp = mcp
         .preflight_dalfox(Parameters(params))
@@ -1735,6 +1741,8 @@ async fn test_preflight_dalfox_rejects_bad_method_and_encoder() {
             skip_mining: true,
             skip_discovery: true,
             encoders: vec!["none".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
         }
     }
 
@@ -1750,6 +1758,8 @@ async fn test_preflight_dalfox_rejects_bad_method_and_encoder() {
     let err = mcp
         .preflight_dalfox(Parameters(PreflightDalfoxParams {
             encoders: vec!["base-64".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
             ..preflight_params("http://127.0.0.1:1/?q=a")
         }))
         .await
@@ -1792,6 +1802,8 @@ async fn test_preflight_dalfox_reports_the_normalized_method() {
             skip_mining: true,
             skip_discovery: true,
             encoders: vec!["none".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
         }))
         .await
         .expect("lowercase method must be normalized, not rejected");
@@ -1842,5 +1854,81 @@ async fn test_scan_with_dalfox_bounds_retained_finished_scans() {
     assert!(
         !jobs.contains_key("old00000"),
         "the oldest finished scan is evicted"
+    );
+}
+
+// ---------------------------------------------------------------------------
+// Proxy: accepted, then silently resolved away
+//
+// `Target::build_client` resolves the proxy with `reqwest::Proxy::all(..).ok()`
+// and falls back to **no proxy** when that fails. A scan started with a typo'd
+// `proxy` therefore connected straight to the target — bypassing the intercept
+// proxy / tunnel the agent asked for, putting traffic on a path it did not
+// intend — and still settled `done`, reporting a successful scan. Both MCP
+// tools now refuse it at the boundary, matching the REST server.
+// ---------------------------------------------------------------------------
+
+#[tokio::test]
+async fn test_scan_with_dalfox_rejects_unusable_proxy() {
+    let mcp = DalfoxMcp::new();
+    for bad in ["not a url", "http://", "   "] {
+        let params = ScanWithDalfoxParams {
+            proxy: Some(bad.to_string()),
+            ..default_scan_params("http://127.0.0.1:1/")
+        };
+        let err = mcp
+            .scan_with_dalfox(Parameters(params))
+            .await
+            .expect_err("an unusable proxy must be refused, not silently dropped");
+        assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+        assert!(
+            err.message.contains("proxy"),
+            "the error must name the offending option, got: {}",
+            err.message
+        );
+    }
+    assert!(
+        mcp.lock_jobs().is_empty(),
+        "a refused submission must not leave a queued job behind"
+    );
+
+    // A usable proxy spelling is still accepted (the scan then fails to reach
+    // the dead proxy, which is a visible `error`, not a silent direct connect).
+    let params = ScanWithDalfoxParams {
+        proxy: Some("socks5://127.0.0.1:1080".to_string()),
+        ..default_scan_params("http://127.0.0.1:1/")
+    };
+    assert!(mcp.scan_with_dalfox(Parameters(params)).await.is_ok());
+}
+
+#[tokio::test]
+async fn test_preflight_dalfox_rejects_unusable_proxy() {
+    let mcp = DalfoxMcp::new();
+    let err = mcp
+        .preflight_dalfox(Parameters(PreflightDalfoxParams {
+            target: "http://127.0.0.1:1/".to_string(),
+            param: vec![],
+            method: "GET".to_string(),
+            data: None,
+            headers: vec![],
+            cookies: vec![],
+            user_agent: None,
+            timeout: 1,
+            proxy: Some("not a url".to_string()),
+            follow_redirects: false,
+            insecure: true,
+            skip_mining: true,
+            skip_discovery: true,
+            encoders: vec!["none".to_string()],
+            max_payloads_per_param: 0,
+            deep_scan: false,
+        }))
+        .await
+        .expect_err("an unusable proxy must be refused, not silently dropped");
+    assert_eq!(err.code, rmcp::model::ErrorCode::INVALID_PARAMS);
+    assert!(
+        err.message.contains("proxy"),
+        "the error must name the offending option, got: {}",
+        err.message
     );
 }

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -460,6 +460,46 @@ pub(crate) fn effective_payload_cap(max_payloads: usize, deep_scan: bool) -> usi
     }
 }
 
+/// Requests one parameter will cost the scan, mirroring `run_scanning`'s own
+/// fan-out: it builds a reflection payload set and a DOM payload set, truncates
+/// **each** to the effective per-parameter cap, and then sends one request per
+/// payload in both (`total_tasks += reflection.len() + dom.len()`).
+///
+/// The DOM half used to be missing here, so `/preflight` quoted roughly half the
+/// requests the scan would send — on the one number the endpoint exists to
+/// produce. `cmd::scan::analysis` already estimated it this way for `--dry-run`;
+/// this brings the REST and MCP endpoints onto the same arithmetic.
+///
+/// Still a lower bound: WAF mutation/encoder expansion and the shared CSP/tech
+/// payloads appended after the cap are not counted, matching the CLI's caveat.
+pub(crate) fn estimate_param_requests(
+    p: &Param,
+    scan_args: &ScanArgs,
+    enc_factor: usize,
+    apply_cap: &dyn Fn(usize) -> usize,
+) -> usize {
+    let refl_len = if let Some(ctx) = &p.injection_context {
+        crate::scanning::xss_common::get_dynamic_payloads(ctx, scan_args)
+            .unwrap_or_else(|_| vec![])
+            .len()
+    } else {
+        let html_len = crate::payload::get_dynamic_xss_html_payloads().len() * enc_factor;
+        let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
+        html_len + js_len
+    };
+    let dom_len = match &p.injection_context {
+        // A JS-context param gets no DOM-verification pass.
+        Some(crate::parameter_analysis::InjectionContext::Javascript(_)) => 0,
+        Some(ctx) => crate::scanning::xss_common::generate_dynamic_payloads(ctx).len() * enc_factor,
+        None => {
+            (crate::payload::get_dynamic_xss_html_payloads().len()
+                + crate::payload::get_dynamic_xss_attribute_payloads().len())
+                * enc_factor
+        }
+    };
+    apply_cap(refl_len).saturating_add(apply_cap(dom_len))
+}
+
 pub(crate) fn get_dom_payloads(
     param: &Param,
     args: &ScanArgs,

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2765,3 +2765,107 @@ fn url_attr_reflection_in_a_normal_href_is_still_recognised() {
         "a marker in body text is not URL-attr-only"
     );
 }
+
+// ---------------------------------------------------------------------------
+// estimate_param_requests — the shared preflight/dry-run request estimator
+//
+// `run_scanning` fans a parameter out into a reflection payload set AND a DOM
+// payload set, truncates each to the effective cap, and sends one request per
+// payload in both. The REST `/preflight` endpoint and the MCP `preflight_dalfox`
+// tool used to count only the reflection half, so they quoted roughly half the
+// real volume — on the one number those surfaces exist to produce. All three
+// estimates now call this, so it is worth pinning each branch directly rather
+// than only through a live-target preflight (which never reaches the
+// no-context and JS-context arms).
+// ---------------------------------------------------------------------------
+
+fn param_with_context(ctx: Option<InjectionContext>) -> Param {
+    Param {
+        name: "q".to_string(),
+        value: "seed".to_string(),
+        location: Location::Query,
+        injection_context: ctx,
+        valid_specials: None,
+        invalid_specials: None,
+        pre_encoding: None,
+        pre_encoding_pipeline: None,
+        wire_name: None,
+        form_action_url: None,
+        form_origin_url: None,
+        framework_sink: None,
+        escaped_specials: None,
+        js_breakout: None,
+    }
+}
+
+#[test]
+fn test_estimate_param_requests_counts_both_scan_phases() {
+    let args = default_scan_args();
+    let uncapped = |n: usize| n;
+
+    // HTML / Attribute / AttributeUrl / Css and the unknown-context fallback all
+    // run both phases, so each must be billed strictly more than its reflection
+    // half alone — that difference is exactly what the old estimate dropped.
+    for ctx in [
+        None,
+        Some(InjectionContext::Html(None)),
+        Some(InjectionContext::Attribute(None)),
+        Some(InjectionContext::AttributeUrl(None)),
+        Some(InjectionContext::Css(None)),
+    ] {
+        let p = param_with_context(ctx.clone());
+        let refl_only = match &p.injection_context {
+            Some(c) => crate::scanning::xss_common::get_dynamic_payloads(c, &args)
+                .expect("reflection payloads")
+                .len(),
+            None => {
+                crate::payload::get_dynamic_xss_html_payloads().len()
+                    + crate::payload::XSS_JAVASCRIPT_PAYLOADS.len()
+            }
+        };
+        let total = estimate_param_requests(&p, &args, 1, &uncapped);
+        assert!(
+            total > refl_only,
+            "context {ctx:?} runs a DOM phase too, so the estimate must exceed \
+             the reflection-only count ({refl_only}), got {total}"
+        );
+    }
+
+    // A JS-context param gets no DOM-verification pass, so it is billed for the
+    // reflection set alone — the one branch where the two agree.
+    let js = param_with_context(Some(InjectionContext::Javascript(None)));
+    let js_refl = crate::scanning::xss_common::get_dynamic_payloads(
+        js.injection_context.as_ref().expect("js context"),
+        &args,
+    )
+    .expect("reflection payloads")
+    .len();
+    assert_eq!(estimate_param_requests(&js, &args, 1, &uncapped), js_refl);
+}
+
+#[test]
+fn test_estimate_param_requests_caps_each_phase_separately() {
+    let args = default_scan_args();
+    // `run_scanning` truncates the reflection set and the DOM set to `cap`
+    // *each*, so a two-phase parameter costs up to `2 * cap` — not `cap`.
+    // Clamping the combined figure at `cap` is what halved the quote.
+    let cap = 5usize;
+    let apply_cap = move |n: usize| n.min(cap);
+    let html = param_with_context(Some(InjectionContext::Html(None)));
+    assert_eq!(
+        estimate_param_requests(&html, &args, 1, &apply_cap),
+        2 * cap,
+        "both phases generate well over {cap} payloads, so each is capped at \
+         {cap} and the parameter costs {}",
+        2 * cap
+    );
+
+    // A JS-context param has no DOM phase, so it stops at one cap.
+    let js = param_with_context(Some(InjectionContext::Javascript(None)));
+    assert_eq!(estimate_param_requests(&js, &args, 1, &apply_cap), cap);
+
+    // `cap == 0` is the --deep-scan spelling of "unlimited" and must not zero
+    // the estimate.
+    let unlimited = |n: usize| n;
+    assert!(estimate_param_requests(&html, &args, 1, &unlimited) > 2 * cap);
+}

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -981,20 +981,19 @@ pub(crate) async fn preflight_handler(
                 // the estimate reflects what scanning actually fans out to.
                 cap_reflection_params(&mut target);
 
-                let enc_factor = {
-                    let encs = &scan_args.encoders;
-                    if encs.iter().any(|e| e == "none") {
-                        1usize
-                    } else {
-                        let mut f = 1usize;
-                        for e in ["url", "html", "2url", "3url", "4url", "base64"] {
-                            if encs.iter().any(|x| x == e) {
-                                f += 1;
-                            }
-                        }
-                        f
-                    }
-                };
+                // Shared with the expansion itself, so an encoder the scan
+                // applies can't be missing from the estimate (the hand-rolled
+                // list here used to omit htmlpad/unicode/zwsp).
+                let enc_factor = crate::encoding::encoder_expansion_factor(&scan_args.encoders);
+                // Mirror the per-parameter payload cap the scan enforces
+                // (`run_scanning` truncates each param's payload set to it).
+                // Without this the estimate quoted a number the scan would
+                // never send — 3912 requests for a parameter capped at 3000.
+                let cap = crate::scanning::effective_payload_cap(
+                    opts.max_payloads_per_param.unwrap_or(0),
+                    opts.deep_scan.unwrap_or(false),
+                );
+                let apply_cap = |n: usize| -> usize { if cap == 0 { n } else { n.min(cap) } };
                 let mut estimated_requests: usize = 0;
                 let discovered_params: Vec<serde_json::Value> = target
                     .reflection_params
@@ -1006,14 +1005,16 @@ pub(crate) async fn preflight_handler(
                             // must not bill any (they stay listed as discovered).
                             0
                         } else if let Some(ctx) = &p.injection_context {
-                            crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
-                                .unwrap_or_else(|_| vec![])
-                                .len()
+                            apply_cap(
+                                crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
+                                    .unwrap_or_else(|_| vec![])
+                                    .len(),
+                            )
                         } else {
                             let html_len =
                                 crate::payload::get_dynamic_xss_html_payloads().len() * enc_factor;
                             let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                            html_len + js_len
+                            apply_cap(html_len + js_len)
                         };
                         estimated_requests = estimated_requests.saturating_add(payload_count);
                         serde_json::json!({

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -1004,17 +1004,10 @@ pub(crate) async fn preflight_handler(
                             // phase sends no requests for them, so the estimate
                             // must not bill any (they stay listed as discovered).
                             0
-                        } else if let Some(ctx) = &p.injection_context {
-                            apply_cap(
-                                crate::scanning::xss_common::get_dynamic_payloads(ctx, &scan_args)
-                                    .unwrap_or_else(|_| vec![])
-                                    .len(),
-                            )
                         } else {
-                            let html_len =
-                                crate::payload::get_dynamic_xss_html_payloads().len() * enc_factor;
-                            let js_len = crate::payload::XSS_JAVASCRIPT_PAYLOADS.len() * enc_factor;
-                            apply_cap(html_len + js_len)
+                            crate::scanning::estimate_param_requests(
+                                p, &scan_args, enc_factor, &apply_cap,
+                            )
                         };
                         estimated_requests = estimated_requests.saturating_add(payload_count);
                         serde_json::json!({

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -574,7 +574,12 @@ pub(crate) async fn send_terminal_webhook(
     client: Option<reqwest::Client>,
 ) {
     let Some(cb_url) = callback_url else { return };
-    if !(cb_url.starts_with("http://") || cb_url.starts_with("https://")) {
+    // Same scheme test `validate_scan_options` gates submission on, so a URL it
+    // accepted can't be silently dropped here. Spelled with the shared helper
+    // rather than a literal `starts_with`: schemes are case-insensitive, so the
+    // old byte-exact prefix compare would have discarded a `HTTPS://…` callback
+    // the boundary check had just approved.
+    if !has_http_scheme(&cb_url) {
         return;
     }
     let payload = serde_json::json!({

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -4335,6 +4335,7 @@ async fn test_preflight_estimate_respects_the_scan_time_payload_cap() {
         ..ScanOptions::default()
     };
 
+    let cap = crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP as u64;
     let capped = preflight_estimate(addr, base.clone()).await;
     let params = capped["params"].as_array().expect("params array");
     assert!(!params.is_empty(), "reflecting target must discover params");
@@ -4342,11 +4343,22 @@ async fn test_preflight_estimate_respects_the_scan_time_payload_cap() {
         let est = p["estimated_requests"]
             .as_u64()
             .expect("per-param estimate");
+        // `run_scanning` truncates the reflection set and the DOM set to `cap`
+        // each, then sends one request per payload in both — so a parameter
+        // costs at most `2 * cap`, and the estimate must not exceed that.
         assert!(
-            est <= crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP as u64,
+            est <= 2 * cap,
             "no parameter may be quoted more requests than the scan will send it \
-             (cap {}), got {est} for {p}",
-            crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP
+             (reflection + DOM, {cap} each), got {est} for {p}"
+        );
+        // ...and must not fall below one capped half either. Clamping the whole
+        // per-param figure at `cap` — i.e. counting only the reflection phase —
+        // halved the quote for exactly the sprawling parameters callers reach
+        // for preflight to size.
+        assert!(
+            est > cap,
+            "the estimate must count the DOM phase too, not just reflection: \
+             got {est} for {p} with a per-half cap of {cap}"
         );
     }
 
@@ -4381,7 +4393,7 @@ async fn test_preflight_estimate_respects_the_scan_time_payload_cap() {
 /// the boundary instead.
 #[test]
 fn test_validate_scan_options_rejects_unusable_proxy() {
-    for bad in ["not a url", "http://", "   "] {
+    for bad in ["not a url", "http://"] {
         let mut opts = ScanOptions {
             proxy: Some(bad.to_string()),
             ..ScanOptions::default()
@@ -4394,19 +4406,48 @@ fn test_validate_scan_options_rejects_unusable_proxy() {
         );
     }
     // Forms reqwest can actually use stay accepted, including the scheme-less
-    // `host:port` spelling and SOCKS.
-    for good in [
-        "http://127.0.0.1:8080",
-        "127.0.0.1:8080",
-        "socks5://127.0.0.1:1080",
+    // `host:port` spelling and SOCKS — and the *normalized* value is what gets
+    // stored, because that is the string `build_client` later feeds to
+    // `Proxy::all`. `str::trim` strips all Unicode whitespace while `url::Url`
+    // strips only ASCII, so validating the trimmed form while storing the raw
+    // one would let a NBSP-prefixed copy-paste pass the check and still resolve
+    // away to no proxy — the very hole this validation exists to close.
+    for (given, stored) in [
+        ("http://127.0.0.1:8080", "http://127.0.0.1:8080"),
+        ("127.0.0.1:8080", "127.0.0.1:8080"),
+        ("socks5://127.0.0.1:1080", "socks5://127.0.0.1:1080"),
+        ("  http://127.0.0.1:8080  ", "http://127.0.0.1:8080"),
+        ("\u{a0}http://127.0.0.1:8080", "http://127.0.0.1:8080"),
     ] {
         let mut opts = ScanOptions {
-            proxy: Some(good.to_string()),
+            proxy: Some(given.to_string()),
             ..ScanOptions::default()
         };
+        validate_scan_options(&mut opts)
+            .unwrap_or_else(|e| panic!("'{given}' is a usable proxy and must be accepted: {e}"));
+        assert_eq!(
+            opts.proxy.as_deref(),
+            Some(stored),
+            "the stored proxy must be the normalized form the client builder resolves"
+        );
         assert!(
-            validate_scan_options(&mut opts).is_ok(),
-            "'{good}' is a usable proxy and must be accepted"
+            reqwest::Proxy::all(opts.proxy.as_deref().expect("proxy")).is_ok(),
+            "whatever validation stored must survive `Proxy::all`, or the scan \
+             silently goes direct anyway"
+        );
+    }
+
+    // Empty already meant "no proxy" and still does: refusing it would break the
+    // routine `?proxy=` templated-query shape without closing any hole.
+    for empty in ["", "   "] {
+        let mut opts = ScanOptions {
+            proxy: Some(empty.to_string()),
+            ..ScanOptions::default()
+        };
+        assert!(validate_scan_options(&mut opts).is_ok());
+        assert_eq!(
+            opts.proxy, None,
+            "an empty proxy must normalize to absent, not stay an empty string"
         );
     }
 }
@@ -4417,7 +4458,7 @@ fn test_validate_scan_options_rejects_unusable_proxy() {
 /// already been thrown away at submission time.
 #[test]
 fn test_validate_scan_options_rejects_non_http_callback_url() {
-    for bad in ["file:///etc/passwd", "ftp://x/cb", "example.com/cb", ""] {
+    for bad in ["file:///etc/passwd", "ftp://x/cb", "example.com/cb"] {
         let mut opts = ScanOptions {
             callback_url: Some(bad.to_string()),
             ..ScanOptions::default()
@@ -4434,6 +4475,17 @@ fn test_validate_scan_options_rejects_non_http_callback_url() {
         ..ScanOptions::default()
     };
     assert!(validate_scan_options(&mut opts).is_ok());
+
+    // Empty already meant "no webhook" and still does — same templated-query
+    // reasoning as `proxy` above.
+    for empty in ["", "   "] {
+        let mut opts = ScanOptions {
+            callback_url: Some(empty.to_string()),
+            ..ScanOptions::default()
+        };
+        assert!(validate_scan_options(&mut opts).is_ok());
+        assert_eq!(opts.callback_url, None);
+    }
 }
 
 /// The boundary check and the dispatcher must agree on what counts as an

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -4422,7 +4422,14 @@ async fn test_preflight_estimate_respects_the_scan_time_payload_cap() {
 /// the boundary instead.
 #[test]
 fn test_validate_scan_options_rejects_unusable_proxy() {
-    for bad in ["not a url", "http://"] {
+    for bad in [
+        "not a url",
+        "http://",
+        // Parses and passes `Proxy::all`, then hyper-util drops it and the
+        // scan would go DIRECT — the same hole the CLI startup gate closes.
+        "ftp://127.0.0.1:8080",
+        "socks6://127.0.0.1:1080",
+    ] {
         let mut opts = ScanOptions {
             proxy: Some(bad.to_string()),
             ..ScanOptions::default()
@@ -4434,16 +4441,15 @@ fn test_validate_scan_options_rejects_unusable_proxy() {
             "the 400 must name the offending option, got: {err}"
         );
     }
-    // Forms reqwest can actually use stay accepted, including the scheme-less
-    // `host:port` spelling and SOCKS — and the *normalized* value is what gets
-    // stored, because that is the string `build_client` later feeds to
-    // `Proxy::all`. `str::trim` strips all Unicode whitespace while `url::Url`
-    // strips only ASCII, so validating the trimmed form while storing the raw
-    // one would let a NBSP-prefixed copy-paste pass the check and still resolve
-    // away to no proxy — the very hole this validation exists to close.
+    // Forms the CLI also accepts stay accepted, and the *normalized* value is
+    // what gets stored, because that is the string `build_client` later feeds
+    // to `Proxy::all`. `str::trim` strips all Unicode whitespace while
+    // `url::Url` strips only ASCII, so validating the trimmed form while
+    // storing the raw one would let a NBSP-prefixed copy-paste pass the check
+    // and still resolve away to no proxy — the very hole this write-back
+    // exists to close.
     for (given, stored) in [
         ("http://127.0.0.1:8080", "http://127.0.0.1:8080"),
-        ("127.0.0.1:8080", "127.0.0.1:8080"),
         ("socks5://127.0.0.1:1080", "socks5://127.0.0.1:1080"),
         ("  http://127.0.0.1:8080  ", "http://127.0.0.1:8080"),
         ("\u{a0}http://127.0.0.1:8080", "http://127.0.0.1:8080"),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -4293,3 +4293,178 @@ async fn test_retention_cap_evicts_oldest_finished_scans_only() {
         "the newest finished scan survives"
     );
 }
+
+// ---------------------------------------------------------------------------
+// /preflight estimate: the per-parameter payload cap the scan actually enforces
+//
+// `run_scanning` truncates each parameter's payload set to
+// `effective_payload_cap(max_payloads_per_param, deep_scan)` — 3000 by default.
+// The REST estimate did not, so /preflight quoted a request budget the scan
+// would never spend: on a reflecting target it reported 7008 requests for a run
+// capped at 6000, and 14016 with five encoders selected. Sizing a scan is the
+// entire purpose of the endpoint, so an estimate that ignores the cap is wrong
+// in the one number callers act on. The CLI's `--dry-run` estimate has always
+// applied the cap; this brings REST (and MCP) in line.
+// ---------------------------------------------------------------------------
+
+async fn preflight_estimate(addr: SocketAddr, options: ScanOptions) -> serde_json::Value {
+    let state = make_state(None, None, false, false, "cb");
+    let resp = preflight_handler(
+        State(state),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            target: format!("http://{addr}/?q=1"),
+            options: Some(options),
+        })),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    serde_json::from_str::<serde_json::Value>(&response_body_string(resp).await).expect("json")
+        ["data"]
+        .clone()
+}
+
+#[tokio::test]
+async fn test_preflight_estimate_respects_the_scan_time_payload_cap() {
+    let addr = start_reflecting_target_server().await;
+    let base = ScanOptions {
+        timeout: Some(5),
+        skip_mining: Some(true),
+        ..ScanOptions::default()
+    };
+
+    let capped = preflight_estimate(addr, base.clone()).await;
+    let params = capped["params"].as_array().expect("params array");
+    assert!(!params.is_empty(), "reflecting target must discover params");
+    for p in params {
+        let est = p["estimated_requests"]
+            .as_u64()
+            .expect("per-param estimate");
+        assert!(
+            est <= crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP as u64,
+            "no parameter may be quoted more requests than the scan will send it \
+             (cap {}), got {est} for {p}",
+            crate::cmd::scan::DEFAULT_PAYLOAD_SAFETY_CAP
+        );
+    }
+
+    // The cap is the *scan's* cap, not a hardcoded ceiling on the estimate:
+    // raising `max_payloads_per_param` must raise the quote with it, otherwise
+    // this test would also pass against an estimate that simply clamps.
+    let raised = preflight_estimate(
+        addr,
+        ScanOptions {
+            max_payloads_per_param: Some(100_000),
+            ..base
+        },
+    )
+    .await;
+    assert!(
+        raised["estimated_total_requests"].as_u64().expect("total")
+            > capped["estimated_total_requests"].as_u64().expect("total"),
+        "lifting the per-param cap must raise the estimate: capped={} raised={}",
+        capped["estimated_total_requests"],
+        raised["estimated_total_requests"]
+    );
+}
+
+// ---------------------------------------------------------------------------
+// validate_scan_options: options that were accepted and then silently dropped
+// ---------------------------------------------------------------------------
+
+/// `Target::build_client` resolves the proxy with `Proxy::all(..).ok()` and
+/// falls back to **no proxy** when that fails. A scan submitted with a typo'd
+/// `proxy` therefore connected straight to the target — bypassing the intercept
+/// proxy / tunnel the caller asked for — and still settled `done`. Refuse it at
+/// the boundary instead.
+#[test]
+fn test_validate_scan_options_rejects_unusable_proxy() {
+    for bad in ["not a url", "http://", "   "] {
+        let mut opts = ScanOptions {
+            proxy: Some(bad.to_string()),
+            ..ScanOptions::default()
+        };
+        let err = validate_scan_options(&mut opts)
+            .expect_err("an unusable proxy must be refused, not silently dropped");
+        assert!(
+            err.contains("proxy"),
+            "the 400 must name the offending option, got: {err}"
+        );
+    }
+    // Forms reqwest can actually use stay accepted, including the scheme-less
+    // `host:port` spelling and SOCKS.
+    for good in [
+        "http://127.0.0.1:8080",
+        "127.0.0.1:8080",
+        "socks5://127.0.0.1:1080",
+    ] {
+        let mut opts = ScanOptions {
+            proxy: Some(good.to_string()),
+            ..ScanOptions::default()
+        };
+        assert!(
+            validate_scan_options(&mut opts).is_ok(),
+            "'{good}' is a usable proxy and must be accepted"
+        );
+    }
+}
+
+/// `send_terminal_webhook` dials http(s) only and returns silently otherwise,
+/// so a `callback_url` with any other scheme was accepted with `200 OK` and
+/// then discarded — the subscriber waited forever for a callback that had
+/// already been thrown away at submission time.
+#[test]
+fn test_validate_scan_options_rejects_non_http_callback_url() {
+    for bad in ["file:///etc/passwd", "ftp://x/cb", "example.com/cb", ""] {
+        let mut opts = ScanOptions {
+            callback_url: Some(bad.to_string()),
+            ..ScanOptions::default()
+        };
+        let err = validate_scan_options(&mut opts)
+            .expect_err("a callback_url the webhook can never dial must be refused");
+        assert!(
+            err.contains("callback_url"),
+            "the 400 must name the offending option, got: {err}"
+        );
+    }
+    let mut opts = ScanOptions {
+        callback_url: Some("https://hooks.example/cb".to_string()),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&mut opts).is_ok());
+}
+
+/// The boundary check and the dispatcher must agree on what counts as an
+/// http(s) callback, or validation just moves the silent drop one step later.
+/// URI schemes are case-insensitive and `validate_scan_options` compares them
+/// that way; the dispatcher's test has to as well, and the value it dials has
+/// to be the normalized one validation approved.
+#[test]
+fn test_callback_url_validation_and_dispatch_agree_on_the_scheme() {
+    for accepted in [
+        "https://hooks.example/cb",
+        "HTTPS://hooks.example/cb",
+        "  http://hooks.example/cb  ",
+    ] {
+        let mut opts = ScanOptions {
+            callback_url: Some(accepted.to_string()),
+            ..ScanOptions::default()
+        };
+        validate_scan_options(&mut opts)
+            .unwrap_or_else(|e| panic!("'{accepted}' must be accepted, got: {e}"));
+        let stored = opts.callback_url.expect("callback_url survives validation");
+        assert_eq!(
+            stored,
+            accepted.trim(),
+            "the stored callback_url must be the normalized (trimmed) form the \
+             dispatcher will dial"
+        );
+        assert!(
+            has_http_scheme(&stored),
+            "'{stored}' passed validation, so the dispatcher's scheme test must \
+             accept it too — otherwise the webhook is silently dropped"
+        );
+    }
+}

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -78,14 +78,6 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     if let Some(name) = opts.force_waf.as_deref() {
         crate::cmd::scan::parse_force_waf_arg(name)?;
     }
-    // Reuse the CLI's proxy validator: `opts.proxy` flows straight into
-    // `ScanArgs.proxy` and is resolved with `reqwest::Proxy::all(..).ok()`, so a
-    // value reqwest can't route (a typo, or an `ftp://`/`socks6://` scheme that
-    // parses but is silently dropped) makes the job scan DIRECT while reporting
-    // `done`. Refuse it here so server + MCP behave like the CLI startup gate.
-    if let Some(p) = opts.proxy.as_deref() {
-        crate::cmd::scan::validate_proxy_url(p)?;
-    }
     if let Some(c) = opts.waf_min_confidence
         && !(0.0..=1.0).contains(&c)
     {

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -93,10 +93,11 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     }
     // An unusable proxy is resolved away to "no proxy" when the scan's client is
     // built, so the scan silently went *direct* to the target instead of through
-    // the tunnel the caller asked for — and still reported `done`. Shared with
-    // MCP; see `crate::job::validate_proxy`.
+    // the tunnel the caller asked for — and still reported `done`. The
+    // normalized value is written back because that is what the client builder
+    // later resolves; see `crate::job::normalize_proxy`. Shared with MCP.
     if let Some(proxy) = &opts.proxy {
-        crate::job::validate_proxy(proxy)?;
+        opts.proxy = crate::job::normalize_proxy(proxy)?;
     }
     // `send_terminal_webhook` dials http(s) only and returns silently for
     // anything else, so a `callback_url` with another scheme was accepted with
@@ -109,13 +110,19 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     // dropped by the dispatcher's scheme test on the untrimmed one.
     if let Some(cb) = &opts.callback_url {
         let cb = cb.trim();
-        if !has_http_scheme(cb) {
+        if cb.is_empty() {
+            // Empty already meant "no webhook" and still does. Refusing it would
+            // break the routine `?callback_url=` templated-query shape without
+            // closing any silent-drop hole.
+            opts.callback_url = None;
+        } else if !has_http_scheme(cb) {
             return Err(format!(
                 "callback_url must start with http:// or https:// (got '{}')",
                 crate::utils::log::sanitize_log_message(cb)
             ));
+        } else {
+            opts.callback_url = Some(cb.to_string());
         }
-        opts.callback_url = Some(cb.to_string());
     }
     Ok(())
 }

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -91,6 +91,32 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     if let Some(headers) = &opts.header {
         crate::job::validate_header_list(headers)?;
     }
+    // An unusable proxy is resolved away to "no proxy" when the scan's client is
+    // built, so the scan silently went *direct* to the target instead of through
+    // the tunnel the caller asked for — and still reported `done`. Shared with
+    // MCP; see `crate::job::validate_proxy`.
+    if let Some(proxy) = &opts.proxy {
+        crate::job::validate_proxy(proxy)?;
+    }
+    // `send_terminal_webhook` dials http(s) only and returns silently for
+    // anything else, so a `callback_url` with another scheme was accepted with
+    // `200 OK` and then never fired — leaving the subscriber waiting forever for
+    // a callback that was discarded at submission time.
+    //
+    // Normalizing (trim) rather than only checking is load-bearing: the stored
+    // `callback_url` is what the dispatcher later dials, so a value with
+    // surrounding whitespace would pass a check on the trimmed form and then be
+    // dropped by the dispatcher's scheme test on the untrimmed one.
+    if let Some(cb) = &opts.callback_url {
+        let cb = cb.trim();
+        if !has_http_scheme(cb) {
+            return Err(format!(
+                "callback_url must start with http:// or https:// (got '{}')",
+                crate::utils::log::sanitize_log_message(cb)
+            ));
+        }
+        opts.callback_url = Some(cb.to_string());
+    }
     Ok(())
 }
 


### PR DESCRIPTION
Four defects on the async front ends (`dalfox server` / `dalfox mcp`). The first two are the same shape: **the API accepts an option, reports success, and then does something other than what was asked.** The last two are the `/preflight` request estimate being wrong.

Rebased onto `main` after #1389 (CLI `--proxy` / `--sxss-url` fail-fast). That PR closed the same silent-direct hole on the CLI and REST *scheme* side; this one still owns REST/MCP write-back, empty-as-absent, MCP coverage, `callback_url`, and the preflight estimate. The follow-up commit shares #1389's routable-scheme gate so `ftp://` / `socks6://` cannot pass REST/MCP, get dropped by hyper-util, and scan DIRECT.

## 1. `proxy` was never validated — the scan silently went direct

`Target::build_client` resolves the proxy with `reqwest::Proxy::all(..).ok()` and falls back to *no proxy* when that fails. So a submitted scan with a typo'd `proxy` connected **straight to the target**, bypassing the intercept proxy / SOCKS tunnel the caller asked for, putting traffic on a path they never intended — and still settled `done`, reporting a perfectly successful scan.

Now rejected at the boundary on all four surfaces: REST `POST /scan`, `GET /scan`, `POST /preflight`, and the MCP `scan_with_dalfox` / `preflight_dalfox` tools.

The validator returns the **normalized** value rather than just `Ok(())`, and the caller stores that. This is load-bearing: `str::trim` strips all Unicode whitespace while `url::Url` strips only ASCII, so validating the trimmed form while storing the raw one would let `"\u{a0}http://127.0.0.1:8080"` — an ordinary copy-paste artifact — pass the check and still resolve away to no proxy, leaving the hole exactly where it was.

Empty is normalized to absent rather than refused: it already meant "no proxy" and still does, so a 400 would close no hole while breaking the routine `?proxy=` templated-query shape. Same for `callback_url`. (CLI `--proxy ""` is still an error — that is an operator mistake, not a templated empty field. #1389.)

Unroutable schemes (`ftp://`, `socks6://`, …) share the CLI's `check_routable_proxy` gate. `Proxy::all` accepts them; hyper-util then drops them and the scan would go DIRECT.

## 2. `callback_url` with a non-http(s) scheme was accepted, then thrown away

`send_terminal_webhook` dials `http(s)` only and returns silently otherwise, so `"callback_url": "ftp://…"` got `200 OK` at submission and the subscriber then waited forever for a callback that had already been discarded.

Now a `400`. The dispatcher's own scheme test also moved from a byte-exact `starts_with("http://")` to the shared case-insensitive `has_http_scheme` — otherwise validation would accept `HTTPS://…` and the dispatcher would drop it anyway, one step later.

## 3. `/preflight` counted only half the scan

`run_scanning` builds a **reflection** payload set and a **DOM** payload set per parameter, truncates *each* to the effective per-parameter cap, and sends one request per payload in both:

```rust
total_tasks += reflection_payloads.len() + dom_payloads.len();
```

The REST and MCP estimates only ever counted the reflection half, and did not apply the cap at all — so the quote was wrong in both directions depending on the parameter, on the one number the endpoint exists to produce. The CLI's `--dry-run` estimate already had this right.

Rather than fix a third copy, the arithmetic moved to `scanning::estimate_param_requests`, next to the `total_tasks` computation it mirrors, and all three call sites now share it.

## 4. The encoder expansion factor had drifted in four places

The multiplier was re-derived from a hand-written literal list at four call sites, and that list named only `url, html, 2url, 3url, 4url, base64`. `htmlpad`, `unicode` and `zwsp` are all accepted by `--encoders` and all genuinely expand the payload set, so a caller selecting them was quoted an estimate below what the scan would send.

Replaced with `encoding::encoder_expansion_factor`, computed from the expansion's own order array. A test asserts the factor equals the real expansion width for every value in `ENCODER_VALUES`, so the estimate cannot fall behind the expansion again.

`preflight_dalfox` also gained `max_payloads_per_param` / `deep_scan` — needed to describe the scan being sized, exactly the role `encoders` already played there — and bounds `max_payloads_per_param` the way `scan_with_dalfox` does, so it can't quote an estimate for a scan the scan tool would refuse.

## Tests

Regression tests, each mutation-verified (revert the fix, confirm the test fails):

- `encoder_expansion_factor` matches the real expansion width, and counts every value in `ENCODER_VALUES`
- `/preflight` quotes at most `2 * cap` per parameter **and more than `cap`** — the second bound is what fails if the DOM phase stops being counted — and follows the cap upward when `max_payloads_per_param` is raised, so it isn't just clamping
- REST + MCP refuse an unusable `proxy` (including unroutable schemes), store the normalized form (NBSP case included), and treat empty as absent; a refused MCP submission leaves no queued job behind
- REST refuses a non-http(s) `callback_url`; validation and dispatch agree on the scheme
- `preflight_dalfox` bounds `max_payloads_per_param` like the scan tool
- Direct unit tests for all four `estimate_param_requests` branches, plus `cap == 0` (`--deep-scan`) still meaning unlimited

`cargo test --lib` (2298), `cargo clippy --all-targets -D warnings`, `cargo fmt --check` all clean on the follow-up commit.

Docs updated on both language twins (`integrations/server.md`, `integrations/mcp.md`) plus `skills/dalfox/references/mcp.md`, whose preflight parameter list was stale (it claimed preflight took no `encoders`).

---

Reviewed with `/code-review high`, which caught the half-fix in #3 and the trim/store mismatch in #1; both are fixed in the second commit. The fourth commit folds in #1389's scheme gate after that PR landed on `main`.