### PR TITLE
fix(mcp): stop caching the scan runtime in thread-local storage

### DIFF
--- a/.github/workflows/ci-extended.yml
+++ b/.github/workflows/ci-extended.yml
@@ -32,6 +32,33 @@ jobs:
           toolchain: ${{ steps.msrv.outputs.version }}
       - name: Build at MSRV (locked deps)
         run: cargo +${{ steps.msrv.outputs.version }} build --locked --all-targets
+  msrv-windows:
+    name: MSRV on Windows (tests)
+    runs-on: windows-latest
+    # The `msrv` job above only *builds*, and only on Linux, so it cannot see a
+    # defect that needs an older toolchain and Windows at the same time. One
+    # did: a tokio runtime cached in a `thread_local!` deadlocked thread exit
+    # inside the Windows loader lock, wedging `cargo test` on Rust 1.97.1 while
+    # 1.98.0 ran clean. ci.yml's windows leg uses whatever Rust the runner
+    # image happens to ship, so it went green the moment the image fleet
+    # rolled forward -- with the defect still in the tree. Pinning the declared
+    # MSRV here keeps that combination covered no matter what the image ships.
+    timeout-minutes: 30
+    steps:
+      - uses: actions/checkout@v7
+      - name: Read MSRV from Cargo.toml
+        id: msrv
+        shell: bash
+        run: |
+          rv=$(grep -m1 '^rust-version' Cargo.toml | sed 's/.*=//; s/[" ]//g')
+          echo "version=$rv" >> "$GITHUB_OUTPUT"
+          echo "Declared MSRV: $rv"
+      - name: Install pinned MSRV toolchain
+        uses: dtolnay/rust-toolchain@master
+        with:
+          toolchain: ${{ steps.msrv.outputs.version }}
+      - name: Run tests at MSRV (locked deps)
+        run: cargo +${{ steps.msrv.outputs.version }} test --locked
   ignored-tests:
     name: Ignored / functional tests
     runs-on: ubuntu-latest

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,10 @@ jobs:
   build:
     name: Build & Test (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
+    # The default is the 6-hour job limit. A test that wedges (the windows leg
+    # has done exactly that) then burns six runner-hours before anyone sees a
+    # red check; the whole matrix normally finishes in under six minutes.
+    timeout-minutes: 30
     strategy:
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
@@ -25,6 +29,7 @@ jobs:
         run: cargo test --verbose
   lint:
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v7
       - name: Install latest stable
@@ -38,6 +43,7 @@ jobs:
         run: cargo clippy --all-targets --all-features -- -D warnings
   coverage:
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v7
       - uses: dtolnay/rust-toolchain@stable

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -51,42 +51,41 @@ use crate::{
     target_parser::parse_target,
 };
 
-thread_local! {
-    /// Per-blocking-thread current_thread runtime. Built lazily on first use
-    /// and reused for the lifetime of the worker thread, so the second scan
-    /// scheduled onto the same blocking-pool slot doesn't pay
-    /// `Builder::new_current_thread().build()` again.
-    static SCAN_RUNTIME: std::cell::RefCell<Option<tokio::runtime::Runtime>> =
-        const { std::cell::RefCell::new(None) };
-}
-
-/// Run `f` on a current_thread runtime cached in thread-local storage and
-/// return its result. The closure receives a borrow of the runtime so
-/// callers can issue `block_on`. Returns `None` if runtime construction
-/// fails — extremely rare; `tag` is logged to identify the call site.
-fn run_on_thread_runtime<F, R>(tag: &str, f: F) -> Option<R>
+/// Run `f` on a current_thread runtime and return its result. The closure
+/// receives a borrow of the runtime so callers can issue `block_on`. Returns
+/// `None` if runtime construction fails — extremely rare; `tag` is logged to
+/// identify the call site.
+///
+/// The runtime is a plain local, built and dropped inside the caller's
+/// `spawn_blocking` closure, and it has to stay that way. Caching it in a
+/// `thread_local!` — which this did, to save the ~ms of `Builder::build()` on
+/// the second scan scheduled onto the same blocking-pool slot — deadlocks the
+/// whole process on Windows. Windows runs TLS destructors from
+/// `ntdll!LdrShutdownThread`, with the loader lock held; dropping a runtime
+/// there joins that runtime's own blocking threads (hyper resolves DNS on
+/// `spawn_blocking`, so they exist), and those threads cannot finish exiting
+/// without the same lock. Every thread that tries to exit afterwards parks in
+/// `LdrpDrainWorkQueue` and the process wedges — `cargo test` on the Windows
+/// CI leg stopped dead after 501 of 2308 tests and burned the 6-hour job limit.
+/// The REST server's `spawn_scan_task` has always built the runtime as a local;
+/// this matches it.
+fn run_on_scan_runtime<F, R>(tag: &str, f: F) -> Option<R>
 where
     F: FnOnce(&tokio::runtime::Runtime) -> R,
 {
-    SCAN_RUNTIME.with(|cell| {
-        let mut slot = cell.borrow_mut();
-        if slot.is_none() {
-            match tokio::runtime::Builder::new_current_thread()
-                .enable_all()
-                .build()
-            {
-                Ok(rt) => *slot = Some(rt),
-                Err(e) => {
-                    DalfoxMcp::log(
-                        "ERR",
-                        &format!("runtime build failed for tag={}: {}", tag, e),
-                    );
-                    return None;
-                }
-            }
+    match tokio::runtime::Builder::new_current_thread()
+        .enable_all()
+        .build()
+    {
+        Ok(rt) => Some(f(&rt)),
+        Err(e) => {
+            DalfoxMcp::log(
+                "ERR",
+                &format!("runtime build failed for tag={}: {}", tag, e),
+            );
+            None
         }
-        slot.as_ref().map(f)
-    })
+    }
 }
 
 /// Transition a non-terminal job into `Error` with the supplied message.
@@ -1134,8 +1133,8 @@ browser execution; only detection_method=oob observes a real browser."
         // scans on the same thread skip the rebuild (saves ~ms of setup).
         //
         // Two failure modes used to leak the job into Queued forever:
-        // 1) `run_on_thread_runtime` returns None when the cached runtime
-        //    can't be built — `run_job` then never runs.
+        // 1) `run_on_scan_runtime` returns None when the scan runtime can't
+        //    be built — `run_job` then never runs.
         // 2) A panic inside `run_job` (parameter analysis, scanning, etc.)
         //    bubbles out of the spawn_blocking task and is dropped because
         //    the JoinHandle isn't awaited.
@@ -1150,7 +1149,7 @@ browser execution; only detection_method=oob observes a real browser."
             let jobs_for_recovery = handler.jobs.clone();
 
             let result = std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
-                let ran = run_on_thread_runtime(&sid_for_log, |rt| {
+                let ran = run_on_scan_runtime(&sid_for_log, |rt| {
                     rt.block_on(handler.run_job(sid, scan_args));
                 });
                 if ran.is_none() {
@@ -1636,7 +1635,7 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
         let result = tokio::task::spawn_blocking(move || {
             let _preflight_permit = preflight_permit;
             let target_url_for_err_inner = target_url_for_err.clone();
-            run_on_thread_runtime(&target_url_for_err_inner, |rt| {
+            run_on_scan_runtime(&target_url_for_err_inner, |rt| {
                 rt.block_on(async {
                     // Reachability check: send a probe via the target's fully-hydrated
                     // HTTP stack so proxy, custom headers, cookies, User-Agent, method,


### PR DESCRIPTION
The `CI / Build & Test (windows-latest)` leg has been wedging at 501 of 2308
tests and getting cancelled at the 6-hour job limit on every run since
2026-08-20. It is a **Windows loader-lock deadlock in our own code**, not a
runner problem.

## Root cause

`src/mcp/mod.rs` cached the nested current_thread scan runtime in a
`thread_local!`, so the runtime lived as long as the tokio blocking-pool thread
that built it. Windows runs TLS destructors from `ntdll!LdrShutdownThread`,
**with the loader lock held**. Dropping a tokio runtime there joins that
runtime's own blocking threads — hyper resolves DNS on `spawn_blocking`, so
they exist — and those threads cannot finish exiting without the same lock.
From then on every thread that tries to exit parks in `LdrpDrainWorkQueue` and
the process never moves again.

A non-invasive `cdb` attach to a wedged harness, with libtest's thread names:

```
 4  "tokio-rt-worker"                                    ntdll!NtWaitForSingleObject
 5  "tokio-rt-worker"                                    ntdll!LdrpDrainWorkQueue+0x199
 7  "tokio-rt-worker"                                    ntdll!LdrShutdownThread+0x99
 8  "oob::interactsh::crypto::tests::oaep_and_ctr_..."   ntdll!RtlExitUserThread+0x46
 9  "oob::interactsh::tests::payload_url_is_33_..."      KERNEL32!BaseThreadInitThunk

 0  "main"                                               KERNELBASE!WaitForSingleObjectEx
 2  "mcp::tests::test_scan_with_dalfox_rejects_unusable_proxy"
 6  "mcp::tests::test_scan_with_dalfox_wait_returns_terminal_on_unreachable"
```

Five threads that had *finished their work* stuck in thread exit; the rest
blocked joining them. CPU flat at 0%, no sockets open.

#1388 was the trigger, not the bug: `test_scan_with_dalfox_rejects_unusable_proxy`
queues three background scans, so three blocking-pool threads carry a cached
runtime into thread exit.

## Why it looked like a runner-image problem

It reproduces on Rust **1.97.1** and not on **1.98.0**, and the toolchain ships
with the runner image:

| runner image | Rust | windows leg, post-#1388 |
| --- | --- | --- |
| `20260810.198.2`, `20260818.207.1` | 1.97.1 | cancelled 12/12 |
| `20260824.214.3` | 1.98.0 | green 6/6 |

The toolchain only shifts the timing. Left alone, the check would have gone
green by itself as the fleet rolled forward, with the defect still in the tree.

## The fix

Build the runtime as a plain local inside the `spawn_blocking` closure, so the
drop happens in ordinary code with no loader lock held. This is what the REST
server's `spawn_scan_task` has always done — MCP now matches it. There is no
`thread_local!` left anywhere in `src/`.

Cost is one `Builder::new_current_thread().enable_all().build()` per scan job,
which is what the cache existed to avoid.

## Verification

Pinned-toolchain Windows runs of the exact `ci.yml` command:

| | Rust 1.97.1 | Rust 1.98.0 |
| --- | --- | --- |
| before | **wedged 4/4** (stdout frozen at 502 lines for 20 min) | green 2/2 |
| after | **green 2/2** (`cargo exited rc=0 after 150s`) | — |

Local: `cargo test` green on stable and at MSRV 1.93; clippy `-D warnings` and
`cargo fmt --check` clean.

## Also in this PR

- `ci.yml`: `timeout-minutes` on build / lint / coverage. Without it a job runs
  to GitHub's 6-hour default — this one burned six runner-hours per push and
  the red check only appeared six hours after the offending commit.
- `ci-extended.yml`: a **MSRV on Windows (tests)** job. The existing `msrv` job
  only builds, and only on Linux, so it structurally cannot catch a defect that
  needs an old toolchain and Windows together. Pinning `rust-version` keeps
  that combination covered no matter what Rust the runner image ships.