### PR TITLE
refactor(param): one reflection-analysis builder for 19 probe sites

### DIFF
--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -17,9 +17,7 @@
 //! Respects `--skip-discovery`, `--skip-reflection-header`, etc.
 
 use crate::cmd::scan::ScanArgs;
-use crate::parameter_analysis::{
-    Location, Param, classify_special_chars, detect_injection_context, detect_js_breakout,
-};
+use crate::parameter_analysis::{Location, Param, ReflectionAnalysis};
 use crate::scanning::url_inject::build_injected_url;
 use crate::target_parser::Target;
 use std::sync::{Arc, OnceLock};
@@ -388,20 +386,11 @@ pub async fn check_query_discovery(
                     } else if let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
-                        let (valid, invalid) = classify_special_chars(&text);
-                        let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
-                            &text,
-                            crate::scanning::markers::bracketed_marker(),
-                        )
-                        .map(ToString::to_string);
-                        discovered = Some(Param {
-                            injection_context: Some(detect_injection_context(&text)),
-                            valid_specials: Some(valid),
-                            invalid_specials: Some(invalid),
-                            framework_sink,
-                            js_breakout: detect_js_breakout(&text),
-                            ..Param::new(name, value, crate::parameter_analysis::Location::Query)
-                        });
+                        discovered = Some(
+                            Param::new(name, value, crate::parameter_analysis::Location::Query)
+                                .with_reflection_analysis(&text)
+                                .with_framework_sink(&text),
+                        );
                     }
                 }
                 if delay > 0 {
@@ -460,16 +449,17 @@ pub async fn check_query_discovery(
                 // and leaving specials as None ensures all payload types are tried
                 // without adaptive filtering that would incorrectly block payloads.
                 discovered_names.insert(name.clone());
-                batch.push(Param {
-                    injection_context: Some(detect_injection_context(&text)),
-                    pre_encoding: Some(enc_name.to_string()),
-                    js_breakout: detect_js_breakout(&text),
-                    ..Param::new(
-                        name.clone(),
-                        value.to_string(),
-                        crate::parameter_analysis::Location::Query,
-                    )
-                });
+                batch.push(
+                    Param {
+                        pre_encoding: Some(enc_name.to_string()),
+                        ..Param::new(
+                            name.clone(),
+                            value.to_string(),
+                            crate::parameter_analysis::Location::Query,
+                        )
+                    }
+                    .with_reflection_context(&text),
+                );
                 break; // Found working encoding, no need to try more
             }
             if target.delay > 0 {
@@ -534,17 +524,18 @@ pub async fn check_query_discovery(
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
                 discovered_names.insert(display_name.clone());
-                batch.push(Param {
-                    injection_context: Some(detect_injection_context(&text)),
-                    pre_encoding_pipeline: Some(nf.pipeline.clone()),
-                    wire_name: Some(name.clone()),
-                    js_breakout: detect_js_breakout(&text),
-                    ..Param::new(
-                        display_name,
-                        nf.original_value.clone(),
-                        crate::parameter_analysis::Location::Query,
-                    )
-                });
+                batch.push(
+                    Param {
+                        pre_encoding_pipeline: Some(nf.pipeline.clone()),
+                        wire_name: Some(name.clone()),
+                        ..Param::new(
+                            display_name,
+                            nf.original_value.clone(),
+                            crate::parameter_analysis::Location::Query,
+                        )
+                    }
+                    .with_reflection_context(&text),
+                );
             }
             if target.delay > 0 {
                 sleep(Duration::from_millis(target.delay)).await;
@@ -620,18 +611,14 @@ pub async fn check_query_discovery(
             && let Ok(text) = crate::utils::http::read_body(resp).await
             && crate::scanning::markers::classify_probe_reflection(&text).detected()
         {
-            let (valid, invalid) = classify_special_chars(&text);
-            batch.push(Param {
-                injection_context: Some(detect_injection_context(&text)),
-                valid_specials: Some(valid),
-                invalid_specials: Some(invalid),
-                js_breakout: detect_js_breakout(&text),
-                ..Param::new(
+            batch.push(
+                Param::new(
                     "__dalfox_key_inject__".to_string(),
                     String::new(),
                     crate::parameter_analysis::Location::Query,
                 )
-            });
+                .with_reflection_analysis(&text),
+            );
         }
         if target.delay > 0 {
             sleep(Duration::from_millis(target.delay)).await;
@@ -789,24 +776,15 @@ pub async fn check_header_discovery(
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    let framework_sink = crate::parameter_analysis::detect_framework_html_sink(
-                        &text,
-                        crate::scanning::markers::bracketed_marker(),
-                    )
-                    .map(ToString::to_string);
-                    discovered = Some(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        framework_sink,
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
+                    discovered = Some(
+                        Param::new(
                             header_name,
                             header_value,
                             crate::parameter_analysis::Location::Header,
                         )
-                    });
+                        .with_reflection_analysis(&text)
+                        .with_framework_sink(&text),
+                    );
                 }
                 if delay > 0 {
                     sleep(Duration::from_millis(delay)).await;
@@ -982,18 +960,14 @@ pub async fn check_path_discovery(
                                 true
                             };
                         if exploitable_context && bracket_survives {
-                            let (valid, invalid) = classify_special_chars(&text);
-                            discovered = Some(Param {
-                                injection_context: Some(detect_injection_context(&text)),
-                                valid_specials: Some(valid),
-                                invalid_specials: Some(invalid),
-                                js_breakout: detect_js_breakout(&text),
-                                ..Param::new(
+                            discovered = Some(
+                                Param::new(
                                     param_name,
                                     original_value,
                                     crate::parameter_analysis::Location::Path,
                                 )
-                            });
+                                .with_reflection_analysis(&text),
+                            );
                         }
                     }
                 }
@@ -1091,18 +1065,14 @@ pub async fn check_cookie_discovery(
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    discovered = Some(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
+                    discovered = Some(
+                        Param::new(
                             cookie_name,
                             cookie_value,
                             crate::parameter_analysis::Location::Header,
                         )
-                    });
+                        .with_reflection_analysis(&text),
+                    );
                 }
                 if delay > 0 {
                     sleep(Duration::from_millis(delay)).await;
@@ -1276,20 +1246,18 @@ pub async fn check_form_discovery(
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    batch.push(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        form_action_url: Some(form_url.to_string()),
-                        form_origin_url: Some(target.url.to_string()),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
-                            field_name.clone(),
-                            field_value.clone(),
-                            crate::parameter_analysis::Location::MultipartBody,
-                        )
-                    });
+                    batch.push(
+                        Param {
+                            form_action_url: Some(form_url.to_string()),
+                            form_origin_url: Some(target.url.to_string()),
+                            ..Param::new(
+                                field_name.clone(),
+                                field_value.clone(),
+                                crate::parameter_analysis::Location::MultipartBody,
+                            )
+                        }
+                        .with_reflection_analysis(&text),
+                    );
                 }
                 if target.delay > 0 {
                     sleep(Duration::from_millis(target.delay)).await;
@@ -1347,20 +1315,18 @@ pub async fn check_form_discovery(
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    batch.push(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        form_action_url: Some(form_url.to_string()),
-                        form_origin_url: Some(target.url.to_string()),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
-                            field_name.clone(),
-                            field_value.clone(),
-                            crate::parameter_analysis::Location::Body,
-                        )
-                    });
+                    batch.push(
+                        Param {
+                            form_action_url: Some(form_url.to_string()),
+                            form_origin_url: Some(target.url.to_string()),
+                            ..Param::new(
+                                field_name.clone(),
+                                field_value.clone(),
+                                crate::parameter_analysis::Location::Body,
+                            )
+                        }
+                        .with_reflection_analysis(&text),
+                    );
                 }
                 if target.delay > 0 {
                     sleep(Duration::from_millis(target.delay)).await;
@@ -1390,20 +1356,18 @@ pub async fn check_form_discovery(
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let (valid, invalid) = classify_special_chars(&text);
-                    batch.push(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        form_action_url: Some(form_url.to_string()),
-                        form_origin_url: Some(target.url.to_string()),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
-                            field_name.clone(),
-                            field_value.clone(),
-                            crate::parameter_analysis::Location::Query,
-                        )
-                    });
+                    batch.push(
+                        Param {
+                            form_action_url: Some(form_url.to_string()),
+                            form_origin_url: Some(target.url.to_string()),
+                            ..Param::new(
+                                field_name.clone(),
+                                field_value.clone(),
+                                crate::parameter_analysis::Location::Query,
+                            )
+                        }
+                        .with_reflection_analysis(&text),
+                    );
                 }
                 if target.delay > 0 {
                     sleep(Duration::from_millis(target.delay)).await;
@@ -1433,21 +1397,20 @@ pub async fn check_form_discovery(
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
-                let (valid, invalid) = classify_special_chars(&text);
+                let analysis = ReflectionAnalysis::of(&text);
                 for (field_name, field_value) in &fields {
-                    batch.push(Param {
-                        injection_context: Some(detect_injection_context(&text)),
-                        valid_specials: Some(valid.clone()),
-                        invalid_specials: Some(invalid.clone()),
-                        form_action_url: Some(form_url.to_string()),
-                        form_origin_url: Some(target.url.to_string()),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(
-                            field_name.clone(),
-                            field_value.clone(),
-                            crate::parameter_analysis::Location::JsonBody,
-                        )
-                    });
+                    batch.push(
+                        Param {
+                            form_action_url: Some(form_url.to_string()),
+                            form_origin_url: Some(target.url.to_string()),
+                            ..Param::new(
+                                field_name.clone(),
+                                field_value.clone(),
+                                crate::parameter_analysis::Location::JsonBody,
+                            )
+                        }
+                        .with_analysis(&analysis),
+                    );
                 }
             }
         }
@@ -1515,20 +1478,18 @@ pub async fn check_form_discovery(
                         && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
-                        let (valid, invalid) = classify_special_chars(&text);
-                        batch.push(Param {
-                            injection_context: Some(detect_injection_context(&text)),
-                            valid_specials: Some(valid),
-                            invalid_specials: Some(invalid),
-                            form_action_url: Some(target.url.to_string()),
-                            form_origin_url: Some(target.url.to_string()),
-                            js_breakout: detect_js_breakout(&text),
-                            ..Param::new(
-                                key.clone(),
-                                "a".to_string(),
-                                crate::parameter_analysis::Location::JsonBody,
-                            )
-                        });
+                        batch.push(
+                            Param {
+                                form_action_url: Some(target.url.to_string()),
+                                form_origin_url: Some(target.url.to_string()),
+                                ..Param::new(
+                                    key.clone(),
+                                    "a".to_string(),
+                                    crate::parameter_analysis::Location::JsonBody,
+                                )
+                            }
+                            .with_reflection_analysis(&text),
+                        );
                     }
                     if target.delay > 0 {
                         sleep(Duration::from_millis(target.delay)).await;
@@ -1588,20 +1549,18 @@ pub async fn check_form_discovery(
                         && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
-                        let (valid, invalid) = classify_special_chars(&text);
-                        batch.push(Param {
-                            injection_context: Some(detect_injection_context(&text)),
-                            valid_specials: Some(valid),
-                            invalid_specials: Some(invalid),
-                            form_action_url: Some(target.url.to_string()),
-                            form_origin_url: Some(target.url.to_string()),
-                            js_breakout: detect_js_breakout(&text),
-                            ..Param::new(
-                                field_name.clone(),
-                                field_value.clone(),
-                                crate::parameter_analysis::Location::JsonBody,
-                            )
-                        });
+                        batch.push(
+                            Param {
+                                form_action_url: Some(target.url.to_string()),
+                                form_origin_url: Some(target.url.to_string()),
+                                ..Param::new(
+                                    field_name.clone(),
+                                    field_value.clone(),
+                                    crate::parameter_analysis::Location::JsonBody,
+                                )
+                            }
+                            .with_reflection_analysis(&text),
+                        );
                     }
                     if target.delay > 0 {
                         sleep(Duration::from_millis(target.delay)).await;

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -160,11 +160,7 @@ fn make_any_param(
         )
     };
     if let Some(text) = response_text {
-        let (valid, invalid) = crate::parameter_analysis::classify_special_chars(text);
-        param.injection_context = Some(detect_injection_context(text));
-        param.valid_specials = Some(valid);
-        param.invalid_specials = Some(invalid);
-        param.js_breakout = detect_js_breakout(text);
+        param = param.with_reflection_analysis(text);
     } else if let Some(sample) = mined_sample {
         param.value = sample.value.clone();
         param.injection_context = sample.injection_context.clone();
@@ -866,21 +862,15 @@ pub async fn probe_dictionary_params(
                             {
                                 st.record_reflection();
                                 if !st.collapsed {
-                                    let context = detect_injection_context(&text);
-                                    let (valid, invalid) =
-                                        crate::parameter_analysis::classify_special_chars(&text);
-                                    discovered = Some(Param {
-                                        injection_context: Some(context),
-                                        valid_specials: Some(valid),
-                                        invalid_specials: Some(invalid),
-                                        js_breakout: detect_js_breakout(&text),
-                                        ..Param::new(
+                                    discovered = Some(
+                                        Param::new(
                                             param_name.clone(),
                                             crate::scanning::markers::bracketed_marker()
                                                 .to_string(),
                                             crate::parameter_analysis::Location::Query,
                                         )
-                                    });
+                                        .with_reflection_analysis(&text),
+                                    );
                                     if !silence {
                                         eprintln!(
                                             "Discovered parameter: {} (EWMA {:.2}, {}/{})",
@@ -1048,20 +1038,14 @@ pub async fn probe_body_params(
                         if crate::scanning::markers::classify_probe_reflection(&text).detected() {
                             st.record_reflection();
                             if !st.collapsed {
-                                let context = detect_injection_context(&text);
-                                let (valid, invalid) =
-                                    crate::parameter_analysis::classify_special_chars(&text);
-                                discovered = Some(Param {
-                                    injection_context: Some(context),
-                                    valid_specials: Some(valid),
-                                    invalid_specials: Some(invalid),
-                                    js_breakout: detect_js_breakout(&text),
-                                    ..Param::new(
+                                discovered = Some(
+                                    Param::new(
                                         param_name_cloned.clone(),
                                         crate::scanning::markers::bracketed_marker().to_string(),
                                         Location::Body,
                                     )
-                                });
+                                    .with_reflection_analysis(&text),
+                                );
                                 if !silence {
                                     eprintln!(
                                         "Discovered body param: {} (EWMA {:.2}, {}/{})",
@@ -1292,22 +1276,16 @@ pub async fn probe_response_id_params(
                             {
                                 st.record_reflection();
                                 if !st.collapsed {
-                                    let context = detect_injection_context(&text);
-                                    let (valid, invalid) =
-                                        crate::parameter_analysis::classify_special_chars(&text);
                                     // Store discovered Param for return (batched later)
-                                    discovered = Some(Param {
-                                        injection_context: Some(context),
-                                        valid_specials: Some(valid),
-                                        invalid_specials: Some(invalid),
-                                        js_breakout: detect_js_breakout(&text),
-                                        ..Param::new(
+                                    discovered = Some(
+                                        Param::new(
                                             param.clone(),
                                             crate::scanning::markers::bracketed_marker()
                                                 .to_string(),
                                             crate::parameter_analysis::Location::Query,
                                         )
-                                    });
+                                        .with_reflection_analysis(&text),
+                                    );
                                     if !silence {
                                         eprintln!(
                                             "Discovered DOM param: {} (EWMA {:.2}, {}/{})",
@@ -1495,20 +1473,14 @@ pub async fn probe_json_body_params(
                     if crate::scanning::markers::classify_probe_reflection(&text).detected() {
                         st.record_reflection();
                         if !st.collapsed {
-                            let context = detect_injection_context(&text);
-                            let (valid, invalid) =
-                                crate::parameter_analysis::classify_special_chars(&text);
-                            discovered = Some(Param {
-                                injection_context: Some(context),
-                                valid_specials: Some(valid),
-                                invalid_specials: Some(invalid),
-                                js_breakout: detect_js_breakout(&text),
-                                ..Param::new(
+                            discovered = Some(
+                                Param::new(
                                     param_name_cloned.clone(),
                                     crate::scanning::markers::bracketed_marker().to_string(),
                                     Location::JsonBody,
                                 )
-                            });
+                                .with_reflection_analysis(&text),
+                            );
                             if !silence {
                                 eprintln!(
                                     "Discovered JSON body param: {} (EWMA {:.2}, {}/{})",
@@ -1659,18 +1631,13 @@ pub async fn probe_multipart_params(
                     && let Ok(text) = crate::utils::http::read_body(r).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
-                    let context = detect_injection_context(&text);
-                    let (valid, invalid) = crate::parameter_analysis::classify_special_chars(&text);
                     if !silence {
                         eprintln!("Discovered multipart field: {}", field_name);
                     }
-                    discovered = Some(Param {
-                        injection_context: Some(context),
-                        valid_specials: Some(valid),
-                        invalid_specials: Some(invalid),
-                        js_breakout: detect_js_breakout(&text),
-                        ..Param::new(field_name, marker.to_string(), Location::MultipartBody)
-                    });
+                    discovered = Some(
+                        Param::new(field_name, marker.to_string(), Location::MultipartBody)
+                            .with_reflection_analysis(&text),
+                    );
                 }
                 drop(permit);
                 discovered

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -198,10 +198,98 @@ impl Param {
         }
     }
 
+    /// Fill in the analysis fields every reflection probe derives from the
+    /// response body its marker came back in: the injection context, the naive
+    /// special-character split, and the observed JS breakout closer.
+    ///
+    /// Discovery and mining probe more than a dozen injection points — query,
+    /// header, cookie, path, form (GET / POST / multipart / JSON) and the four
+    /// mining wordlist fan-outs — and every one of them reached those four
+    /// assignments by hand, which made each new analysis field a ~19-site
+    /// mechanical edit. Chain this onto the literal instead, so a site spells
+    /// out only the fields that are specific to it:
+    ///
+    /// ```ignore
+    /// Param {
+    ///     form_action_url: Some(form_url.to_string()),
+    ///     ..Param::new(name, value, Location::Body)
+    /// }
+    /// .with_reflection_analysis(&text)
+    /// ```
+    ///
+    /// This scans `body` once per call. When one body feeds several params,
+    /// compute a [`ReflectionAnalysis`] up front and apply it with
+    /// [`Param::with_analysis`] instead.
+    pub(crate) fn with_reflection_analysis(self, body: &str) -> Self {
+        self.with_analysis(&ReflectionAnalysis::of(body))
+    }
+
+    /// [`Param::with_reflection_analysis`] against an analysis already computed
+    /// for the body in hand.
+    pub(crate) fn with_analysis(mut self, analysis: &ReflectionAnalysis) -> Self {
+        self.injection_context = Some(analysis.injection_context.clone());
+        self.valid_specials = Some(analysis.valid_specials.clone());
+        self.invalid_specials = Some(analysis.invalid_specials.clone());
+        self.js_breakout = analysis.js_breakout.clone();
+        self
+    }
+
+    /// The context half of [`Param::with_reflection_analysis`], leaving
+    /// `valid_specials`/`invalid_specials` unset.
+    ///
+    /// The pre-encoded query probes (base64 / nested pipeline) skip the
+    /// special-character split on purpose: the encoding already carries the
+    /// payload past HTTP-level filtering, and leaving the split `None` tells
+    /// synthesis to try every payload type rather than adaptively dropping the
+    /// ones a raw-reflection probe would have ruled out.
+    pub(crate) fn with_reflection_context(mut self, body: &str) -> Self {
+        self.injection_context = Some(detect_injection_context(body));
+        self.js_breakout = detect_js_breakout(body);
+        self
+    }
+
+    /// Record the framework innerHTML-style sink the marker landed inside, if
+    /// any (see [`Param::framework_sink`]).
+    ///
+    /// Only the query and header discovery stages probe for this today; the
+    /// remaining stages leave `framework_sink` unset.
+    pub(crate) fn with_framework_sink(mut self, body: &str) -> Self {
+        self.framework_sink =
+            detect_framework_html_sink(body, crate::scanning::markers::bracketed_marker())
+                .map(ToString::to_string);
+        self
+    }
+
     /// HTTP-level parameter name (parent param when this is a nested-field
     /// virtual param, otherwise `name`).
     pub(crate) fn effective_wire_name(&self) -> &str {
         self.wire_name.as_deref().unwrap_or(&self.name)
+    }
+}
+
+/// What a reflecting response body says about the injection point it reflected
+/// in, computed once for that body and applied to one or more `Param`s.
+///
+/// See [`Param::with_reflection_analysis`] for the one-shot form; reach for
+/// this type only when a single response yields several params (the JSON-form
+/// probe posts every field at once and attributes the same body to each).
+pub(crate) struct ReflectionAnalysis {
+    injection_context: InjectionContext,
+    valid_specials: Vec<char>,
+    invalid_specials: Vec<char>,
+    js_breakout: Option<String>,
+}
+
+impl ReflectionAnalysis {
+    /// Analyze a response body that already contains the reflection marker.
+    pub(crate) fn of(body: &str) -> Self {
+        let (valid_specials, invalid_specials) = classify_special_chars(body);
+        Self {
+            injection_context: detect_injection_context(body),
+            valid_specials,
+            invalid_specials,
+            js_breakout: detect_js_breakout(body),
+        }
     }
 }
 

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1610,3 +1610,137 @@ async fn active_probe_omits_user_agent_for_the_no_override_sentinel() {
         "the empty sentinel must not become a blank User-Agent header; saw {uas:?}"
     );
 }
+
+// --- Reflection-analysis builders -----------------------------------------
+//
+// Every discovery and mining probe funnels through these three methods, so the
+// contract they pin is "which fields does a reflecting probe fill in" — the
+// question each of the ~19 former hand-written copies answered on its own.
+
+/// A body that reflects the marker inside a nested inline-`<script>` literal,
+/// so all four analysis fields come back populated — `js_breakout` in
+/// particular, which stays `None` for a reflection in plain HTML and would
+/// make an equality assertion against it vacuous.
+fn script_reflection_body() -> String {
+    format!(
+        r#"<html><body><script>render({{ opts: [ "{marker}" ] }})</script></body></html>"#,
+        marker = crate::scanning::markers::bracketed_marker()
+    )
+}
+
+/// A body that reflects the marker inside a Vue `v-html` attribute — an
+/// innerHTML-style framework sink. The marker must not appear anywhere else:
+/// `detect_framework_html_sink` bails to `None` as soon as one occurrence
+/// lives outside a recognised attribute.
+fn framework_sink_body() -> String {
+    format!(
+        r#"<html><body><div v-html="{marker}"></div></body></html>"#,
+        marker = crate::scanning::markers::bracketed_marker()
+    )
+}
+
+#[test]
+fn with_reflection_analysis_fills_every_probe_derived_field() {
+    let body = script_reflection_body();
+    let p = Param::new("q", "v", Location::Query).with_reflection_analysis(&body);
+
+    // The four fields every probe derives from the body it reflected in. Each
+    // must actually carry a value here, or the equality checks below would
+    // pass just as happily against a method that sets nothing.
+    let (valid, invalid) = classify_special_chars(&body);
+    assert!(!valid.is_empty(), "fixture must exercise valid specials");
+    assert!(
+        !invalid.is_empty(),
+        "fixture must exercise invalid specials"
+    );
+    assert_eq!(p.injection_context, Some(detect_injection_context(&body)));
+    assert_eq!(p.valid_specials, Some(valid));
+    assert_eq!(p.invalid_specials, Some(invalid));
+    assert_eq!(
+        p.js_breakout,
+        Some("\"]})".to_string()),
+        "js_breakout must carry the observed closer"
+    );
+
+    // Nothing else moves: the identifying fields and every stage-specific
+    // field stay exactly as the caller left them.
+    assert_eq!(p.name, "q");
+    assert_eq!(p.value, "v");
+    assert_eq!(p.location, Location::Query);
+    assert_eq!(p.framework_sink, None, "framework sink is opt-in");
+    assert_eq!(p.pre_encoding, None);
+    assert_eq!(p.pre_encoding_pipeline, None);
+    assert_eq!(p.wire_name, None);
+    assert_eq!(p.form_action_url, None);
+    assert_eq!(p.form_origin_url, None);
+    assert_eq!(p.escaped_specials, None);
+}
+
+#[test]
+fn with_reflection_analysis_preserves_caller_set_fields() {
+    let p = Param {
+        form_action_url: Some("http://h/post".to_string()),
+        form_origin_url: Some("http://h/".to_string()),
+        wire_name: Some("qs".to_string()),
+        ..Param::new("field", "value", Location::Body)
+    }
+    .with_reflection_analysis(&script_reflection_body());
+
+    assert_eq!(p.form_action_url.as_deref(), Some("http://h/post"));
+    assert_eq!(p.form_origin_url.as_deref(), Some("http://h/"));
+    assert_eq!(p.wire_name.as_deref(), Some("qs"));
+    assert!(p.valid_specials.is_some());
+}
+
+#[test]
+fn with_reflection_context_leaves_the_special_split_unset() {
+    // The pre-encoded query probes rely on this: a `None` split tells payload
+    // synthesis to try every type instead of adaptively dropping the ones a
+    // raw-reflection probe ruled out. Setting them here would silently narrow
+    // base64/nested-pipeline payload coverage.
+    let body = script_reflection_body();
+    let p = Param::new("q", "v", Location::Query).with_reflection_context(&body);
+
+    assert_eq!(p.injection_context, Some(detect_injection_context(&body)));
+    assert_eq!(p.js_breakout, Some("\"]})".to_string()));
+    assert_eq!(p.valid_specials, None, "special split must stay unset");
+    assert_eq!(p.invalid_specials, None, "special split must stay unset");
+}
+
+#[test]
+fn with_framework_sink_records_the_innerhtml_sink() {
+    let p = Param::new("q", "v", Location::Query).with_framework_sink(&framework_sink_body());
+    assert_eq!(p.framework_sink.as_deref(), Some("v-html"));
+
+    // A body with no framework attribute leaves it unset rather than guessing.
+    let q = Param::new("q", "v", Location::Query).with_framework_sink(&script_reflection_body());
+    assert_eq!(q.framework_sink, None);
+}
+
+#[test]
+fn one_analysis_applies_identically_to_many_params() {
+    // The JSON-form probe posts every field in one request and attributes the
+    // same body to each field, so `with_analysis` must be indistinguishable
+    // from calling `with_reflection_analysis` per param — only cheaper.
+    let body = script_reflection_body();
+    let analysis = ReflectionAnalysis::of(&body);
+
+    for name in ["a", "b", "c"] {
+        let shared = Param::new(name, "v", Location::JsonBody).with_analysis(&analysis);
+        let per_param = Param::new(name, "v", Location::JsonBody).with_reflection_analysis(&body);
+        assert_eq!(
+            shared.injection_context, per_param.injection_context,
+            "{name}"
+        );
+        assert_eq!(shared.valid_specials, per_param.valid_specials, "{name}");
+        assert_eq!(
+            shared.invalid_specials, per_param.invalid_specials,
+            "{name}"
+        );
+        assert_eq!(shared.js_breakout, per_param.js_breakout, "{name}");
+        assert!(
+            shared.js_breakout.is_some(),
+            "fixture must exercise js_breakout"
+        );
+    }
+}


### PR DESCRIPTION
## What

Every discovery and mining probe that lands on a reflected parameter derives the same four fields from the response body its marker came back in — `injection_context`, the naive `valid_specials`/`invalid_specials` split, and `js_breakout`. All **19 sites** spelled those out by hand:

- discovery: query, header, cookie, path, form GET / POST / multipart / JSON (+2 inline-JSON variants), key-injection, and the 2 pre-encoded query probes
- mining: dictionary, body, response-id, JSON body, multipart, and the synthetic `any` param

So every new analysis field was a 19-site mechanical edit — the same class of tax `Param::new` removed in #1390, one layer down — and the sites had already drifted apart.

## How

`Param` gains three named builders plus a `ReflectionAnalysis` value:

```rust
Param {
    form_action_url: Some(form_url.to_string()),
    ..Param::new(name, value, Location::Body)
}
.with_reflection_analysis(&text)
```

Two variants keep the deliberate differences visible in the type rather than in a nearby comment:

- **`with_reflection_context`** — the context half without the special split, which the pre-encoded query probes (base64, nested pipeline) leave unset *on purpose*: a `None` split tells synthesis to try every payload type instead of adaptively dropping the ones a raw-reflection probe ruled out.
- **`with_framework_sink`** — opt-in, because only the query and header stages probe for a framework innerHTML sink today.

`ReflectionAnalysis::of` computes the analysis once for a body that yields several params. The JSON-form probe re-ran `detect_injection_context` / `detect_js_breakout` once per field on one shared body and now runs them once; both are pure functions of the body, so the params it emits are unchanged.

Call sites shrink **214 → 140 lines**. Adding an analysis field is now a one-site edit.

## Verification

Behavior preservation was checked against the harnesses, not by inspection:

| gate | result |
| --- | --- |
| `cargo test` | 2566 passed, 0 failed |
| `cargo clippy --all-targets --all-features -D warnings` | clean |
| `just effectiveness` (809 labelled cases) | gate 5/5, **no metric moved** — identical tp/fp/fn/recall/precision vs the committed snapshot |
| `just replay-corpus` (42 benign pages) | 42/42, no new false positive |
| `just perf-budget` | **5493 → 5493 requests (+0.0)**, every scenario identical |

The 5 new tests pin what the builders fill in *and* what they must leave alone. Each was mutation-checked — dropping a field, swapping the valid/invalid splits, forcing the framework sink to `None` — to confirm it fails when the contract breaks. The first draft's `js_breakout` assertion was vacuous (both sides `None` on an HTML-only fixture) and the mutation run caught it; the fixture is now a nested inline-`<script>` reflection.

## Noted, not changed

`framework_sink` is computed only by the query and header stages; path, cookie, form and mining skip it. Its only consumer is the `inject_type` label (`scanning/mod.rs`), so this is a reporting asymmetry rather than a recall gap — changing it would alter output and add an HTML parse per probe, so it stays out of a behavior-preserving refactor. It is now a one-line change to close if wanted.