### PR TITLE
fix(scan,server): fail fast on unroutable --proxy and non-http --sxss-url

### DIFF
--- a/docs/content/reference/cli.ko.md
+++ b/docs/content/reference/cli.ko.md
@@ -146,7 +146,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--rate-limit` | `-r`, `--rl` | `0` | 모든 워커와 대상에 걸쳐 공유되는 **전역** 아웃바운드 요청 속도를 초당 요청 수로 제한합니다 (`0` = 무제한). 하나의 워커만 간격을 두는 `--delay`와 달리, `workers × concurrent targets`에서 한꺼번에 나가는 전체 요청량을 제한하므로 공유 IP / 엣지 WAF 임계값에 더 친화적입니다. |
 | `--retries` | — | `0` | HTTP 5xx 및 일시적 전송 오류(타임아웃, 연결 재설정) 시 실패한 요청을 이 횟수만큼 재시도합니다 (`0` = 끔). HTTP 429는 이 값과 무관하게 항상 재시도합니다. |
 | `--retry-delay` | — | `1000` | `--retries` 시도 사이의 지수 백오프 기본 지연(ms) (시도마다 두 배로 증가, 내부적으로 상한 적용). 429에서는 서버의 `Retry-After` 헤더가 우선합니다. |
-| `--proxy` | — | — | 프록시 URL (`http://`, `socks5://`) |
+| `--proxy` | — | — | 프록시 URL — `http(s)://` 또는 `socks4/5(h)://`만 허용; 라우팅 불가한 스킴(예: `ftp://`)은 조용히 직접 스캔하지 않고 시작 시 거부됨 |
 | `--insecure` | — | `true` | TLS/SSL 인증서 검증을 건너뜁니다 (자체 서명, 만료, 호스트명 불일치 인증서 허용). 스캐너 사용을 위해 기본적으로 켜져 있으며, 인증서 검증을 강제하려면 `--insecure=false`를 전달합니다. |
 | `--follow-redirects` | `-F` | false | 3xx 응답을 따라갑니다 |
 | `--ignore-return` | — | — | 무시할 HTTP 상태 코드 |
@@ -178,7 +178,7 @@ dalfox scan [TARGETS]... [FLAGS]
 | `--skip-xss-scanning` | — | false | 페이로드 주입을 건너뜁니다 |
 | `--deep-scan` | — | false | 첫 탐지 결과 이후에도 계속 테스트합니다 |
 | `--sxss` | — | false | Stored XSS 모드를 활성화합니다 |
-| `--sxss-url` | — | — | SXSS용 조회 URL |
+| `--sxss-url` | — | — | SXSS용 조회 URL (절대 `http(s)://`); `--sxss`와 함께일 때만 사용됨 |
 | `--sxss-method` | — | `GET` | 조회 메서드 |
 | `--sxss-retries` | — | `3` | 저장된 출력을 가져올 때 조회 URL에 대한 재시도 횟수 |
 | `--max-payloads-per-param` | — | `0` | 파라미터별로 테스트하는 페이로드 수 제한 (`0`은 `--deep-scan`이 없으면 세트당 3000개의 내장 안전 상한을 적용) |

--- a/docs/content/reference/cli.md
+++ b/docs/content/reference/cli.md
@@ -147,7 +147,7 @@ Monitoring turns itself on whenever credentials are present (`--cookies`,
 | `--rate-limit` | `-r`, `--rl` | `0` | Cap the **global** outbound request rate in requests/second, shared across every worker and target (`0` = unlimited). Unlike `--delay` (which only spaces one worker), this bounds the total in-flight burst from `workers × concurrent targets` — friendlier to shared-IP / edge WAF thresholds. |
 | `--retries` | — | `0` | Retry failed requests on HTTP 5xx and transient transport errors (timeouts, connection resets) up to this many times (`0` = off). HTTP 429 is always retried regardless. |
 | `--retry-delay` | — | `1000` | Base delay (ms) for the exponential backoff between `--retries` attempts (doubles each attempt, capped internally). A server `Retry-After` header takes precedence on 429. |
-| `--proxy` | — | — | Proxy URL (`http://`, `socks5://`) |
+| `--proxy` | — | — | Proxy URL — `http(s)://` or `socks4/5(h)://` only; an unroutable scheme (e.g. `ftp://`) is rejected up front instead of silently scanning direct |
 | `--insecure` | — | `true` | Skip TLS/SSL certificate verification (accept self-signed, expired, or hostname-mismatched certs). On by default for scanner use; pass `--insecure=false` to enforce certificate validation. |
 | `--follow-redirects` | `-F` | false | Follow 3xx responses |
 | `--ignore-return` | — | — | HTTP status codes to ignore |
@@ -179,7 +179,7 @@ Monitoring turns itself on whenever credentials are present (`--cookies`,
 | `--skip-xss-scanning` | — | false | Skip payload injection |
 | `--deep-scan` | — | false | Keep testing after first finding |
 | `--sxss` | — | false | Enable Stored XSS mode |
-| `--sxss-url` | — | — | Retrieval URL for SXSS |
+| `--sxss-url` | — | — | Retrieval URL for SXSS (absolute `http(s)://`); only used with `--sxss` |
 | `--sxss-method` | — | `GET` | Retrieval method |
 | `--sxss-retries` | — | `3` | Retries on the retrieval URL when fetching stored output |
 | `--max-payloads-per-param` | — | `0` | Cap payloads tested per parameter (`0` applies a built-in safety cap of 3000 per set unless `--deep-scan` is set) |

--- a/skills/dalfox/references/cli.md
+++ b/skills/dalfox/references/cli.md
@@ -79,7 +79,7 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 | `--retry-delay` | 1000 ms | Base delay for the `--retries` exponential backoff |
 | `--insecure[=bool]` | true | TLS posture. Default skips certificate validation (scanner-friendly); `--insecure=false` enforces validation |
 | `-F, --follow-redirects` | false | |
-| `--proxy` | — | `http://...` or `socks5://...` |
+| `--proxy` | — | `http(s)://` or `socks4/5(h)://` only; unroutable schemes rejected up front |
 | `--ignore-return` | (none) | Comma-separated status codes to drop before analysis (e.g. `302,403,404`) |
 | `--workers` | 50 | Concurrent workers |
 | `--max-concurrent-targets` | 50 | For file/pipe input |
@@ -114,7 +114,7 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 | Flag | Notes |
 |------|-------|
 | `--sxss` | Enable stored XSS mode |
-| `--sxss-url` | Where to look for the stored reflection (auto-detect if omitted) |
+| `--sxss-url` | Where to look for the stored reflection, absolute `http(s)://` (auto-detect if omitted); only used with `--sxss` |
 | `--sxss-method` | GET/POST for the check |
 | `--sxss-retries` | 3 (increase for slow propagation) |
 

--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -56,6 +56,9 @@ pub use args::{
 };
 pub(crate) use args::{parse_force_waf_arg, parse_http_method_arg};
 pub(crate) use logging::log_info;
+// Shared with the server/MCP option validator so all three entry points refuse
+// the same unroutable proxy values.
+pub(crate) use validation::validate_proxy_url;
 
 static GLOBAL_ENCODERS: OnceLock<Vec<String>> = OnceLock::new();
 
@@ -240,7 +243,8 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     if GLOBAL_ENCODERS.get().is_none() {
         let _ = GLOBAL_ENCODERS.set(args.encoders.clone());
     }
-    // Startup gate: numeric ranges, session-check inputs, the custom-payload
+    // Startup gate: numeric ranges, session-check inputs, the
+    // --session-check-url / --sxss-url / --proxy URL shapes, the custom-payload
     // file, and the process-wide rate limiter. Each failure it catches would
     // otherwise surface mid-scan as a result rather than a mistake.
     if let Err(outcome) = startup::prepare_and_validate(args) {

--- a/src/cmd/scan/startup.rs
+++ b/src/cmd/scan/startup.rs
@@ -9,24 +9,27 @@ use std::fs;
 
 use super::args::ScanArgs;
 use super::logging::log_warn;
-use super::validation::validate_numeric_args;
+use super::validation::{validate_http_url, validate_numeric_args, validate_proxy_url};
 use super::{ScanOutcome, emit_error, session};
 
 /// Everything that must hold — and be installed — before the first request
-/// goes out: numeric ranges, the session-check inputs, and the custom-payload
-/// file, plus the process-wide rate limiter.
+/// goes out: numeric ranges, the session-check inputs, the `--session-check-url`
+/// / `--sxss-url` / `--proxy` URL shapes, and the custom-payload file, plus the
+/// process-wide rate limiter.
 ///
 /// These are grouped because they share one property: each failure they catch
 /// is otherwise discovered *mid-scan*, where it reads as a result rather than a
 /// mistake. An unreadable `--custom-payload` under `--only-custom-payload`
 /// sends zero attack payloads and prints `0 XSS`, which is exactly what a CI
 /// gate treats as a clean target; a bad `--session-check` regex only fires when
-/// a probe does, potentially an hour in.
+/// a probe does, potentially an hour in; a `--proxy` reqwest can't route sends
+/// the whole scan DIRECT with nothing said.
 ///
 /// `Err` carries the outcome `run_scan` returns; the error text has already
-/// been emitted. Warnings (additive-mode payload problems) are emitted here and
-/// do not stop the scan. The order of the checks is load-bearing for what
-/// reaches stderr first, so it is preserved exactly as it ran inline.
+/// been emitted. Warnings (additive-mode payload problems, an inert `--sxss-url`)
+/// are emitted here and do not stop the scan. The order of the checks is
+/// load-bearing for what reaches stderr first, so it is preserved exactly as it
+/// ran inline.
 pub(crate) fn prepare_and_validate(args: &ScanArgs) -> Result<(), super::ScanOutcome> {
     // Validate numeric args up front so misconfigurations (workers: 0,
     // max_targets_per_host: 0, absurd timeouts) fail fast with a clear
@@ -68,15 +71,49 @@ pub(crate) fn prepare_and_validate(args: &ScanArgs) -> Result<(), super::ScanOut
         );
         return Err(ScanOutcome::Error);
     }
-    if let Some(u) = &args.session_check_url
-        && url::Url::parse(u).is_err()
-    {
-        emit_error(
-            &args.format,
-            crate::cmd::error_codes::PARSE_ERROR,
-            &format!("--session-check-url is not a valid absolute URL: {u}"),
+
+    // `--session-check-url` and `--sxss-url` are each consulted only when a
+    // probe / stored-XSS re-check fires — potentially an hour in — and are
+    // parsed there with `url::Url::parse(..).ok()`, so a relative, malformed,
+    // or non-http value drops out silently: the check the operator asked for
+    // never runs. `--proxy` is likewise resolved by the shared client builder
+    // with `reqwest::Proxy::all(..).ok()`, so a value reqwest can't route (a
+    // typo, or a scheme like `ftp://`/`socks6://` that parses but is silently
+    // dropped) sends every request DIRECT to the target — for a pentester
+    // routing through Burp/ZAP the attack traffic then leaks outside the
+    // intended path and never appears in the intercepting proxy. Validate all
+    // three up front with the same parsers the scan uses, so a mistake fails
+    // fast with a clear message instead of quietly changing what the scan does.
+    // The validators return self-contained messages (the operator-supplied
+    // value is never echoed), so a proxy password can't leak and a value with
+    // an embedded newline can't forge a log line.
+    for checked in [
+        args.session_check_url
+            .as_deref()
+            .map(|u| validate_http_url(u, "--session-check-url")),
+        args.sxss_url
+            .as_deref()
+            .map(|u| validate_http_url(u, "--sxss-url")),
+        args.proxy.as_deref().map(validate_proxy_url),
+    ] {
+        if let Some(Err(msg)) = checked {
+            emit_error(&args.format, crate::cmd::error_codes::PARSE_ERROR, &msg);
+            return Err(ScanOutcome::Error);
+        }
+    }
+
+    // `--sxss-url` is read only when `--sxss` is set (see
+    // `check_reflection`/`check_dom_verification`, both gated on `if args.sxss`).
+    // Supplying the check URL without enabling stored-XSS mode — the single most
+    // common way it's misconfigured, since the docs pair the two — otherwise
+    // does nothing at all and reports a clean scan. Warn rather than error: it
+    // may be a config template that toggles `--sxss` separately, but the
+    // operator should hear that the URL is inert.
+    if args.sxss_url.is_some() && !args.sxss {
+        log_warn(
+            args,
+            "--sxss-url has no effect without --sxss (stored-XSS mode is off); add --sxss to use it",
         );
-        return Err(ScanOutcome::Error);
     }
 
     // `--only-custom-payload` with no `--custom-payload` at all is the same

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -220,6 +220,11 @@ fn validate_numeric_args_rejects_waf_min_confidence_out_of_range() {
     assert!(validate_numeric_args(&args).is_err());
 }
 
+// Note: the `--proxy` / `--sxss-url` / `--session-check-url` shape validation
+// is unit-tested directly against the pure validators in `validation.rs`
+// (`validate_proxy_url` / `validate_http_url`), which avoids driving the
+// global rate limiter that `prepare_and_validate` installs.
+
 #[test]
 fn test_allowed_content_types() {
     assert!(is_allowed_content_type("text/html"));

--- a/src/cmd/scan/validation.rs
+++ b/src/cmd/scan/validation.rs
@@ -154,6 +154,83 @@ pub(crate) fn validate_numeric_args(
     Ok(())
 }
 
+/// Proxy URL schemes reqwest can actually route through.
+///
+/// `reqwest::Proxy::all` accepts *any* string that parses as a URL with a host,
+/// but hyper-util's proxy matcher silently drops every scheme outside this set
+/// at request time — so an `ftp://`, `gopher://`, `socks6://`, or `file://`
+/// value passes `Proxy::all` yet sends every request DIRECT to the target.
+/// Gating on this list turns that silent scope hazard into a fast, clear
+/// rejection.
+pub(crate) const SUPPORTED_PROXY_SCHEMES: &[&str] =
+    &["http", "https", "socks4", "socks4a", "socks5", "socks5h"];
+
+/// Validate a `--proxy` value the way the scan will actually use it: non-empty,
+/// a scheme reqwest routes through, and accepted by the same
+/// `reqwest::Proxy::all` the shared client builder
+/// ([`crate::target_parser::Target::build_client`]) calls.
+///
+/// Deliberately self-contained: the returned message never echoes the value, so
+/// a proxy carrying embedded credentials (`http://user:pass@host`) can't leak
+/// into stderr/CI logs and a value with a stray newline can't forge a log line.
+/// Returns `Err(message)` on failure; `String` so the server/MCP validator
+/// ([`crate::server::util::validate_scan_options`]) can reuse it verbatim.
+pub(crate) fn validate_proxy_url(value: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        // Empty (a blank config field, or `--proxy "$UNSET"` from the shell) is
+        // rejected rather than tolerated: silently running DIRECT is the exact
+        // hazard this check exists to close. Omit the flag for no proxy.
+        return Err(
+            "--proxy is empty (omit the flag entirely to scan without a proxy)".to_string(),
+        );
+    }
+    let scheme = match url::Url::parse(trimmed) {
+        Ok(u) => u.scheme().to_ascii_lowercase(),
+        Err(_) => return Err(PROXY_SHAPE_HINT.to_string()),
+    };
+    if !SUPPORTED_PROXY_SCHEMES.contains(&scheme.as_str()) {
+        return Err(format!(
+            "--proxy scheme '{scheme}' is not routable — reqwest silently drops it and would scan DIRECT; use one of: {}",
+            SUPPORTED_PROXY_SCHEMES.join(", ")
+        ));
+    }
+    // Belt-and-suspenders: reject anything `reqwest::Proxy::all` itself won't
+    // accept, so whatever passes here is exactly what the client will use.
+    if reqwest::Proxy::all(trimmed).is_err() {
+        return Err(PROXY_SHAPE_HINT.to_string());
+    }
+    Ok(())
+}
+
+const PROXY_SHAPE_HINT: &str = "--proxy is not a usable proxy URL (expected e.g. http://127.0.0.1:8080 or socks5://127.0.0.1:9050)";
+
+/// Validate an HTTP(S) URL flag (`--sxss-url`, `--session-check-url`): non-empty,
+/// absolute, and an `http`/`https` scheme.
+///
+/// `url::Url::parse` alone accepts `mailto:`, `javascript:`, `file:` and other
+/// non-fetchable schemes, which would pass the old parse-only check and then
+/// silently degrade at request time (the value can never be fetched). Requiring
+/// an HTTP scheme closes that. `flag` names the offending flag in the message;
+/// the value is not echoed, so an operator-supplied string can't inject into the
+/// log line.
+pub(crate) fn validate_http_url(value: &str, flag: &str) -> Result<(), String> {
+    let trimmed = value.trim();
+    if trimmed.is_empty() {
+        return Err(format!("{flag} is empty (omit the flag to leave it unset)"));
+    }
+    match url::Url::parse(trimmed) {
+        Ok(u) if matches!(u.scheme(), "http" | "https") => Ok(()),
+        Ok(u) => Err(format!(
+            "{flag} scheme '{}' is not fetchable; use an absolute http:// or https:// URL",
+            u.scheme()
+        )),
+        Err(_) => Err(format!(
+            "{flag} is not a valid absolute http:// or https:// URL"
+        )),
+    }
+}
+
 /// Does this positional argument *look* like a URL or host rather than
 /// a file path? Used to break the "input is both a domain and a local
 /// file" tie in favour of the URL, instead of silently slurping the
@@ -266,6 +343,77 @@ mod input_shape_tests {
         assert!(!looks_like_url_input("nodot"));
         assert!(!looks_like_url_input(".."));
         assert!(!looks_like_url_input(".config"));
+    }
+
+    #[test]
+    fn proxy_url_accepts_routable_schemes() {
+        for p in [
+            "http://127.0.0.1:8080",
+            "https://proxy.corp:3128",
+            "socks5://127.0.0.1:9050",
+            "socks5h://127.0.0.1:9050",
+            "socks4://127.0.0.1:1080",
+            // Leading/trailing whitespace is trimmed, not rejected.
+            "  http://127.0.0.1:8080  ",
+        ] {
+            assert!(validate_proxy_url(p).is_ok(), "{p} should be accepted");
+        }
+    }
+
+    #[test]
+    fn proxy_url_rejects_unroutable_schemes_that_parse_fine() {
+        // These all parse as URLs and pass `reqwest::Proxy::all`, but reqwest
+        // silently drops them at request time — the DIRECT-scan hazard.
+        for p in [
+            "ftp://127.0.0.1:8080",
+            "gopher://burp:8080",
+            "socks6://127.0.0.1:1080",
+            "file:///etc/passwd",
+        ] {
+            let err = validate_proxy_url(p).unwrap_err();
+            assert!(
+                err.contains("not routable"),
+                "{p} should be rejected as unroutable, got: {err}"
+            );
+        }
+    }
+
+    #[test]
+    fn proxy_url_rejects_empty_and_garbage() {
+        assert!(validate_proxy_url("").unwrap_err().contains("empty"));
+        assert!(validate_proxy_url("   ").unwrap_err().contains("empty"));
+        assert!(validate_proxy_url("::not a url::").is_err());
+    }
+
+    #[test]
+    fn proxy_url_error_never_echoes_credentials() {
+        // A password in the proxy URL must not appear in the error text.
+        let err = validate_proxy_url("ftp://user:S3cr3t@host:8080").unwrap_err();
+        assert!(!err.contains("S3cr3t"), "error leaked credentials: {err}");
+    }
+
+    #[test]
+    fn http_url_accepts_absolute_http_and_https() {
+        assert!(validate_http_url("http://app.example/me", "--sxss-url").is_ok());
+        assert!(validate_http_url("https://app.example/me", "--sxss-url").is_ok());
+        assert!(validate_http_url("  https://app.example/me  ", "--sxss-url").is_ok());
+    }
+
+    #[test]
+    fn http_url_rejects_non_fetchable_schemes_and_relatives() {
+        for u in [
+            "mailto:x@y",
+            "javascript:alert(1)",
+            "file:///etc/passwd",
+            "/relative/path",
+            "app.example/me",
+            "",
+        ] {
+            assert!(
+                validate_http_url(u, "--sxss-url").is_err(),
+                "{u} should be rejected"
+            );
+        }
     }
 
     #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2276,6 +2276,35 @@ fn test_validate_scan_options_rejects_out_of_range() {
 }
 
 #[test]
+fn test_validate_scan_options_proxy() {
+    // A routable proxy is accepted, matching the CLI startup gate.
+    assert!(
+        validate_scan_options(&mut ScanOptions {
+            proxy: Some("http://127.0.0.1:8080".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_ok()
+    );
+    // An unroutable scheme parses fine but reqwest drops it (job would scan
+    // DIRECT while reporting `done`), so server/MCP refuse it like the CLI.
+    assert!(
+        validate_scan_options(&mut ScanOptions {
+            proxy: Some("ftp://127.0.0.1:8080".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_err()
+    );
+    // Garbage is refused too.
+    assert!(
+        validate_scan_options(&mut ScanOptions {
+            proxy: Some("::not a url::".to_string()),
+            ..ScanOptions::default()
+        })
+        .is_err()
+    );
+}
+
+#[test]
 fn test_validate_scan_options_waf_fields() {
     // waf_bypass must be one of the CLI's three modes.
     assert!(

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -78,6 +78,14 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     if let Some(name) = opts.force_waf.as_deref() {
         crate::cmd::scan::parse_force_waf_arg(name)?;
     }
+    // Reuse the CLI's proxy validator: `opts.proxy` flows straight into
+    // `ScanArgs.proxy` and is resolved with `reqwest::Proxy::all(..).ok()`, so a
+    // value reqwest can't route (a typo, or an `ftp://`/`socks6://` scheme that
+    // parses but is silently dropped) makes the job scan DIRECT while reporting
+    // `done`. Refuse it here so server + MCP behave like the CLI startup gate.
+    if let Some(p) = opts.proxy.as_deref() {
+        crate::cmd::scan::validate_proxy_url(p)?;
+    }
     if let Some(c) = opts.waf_min_confidence
         && !(0.0..=1.0).contains(&c)
     {

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -126,7 +126,18 @@ impl Target {
     /// checks, blind callbacks, etc.) now share a pooled connection set.
     pub(crate) fn build_client_or_default(&self) -> Client {
         self.build_client().unwrap_or_else(|e| {
-            if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
+            // The default client carries no proxy, no `insecure` posture, and
+            // no timeout. Dropping the proxy silently is the one fallback that
+            // is a scope hazard rather than a mild degradation — the operator
+            // asked for their traffic to go through a proxy and it would go
+            // DIRECT — so warn unconditionally in that case (not just under
+            // --debug), even though `--proxy` is now validated up front and this
+            // path is only reachable on a rarer, non-proxy build failure.
+            if self.proxy.as_deref().is_some_and(|p| !p.trim().is_empty()) {
+                eprintln!(
+                    "[warn] HTTP client build failed ({e}); the configured proxy is NOT in effect and requests will go direct"
+                );
+            } else if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {
                 eprintln!("[warn] failed to build client: {}, using default", e);
             }
             Client::new()


### PR DESCRIPTION
## Summary

A review of the flags `dalfox scan` consumes surfaced a class of **silent-drop** defects: a flag parsed mid-scan with `.ok()` was quietly discarded on a malformed value, so the scan did something other than what the operator asked for — with no error.

### Fixed

- **`--proxy` routes DIRECT on an unroutable scheme.** The shared client builder resolves the proxy with `reqwest::Proxy::all(..).ok()`, which accepts *any* string that parses as a URL with a host. hyper-util then silently drops every scheme outside `http/https/socks4/4a/5/5h` at request time. So `--proxy ftp://…`, `socks6://…`, `file://…`, or a plain typo "validated" and **every request went direct to the target** — for a pentester routing through Burp/ZAP the attack traffic leaks outside the intended path and never shows up in the intercepting proxy. Now validated up front (parse + scheme allowlist + the same `Proxy::all` the client uses).
- **`--sxss-url` / `--session-check-url` silently ignored.** Parsed with `url::Url::parse(..).ok()` only when a probe fires (potentially an hour in), so a relative or non-fetchable value (`mailto:`, `javascript:`, `file:`) dropped out silently and the operator's check never ran. Now required to be an absolute `http(s)://` URL, up front.
- **`--sxss-url` without `--sxss` is inert.** The check URL is read only under `if args.sxss`, so supplying it without stored-XSS mode does nothing and reports a clean scan — the single most common misconfig (the docs pair the two). Now warns.
- **Server/MCP parity.** The proxy validator is reused in `validate_scan_options`, so REST + MCP refuse the same values instead of running a job that scans direct while reporting `done`.
- **End-to-end invariant.** `build_client_or_default` now warns unconditionally (not just under `--debug`) when a build failure would drop a *configured* proxy.

### Implementation notes

- Two pure validators (`validate_proxy_url`, `validate_http_url`) live in `scan::validation` — reusable by CLI + server/MCP and unit-testable without touching global state. Their messages are **self-contained** (the operator value is never echoed), so a proxy password can't leak into CI logs and an embedded newline can't forge a log line.
- The three near-duplicate parse-or-die blocks in the startup gate collapse into one loop.
- Empty values are rejected consistently (fail-closed: an empty proxy never silently scans direct).

### Tests

- Pure-function unit tests: routable vs. parses-but-unroutable schemes (`ftp://`, `socks6://`, `file://`), non-http/relative URLs (`mailto:`, `javascript:`, `/rel`), empty, and a no-credential-echo assertion.
- Server proxy-parity test in `validate_scan_options`.
- Full `cargo test --lib` (2284) green; clippy + fmt clean.

### Provenance

This started as a smaller `--proxy`/`--sxss-url` up-front check; a `/code-review` pass caught that the first cut of the proxy gate missed the exact unroutable-scheme case it was meant to close (`Proxy::all` accepts `ftp://`), plus consistency/parity/test-hygiene gaps — all addressed here.

CHANGELOG is left to the maintainer's release-batched process (matches repo cadence).