### PR TITLE
fix(scan): keep query injection out of the URL fragment

### DIFF
--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -162,11 +162,19 @@ pub(crate) fn build_injected_url(base: &url::Url, param: &Param, injected: &str)
         Location::Query => {
             // Build the URL string directly without cloning Url or allocating Vec
             let base_str = base.as_str();
-            // Find prefix before query (scheme + authority + path)
-            let prefix = if let Some(q_pos) = base_str.find('?') {
-                &base_str[..q_pos]
-            } else {
-                base_str
+            // Prefix = scheme + authority + path, i.e. everything before the
+            // query ('?') or fragment ('#'), whichever comes first. A real
+            // query separator always precedes the fragment, so this lands on
+            // the query when there is one and on the fragment otherwise. A bare
+            // `find('?')` instead splits on the first '?' *anywhere*, which for
+            // a fragmented URL with no query (`…#section`, or a hash-router
+            // `…#/route?tab=1`) is either absent or sits inside the fragment —
+            // both leave the fragment in the prefix, so the injected pair is
+            // appended into the re-emitted fragment and the server, which never
+            // receives the fragment, sees no query at all.
+            let prefix = match base_str.find(['?', '#']) {
+                Some(cut) => &base_str[..cut],
+                None => base_str,
             };
             // Preserve fragment
             let fragment = base.fragment();
@@ -372,10 +380,13 @@ pub(crate) fn build_hpp_url(
     }
 
     let base_str = base.as_str();
-    let prefix = if let Some(q_pos) = base_str.find('?') {
-        &base_str[..q_pos]
-    } else {
-        base_str
+    // Cut before the query or fragment, whichever comes first — the fragment is
+    // re-appended below, so a bare `find('?')` (which can match a '?' inside a
+    // fragment, or miss entirely on `…#section`) would strand the HPP pairs in
+    // the fragment. See the matching note in `build_injected_url`'s Query arm.
+    let prefix = match base_str.find(['?', '#']) {
+        Some(cut) => &base_str[..cut],
+        None => base_str,
     };
     let fragment = base.fragment();
 

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -23,6 +23,54 @@ fn test_query_injection_append() {
 }
 
 #[test]
+fn test_query_injection_on_fragmented_url_reaches_server() {
+    // A target URL with a fragment (and no real query) must still get the
+    // injected pair into the *query*, not the fragment. Regression: the prefix
+    // was cut at the first '?' anywhere in the serialized URL, which for these
+    // shapes is absent or lives inside the fragment, so the pair landed in the
+    // re-emitted fragment and the server saw no query at all.
+    for base_str in [
+        "https://example.com/a/b#section",         // fragment, no '?' in it
+        "https://example.com/a/b#x?y=z",           // fragment containing a '?'
+        "https://example.com/search#/route?tab=1", // SPA hash router
+    ] {
+        let base = make_url(base_str);
+        let param = Param::new("q", "", Location::Query);
+        let out = build_injected_url(&base, &param, "PAY");
+        let parsed = Url::parse(&out).expect("parseable");
+        assert_eq!(
+            parsed.query(),
+            Some("q=PAY"),
+            "payload must reach the server as a query for base {base_str:?}, got {out:?}"
+        );
+    }
+}
+
+#[test]
+fn test_query_injection_with_query_and_fragment_appends_to_query() {
+    // Control: a real query present means the '?' split is already correct, and
+    // the fragment must be preserved untouched at the end.
+    let base = make_url("https://example.com/a/b?c=d#frag");
+    let param = Param::new("q", "", Location::Query);
+    let out = build_injected_url(&base, &param, "PAY");
+    let parsed = Url::parse(&out).expect("parseable");
+    assert_eq!(parsed.query(), Some("c=d&q=PAY"));
+    assert_eq!(parsed.fragment(), Some("frag"));
+}
+
+#[test]
+fn test_hpp_url_on_fragmented_url_reaches_server() {
+    // Same defect in the HPP builder: the duplicated pairs must land in the
+    // query even when the base URL carries a fragment.
+    let base = make_url("https://example.com/a/b#section");
+    let param = Param::new("q", "safe", Location::Query);
+    let out = build_hpp_url(&base, &param, "PAY", HppPosition::Last).expect("query location");
+    let parsed = Url::parse(&out).expect("parseable");
+    assert_eq!(parsed.query(), Some("q=safe&q=PAY"));
+    assert_eq!(parsed.fragment(), Some("section"));
+}
+
+#[test]
 fn test_query_injection_preserves_existing_percent_encoding() {
     let base = make_url("https://example.com/path?q=seed");
     let param = Param::new("q", "seed", Location::Query);


### PR DESCRIPTION
## Summary

Query-parameter injection was silently misplaced into the URL **fragment** whenever the target URL carried one — so the payload never reached the server and the scan produced a false negative.

`build_injected_url` (Query arm) and `build_hpp_url` computed the URL prefix with `base_str.find('?')`. That matches the first `?` *anywhere* in the serialized URL — including one inside a fragment — and never strips the fragment from the prefix. Both functions re-append the fragment afterward, so the injected query pair ended up inside the re-emitted fragment.

## Impact (measured)

| target URL | injected output | server sees |
|---|---|---|
| `…/a/b#section` | `…/a/b#section?q=PAY#section` | **query=None** |
| `…/a/b#x?y=z` | `…/a/b#x?q=PAY#x?y=z` | **query=None** |
| `…/search#/route?tab=1` (SPA) | `…/search#/route?q=PAY#…` | **query=None** |
| `…/a/b?c=d#frag` (real query) | `…/a/b?c=d&q=PAY#frag` | `c=d&q=PAY` ✓ |

Targets retain their fragment (`test_parse_target_with_fragment`), and query discovery/mining runs these builders against `target.url`, so query-parameter XSS on any fragmented target — hash-router / SPA URLs especially — was a silent false negative. The existing fuzz test only asserted the output *parses*, not that the payload reaches the query, so it stayed green.

## Fix

Cut the prefix at `find(['?', '#'])` — the earlier of the query or fragment. A real query separator always precedes the fragment, so this lands on the query when there is one and on the fragment otherwise, and never on a `?` that sits inside the fragment. Applied to both `build_injected_url` and `build_hpp_url`.

## Tests

- `test_query_injection_on_fragmented_url_reaches_server` — payload reaches the server as a query for the three fragmented shapes above.
- `test_query_injection_with_query_and_fragment_appends_to_query` — control: existing query + fragment preserved.
- `test_hpp_url_on_fragmented_url_reaches_server` — same defect in the HPP builder.

`cargo clippy` clean; all 1007 scanning lib tests pass.