### PR TITLE
fix(scan,server): harden request construction and input validation

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -161,6 +161,28 @@ pub(crate) fn validate_header_list(headers: &[String]) -> Result<(), String> {
     Ok(())
 }
 
+/// Reject a `User-Agent` or cookie value reqwest cannot put on the wire.
+///
+/// Same rationale as [`validate_header_list`]: both a supplied `user_agent`
+/// (pushed on as a `User-Agent` header by `hydrate_target` / the reachability
+/// probe) and each cookie value (composed into the `Cookie` header) become
+/// header values, and a control byte in one fails reqwest on the *builder* for
+/// every request in the job — so the reachability probe fails and the scan
+/// settles `unreachable` / `CONNECTION_FAILED`, blaming a live target for what
+/// is really malformed input. Validating here turns that into a precise 400 at
+/// submission. `HeaderValue::try_from(&str)` is exactly what reqwest's
+/// `.header()` applies, so obs-text stays legal (a UTF-8 UA passes).
+pub(crate) fn validate_header_value(field: &str, value: &str) -> Result<(), String> {
+    if reqwest::header::HeaderValue::try_from(value).is_err() {
+        return Err(format!(
+            "invalid {} value '{}'",
+            field,
+            crate::utils::log::sanitize_log_message(value)
+        ));
+    }
+    Ok(())
+}
+
 /// Validate and normalize a caller-supplied proxy URL, rejecting anything
 /// reqwest cannot actually route through (unparseable, or a scheme like
 /// `ftp://` / `socks6://` that `Proxy::all` accepts then silently drops).

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -468,3 +468,15 @@ fn rest_and_mcp_requests_agree_on_scan_args() {
         "a default REST scan and a default MCP scan must run identically"
     );
 }
+
+#[test]
+fn validate_header_value_matches_reqwest_builder_semantics() {
+    // What reqwest's `.header()` accepts for a &str value, this must accept —
+    // and reject the control bytes that fail the builder. Obs-text (a UTF-8
+    // User-Agent) is legal; CR/LF/NUL are not.
+    assert!(validate_header_value("user_agent", "Mozilla/5.0 (caf\u{e9})").is_ok());
+    assert!(validate_header_value("cookie", "sid=abc; theme=dark").is_ok());
+    assert!(validate_header_value("user_agent", "Mozilla\r\nX: 1").is_err());
+    assert!(validate_header_value("user_agent", "Mozilla\nX: 1").is_err());
+    assert!(validate_header_value("cookie", "sid=a\0b").is_err());
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -907,9 +907,21 @@ browser execution; only detection_method=oob observes a real browser."
         }
         // Same shared check the REST server runs: a malformed header makes
         // reqwest fail on the builder for every request in the job, which
-        // surfaces as the *target* being reported unreachable.
+        // surfaces as the *target* being reported unreachable. `user_agent` and
+        // each cookie value become header values too, so they fail the builder
+        // the same way and get the same submission-time check.
         if let Err(e) = crate::job::validate_header_list(&headers) {
             return Err(ErrorData::invalid_params(e, None));
+        }
+        if let Some(ua) = user_agent.as_deref().filter(|s| !s.is_empty())
+            && let Err(e) = crate::job::validate_header_value("user_agent", ua)
+        {
+            return Err(ErrorData::invalid_params(e, None));
+        }
+        for cookie in &cookies {
+            if let Err(e) = crate::job::validate_header_value("cookie", cookie) {
+                return Err(ErrorData::invalid_params(e, None));
+            }
         }
         // An unusable proxy is resolved away to "no proxy" when the scan's
         // client is built, so the scan silently went *direct* to the target
@@ -1525,6 +1537,14 @@ Use before scan_with_dalfox to estimate scan impact and verify reachability."
             .map_err(|e| ErrorData::invalid_params(e, None))?;
         crate::job::validate_header_list(&params.headers)
             .map_err(|e| ErrorData::invalid_params(e, None))?;
+        if let Some(ua) = params.user_agent.as_deref().filter(|s| !s.is_empty()) {
+            crate::job::validate_header_value("user_agent", ua)
+                .map_err(|e| ErrorData::invalid_params(e, None))?;
+        }
+        for cookie in &params.cookies {
+            crate::job::validate_header_value("cookie", cookie)
+                .map_err(|e| ErrorData::invalid_params(e, None))?;
+        }
         // Same silent-fallback hazard as the scan tool: an unusable proxy would
         // make the reachability probe go direct and report the target reachable
         // through a path the caller never asked for.

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -1233,7 +1233,7 @@ pub async fn check_form_discovery(
                         form = form.text(n.clone(), v.clone());
                     }
                 }
-                let rb = crate::utils::build_request(
+                let rb = crate::utils::build_body_request_base(
                     &client,
                     target,
                     reqwest::Method::POST,
@@ -1301,8 +1301,13 @@ pub async fn check_form_discovery(
                     },
                 );
                 let m = reqwest::Method::POST;
-                let rb =
-                    crate::utils::build_request(&client, target, m, form_url.clone(), Some(body));
+                let rb = crate::utils::build_body_request_base(
+                    &client,
+                    target,
+                    m,
+                    form_url.clone(),
+                    Some(body),
+                );
                 let rb = crate::utils::apply_header_overrides(
                     rb,
                     &[(
@@ -1386,8 +1391,13 @@ pub async fn check_form_discovery(
                 serde_json::Value::Object(map).to_string()
             };
             let m = reqwest::Method::POST;
-            let rb =
-                crate::utils::build_request(&client, target, m, form_url.clone(), Some(json_body));
+            let rb = crate::utils::build_body_request_base(
+                &client,
+                target,
+                m,
+                form_url.clone(),
+                Some(json_body),
+            );
             let rb = crate::utils::apply_header_overrides(
                 rb,
                 &[("Content-Type".to_string(), "application/json".to_string())],
@@ -1462,7 +1472,7 @@ pub async fn check_form_discovery(
                     }
                     let json_body = serde_json::Value::Object(map).to_string();
                     let m = reqwest::Method::POST;
-                    let rb = crate::utils::build_request(
+                    let rb = crate::utils::build_body_request_base(
                         &client,
                         target,
                         m,
@@ -1533,7 +1543,7 @@ pub async fn check_form_discovery(
                     }
                     let json_body = serde_json::Value::Object(map).to_string();
                     let m = reqwest::Method::POST;
-                    let rb = crate::utils::build_request(
+                    let rb = crate::utils::build_body_request_base(
                         &client,
                         target,
                         m,

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -1013,7 +1013,7 @@ pub async fn probe_body_params(
                         .await
                         .expect("acquire semaphore permit");
                     let m = parsed_method;
-                    let base = crate::utils::build_request(
+                    let base = crate::utils::build_body_request_base(
                         &client_clone,
                         &target_clone,
                         m,
@@ -1451,7 +1451,7 @@ pub async fn probe_json_body_params(
                     )
                 });
 
-                let base = crate::utils::build_request(
+                let base = crate::utils::build_body_request_base(
                     &client_clone,
                     &target_clone,
                     parsed_method,
@@ -1621,9 +1621,14 @@ pub async fn probe_multipart_params(
 
                 let method =
                     crate::scanning::url_inject::body_location_method(&target_clone.method);
-                let request =
-                    crate::utils::build_request(&client_clone, &target_clone, method, url, None)
-                        .multipart(form);
+                let request = crate::utils::build_body_request_base(
+                    &client_clone,
+                    &target_clone,
+                    method,
+                    url,
+                    None,
+                )
+                .multipart(form);
                 crate::record_outbound_request().await;
 
                 let mut discovered: Option<Param> = None;

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -784,7 +784,17 @@ async fn window_overflow_probe(
         return None;
     }
 
-    let batched_chars: String = SPECIAL_PROBE_CHARS.iter().collect();
+    // Use the transport-aware probe set, not raw `SPECIAL_PROBE_CHARS`: for a
+    // cookie param the latter still contains `;`, which ends the cookie value
+    // on the wire and truncates the probe before the CLOSE marker — so
+    // `extract_reflected_segment` finds nothing and this window probe returns
+    // `None` even when the special chars *would* reflect past the window. That
+    // silently disabled window-limited-WAF detection for every cookie param,
+    // the exact inconsistency `probe_chars_for` exists to prevent on the normal
+    // path. `;` is folded back into `invalid` centrally via
+    // `transport_invalid_chars`, so dropping it here loses no classification.
+    let probe_chars = probe_chars_for(target, param);
+    let batched_chars: String = probe_chars.iter().collect();
     let probe = format!(
         "{}{}{}{}",
         crate::encoding::pre_encoding::waf_window_pad(),
@@ -800,7 +810,7 @@ async fn window_overflow_probe(
     let segment = resp.as_deref().and_then(extract_reflected_segment)?;
     let mut valid = Vec::new();
     let mut invalid = Vec::new();
-    for &c in SPECIAL_PROBE_CHARS {
+    for &c in &probe_chars {
         if char_reflected_in_segment(segment, c) {
             valid.push(c);
         } else {

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -711,7 +711,7 @@ pub(crate) fn build_body_request(
     let parsed_url = resolve_form_action_url(param, target);
     let body = Some(urlencoded_body(target.data.as_deref(), &param.name, value));
     let method = body_location_method_for_param(&target.method, param);
-    let base = crate::utils::build_request(client, target, method, parsed_url, body);
+    let base = crate::utils::build_body_request_base(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
         &[(
@@ -736,7 +736,7 @@ pub(crate) fn build_json_body_request(
         value,
     ));
     let method = body_location_method_for_param(&target.method, param);
-    let base = crate::utils::build_request(client, target, method, parsed_url, body);
+    let base = crate::utils::build_body_request_base(client, target, method, parsed_url, body);
     crate::utils::apply_header_overrides(
         base,
         &[("Content-Type".to_string(), "application/json".to_string())],
@@ -745,6 +745,10 @@ pub(crate) fn build_json_body_request(
 
 /// `multipart/form-data` body injection. No explicit `Content-Type` override:
 /// reqwest derives it from the form, and it must carry the generated boundary.
+/// `build_body_request_base` drops any `Content-Type` inherited from an imported
+/// target so reqwest's boundary-carrying one is the only value on the wire — a
+/// leftover captured `multipart/...; boundary=OLD` would be the first header the
+/// server frames the body with, seeing zero parts.
 pub(crate) fn build_multipart_request(
     client: &Client,
     target: &Target,
@@ -754,7 +758,7 @@ pub(crate) fn build_multipart_request(
     let parsed_url = resolve_form_action_url(param, target);
     let form = multipart_form(target.data.as_deref(), &param.name, value);
     let method = body_location_method_for_param(&target.method, param);
-    crate::utils::build_request(client, target, method, parsed_url, None).multipart(form)
+    crate::utils::build_body_request_base(client, target, method, parsed_url, None).multipart(form)
 }
 
 /// Query / Path injection: the payload goes into the URL and the target's own

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -673,6 +673,90 @@ fn test_build_inject_request_multipart_keeps_generated_boundary() {
     );
 }
 
+/// An imported (raw-http/HAR) target carries its captured `Content-Type` in
+/// `target.headers`. reqwest *appends* headers, so a body injector that also
+/// sets a `Content-Type` would send two — and a server frames the body with the
+/// first (captured) one. Every body-injection path must therefore emit exactly
+/// one `Content-Type`, its own.
+#[test]
+fn test_body_injection_drops_captured_content_type_urlencoded() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let mut target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    // Simulate a raw-http/HAR import that captured a JSON Content-Type.
+    target.headers = vec![("Content-Type".to_string(), "application/json".to_string())];
+    let param = make_param(Location::Body, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    let cts: Vec<_> = req
+        .headers()
+        .get_all(reqwest::header::CONTENT_TYPE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    assert_eq!(
+        cts,
+        vec!["application/x-www-form-urlencoded"],
+        "exactly one Content-Type, the injector's, must be on the wire"
+    );
+}
+
+#[test]
+fn test_body_injection_drops_captured_content_type_json() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let mut target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    target.headers = vec![(
+        "content-type".to_string(),
+        "text/plain; charset=utf-8".to_string(),
+    )];
+    let param = make_param(Location::JsonBody, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    let cts: Vec<_> = req
+        .headers()
+        .get_all(reqwest::header::CONTENT_TYPE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    assert_eq!(cts, vec!["application/json"]);
+}
+
+/// The worst case: a captured `multipart/form-data; boundary=OLD` left beside
+/// reqwest's boundary-carrying one makes the server frame the body with the
+/// stale boundary and see zero parts. Only reqwest's may survive.
+#[test]
+fn test_multipart_injection_drops_captured_multipart_content_type() {
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let mut target = crate::target_parser::parse_target("http://example.test/").expect("target");
+    target.headers = vec![(
+        "Content-Type".to_string(),
+        "multipart/form-data; boundary=----OLD".to_string(),
+    )];
+    let param = make_param(Location::MultipartBody, "q");
+    let req = build_inject_request(&client, &target, &param, "PAYLOAD")
+        .build()
+        .expect("request builds");
+
+    let cts: Vec<_> = req
+        .headers()
+        .get_all(reqwest::header::CONTENT_TYPE)
+        .iter()
+        .filter_map(|v| v.to_str().ok())
+        .collect();
+    assert_eq!(cts.len(), 1, "exactly one Content-Type, got: {cts:?}");
+    assert!(
+        cts[0].starts_with("multipart/form-data; boundary=") && !cts[0].contains("----OLD"),
+        "only reqwest's generated boundary may survive, got: {}",
+        cts[0]
+    );
+}
+
 /// A cookie param routes to the `Cookie` header, not a same-named header —
 /// the dispatcher must keep delegating `Header` to `build_header_request`.
 #[test]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -2231,6 +2231,46 @@ fn test_validate_scan_options_rejects_malformed_headers() {
 }
 
 #[test]
+fn test_validate_scan_options_rejects_malformed_user_agent_and_cookie() {
+    // `user_agent` and `cookie` also become header values on the wire, so a
+    // control byte in either fails reqwest's builder for every request — the
+    // same "live target reported unreachable" failure the header check exists
+    // to prevent. They were previously unvalidated.
+    let mut bad_ua = ScanOptions {
+        user_agent: Some("Mozilla/5.0\r\nX-Injected: 1".to_string()),
+        ..ScanOptions::default()
+    };
+    assert!(
+        validate_scan_options(&mut bad_ua).is_err(),
+        "a CRLF in user_agent must be rejected"
+    );
+
+    let mut bad_cookie = ScanOptions {
+        cookie: Some("sid=abc\ndef".to_string()),
+        ..ScanOptions::default()
+    };
+    assert!(
+        validate_scan_options(&mut bad_cookie).is_err(),
+        "a newline in a cookie value must be rejected"
+    );
+
+    // A UTF-8 User-Agent and an ordinary cookie still pass; an empty
+    // user_agent (the "no override" sentinel) must not be rejected.
+    let mut ok = ScanOptions {
+        user_agent: Some("Mozilla/5.0 (caf\u{e9})".to_string()),
+        cookie: Some("sid=abc; theme=dark".to_string()),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&mut ok).is_ok());
+
+    let mut empty_ua = ScanOptions {
+        user_agent: Some(String::new()),
+        ..ScanOptions::default()
+    };
+    assert!(validate_scan_options(&mut empty_ua).is_ok());
+}
+
+#[test]
 fn test_validate_scan_options_rejects_out_of_range() {
     let mut bad_timeout = ScanOptions {
         timeout: Some(0),

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -91,6 +91,16 @@ pub(crate) fn validate_scan_options(opts: &mut ScanOptions) -> Result<(), String
     if let Some(headers) = &opts.header {
         crate::job::validate_header_list(headers)?;
     }
+    // `user_agent` and `cookie` become header values too (User-Agent / Cookie),
+    // and the same reqwest builder-failure that `validate_header_list` guards
+    // against makes a live target look unreachable. Checked here so both front
+    // ends reject a control byte in either at submission rather than mid-scan.
+    if let Some(ua) = opts.user_agent.as_deref().filter(|s| !s.is_empty()) {
+        crate::job::validate_header_value("user_agent", ua)?;
+    }
+    if let Some(cookie) = opts.cookie.as_deref().filter(|s| !s.is_empty()) {
+        crate::job::validate_header_value("cookie", cookie)?;
+    }
     // An unusable proxy is resolved away to "no proxy" when the scan's client is
     // built, so the scan silently went *direct* to the target instead of through
     // the tunnel the caller asked for — and still reported `done`. The

--- a/src/target_parser/har.rs
+++ b/src/target_parser/har.rs
@@ -143,7 +143,6 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
         let mut headers: Vec<(String, String)> = Vec::new();
         let mut cookies: Vec<(String, String)> = Vec::new();
         let mut user_agent: Option<String> = None;
-        let mut saw_cookie_header = false;
 
         for h in &req.headers {
             let name = h.name.trim();
@@ -153,7 +152,6 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
                 continue;
             }
             if name.eq_ignore_ascii_case("cookie") {
-                saw_cookie_header = true;
                 for kv in h.value.split(';') {
                     if let Some((k, v)) = kv.trim().split_once('=') {
                         let k = k.trim();
@@ -178,10 +176,15 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
             headers.push((name.to_string(), h.value.clone()));
         }
 
-        // The structured `cookies` array is a fallback for captures that record
-        // cookies but no `Cookie` header; when a header was present it already
-        // populated `cookies`, so don't double-count.
-        if !saw_cookie_header && !req.cookies.is_empty() {
+        // The structured `cookies` array is a fallback for captures that carry
+        // no usable `Cookie` header. Gate on whether the header path actually
+        // produced cookies, not on whether a `Cookie` header merely existed: a
+        // redacting/normalising exporter can emit an empty (or all-invalid)
+        // `Cookie` header alongside a populated `cookies[]`, and keying on the
+        // header's presence would then discard the real cookies and scan the
+        // capture logged-out. When the header did yield cookies this stays
+        // non-empty, so the fallback still can't double-count.
+        if cookies.is_empty() && !req.cookies.is_empty() {
             cookies = req
                 .cookies
                 .iter()

--- a/src/target_parser/har/tests.rs
+++ b/src/target_parser/har/tests.rs
@@ -139,6 +139,43 @@ fn falls_back_to_cookies_array_without_cookie_header() {
 }
 
 #[test]
+fn falls_back_to_cookies_array_when_cookie_header_is_empty() {
+    // A redacting/normalising exporter can emit an empty `Cookie` header
+    // alongside a populated structured `cookies[]`. Keying the fallback on
+    // the header's mere presence discarded the real cookies and scanned the
+    // capture logged-out; the fallback must fire whenever the header path
+    // produced no usable cookie.
+    let har = r#"{"log":{"entries":[{"request":{
+            "method":"GET","url":"https://example.com/",
+            "headers":[{"name":"Cookie","value":""}],
+            "cookies":[{"name":"session","value":"abc"}]
+        }}]}}"#;
+    let targets = parse_har(har).unwrap();
+    assert_eq!(targets[0].cookies.len(), 1);
+    assert_eq!(
+        targets[0].cookies[0],
+        ("session".to_string(), "abc".to_string())
+    );
+}
+
+#[test]
+fn cookie_header_wins_over_structured_array_no_double_count() {
+    // When the Cookie header yields cookies, the structured array must not be
+    // merged on top (no duplicates).
+    let har = r#"{"log":{"entries":[{"request":{
+            "method":"GET","url":"https://example.com/",
+            "headers":[{"name":"Cookie","value":"sid=fromheader"}],
+            "cookies":[{"name":"sid","value":"fromarray"},{"name":"extra","value":"x"}]
+        }}]}}"#;
+    let targets = parse_har(har).unwrap();
+    assert_eq!(targets[0].cookies.len(), 1);
+    assert_eq!(
+        targets[0].cookies[0],
+        ("sid".to_string(), "fromheader".to_string())
+    );
+}
+
+#[test]
 fn trims_whitespace_in_cookies_array_values() {
     // Values from the structured `cookies` fallback must be trimmed the same
     // way the Cookie-header path trims them, so a HAR exporter that pads the

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -480,7 +480,22 @@ pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::E
             "http"
         };
         let base = format!("{}://{}", scheme, host);
-        Url::parse(&base)?.join(uri)?
+        // An origin-form request-target is an absolute path on `host`, so it is
+        // appended to `base` textually rather than joined. `Url::join` treats a
+        // `//…`-prefixed target as an RFC 3986 network-path reference and parses
+        // its first segment as a *new authority* — so `GET //evil.com/admin`
+        // with `Host: internal.local` would silently retarget the scan at
+        // `http://evil.com/admin`, dropping the Host header entirely. Such
+        // double-slash paths turn up in real proxy captures (buggy client-side
+        // URL joins). Concatenating keeps the authority pinned to `host`, and
+        // still normalizes dot-segments and percent-encodes exactly as `join`
+        // did for the ordinary single-slash case. Non-path forms (`*`,
+        // authority-form) don't start with `/`, so they fall back to `join`.
+        if uri.starts_with('/') {
+            Url::parse(&format!("{}{}", base, uri))?
+        } else {
+            Url::parse(&base)?.join(uri)?
+        }
     };
 
     Ok(Target {

--- a/src/target_parser/raw_http_tests.rs
+++ b/src/target_parser/raw_http_tests.rs
@@ -49,6 +49,40 @@ fn test_parse_raw_http_origin_form() {
 }
 
 #[test]
+fn test_parse_raw_http_origin_form_double_slash_keeps_host() {
+    // A `//…`-prefixed origin-form request-target (routine in real proxy
+    // captures from buggy client-side URL joins) must stay a path on the
+    // Host, not be parsed as a network-path reference whose first segment
+    // becomes a new authority. `Url::join` would have retargeted this at
+    // `http://api/v1/users`, dropping the Host header.
+    let raw = "GET //api/v1/users HTTP/1.1\r\nHost: internal.local\r\n\r\n";
+    let t = parse_raw_http_request(raw).expect("should parse double-slash origin-form");
+    assert_eq!(t.url.host_str(), Some("internal.local"));
+    assert_eq!(t.url.as_str(), "http://internal.local//api/v1/users");
+}
+
+#[test]
+fn test_parse_raw_http_origin_form_double_slash_no_host_hijack() {
+    // The security-relevant shape: a `//evil.com/…` target must not move the
+    // scan off the `Host`-named server.
+    let raw = "GET //evil.com/admin HTTP/1.1\r\nHost: internal.local\r\n\r\n";
+    let t = parse_raw_http_request(raw).expect("should parse");
+    assert_eq!(
+        t.url.host_str(),
+        Some("internal.local"),
+        "the Host header must win over a `//host`-shaped request-target"
+    );
+}
+
+#[test]
+fn test_parse_raw_http_origin_form_normalizes_dot_segments() {
+    // The concat path must still normalize `..`/`.` like `Url::join` did.
+    let raw = "GET /a/../b?x=1 HTTP/1.1\r\nHost: h.local\r\n\r\n";
+    let t = parse_raw_http_request(raw).expect("should parse");
+    assert_eq!(t.url.as_str(), "http://h.local/b?x=1");
+}
+
+#[test]
 fn test_parse_raw_http_https_host_port() {
     let raw = "GET /p HTTP/1.1\r\nHost: secure.example.com:443\r\n\r\n";
     let t = parse_raw_http_request(raw).expect("should infer https from :443");

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -86,9 +86,29 @@ pub fn has_header(headers: &[(String, String)], name: &str) -> bool {
 /// If `cookie_header` is Some, attach it. Otherwise, if no Cookie header exists in headers,
 /// auto-attach from target.cookies (when non-empty).
 pub(crate) fn apply_headers_ua_cookies(
+    rb: RequestBuilder,
+    target: &Target,
+    cookie_header: Option<String>,
+) -> RequestBuilder {
+    apply_headers_ua_cookies_inner(rb, target, cookie_header, false)
+}
+
+/// Same as [`apply_headers_ua_cookies`], but with `suppress_content_type`.
+///
+/// A body injector generates a *new* body in a chosen wire format and then sets
+/// the matching `Content-Type` itself. reqwest's `.header()` / `.multipart()`
+/// *append*, so a `Content-Type` copied from an imported (raw-http/HAR) target's
+/// `target.headers` would remain the **first** value alongside the injector's —
+/// and a server frames the body with the first `Content-Type`, so it parses the
+/// injected body under the stale captured type (worst case: a captured
+/// multipart boundary makes every multipart injection frame zero parts and test
+/// nothing). Suppressing the inherited value here lets the injector's be the
+/// only one on the wire.
+fn apply_headers_ua_cookies_inner(
     mut rb: RequestBuilder,
     target: &Target,
     cookie_header: Option<String>,
+    suppress_content_type: bool,
 ) -> RequestBuilder {
     // Apply user provided headers first. Skip `Accept-Encoding`: setting it
     // manually disables reqwest's transparent decompression, so the body comes
@@ -97,6 +117,9 @@ pub(crate) fn apply_headers_ua_cookies(
     // decompression on, mirroring the HAR import path's `is_skippable_har_header`.
     for (k, v) in &target.headers {
         if k.eq_ignore_ascii_case("accept-encoding") {
+            continue;
+        }
+        if suppress_content_type && k.eq_ignore_ascii_case("content-type") {
             continue;
         }
         rb = rb.header(k, v);
@@ -139,6 +162,28 @@ pub(crate) fn build_request(
 ) -> RequestBuilder {
     let rb = client.request(method, url);
     let rb = apply_headers_ua_cookies(rb, target, None);
+    if let Some(b) = body { rb.body(b) } else { rb }
+}
+
+/// Build a RequestBuilder for a body injector, dropping any `Content-Type`
+/// inherited from `target.headers`.
+///
+/// The caller sets the injected body's `Content-Type` itself (via
+/// `apply_header_overrides` or reqwest's `.multipart()`); reqwest appends rather
+/// than replaces, so a captured `Content-Type` from an imported target would
+/// otherwise survive as a duplicate first value the server acts on. See
+/// [`apply_headers_ua_cookies_inner`]. Query/Path injectors keep using
+/// [`build_request`], which preserves the captured `Content-Type` since they
+/// re-send the original body verbatim.
+pub(crate) fn build_body_request_base(
+    client: &Client,
+    target: &Target,
+    method: Method,
+    url: Url,
+    body: Option<String>,
+) -> RequestBuilder {
+    let rb = client.request(method, url);
+    let rb = apply_headers_ua_cookies_inner(rb, target, None, true);
     if let Some(b) = body { rb.body(b) } else { rb }
 }
 

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -644,3 +644,70 @@ fn test_headers_declare_nosniff() {
     headers.insert("x-content-type-options", HeaderValue::from_static("sniff"));
     assert!(!headers_declare_nosniff(&headers));
 }
+
+// ---- build_body_request_base: captured Content-Type suppression ----
+
+#[test]
+fn build_body_request_base_drops_inherited_content_type() {
+    // A body injector/probe sets the injected body's Content-Type itself, and
+    // reqwest appends. A Content-Type inherited from an imported (raw-http/HAR)
+    // target's headers must be dropped here so it can't survive as a duplicate
+    // first value the server frames the body with. Every "build a new body in
+    // format X" sender (the url_inject injectors and the discovery/mining body
+    // probes) routes through this helper to avoid that class of drift.
+    let mut target = parse_target("https://example.com/path").unwrap();
+    target.headers = vec![
+        (
+            "Content-Type".to_string(),
+            "multipart/form-data; boundary=----OLD".to_string(),
+        ),
+        ("X-Keep".to_string(), "1".to_string()),
+    ];
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let req = build_body_request_base(
+        &client,
+        &target,
+        reqwest::Method::POST,
+        target.url.clone(),
+        Some("a=b".to_string()),
+    )
+    .build()
+    .expect("request should build");
+
+    assert!(
+        req.headers().get(reqwest::header::CONTENT_TYPE).is_none(),
+        "the inherited Content-Type must be dropped so the caller's is the only one"
+    );
+    assert_eq!(
+        req.headers().get("X-Keep").and_then(|v| v.to_str().ok()),
+        Some("1"),
+        "unrelated inherited headers must be preserved"
+    );
+}
+
+#[test]
+fn build_request_keeps_inherited_content_type() {
+    // The plain builder (query/path/header injection re-sends the original body
+    // verbatim) must NOT drop the captured Content-Type — only the body-format
+    // senders do.
+    let mut target = parse_target("https://example.com/path").unwrap();
+    target.headers = vec![("Content-Type".to_string(), "application/json".to_string())];
+    crate::ensure_crypto_provider();
+    let client = reqwest::Client::new();
+    let req = build_request(
+        &client,
+        &target,
+        reqwest::Method::POST,
+        target.url.clone(),
+        target.data.clone(),
+    )
+    .build()
+    .expect("request should build");
+    assert_eq!(
+        req.headers()
+            .get(reqwest::header::CONTENT_TYPE)
+            .and_then(|v| v.to_str().ok()),
+        Some("application/json"),
+    );
+}

--- a/src/utils/mod.rs
+++ b/src/utils/mod.rs
@@ -46,10 +46,11 @@ pub use banner::print_banner_once;
 pub(crate) use scan_id::{make_scan_id, make_unique_scan_id, short_scan_id};
 // Re-export http helpers at `crate::utils::*`
 pub(crate) use http::{
-    apply_header_overrides, build_preflight_request, build_request, build_request_with_cookie,
-    compose_cookie_header_excluding, content_type_is_inert_data_with_nosniff, content_type_primary,
-    headers_declare_nosniff, is_htmlish_content_type, is_javascript_content_type,
-    is_xss_scannable_content_type, send_with_retry,
+    apply_header_overrides, build_body_request_base, build_preflight_request, build_request,
+    build_request_with_cookie, compose_cookie_header_excluding,
+    content_type_is_inert_data_with_nosniff, content_type_primary, headers_declare_nosniff,
+    is_htmlish_content_type, is_javascript_content_type, is_xss_scannable_content_type,
+    send_with_retry,
 };
 
 // Re-export remote payload/wordlist getters at `crate::utils::*`


### PR DESCRIPTION
## Summary

Auditing the target/request-construction and input-validation surfaces surfaced six verified defects. Each was **silent** — the scan settled `done` (or reported a live target as `unreachable`) while actually testing the wrong thing, so none would show up as an error. Every fix ships with a regression test; `cargo test` (2323 lib tests), `clippy --all-targets`, and `fmt` are green.

## Fixes

| Severity | Area | Defect |
|---|---|---|
| High | `server`, `mcp`, `job` | `user_agent` / cookie values skipped header-value validation → a live target is reported **unreachable** |
| High | `target_parser` | raw-http `//path` request-target hijacked the Host (`Url::join` network-path reference) |
| High | `scan`, `param` | body injectors + discovery/mining body probes sent a **duplicate `Content-Type`** on imported targets → server frames the body with the stale one (multipart probes test nothing) |
| Medium | `target_parser/har` | an empty `Cookie` header discarded the structured `cookies[]` fallback → scanned logged-out |
| Medium | `param` | `window_overflow_probe` injected `;` into cookie values, truncating the probe → window-limited-WAF detection silently off for every cookie param |

### Details

- **Header-value validation.** `user_agent` and cookie values become `User-Agent` / `Cookie` headers, and a control byte fails reqwest on the *builder* for every request in the job — so the reachability probe fails and the scan blames the target, the exact failure `validate_header_list` already guards against for `header`. Added a shared `job::validate_header_value` and wired it into REST `validate_scan_options` and both MCP tools (scan + preflight). `HeaderValue::try_from(&str)` is exactly what reqwest's `.header()` applies, so obs-text (a UTF-8 UA) still passes.

- **Double-slash request-target.** An origin-form target beginning with `//` was passed to `Url::join`, which parses its first segment as a *new authority* — `GET //evil.com/admin` with `Host: internal.local` silently retargeted the scan at `evil.com`. The path is now appended to the Host-derived base textually; dot-segment normalization and percent-encoding are unchanged for the ordinary single-slash case.

- **Duplicate `Content-Type`.** An imported (raw-http/HAR) target keeps its captured `Content-Type` in `target.headers`, and reqwest *appends*, so a body sender that also sets its format's `Content-Type` put two on the wire; servers frame the body with the first (stale) one. Worst case, a captured multipart boundary makes every multipart probe frame zero parts. Added `utils::build_body_request_base` (drops the inherited value) and routed **all 11 new-body senders** — the 3 `url_inject` injectors plus the 8 discovery/mining body probes — through it, so the whole class is covered rather than just the injection path.

- **HAR empty Cookie header.** The `cookies[]` fallback was keyed on whether a `Cookie` header *existed*, not whether it *yielded* cookies. A redacting exporter emitting an empty `Cookie` header alongside a populated `cookies[]` was scanned logged-out. Now gated on `cookies.is_empty()` (still no double-count when the header did produce cookies).

- **Cookie `;` in the window probe.** `window_overflow_probe` built from raw `SPECIAL_PROBE_CHARS`, whose `;` ends a cookie value on the wire and truncates the probe before the CLOSE marker — so it returned `None` and window-limited-WAF detection was off for every cookie param. Switched to the transport-aware `probe_chars_for` (the normal path already uses it); `;` is still folded into `invalid` centrally via `transport_invalid_chars`.

## Test plan

- `cargo test` — 2323 lib tests + integration tests pass (ignored benchmarks skipped as usual)
- `cargo clippy --all-targets` — clean
- `cargo fmt` — clean
- New regression tests: raw-http `//`-target host preservation, HAR empty-cookie fallback, cookie window-probe char set (via `probe_chars_for` invariant), `validate_header_value` semantics + REST UA/cookie rejection, and single-`Content-Type` assertions for all body-injection paths + the `build_body_request_base` helper contract.