### PR TITLE
fix(nix): repair the broken flake build and gate it in CI

### DIFF
--- a/.envrc
+++ b/.envrc
@@ -1,0 +1,6 @@
+# direnv (https://direnv.net) + nix-direnv: entering this directory drops you
+# into the flake's dev shell (Rust toolchain, just, Crystal for scripts/).
+#
+# Opt-in — nothing happens unless you have direnv installed and run
+# `direnv allow` here. `.direnv/` is gitignored.
+use flake

--- a/.github/workflows/ci-packaging.yml
+++ b/.github/workflows/ci-packaging.yml
@@ -14,6 +14,8 @@ on:
       - "**/*.rs"
       - aur/PKGBUILD
       - snap/snapcraft.yaml
+      - flake.nix
+      - flake.lock
       - .github/workflows/ci-packaging.yml
   pull_request:
     branches: [main]
@@ -23,6 +25,8 @@ on:
       - "**/*.rs"
       - aur/PKGBUILD
       - snap/snapcraft.yaml
+      - flake.nix
+      - flake.lock
       - .github/workflows/ci-packaging.yml
   workflow_dispatch:
 env:
@@ -81,3 +85,53 @@ jobs:
       - uses: actions/checkout@v7
       - name: Build snap
         uses: snapcore/action-build@v1
+
+  nix:
+    name: Nix flake build
+    runs-on: ubuntu-latest
+    # The flake is the only packaging path nothing else exercises: it pins its
+    # own toolchain via rust-overlay, so it can silently fall behind
+    # `rust-version` in Cargo.toml and stay broken until a user reports it
+    # (which is exactly what happened between #1158 and now). Evaluating and
+    # building it here turns that into a red check.
+    #
+    # Like the sibling jobs, this is an uncached full source build, hence the
+    # timeout. The first two steps are the same gates as `just nix-check` /
+    # `just nix-build` — keep the three in sync when you change one.
+    timeout-minutes: 45
+    steps:
+      - uses: actions/checkout@v7
+      - uses: cachix/install-nix-action@v31
+        with:
+          extra_nix_config: |
+            experimental-features = nix-command flakes
+      - name: Check every flake output evaluates
+        run: nix flake check --no-build --all-systems
+      - name: Check the overlay instantiates
+        # `nix flake check` only verifies that overlays.default is a lambda —
+        # it never applies it. The overlay is the documented NixOS install
+        # path and it builds against the *consumer's* rustPlatform, so it is a
+        # different derivation from packages.default and needs its own check.
+        run: |
+          nix eval --raw --impure --expr '
+            let
+              flake = builtins.getFlake (toString ./.);
+              pkgs = import flake.inputs.nixpkgs {
+                system = builtins.currentSystem;
+                overlays = [ flake.overlays.default ];
+              };
+            in
+            pkgs.dalfox.drvPath
+          '
+      - name: Build the package
+        run: nix build .#default --print-build-logs
+      - name: Smoke test the binary
+        run: ./result/bin/dalfox --version
+      - name: Assert the generated artifacts are installed
+        # postInstall renders these from the freshly built binary; a silent
+        # regression there is exactly the class the .deb guard catches too.
+        run: |
+          test -f result/share/man/man1/dalfox.1.gz
+          test -f result/share/bash-completion/completions/dalfox.bash
+          test -f result/share/zsh/site-functions/_dalfox
+          test -f result/share/fish/vendor_completions.d/dalfox.fish

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -215,10 +215,11 @@ Handy task aliases (from `justfile`):
 - `just test_all` — `cargo test -- --include-ignored`
 - `just dev` (alias `just d`) — debug build
 - `just build` (alias `just b`) — release build
-- `just version-check` (alias `just vc`) / `just version-update` (alias `just vu`) — keep version in lockstep across `Cargo.toml`, `Cargo.lock`, `flake.nix`, snap
+- `just version-check` (alias `just vc`) / `just version-update` (alias `just vu`) — keep version in lockstep across `Cargo.toml`, `Cargo.lock`, snap, AUR and the docs (`flake.nix` reads it from `Cargo.toml`, so it is not in the list)
 - `just docs-serve` (alias `just ds`) — serve the docs site locally via hwaro
 - `just docs-dependencies` — install docs tooling (hwaro) on macOS
-- `just nix-update` — update the Nix flake lockfile
+- `just nix-update` — update the Nix flake lockfile (the flake pins its own Rust toolchain, so a stale lock breaks `nix build`)
+- `just nix-check` / `just nix-build` — evaluate every flake output, or build the package the way `nix build github:hahwul/dalfox` does
 
 When behavior changes, add or update tests near the touched module plus one higher-level test when the change crosses module boundaries.
 

--- a/README.md
+++ b/README.md
@@ -67,11 +67,13 @@ nix run github:hahwul/dalfox -- scan https://example.com
 # Install
 nix profile install github:hahwul/dalfox
 
-# Development environment
-nix develop github:hahwul/dalfox
+# Development environment for hacking on Dalfox itself
+git clone https://github.com/hahwul/dalfox && cd dalfox && nix develop
 ```
 
-See [Installation guide](https://dalfox.hahwul.com/getting-started/installation/) for details.
+The flake also exposes `overlays.default`, so NixOS and home-manager users can build Dalfox
+against their own `nixpkgs`. See the [Installation guide](https://dalfox.hahwul.com/getting-started/installation/)
+for that module snippet and the rest of the details.
 
 Prebuilt binaries (including statically-linked musl variants for Linux) are available on the [GitHub Releases](https://github.com/hahwul/dalfox/releases) page.
 

--- a/docs/content/getting-started/installation.ko.md
+++ b/docs/content/getting-started/installation.ko.md
@@ -50,12 +50,47 @@ nix run github:hahwul/dalfox -- scan https://example.com
 
 # 프로필에 설치
 nix profile install github:hahwul/dalfox
-
-# Dalfox가 준비된 개발 셸로 진입
-nix develop github:hahwul/dalfox
 ```
 
-Dalfox는 nixpkgs에 등록되어 있습니다. 최신 릴리스는 먼저 `unstable`에 올라옵니다.
+Dalfox는 nixpkgs에 등록되어 있습니다. 최신 릴리스는 먼저 `unstable`에 올라오므로, 릴리스 사이 기간에는 위 flake 쪽이 `nixpkgs`보다 앞서 있습니다.
+
+flake가 지원하는 시스템은 `x86_64-linux`, `aarch64-linux`, `aarch64-darwin`입니다. nixpkgs `unstable`이 `x86_64-darwin`을 제외했기 때문에 Intel macOS는 빠져 있으니, 아래의 `macos-x86_64` 릴리스 아카이브를 쓰세요.
+
+이 flake가 고정한 nixpkgs 대신 사용자의 `nixpkgs`로 Dalfox를 빌드하려면 오버레이를 쓰세요. 시스템 flake에서는 이렇게 선언합니다.
+
+```nix
+# flake.nix
+{
+  inputs.dalfox.url = "github:hahwul/dalfox";
+
+  outputs = { self, nixpkgs, dalfox, ... }@inputs: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      specialArgs = { inherit inputs; };
+      modules = [ ./configuration.nix ];
+    };
+  };
+}
+```
+
+그리고 `inputs`를 전달받는 모듈에서 적용합니다.
+
+```nix
+# configuration.nix
+{ pkgs, inputs, ... }:
+{
+  nixpkgs.overlays = [ inputs.dalfox.overlays.default ];
+  environment.systemPackages = [ pkgs.dalfox ];
+}
+```
+
+flake는 Dalfox 자체를 개발할 때 쓰는 셸도 제공합니다. Rust 툴체인과 [`just`](https://github.com/casey/just), 테스트 하네스가 필요로 하는 Crystal 런타임이 들어 있고 `dalfox` 바이너리는 포함하지 않습니다.
+
+```bash
+git clone https://github.com/hahwul/dalfox && cd dalfox
+nix develop
+```
+
+[direnv](https://direnv.net)를 설치했다면 저장소의 `.envrc` 덕분에 `direnv allow` 한 번으로 같은 셸이 자동으로 활성화됩니다.
 
 ## Cargo (crates.io)
 

--- a/docs/content/getting-started/installation.md
+++ b/docs/content/getting-started/installation.md
@@ -50,12 +50,47 @@ nix run github:hahwul/dalfox -- scan https://example.com
 
 # Install into your profile
 nix profile install github:hahwul/dalfox
-
-# Drop into a dev shell with Dalfox available
-nix develop github:hahwul/dalfox
 ```
 
-Dalfox lives in nixpkgs. The newest releases land in `unstable` first.
+Dalfox lives in nixpkgs. The newest releases land in `unstable` first, so the flake above is ahead of `nixpkgs` between releases.
+
+The flake builds for `x86_64-linux`, `aarch64-linux` and `aarch64-darwin`. Intel macOS is not among them because nixpkgs `unstable` dropped `x86_64-darwin` — use the `macos-x86_64` release archive below instead.
+
+To build Dalfox against your own `nixpkgs` instead of the one this flake pins, use the overlay. In your system flake:
+
+```nix
+# flake.nix
+{
+  inputs.dalfox.url = "github:hahwul/dalfox";
+
+  outputs = { self, nixpkgs, dalfox, ... }@inputs: {
+    nixosConfigurations.myhost = nixpkgs.lib.nixosSystem {
+      specialArgs = { inherit inputs; };
+      modules = [ ./configuration.nix ];
+    };
+  };
+}
+```
+
+Then, in a module that receives `inputs`:
+
+```nix
+# configuration.nix
+{ pkgs, inputs, ... }:
+{
+  nixpkgs.overlays = [ inputs.dalfox.overlays.default ];
+  environment.systemPackages = [ pkgs.dalfox ];
+}
+```
+
+The flake also exposes a development shell for working on Dalfox itself — the Rust toolchain, [`just`](https://github.com/casey/just) and the Crystal runtime the test harnesses need, but not the `dalfox` binary:
+
+```bash
+git clone https://github.com/hahwul/dalfox && cd dalfox
+nix develop
+```
+
+With [direnv](https://direnv.net) installed, `direnv allow` picks the same shell up automatically from the repo's `.envrc`.
 
 ## Cargo (from crates.io)
 

--- a/flake.lock
+++ b/flake.lock
@@ -20,11 +20,11 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1766902085,
-        "narHash": "sha256-coBu0ONtFzlwwVBzmjacUQwj3G+lybcZ1oeNSQkgC0M=",
+        "lastModified": 1787900134,
+        "narHash": "sha256-VYXO0XZlgj06dxJZRhrD3WoSsvq/c7+/Akyoa22pefw=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "c0b0e0fddf73fd517c3471e546c0df87a42d53f4",
+        "rev": "83199d0d373dd3ac2b9a1996b1d0263f76ab7a4c",
         "type": "github"
       },
       "original": {
@@ -48,11 +48,11 @@
         ]
       },
       "locked": {
-        "lastModified": 1766976750,
-        "narHash": "sha256-w+o3AIBI56tzfMJRqRXg9tSXnpQRN5hAT15o2t9rxYw=",
+        "lastModified": 1788077403,
+        "narHash": "sha256-c20YZQKzQ27qC6Wh729fWRTpI7oV4+7Ur4icKssD4Wc=",
         "owner": "oxalica",
         "repo": "rust-overlay",
-        "rev": "9fe44e7f05b734a64a01f92fc51ad064fb0a884f",
+        "rev": "89e26eeaafa88a2ede4778734acc794ff0299beb",
         "type": "github"
       },
       "original": {

--- a/flake.nix
+++ b/flake.nix
@@ -1,8 +1,6 @@
 {
   description = "Dalfox - A powerful open-source XSS scanner and utility focused on automation";
 
-  # For detailed Nix flake documentation, see NIX.md
-
   inputs = {
     nixpkgs.url = "github:NixOS/nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
@@ -12,61 +10,95 @@
     };
   };
 
-  outputs = { self, nixpkgs, flake-utils, rust-overlay }:
-    flake-utils.lib.eachDefaultSystem (system:
-      let
-        overlays = [ (import rust-overlay) ];
-        pkgs = import nixpkgs {
-          inherit system overlays;
-        };
-        
-        # Use stable Rust toolchain
-        rustToolchain = pkgs.rust-bin.stable.latest.default.override {
-          extensions = [ "rust-src" "rust-analyzer" ];
-        };
+  outputs =
+    {
+      self,
+      nixpkgs,
+      flake-utils,
+      rust-overlay,
+    }:
+    let
+      # The single source of truth for the version is Cargo.toml. Reading it
+      # here keeps `nix build` from drifting behind a release (this file used
+      # to carry its own literal that had to be bumped in lockstep).
+      cargoToml = builtins.fromTOML (builtins.readFile ./Cargo.toml);
 
-        # Build dependencies
-        nativeBuildInputs = with pkgs; [
-          rustToolchain
-          pkg-config
-        ];
+      # Not `eachDefaultSystem`: nixpkgs 26.11 dropped x86_64-darwin, so
+      # keeping it in the list makes `nix flake check --all-systems` (and any
+      # evaluation of that attribute) fail outright.
+      systems = [
+        "x86_64-linux"
+        "aarch64-linux"
+        "aarch64-darwin"
+      ];
 
-        # On modern nixpkgs (Darwin SDK rework), the Security and
-        # SystemConfiguration frameworks are provided by the default stdenv,
-        # so they no longer need to be listed explicitly. The legacy
-        # `darwin.apple_sdk.frameworks.*` stubs have been removed.
-        buildInputs = with pkgs; [
-          openssl
-        ];
-
-        # Common environment for development
-        commonEnv = {
-          RUST_BACKTRACE = "1";
-        };
-
-      in
-      {
-        # Package definition
-        packages.default = pkgs.rustPlatform.buildRustPackage {
+      # The derivation, written callPackage-style so the same definition backs
+      # both `packages.default` (built with the pinned rust-overlay toolchain)
+      # and `overlays.default` (built with whatever rustPlatform the consumer's
+      # nixpkgs provides).
+      dalfoxPackage =
+        {
+          lib,
+          stdenv,
+          rustPlatform,
+          installShellFiles,
+          versionCheckHook,
+        }:
+        let
+          # Cross-compiling to a platform the builder cannot execute rules out
+          # everything that runs the result.
+          canRunResult = stdenv.buildPlatform.canExecute stdenv.hostPlatform;
+        in
+        rustPlatform.buildRustPackage (finalAttrs: {
           pname = "dalfox";
-          version = "3.2.1";
+          version = cargoToml.package.version;
 
-          src = ./.;
-
-          cargoLock = {
-            lockFile = ./Cargo.lock;
+          # Only the inputs cargo actually reads. Editing docs/, skills/ or a
+          # workflow then no longer invalidates the build.
+          #
+          # `./tests` is here even though `doCheck = false` skips it: unit
+          # tests under src/ reach for fixtures like tests/fixtures/sample.har
+          # through CARGO_MANIFEST_DIR, so dropping it would make the package
+          # un-testable the moment anyone flips doCheck on to debug something.
+          src = lib.fileset.toSource {
+            root = ./.;
+            fileset = lib.fileset.unions [
+              ./Cargo.toml
+              ./Cargo.lock
+              ./build.rs
+              ./src
+              ./tests
+            ];
           };
 
-          # `installShellFiles` is package-only (it provides
-          # `installShellCompletion` below); the dev shell has no use for it.
-          nativeBuildInputs = nativeBuildInputs ++ [ pkgs.installShellFiles ];
-          inherit buildInputs;
+          cargoLock.lockFile = ./Cargo.lock;
+
+          # dalfox is pure Rust: reqwest is pinned to rustls + ring
+          # (`default-features = false`), so there is no openssl-sys or
+          # aws-lc-sys in the graph and hence nothing for pkg-config to find.
+          # `installShellFiles` provides `installShellCompletion` below.
+          nativeBuildInputs = [ installShellFiles ];
+
+          # Most of the suite drives live HTTP mock servers and (for the OOB
+          # paths) outbound DNS, neither of which exists in the build sandbox.
+          # CI runs `cargo test` for real; this build only has to produce a
+          # working binary. Matches nixpkgs' own dalfox package.
+          doCheck = false;
+
+          # ... so gate the build on something the sandbox *can* prove: that
+          # the binary starts and reports the version we claim to have built.
+          # Both this and postInstall below run the freshly built binary, so
+          # they share one predicate and must stay in lockstep: rendering the
+          # man page without smoke-testing the binary (or vice versa) is not a
+          # combination we want to be able to reach by editing one of them.
+          nativeInstallCheckInputs = [ versionCheckHook ];
+          doInstallCheck = canRunResult;
+          versionCheckProgramArg = "--version";
 
           # Render the man page and the shell completions with the binary that
           # was just installed rather than shipping generated copies in the
-          # source tree. This runs the built binary, so it applies to native
-          # builds only.
-          postInstall = ''
+          # source tree.
+          postInstall = lib.optionalString canRunResult ''
             mkdir -p $out/share/man/man1
             $out/bin/dalfox man > $out/share/man/man1/dalfox.1
             installShellCompletion --cmd dalfox \
@@ -75,38 +107,113 @@
               --fish <($out/bin/dalfox completion fish)
           '';
 
-          meta = with pkgs.lib; {
-            description = "Dalfox is a powerful open-source XSS scanner and utility focused on automation";
+          meta = {
+            description = "Powerful open-source XSS scanner and utility focused on automation";
             homepage = "https://github.com/hahwul/dalfox";
-            license = licenses.mit;
+            changelog = "https://github.com/hahwul/dalfox/releases/tag/v${finalAttrs.version}";
+            license = lib.licenses.mit;
             maintainers = [ ];
             mainProgram = "dalfox";
+            platforms = lib.platforms.unix;
           };
+        });
+    in
+    flake-utils.lib.eachSystem systems (
+      system:
+      let
+        pkgs = import nixpkgs {
+          inherit system;
+          overlays = [ (import rust-overlay) ];
+        };
+        inherit (pkgs) lib;
+
+        # Building only needs cargo + rustc + std, so use the `minimal`
+        # profile: rustfmt, clippy and the docs would otherwise be dragged
+        # into the build closure for nothing.
+        #
+        # `latest` is relative to the *locked* rust-overlay, so it silently
+        # falls behind whenever Cargo.toml's `rust-version` moves first. The
+        # assertion turns that into an actionable eval-time error (caught by
+        # the cheap `nix flake check --no-build`) instead of an opaque rustc
+        # failure a few hundred crates into the build.
+        buildToolchain =
+          assert lib.assertMsg
+            (lib.versionAtLeast pkgs.rust-bin.stable.latest.minimal.version cargoToml.package.rust-version)
+            ''
+              flake.lock pins Rust ${pkgs.rust-bin.stable.latest.minimal.version}, but Cargo.toml
+              requires rust-version ${cargoToml.package.rust-version}. Run `just nix-update`.
+            '';
+          pkgs.rust-bin.stable.latest.minimal;
+
+        # The dev shell wants the full kit — `default` already carries rustfmt
+        # and clippy (`just lint`), plus the sources rust-analyzer resolves
+        # `std` against.
+        devToolchain = pkgs.rust-bin.stable.latest.default.override {
+          extensions = [
+            "rust-src"
+            "rust-analyzer"
+          ];
         };
 
-        # Development shell
-        devShells.default = pkgs.mkShell (commonEnv // {
-          inherit buildInputs;
-          nativeBuildInputs = nativeBuildInputs ++ (with pkgs; [
-            # Additional development tools
-            cargo-watch
-            cargo-edit
-            just
-          ]);
+        # `buildRustPackage` takes its cargo/rustc from `rustPlatform`, not
+        # from `nativeBuildInputs` — listing a toolchain there does not change
+        # what actually compiles. Bind it explicitly so the pinned toolchain is
+        # the one that builds dalfox.
+        rustPlatform = pkgs.makeRustPlatform {
+          cargo = buildToolchain;
+          rustc = buildToolchain;
+        };
+
+        dalfox = pkgs.callPackage dalfoxPackage { inherit rustPlatform; };
+      in
+      {
+        packages = {
+          default = dalfox;
+          inherit dalfox;
+        };
+
+        # A plain `nix flake check` builds this. Note that both CI and
+        # `just nix-check` pass `--no-build` (evaluation only, all systems) and
+        # get their build coverage from the separate `nix build` step, which
+        # covers the CI runner's system alone.
+        checks.default = dalfox;
+
+        apps.default = flake-utils.lib.mkApp { drv = dalfox; } // {
+          meta.description = "Run the Dalfox XSS scanner";
+        };
+
+        # `nixfmt-tree` rather than bare `nixfmt`: `nix fmt` hands the
+        # formatter a directory, which nixfmt itself cannot take.
+        formatter = pkgs.nixfmt-tree;
+
+        devShells.default = pkgs.mkShell {
+          packages = [
+            devToolchain
+            pkgs.just
+            pkgs.cargo-watch
+            pkgs.cargo-edit
+            # The gates under scripts/ (`just harness`, `just version-check`,
+            # `just docs-lint`, …) are Crystal programs.
+            pkgs.crystal
+          ];
+
+          env.RUST_BACKTRACE = "1";
 
           shellHook = ''
-            echo "🦊 Dalfox development environment"
+            echo "🦊 Dalfox development environment ($(rustc --version))"
             echo "Run 'just' to see available commands"
             echo "Run 'cargo build' to build the project"
             echo "Run 'cargo test' to run tests"
           '';
-        });
-
-        # App for easy running
-        apps.default = {
-          type = "app";
-          program = "${self.packages.${system}.default}/bin/dalfox";
         };
       }
-    );
+    )
+    // {
+      # For NixOS / home-manager users who want dalfox built against their own
+      # nixpkgs rather than this flake's pin:
+      #   nixpkgs.overlays = [ dalfox.overlays.default ];
+      overlays.default = final: prev: {
+        dalfox = final.callPackage dalfoxPackage { };
+      };
+    };
 }

--- a/justfile
+++ b/justfile
@@ -21,18 +21,33 @@ build:
 dev:
     cargo build
 
-# Render the roff man page into target/ for local preview (never committed —
-# packaging generates it from the freshly built binary at release time).
+# Never committed — packaging generates it from the freshly built binary at
+# release time. (`just --list` shows only the last comment line, so the
+# one-line summary goes last.)
+# Render the roff man page into target/ for local preview.
 [group('build')]
 man:
     mkdir -p target/man
     cargo run --quiet -- man > target/man/dalfox.1
     @echo "wrote target/man/dalfox.1 — preview with: man target/man/dalfox.1"
 
+# The flake pins its own Rust toolchain through rust-overlay, so a stale lock
+# silently falls behind Cargo.toml's `rust-version` and breaks `nix build`.
 # Update Nix flake lock.
 [group('build')]
 nix-update:
     nix flake update
+
+# Build the Nix package the way `nix build github:hahwul/dalfox` does.
+[group('build')]
+nix-build:
+    nix build .#default --print-build-logs
+    ./result/bin/dalfox --version
+
+# Evaluate every flake output for every supported system (fast, no build).
+[group('build')]
+nix-check:
+    nix flake check --no-build --all-systems
 
 # Serve docs site locally.
 [group('documents')]

--- a/scripts/version_check.cr
+++ b/scripts/version_check.cr
@@ -1,11 +1,14 @@
 # Reports the version string declared in each file dalfox keeps in lockstep
-# (Cargo.toml, Cargo.lock, flake.nix, snap/snapcraft.yaml, aur/PKGBUILD,
+# (Cargo.toml, Cargo.lock, snap/snapcraft.yaml, aur/PKGBUILD,
 # docs/data/dalfox.json, docs/content/getting-started/installation.md).
 # Exits non-zero when they disagree so it can gate a release.
+#
+# flake.nix is deliberately absent: it reads the version out of Cargo.toml at
+# evaluation time (`builtins.fromTOML`), so it cannot drift and has nothing to
+# bump.
 
 CARGO_TOML  = "Cargo.toml"
 CARGO_LOCK  = "Cargo.lock"
-FLAKE_NIX   = "flake.nix"
 SNAP_YAML   = "snap/snapcraft.yaml"
 AUR_PKGBUILD = "aur/PKGBUILD"
 DOCS_DATA   = "docs/data/dalfox.json"
@@ -26,16 +29,6 @@ end
 def cargo_lock_version : String?
   content = File.read(CARGO_LOCK)
   match = content.match(/name\s*=\s*"dalfox"\s*\nversion\s*=\s*"([^"]+)"/)
-  match ? match[1] : nil
-rescue
-  nil
-end
-
-# flake.nix: any `version = "X";` (the file only has one such line for
-# the dalfox derivation).
-def flake_version : String?
-  content = File.read(FLAKE_NIX)
-  match = content.match(/version\s*=\s*"([^"]+)"\s*;/)
   match ? match[1] : nil
 rescue
   nil
@@ -84,7 +77,6 @@ end
 
 cargo_v   = cargo_toml_version
 lock_v    = cargo_lock_version
-flake_v   = flake_version
 snap_v    = snap_version
 aur_v     = aur_version
 docs_v    = docs_data_version
@@ -92,14 +84,13 @@ install_v = install_doc_version
 
 puts "#{CARGO_TOML.ljust(46)} #{cargo_v || "Not found"}"
 puts "#{CARGO_LOCK.ljust(46)} #{lock_v || "Not found"}"
-puts "#{FLAKE_NIX.ljust(46)} #{flake_v || "Not found"}"
 puts "#{SNAP_YAML.ljust(46)} #{snap_v || "Not found"}"
 puts "#{AUR_PKGBUILD.ljust(46)} #{aur_v || "Not found"}"
 puts "#{DOCS_DATA.ljust(46)} #{docs_v || "Not found"}"
 puts "#{INSTALL_DOC.ljust(46)} #{install_v || "Not found"}"
 puts
 
-versions = [cargo_v, lock_v, flake_v, snap_v, aur_v, docs_v, install_v].compact
+versions = [cargo_v, lock_v, snap_v, aur_v, docs_v, install_v].compact
 
 if versions.empty?
   puts "No versions found!"

--- a/scripts/version_update.cr
+++ b/scripts/version_update.cr
@@ -1,13 +1,16 @@
 # Bumps the dalfox version across every file that hardcodes it
-# (Cargo.toml, Cargo.lock, flake.nix, snap/snapcraft.yaml, aur/PKGBUILD,
+# (Cargo.toml, Cargo.lock, snap/snapcraft.yaml, aur/PKGBUILD,
 # docs/data/dalfox.json, docs/content/getting-started/installation.md).
 # Prompts for the new version interactively and prints a per-file checkmark.
+#
+# flake.nix is deliberately absent: it reads the version out of Cargo.toml at
+# evaluation time (`builtins.fromTOML`), so it cannot drift and has nothing to
+# bump.
 #
 # Pre-release suffixes are allowed (e.g. 3.0.0-dev.1, 3.1.0-rc.1).
 
 CARGO_TOML   = "Cargo.toml"
 CARGO_LOCK   = "Cargo.lock"
-FLAKE_NIX    = "flake.nix"
 SNAP_YAML    = "snap/snapcraft.yaml"
 AUR_PKGBUILD = "aur/PKGBUILD"
 DOCS_DATA    = "docs/data/dalfox.json"
@@ -28,14 +31,6 @@ end
 def cargo_lock_version : String?
   content = File.read(CARGO_LOCK)
   match = content.match(/name\s*=\s*"dalfox"\s*\nversion\s*=\s*"([^"]+)"/)
-  match ? match[1] : nil
-rescue
-  nil
-end
-
-def flake_version : String?
-  content = File.read(FLAKE_NIX)
-  match = content.match(/version\s*=\s*"([^"]+)"\s*;/)
   match ? match[1] : nil
 rescue
   nil
@@ -99,17 +94,6 @@ def update_cargo_lock(new_version : String) : Bool
   )
   return false if updated == content
   File.write(CARGO_LOCK, updated)
-  true
-rescue ex
-  puts "  error: #{ex.message}"
-  false
-end
-
-def update_flake(new_version : String) : Bool
-  content = File.read(FLAKE_NIX)
-  updated = content.sub(/(version\s*=\s*")[^"]+("\s*;)/, "\\1#{new_version}\\2")
-  return false if updated == content
-  File.write(FLAKE_NIX, updated)
   true
 rescue ex
   puts "  error: #{ex.message}"
@@ -188,7 +172,6 @@ end
 
 cargo_v   = cargo_toml_version
 lock_v    = cargo_lock_version
-flake_v   = flake_version
 snap_v    = snap_version
 aur_v     = aur_version
 docs_v    = docs_data_version
@@ -197,14 +180,13 @@ install_v = install_doc_version
 puts "Current versions:"
 puts "  #{CARGO_TOML.ljust(46)} #{cargo_v || "Not found"}"
 puts "  #{CARGO_LOCK.ljust(46)} #{lock_v || "Not found"}"
-puts "  #{FLAKE_NIX.ljust(46)} #{flake_v || "Not found"}"
 puts "  #{SNAP_YAML.ljust(46)} #{snap_v || "Not found"}"
 puts "  #{AUR_PKGBUILD.ljust(46)} #{aur_v || "Not found"}"
 puts "  #{DOCS_DATA.ljust(46)} #{docs_v || "Not found"}"
 puts "  #{INSTALL_DOC.ljust(46)} #{install_v || "Not found"}"
 puts
 
-versions = [cargo_v, lock_v, flake_v, snap_v, aur_v, docs_v, install_v].compact
+versions = [cargo_v, lock_v, snap_v, aur_v, docs_v, install_v].compact
 unique = versions.uniq
 
 if unique.size > 1
@@ -212,7 +194,7 @@ if unique.size > 1
   puts
 end
 
-current = cargo_v || lock_v || flake_v || snap_v || aur_v || docs_v || install_v || "unknown"
+current = cargo_v || lock_v || snap_v || aur_v || docs_v || install_v || "unknown"
 puts "Current: #{current}"
 print "New version (Enter to cancel): "
 input = gets
@@ -242,7 +224,6 @@ total = 0
 [
   {CARGO_TOML, ->{ update_cargo_toml(new_version) }, !cargo_v.nil?},
   {CARGO_LOCK, ->{ update_cargo_lock(new_version) }, !lock_v.nil?},
-  {FLAKE_NIX, ->{ update_flake(new_version) }, !flake_v.nil?},
   {SNAP_YAML, ->{ update_snap(new_version) }, !snap_v.nil?},
   {AUR_PKGBUILD, ->{ update_aur(new_version) }, !aur_v.nil?},
   {DOCS_DATA, ->{ update_docs_data(new_version) }, !docs_v.nil?},


### PR DESCRIPTION
## Why

`nix build .#default` has been failing on `main` since December. The flake pins its own toolchain through rust-overlay, and the locked pin yielded rustc 1.92.0 while `Cargo.toml` requires 1.93. Nothing in CI exercised the flake, so it stayed broken for eight months.

While fixing that, a few more issues surfaced in the same file:

- The toolchain in `nativeBuildInputs` was never used — `buildRustPackage` takes cargo/rustc from `rustPlatform`.
- `doCheck` defaulted to true, so the build would also have failed in `checkPhase` (the suite drives live mock servers and OOB DNS).
- `openssl` + `pkg-config` were carried for a dependency graph that has neither (reqwest is pinned to rustls + ring).
- `version` was a hardcoded literal kept in lockstep by hand.
- `postInstall` runs the built binary with no cross-compilation guard.
- `eachDefaultSystem` includes `x86_64-darwin`, which nixpkgs 26.11 dropped, so `nix flake check --all-systems` failed outright.
- The install docs described `nix develop github:hahwul/dalfox` as "a dev shell with Dalfox available" — it is dalfox's *development* shell and deliberately does not contain the binary.

## What changed

**Package**

- Refresh `flake.lock` (rustc 1.98.0, nixpkgs 2026-08-28).
- Bind the pinned toolchain with `makeRustPlatform`, and **assert at evaluation time** that it satisfies `Cargo.toml`'s `rust-version` — the next drift is an actionable `run just nix-update` rather than an opaque rustc failure hundreds of crates in.
- Read `version` from `Cargo.toml`. flake.nix leaves the version-lockstep set, so it is removed from `scripts/version_check.cr` / `version_update.cr`.
- `doCheck = false` (matching nixpkgs' own dalfox package) with `versionCheckHook` as the install-time gate.
- Drop `openssl` / `pkg-config`; narrow `src` with `lib.fileset`; share one `canExecute` predicate between `postInstall` and the install check.

**Outputs**

- `overlays.default` for NixOS / home-manager users, plus `packages.dalfox`, `checks.default`, `formatter`.
- Crystal added to the dev shell (the gates under `scripts/` need it) and an opt-in `.envrc` for direnv.

**CI**

- New `nix` job in the packaging workflow: evaluate every output for every system, instantiate the overlay (`nix flake check` only checks it is a lambda, it never applies it), build, smoke-run the binary, and assert the man page plus all three shell completions landed.
- `just nix-build` / `just nix-check`.

**Docs** — corrected the `nix develop` description, replaced the overlay snippet (which was not valid Nix: it merged flake inputs with NixOS module options and referenced `inputs` from an unbound scope) with a flake half and a module half, and noted the Intel macOS gap. EN + KO.

## Verification

Run locally on aarch64-darwin:

```
nix flake check --no-build --all-systems   all checks passed
nix build .#default                         exit 0 -> dalfox 3.2.1, closure 57.4 MiB
                                            man1/dalfox.1.gz + bash/zsh/fish completions
nix develop --command ...                   rustc 1.98.0, cargo, just 1.58, Crystal 1.19.1
overlay instantiation                       evaluates (a distinct drv from packages.default)
toolchain assertion                         fires with the intended message when rust-version outruns the lock
crystal run scripts/version_check.cr        All versions match: 3.2.1
crystal run scripts/docs_lint.cr            25 passed
nix-instantiate --parse                     both doc snippets parse
```

The CI artifact assertions use the installed names, checked against a real build: nixpkgs gzips man pages (`dalfox.1.gz`) and `installShellCompletion` writes `completions/dalfox.bash`.

## Follow-up (not in this PR)

nixpkgs' own `pkgs/by-name/da/dalfox/package.nix` still carries the unused `openssl` / `pkg-config` inputs and does not install the man page or completions. Worth an upstream PR.