### PR TITLE
fix(target_parser): drop unsendable headers on raw-http/HAR import

### DIFF
--- a/src/target_parser/har.rs
+++ b/src/target_parser/har.rs
@@ -173,6 +173,20 @@ pub fn parse_har(content: &str) -> Result<Vec<Target>, Box<dyn std::error::Error
             if is_skippable_har_header(name) {
                 continue;
             }
+            // Drop any header reqwest can't put on an HTTP/1.1 wire (a
+            // space-bearing name, a control byte in the value, …). Forwarded
+            // verbatim it would fail the reachability probe and every scan
+            // request, silently marking a live target unreachable. The
+            // `:`-pseudo-header and empty-name cases are already handled above;
+            // this closes the remaining name/value-validity gap and keeps the
+            // raw-HTTP and HAR import paths in step.
+            if !super::is_forwardable_header(name, &h.value) {
+                crate::dbg_log!(
+                    "dropping unsendable HAR header {:?} (name/value rejected by HTTP/1.1)",
+                    name
+                );
+                continue;
+            }
             headers.push((name.to_string(), h.value.clone()));
         }
 

--- a/src/target_parser/har/tests.rs
+++ b/src/target_parser/har/tests.rs
@@ -296,3 +296,32 @@ fn uppercases_method() {
     let targets = parse_har(har).unwrap();
     assert_eq!(targets[0].method, "POST");
 }
+
+#[test]
+fn drops_headers_reqwest_cannot_send() {
+    // A HAR whose capture carries a name with a space and a value with a NUL
+    // control byte (` `). reqwest rejects both at send(), so forwarding
+    // them fails every request for the target and the live host is reported
+    // unreachable. They must be dropped at import while the valid header
+    // survives. (The `:`-pseudo-header / empty-name cases are covered by
+    // `lifts_user_agent_and_drops_managed_headers`.)
+    let har = r#"{"log":{"entries":[{"request":{
+            "method":"GET","url":"https://example.com/",
+            "headers":[
+                {"name":"X Foo","value":"bar"},
+                {"name":"X-Ctl","value":"a\u0000b"},
+                {"name":"X-Good","value":"ok"}
+            ]
+        }}]}}"#;
+    let targets = parse_har(har).unwrap();
+    let t = &targets[0];
+    for (k, v) in &t.headers {
+        assert!(
+            super::super::is_forwardable_header(k, v),
+            "unsendable header survived HAR import: {k:?}={v:?}"
+        );
+    }
+    assert!(t.headers.iter().any(|(k, v)| k == "X-Good" && v == "ok"));
+    assert!(!t.headers.iter().any(|(k, _)| k == "X Foo"));
+    assert!(!t.headers.iter().any(|(k, _)| k == "X-Ctl"));
+}

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -326,6 +326,25 @@ pub(crate) fn is_skippable_request_header(name: &str) -> bool {
     SKIP.iter().any(|s| name.eq_ignore_ascii_case(s))
 }
 
+/// Whether a header imported verbatim from a raw HTTP request or a HAR capture
+/// can actually be put on an HTTP/1.1 wire.
+///
+/// reqwest validates header names/values lazily — a bad one is accepted by
+/// `RequestBuilder::header()` and only rejected at `send()`. Since the imported
+/// headers are attached to *every* request for the target, a single unsendable
+/// header (an empty name, an HTTP/2 pseudo-header like `:authority` that survives
+/// a copy-as-curl / HTTP/2 capture, a name containing a space, or a value
+/// carrying a control byte such as NUL) fails the reachability probe and every
+/// scan request — so a live target is silently reported unreachable and nothing
+/// is tested. Such headers can't be sent on HTTP/1.1 anyway, so drop them at
+/// import (the caller logs the drop) rather than poisoning the whole scan.
+///
+/// Shared by [`parse_raw_http_request`] and the HAR import path so both agree.
+pub(crate) fn is_forwardable_header(name: &str, value: &str) -> bool {
+    use reqwest::header::{HeaderName, HeaderValue};
+    HeaderName::try_from(name).is_ok() && HeaderValue::from_str(value).is_ok()
+}
+
 /// The body of a raw HTTP request: everything after the blank line that ends
 /// the header block, byte-for-byte apart from one optional trailing newline.
 /// `None` when there is no separator or nothing follows it.
@@ -451,7 +470,23 @@ pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::E
                 // recomputes them from the injected body — a stale value
                 // truncates it) and hop-by-hop/`Accept-Encoding` headers, the
                 // same set the HAR import path strips.
-                headers_vec.push((name_trim, value_trim));
+                //
+                // Also drop any header reqwest can't put on the wire — an empty
+                // name (`: value`), an HTTP/2 pseudo-header (`:authority: …`,
+                // which the origin-form request line carries instead and which
+                // a copy-as-curl / HTTP/2 capture routinely includes), a
+                // space-bearing name, or a control byte in the value. Forwarded
+                // verbatim, one of these fails the reachability probe and every
+                // scan request, so the live target is silently reported
+                // unreachable. Mirrors the HAR import path.
+                if is_forwardable_header(&name_trim, &value_trim) {
+                    headers_vec.push((name_trim, value_trim));
+                } else {
+                    crate::dbg_log!(
+                        "dropping unsendable raw-http header {:?} (name/value rejected by HTTP/1.1)",
+                        name_trim
+                    );
+                }
             }
         }
     }

--- a/src/target_parser/raw_http_tests.rs
+++ b/src/target_parser/raw_http_tests.rs
@@ -237,3 +237,55 @@ fn raw_http_does_not_retain_original_cookie_header() {
     assert!(t.cookies.iter().any(|(k, v)| k == "sid" && v == "abc"));
     assert!(t.cookies.iter().any(|(k, v)| k == "a" && v == "b"));
 }
+
+#[test]
+fn raw_http_drops_http2_pseudo_headers_and_keeps_the_rest() {
+    // A copy-as-curl / HTTP/2 capture pasted into a raw-request file carries
+    // `:authority: …` pseudo-headers. `split_once(':')` yields an EMPTY name
+    // for them, which reqwest rejects at send() — poisoning every request for
+    // the target (reachability probe included) so a live host is silently
+    // reported unreachable. They must be dropped at import (as the HAR path
+    // already does), while ordinary headers still survive.
+    let raw = "GET /x HTTP/1.1\r\n:authority: example.com\r\n:scheme: https\r\nHost: example.com\r\nX-Real: keep\r\n\r\n";
+    let t = parse_raw_http_request(raw).expect("should parse");
+    for (k, v) in &t.headers {
+        assert!(
+            is_forwardable_header(k, v),
+            "unsendable header survived import: {:?}={:?} (all headers: {:?})",
+            k,
+            v,
+            t.headers
+        );
+    }
+    assert!(
+        !t.headers
+            .iter()
+            .any(|(k, _)| k.is_empty() || k.starts_with(':')),
+        "pseudo/empty-name header retained, got {:?}",
+        t.headers
+    );
+    assert!(
+        t.headers.iter().any(|(k, v)| k == "X-Real" && v == "keep"),
+        "ordinary header was lost, got {:?}",
+        t.headers
+    );
+}
+
+#[test]
+fn raw_http_drops_headers_reqwest_cannot_send() {
+    // A space in the name and a NUL in the value are both unsendable. Forwarded
+    // verbatim they fail every request; drop them, keep the good one.
+    let raw = "GET /x HTTP/1.1\r\nHost: h\r\nX Foo: bar\r\nX-Ctl: a\u{0}b\r\nX-Good: ok\r\n\r\n";
+    let t = parse_raw_http_request(raw).expect("should parse");
+    for (k, v) in &t.headers {
+        assert!(
+            is_forwardable_header(k, v),
+            "unsendable header survived import: {:?}={:?}",
+            k,
+            v
+        );
+    }
+    assert!(t.headers.iter().any(|(k, v)| k == "X-Good" && v == "ok"));
+    assert!(!t.headers.iter().any(|(k, _)| k == "X Foo"));
+    assert!(!t.headers.iter().any(|(k, _)| k == "X-Ctl"));
+}


### PR DESCRIPTION
## Summary

Hostile-input robustness hunt (A5) of the parser/encoder/WAF/payload surfaces. One verified, grounded defect found and fixed with mutation-verified regression tests; the rest of the surface held up (details in **Also checked** and **Deferred**).

## Finding — raw-http / HAR import forwards headers that fail every request

**Symptom.** Importing a request via a raw-HTTP file (`--input-type raw-http`) or a HAR capture (`--input-type har`) could silently mark a live target **unreachable** and test nothing.

**Root cause** (`src/target_parser/mod.rs`, `src/target_parser/har.rs`). Both import paths forwarded every request header verbatim into `target.headers`. reqwest validates header names/values **lazily** — a malformed one is accepted by `RequestBuilder::header()` and only rejected at `send()` — and the imported headers are attached to *every* request for the target. So one unsendable header failed the reachability probe and every scan request, and the target was reported unreachable. Same failure class as #1404 (server/MCP `user_agent`/cookie), but for the file-import paths.

The most common trigger is an **HTTP/2 pseudo-header**. A copy-as-curl / HTTP/2 capture routinely carries `:authority: …` (plus `:method`/`:path`/`:scheme`). In the raw-HTTP parser `split_once(':')` yields an **empty header name** for those — which `HeaderName::try_from("")` rejects. A name containing a space (`X Foo`) or a value carrying a control byte (NUL) are rejected the same way. The HAR path already skipped `:`-prefixed and empty names, but not space-names or control-char values — a parity gap.

Verified: `HeaderName::try_from` rejects `""`, `":authority"`, `"X Foo"`; `HeaderValue::from_str` rejects a NUL-bearing value — the exact validators reqwest's `.header()` uses. End-to-end against a localhost mock, a raw request carrying `:authority` + a space-name header now reaches the target (`status: findings`) instead of failing.

**Fix.** Add a shared `target_parser::is_forwardable_header(name, value)` (name/value both accepted by reqwest's own `HeaderName`/`HeaderValue` validators) and gate the generic header push in both import paths on it, logging each drop at debug. Such headers can't go on an HTTP/1.1 wire anyway, so dropping them lets the rest of the capture scan rather than poisoning the whole target. Cookie/User-Agent keep their existing dedicated handling.

**Test.** `src/target_parser/raw_http_tests.rs`: `raw_http_drops_http2_pseudo_headers_and_keeps_the_rest`, `raw_http_drops_headers_reqwest_cannot_send`. `src/target_parser/har/tests.rs`: `drops_headers_reqwest_cannot_send`. Each asserts every surviving header is forwardable and the ordinary header is kept. **Mutation-verified**: reverting the guard turns all three RED; restoring it turns them green.

## Also checked (held up — no change needed)

- **WAF bypass mutations** (`src/waf/bypass.rs`): every slice offset originates from an ASCII byte match, so multibyte payloads never split mid-char; the existing `mutations_never_panic_on_multibyte_payloads` table plus a wider ad-hoc fuzz (2/3/4-byte chars, combining marks, ZWSP, BOM at every boundary of realistic skeletons) found no panic.
- **Encoders** (`src/encoding/**`): all `char`-based, depth/round bounded; fuzzed with multibyte, `%`/`%zz` tails, huge repeated strings — no panic.
- **Target parsing** (`src/target_parser/**`): fuzzed truncated/absent-Host/absolute-URI/`//host`/NUL/CR-only/pseudo-header/BOM/invalid-scheme inputs — no panic; `//host` hijack and empty-cookie already fixed (#1404).
- **Bounded I/O**: `utils::fs` (256 MiB cap + non-regular-file refusal + `take()`), `utils::http::read_body_capped` (16 MiB), HTML nesting guard (`parse_document_bounded`, 512), OOB poll body cap (32 MiB) — caps verified on their call paths.
- **OOB interactsh crypto/wire** and **CSP / js-breakout / synthesis** parsers: guarded (bounded depth, ASCII-boundary slices, char-based scans).

## Deferred / out-of-area (for the orchestrator to route)

- `src/scanning/check_dom_verification.rs:242` uses `scraper::Html::parse_fragment(&normalized)` directly instead of `utils::html::parse_document_bounded`. Low risk — the input is a dalfox payload / its entity-decoded form (bounded), not a hostile response — but a `--custom-payload` with pathological nesting would skip the depth guard. Not in my file scope (`src/scanning/**`).

## Green gate

- `cargo build --release` ✅
- `cargo fmt --all -- --check` ✅
- `cargo clippy --all-targets --all-features -- -D warnings` ✅
- `cargo test` ✅ except `payload::synthesis::tests::synthesis_is_fast_and_bounded` — a wall-clock perf guard (`< 5s`) that flaked under sustained machine load average ~90 on 14 cores (concurrent agents). It's in a module untouched by this change and would fail on `main` under the same load; not touched.