### PR TITLE
test(waf): guard mutation slicing against multibyte payloads

### DIFF
--- a/src/waf/bypass/tests.rs
+++ b/src/waf/bypass/tests.rs
@@ -910,3 +910,68 @@ fn scheme_and_multislash_wired_into_regex_wafs() {
     assert!(crs.contains(&MutationType::SchemeBreak));
     assert!(crs.contains(&MutationType::EntityScheme));
 }
+
+/// Every mutation slices the payload at offsets it derives from byte scans
+/// (`find_first_tag_attr_break`, `find_sink_call`, `find_executable_scheme`,
+/// …). Those offsets must always land on a UTF-8 char boundary, or the
+/// `&payload[..idx]` splices panic and take down the whole scan — and the
+/// payload here is attacker-influenced (`--custom-payload`, remote payload
+/// providers). This walks a multibyte char through every byte position of a
+/// set of realistic payload skeletons and asserts no mutation ever panics.
+#[test]
+fn mutations_never_panic_on_multibyte_payloads() {
+    const MUTATIONS: &[MutationType] = &[
+        MutationType::HtmlCommentSplit,
+        MutationType::WhitespaceMutation,
+        MutationType::JsCommentSplit,
+        MutationType::BacktickParens,
+        MutationType::ConstructorChain,
+        MutationType::UnicodeJsEscape,
+        MutationType::MixedHtmlEntities,
+        MutationType::CaseAlternation,
+        MutationType::SlashSeparator,
+        MutationType::HtmlEntityParens,
+        MutationType::SvgAnimateExec,
+        MutationType::ExoticWhitespace,
+        MutationType::KeywordEntityEncode,
+        MutationType::MultiSlash,
+        MutationType::SchemeBreak,
+        MutationType::EntityScheme,
+    ];
+    // Skeletons that each hit a different mutation's scan/slice logic.
+    const BASES: &[&str] = &[
+        "<script>alert(1)</script>",
+        "<svg onload=alert(1)>",
+        "<svg/onload=alert(1)>",
+        "<img src=x onerror=alert(1)>",
+        "javascript:alert(1)",
+        "<a href=javascript:alert(1)>x</a>",
+        "vbscript:msgbox(1)",
+        "alert('XSS')",
+        "\"><script>confirm(document.domain)</script>",
+        "<body onload=prompt(1)>",
+        "<details ontoggle=alert`1`>",
+    ];
+    // Multibyte inserts: 2-, 3-, and 4-byte chars plus a combining mark and a
+    // zero-width joiner — the classic non-boundary landmines.
+    const INSERTS: &[&str] = &["é", "中", "🎯", "\u{0301}", "\u{200b}", "\u{feff}"];
+
+    for base in BASES {
+        for ins in INSERTS {
+            for pos in 0..=base.len() {
+                if !base.is_char_boundary(pos) {
+                    continue;
+                }
+                let mut payload = String::with_capacity(base.len() + ins.len());
+                payload.push_str(&base[..pos]);
+                payload.push_str(ins);
+                payload.push_str(&base[pos..]);
+                for m in MUTATIONS {
+                    // A panic here fails the test with the offending
+                    // (mutation, payload) pair.
+                    let _ = apply_single_mutation(&payload, m);
+                }
+            }
+        }
+    }
+}


### PR DESCRIPTION
## What

Adds a regression test locking in the UTF-8 char-boundary safety of every WAF bypass mutation.

## Why

Each of the 16 WAF bypass mutations (`apply_single_mutation`) derives its slice offsets from byte scans — tag names (`find_first_tag_attr_break`), sink calls (`find_sink_call`), URI schemes (`find_executable_scheme`) — then splices the payload with `&payload[..idx]`. If any offset lands inside a multi-byte UTF-8 char, the splice **panics and aborts the entire scan**. The payload is attacker-influenced via `--custom-payload` and the remote payload providers (PayloadBox/PortSwigger), so this is a reachable crash surface.

The mutations are boundary-safe today — every offset comes from an ASCII-only scan (tag/sink/scheme keywords are ASCII) — but the module had **no** test covering it (74 tests, none touching multibyte). A future refactor could silently break the invariant.

## How

The test walks a 2-byte (`é`), 3-byte (`中`), 4-byte (`🎯`) char, a combining mark, a zero-width space, and a BOM through **every byte position** of 11 realistic payload skeletons, running all 16 mutations on each and asserting none panic.

## Verification

- Mutation-tested: confirmed the test fails (catches the panic) when a deliberate non-boundary slice is injected into `apply_single_mutation`.
- Part of a broader crash hunt that fuzzed all untrusted-input surfaces (WAF mutations, reflection processing, target/HAR/HTTP parsing, encoding, deep AST chains) with 120k+ adversarial inputs — **zero live panics found**; this test is the one gap-closing addition.
- `cargo build`, `cargo clippy --lib`, and the full `waf::bypass` module (74 tests) are green.

Test-only change; no production code touched.