### PR TITLE
fix(server,mcp,payload): daemon-lifecycle defects — preflight pacing, per-job remote cache, draining-job retention, MCP capacity slot

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -330,7 +330,21 @@ pub(crate) struct Job {
     pub started_at_ms: Option<i64>,
     /// Unix ms when the scan reached a terminal state (done/error/cancelled).
     pub finished_at_ms: Option<i64>,
+    /// Liveness handle for the worker that owns this job, if one was spawned.
+    ///
+    /// Held as a `Weak` so the job record never keeps the worker's side alive
+    /// and cloning a `Job` for an outbound response does not look like another
+    /// worker. `strong_count() > 0` means the worker task is still running, and
+    /// therefore may still write results, a final status, or a webhook into
+    /// this entry. See [`Job::is_evictable`].
+    pub worker_lease: Option<std::sync::Weak<()>>,
 }
+
+/// The worker's half of a job's liveness handle: an `Arc` moved into the
+/// spawned task. Dropping it — on completion, on panic, or because the task was
+/// never polled — is what makes [`Job::worker_alive`] go false, so there is no
+/// "clear the flag" path to forget on an error branch.
+pub(crate) type WorkerLease = Arc<()>;
 
 impl Job {
     /// Construct a freshly-queued Job for `target_url`, with timestamps and
@@ -347,7 +361,25 @@ impl Job {
             queued_at_ms: now_ms(),
             started_at_ms: None,
             finished_at_ms: None,
+            worker_lease: None,
         }
+    }
+
+    /// Mint the liveness handle for the worker about to run this job and record
+    /// its `Weak` side on the job. The returned [`WorkerLease`] must be moved
+    /// into the spawned task; retention will not evict this entry until it
+    /// drops.
+    pub(crate) fn issue_worker_lease(&mut self) -> WorkerLease {
+        let lease: WorkerLease = Arc::new(());
+        self.worker_lease = Some(Arc::downgrade(&lease));
+        lease
+    }
+
+    /// True while the worker spawned for this job is still running.
+    pub(crate) fn worker_alive(&self) -> bool {
+        self.worker_lease
+            .as_ref()
+            .is_some_and(|w| w.strong_count() > 0)
     }
 
     pub(crate) fn is_terminal(&self) -> bool {
@@ -355,6 +387,21 @@ impl Job {
             self.status,
             JobStatus::Done | JobStatus::Error | JobStatus::Cancelled
         )
+    }
+
+    /// Terminal **and** nobody is still writing to it.
+    ///
+    /// `is_terminal` alone is not a safe eviction test: cancelling stamps
+    /// `status = Cancelled` and `finished_at_ms` the moment the user asks, but
+    /// the worker keeps draining — it still has partial results to store, a
+    /// final status to reconcile, and (REST) a terminal webhook to fire. Evict
+    /// the entry in that window and `jobs.get_mut(&id)` comes back `None`: the
+    /// results are dropped on the floor, the webhook never fires, and a `GET`
+    /// on the scan_id the client is holding 404s. Automatic retention therefore
+    /// waits for the lease; an explicit `DELETE ?purge=1` still wins, because
+    /// that is the caller asking for exactly this.
+    pub(crate) fn is_evictable(&self) -> bool {
+        self.is_terminal() && !self.worker_alive()
     }
 
     /// Total elapsed ms from `started_at_ms` to `finished_at_ms` (or now, for
@@ -368,9 +415,17 @@ impl Job {
 /// seconds ago. The caller is expected to hold the jobs map's lock.
 pub(crate) fn purge_expired_jobs(jobs: &mut HashMap<String, Job>, retention_secs: i64) {
     let cutoff = now_ms() - retention_secs * 1000;
-    jobs.retain(|_, job| match job.finished_at_ms {
-        Some(finished) => finished >= cutoff,
-        None => true,
+    jobs.retain(|_, job| {
+        // A cancelled job is stamped terminal (status + finished_at_ms) the
+        // moment the user asks, while its worker keeps draining. Retention must
+        // not collect it out from under that worker — see `Job::is_evictable`.
+        if job.worker_alive() {
+            return true;
+        }
+        match job.finished_at_ms {
+            Some(finished) => finished >= cutoff,
+            None => true,
+        }
     });
 }
 
@@ -384,17 +439,19 @@ pub(crate) fn purge_expired_jobs(jobs: &mut HashMap<String, Job>, retention_secs
 /// with nothing bounding the total. This is the bound. Callers apply it while
 /// admitting a new scan, since that is where the jobs lock is already held.
 ///
-/// Only terminal jobs are evicted: a queued/running job still has a worker
+/// Only *settled* jobs are evicted: a queued/running job still has a worker
 /// writing to it, and dropping its entry would strand that worker and lose the
-/// caller's scan_id. If every job is active, the map simply stays over the cap
-/// until they settle.
+/// caller's scan_id. Terminal-but-draining jobs (a cancel stamps the terminal
+/// state immediately while the worker winds down) are held back the same way —
+/// see [`Job::is_evictable`]. If every job is active, the map simply stays over
+/// the cap until they settle.
 pub(crate) fn enforce_retention_cap(jobs: &mut HashMap<String, Job>, cap: usize) {
     if cap == 0 || jobs.len() <= cap {
         return;
     }
     let mut finished: Vec<(String, i64)> = jobs
         .iter()
-        .filter(|(_, job)| job.is_terminal())
+        .filter(|(_, job)| job.is_evictable())
         .map(|(id, job)| (id.clone(), job.finished_at_ms.unwrap_or(job.queued_at_ms)))
         .collect();
     // Oldest first, then by id so two jobs finishing in the same millisecond

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -322,6 +322,102 @@ fn enforce_retention_cap_never_evicts_active_jobs() {
     assert!(!jobs.contains_key("done"));
 }
 
+// ---------------------------------------------------------------------------
+// Worker leases: a cancelled job is stamped terminal while its worker drains
+// ---------------------------------------------------------------------------
+//
+// `cancel_scan_handler` sets `status = Cancelled` and `finished_at_ms` the
+// moment the user asks, so `is_terminal()` is true while the worker is still
+// running — it has partial results to store, a status to reconcile and (REST) a
+// terminal webhook to fire. Retention used to evict on `is_terminal()` alone,
+// so a burst of new submissions could collect that entry out from under the
+// worker: `jobs.get_mut(&id)` then returns None, the results are dropped, the
+// webhook never fires, and a GET on the caller's scan_id 404s.
+
+#[test]
+fn cancelled_job_with_a_live_worker_is_not_evictable() {
+    let mut job = Job::new_queued("http://a".to_string());
+    let lease = job.issue_worker_lease();
+
+    // What DELETE /scan/{id} does to a running job.
+    job.status = JobStatus::Cancelled;
+    job.finished_at_ms = Some(now_ms());
+
+    assert!(job.is_terminal(), "cancel stamps the terminal state at once");
+    assert!(job.worker_alive(), "but the worker is still draining");
+    assert!(
+        !job.is_evictable(),
+        "retention must not collect a job a worker is still writing to"
+    );
+
+    // Worker finishes (or panics): the lease drops and the entry is collectable.
+    drop(lease);
+    assert!(!job.worker_alive());
+    assert!(job.is_evictable());
+}
+
+#[test]
+fn enforce_retention_cap_never_evicts_a_draining_job() {
+    let mut jobs: HashMap<String, Job> = HashMap::new();
+
+    let mut draining = Job::new_queued("http://draining".to_string());
+    let _lease = draining.issue_worker_lease();
+    draining.status = JobStatus::Cancelled;
+    // Oldest by finished_at, so it is the *first* candidate the cap would take.
+    draining.finished_at_ms = Some(1_000);
+    jobs.insert("draining".to_string(), draining);
+
+    let mut settled = Job::new_queued("http://settled".to_string());
+    settled.status = JobStatus::Done;
+    settled.finished_at_ms = Some(2_000);
+    jobs.insert("settled".to_string(), settled);
+
+    enforce_retention_cap(&mut jobs, 1);
+
+    assert!(
+        jobs.contains_key("draining"),
+        "a cancelled-but-draining job must survive the retention cap"
+    );
+    assert!(
+        !jobs.contains_key("settled"),
+        "the settled job is the one that should have been evicted"
+    );
+}
+
+#[test]
+fn purge_expired_jobs_keeps_a_draining_job_past_its_ttl() {
+    let mut jobs: HashMap<String, Job> = HashMap::new();
+    let mut draining = Job::new_queued("http://draining".to_string());
+    let _lease = draining.issue_worker_lease();
+    draining.status = JobStatus::Cancelled;
+    draining.finished_at_ms = Some(now_ms() - (JOB_RETENTION_SECS + 10) * 1000);
+    jobs.insert("draining".to_string(), draining);
+
+    purge_expired_jobs(&mut jobs, JOB_RETENTION_SECS);
+
+    assert!(
+        jobs.contains_key("draining"),
+        "the retention TTL must not collect an entry a worker still owns"
+    );
+
+    // Same job once the worker is gone: now it is past its TTL and collectable.
+    jobs.get_mut("draining").expect("still present").worker_lease = None;
+    purge_expired_jobs(&mut jobs, JOB_RETENTION_SECS);
+    assert!(jobs.is_empty(), "an expired settled job is still purged");
+}
+
+#[test]
+fn a_job_with_no_worker_is_evictable_as_soon_as_it_is_terminal() {
+    // Jobs staged by hand (tests, and any future path that records a terminal
+    // job without spawning a worker) carry no lease, so the lease check must
+    // not turn into "never evict anything".
+    let mut job = Job::new_queued("http://a".to_string());
+    job.status = JobStatus::Done;
+    job.finished_at_ms = Some(now_ms());
+    assert!(!job.worker_alive());
+    assert!(job.is_evictable());
+}
+
 #[test]
 fn enforce_retention_cap_zero_disables_the_cap() {
     let mut jobs: HashMap<String, Job> = HashMap::new();

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -343,7 +343,10 @@ fn cancelled_job_with_a_live_worker_is_not_evictable() {
     job.status = JobStatus::Cancelled;
     job.finished_at_ms = Some(now_ms());
 
-    assert!(job.is_terminal(), "cancel stamps the terminal state at once");
+    assert!(
+        job.is_terminal(),
+        "cancel stamps the terminal state at once"
+    );
     assert!(job.worker_alive(), "but the worker is still draining");
     assert!(
         !job.is_evictable(),
@@ -401,7 +404,9 @@ fn purge_expired_jobs_keeps_a_draining_job_past_its_ttl() {
     );
 
     // Same job once the worker is gone: now it is past its TTL and collectable.
-    jobs.get_mut("draining").expect("still present").worker_lease = None;
+    jobs.get_mut("draining")
+        .expect("still present")
+        .worker_lease = None;
     purge_expired_jobs(&mut jobs, JOB_RETENTION_SECS);
     assert!(jobs.is_empty(), "an expired settled job is still purged");
 }

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -285,6 +285,33 @@ impl DalfoxMcp {
             }
         };
 
+        // Load any requested remote payload/wordlist providers into the caches
+        // before the scan reads them. Mirrors the REST server (`run_scan_job`)
+        // and the CLI; without this the `remote_payloads`/`remote_wordlists`
+        // fields would be silently inert on the MCP path. It runs *here*, inside
+        // the spawned worker, rather than in the tool call — see the note at the
+        // spawn site in `scan_with_dalfox`.
+        //
+        // A failure is logged rather than swallowed: the scan otherwise runs
+        // without the list the caller asked for and still reports success,
+        // which an agent reads as "scanned, found nothing".
+        if (!scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty())
+            && let Err(e) = crate::utils::init_remote_resources_with_options(
+                &scan_args.remote_payloads,
+                &scan_args.remote_wordlists,
+                Some(scan_args.timeout),
+                scan_args.proxy.clone(),
+            )
+            .await
+        {
+            Self::log(
+                "WRN",
+                &format!(
+                    "scan_id={scan_id} remote resource fetch failed ({e}); scanning without the requested remote lists"
+                ),
+            );
+        }
+
         let url = scan_args
             .targets
             .first()
@@ -1024,7 +1051,7 @@ browser execution; only detection_method=oob observes a real browser."
         // MCP has no config surface, so the bound is a constant; submissions
         // past it are rejected so an agent loop can't grow the job map /
         // blocking pool without bound.
-        let scan_id = {
+        let (scan_id, worker_lease) = {
             let mut jobs = self.lock_jobs();
             let active = jobs.values().filter(|j| !j.is_terminal()).count();
             if active >= MAX_ACTIVE_SCANS_MCP {
@@ -1042,13 +1069,18 @@ browser execution; only detection_method=oob observes a real browser."
                 ));
             }
             let id = crate::utils::make_unique_scan_id(&target, |id| jobs.contains_key(id));
-            jobs.insert(id.clone(), Job::new_queued(target.clone()));
+            let mut job = Job::new_queued(target.clone());
+            // Liveness handle for the worker spawned below. Moved into that
+            // task so retention cannot collect this entry while the worker is
+            // still draining — see `Job::is_evictable`.
+            let lease = job.issue_worker_lease();
+            jobs.insert(id.clone(), job);
             // Bound retained *finished* scans too: the check above counts only
             // active jobs, so an agent running many quick scans would otherwise
             // hold every result (raw response bodies included, when
             // include_response was set) until the retention TTL expires.
             crate::job::enforce_retention_cap(&mut jobs, MAX_RETAINED_SCANS_MCP);
-            id
+            (id, lease)
         };
 
         Self::log(
@@ -1114,29 +1146,17 @@ browser execution; only detection_method=oob observes a real browser."
             .into_scan_args(),
         );
 
-        // Load any requested remote payload/wordlist providers into the global
-        // registries before the scan reads them. Mirrors the REST server and
-        // CLI; without this the `remote_payloads`/`remote_wordlists` fields
-        // would be silently inert on the MCP path.
-        // A failure is logged rather than swallowed: the scan otherwise runs
-        // without the list the caller asked for and still reports success,
-        // which an agent reads as "scanned, found nothing".
-        if (!scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty())
-            && let Err(e) = crate::utils::init_remote_resources_with_options(
-                &scan_args.remote_payloads,
-                &scan_args.remote_wordlists,
-                Some(scan_args.timeout),
-                scan_args.proxy.clone(),
-            )
-            .await
-        {
-            Self::log(
-                "WRN",
-                &format!(
-                    "remote resource fetch failed ({e}); scanning without the requested remote lists"
-                ),
-            );
-        }
+        // The remote payload/wordlist fetch used to happen right here, before
+        // the job was handed to a worker. That put a network `.await` — up to
+        // the request timeout against a caller-named host — between "the job is
+        // in the map, counting against MAX_ACTIVE_SCANS_MCP" and "a worker owns
+        // it". An MCP tool call cancelled in that window drops this future, so
+        // the worker is never spawned and the job stays `queued` forever:
+        // nothing moves it to a terminal state, `purge_expired_jobs` only
+        // collects terminal jobs, and the capacity slot is gone for the life of
+        // the process. The REST server never had this hole because it spawns
+        // first and fetches inside the task; the fetch now lives in `run_job`
+        // for the same reason.
 
         // Run the scan on tokio's managed blocking-threadpool. We still need a
         // current_thread runtime inside because analyze_parameters and the
@@ -1156,6 +1176,9 @@ browser execution; only detection_method=oob observes a real browser."
         let handler = self.clone();
         let sid = scan_id.clone();
         tokio::task::spawn_blocking(move || {
+            // Held for the whole task; dropping it releases the job to
+            // retention (see `spawn_scan_task` on the REST side).
+            let _lease = worker_lease;
             let sid_for_log = sid.clone();
             let sid_for_recovery = sid.clone();
             let jobs_for_recovery = handler.jobs.clone();

--- a/src/mcp/tests.rs
+++ b/src/mcp/tests.rs
@@ -510,6 +510,71 @@ async fn test_scan_with_dalfox_queues_and_can_be_queried() {
     assert!(matches!(status, "queued" | "running" | "done" | "error"));
 }
 
+/// The MCP scan tool must not `.await` the remote payload/wordlist fetch.
+///
+/// The job is inserted (counting against `MAX_ACTIVE_SCANS_MCP`) before the
+/// worker is spawned. A network await in between — against a caller-named host,
+/// for up to the request timeout — is a window in which a cancelled tool call
+/// drops this future: the worker is never spawned, nothing moves the job out of
+/// `queued`, `purge_expired_jobs` only collects terminal jobs, and the capacity
+/// slot is gone for the life of the process. The REST server never had this
+/// hole because it spawns first and fetches inside the task; MCP now matches.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_scan_with_dalfox_does_not_await_remote_fetch_in_the_tool_call() {
+    // A provider URL that accepts the connection and never answers, so the
+    // fetch takes the full request timeout.
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind blackhole listener");
+    let addr = listener.local_addr().expect("blackhole addr");
+    let _blackhole = tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((stream, _)) = listener.accept().await {
+            held.push(stream); // keep the connection open, never respond
+        }
+    });
+    crate::payload::register_payload_provider(
+        "mcp-blackhole-provider",
+        vec![format!("http://{addr}/list.txt")],
+    );
+
+    let mcp = DalfoxMcp::new();
+    let params = ScanWithDalfoxParams {
+        // Unreachable target so the scan itself settles quickly once spawned.
+        timeout: 5,
+        remote_payloads: vec!["mcp-blackhole-provider".to_string()],
+        ..default_scan_params("http://127.0.0.1:1/?q=a")
+    };
+
+    let outcome = tokio::time::timeout(
+        Duration::from_millis(500),
+        mcp.scan_with_dalfox(Parameters(params)),
+    )
+    .await;
+    assert!(
+        outcome.is_ok(),
+        "scan_with_dalfox must return as soon as the job is spawned; awaiting \
+         the remote fetch here leaks the capacity slot if the call is cancelled"
+    );
+    let payload = parse_result_json(&outcome.unwrap().expect("scan_with_dalfox should queue"));
+    assert_eq!(payload["status"], "queued");
+
+    // And the job must actually be owned by a worker: it leaves `queued` on its
+    // own rather than sitting there for the life of the process.
+    for _ in 0..200 {
+        {
+            let jobs = mcp.lock_jobs();
+            assert_eq!(jobs.len(), 1, "exactly one job was submitted");
+            let job = jobs.values().next().expect("the job");
+            if job.status != JobStatus::Queued {
+                return;
+            }
+        }
+        sleep(Duration::from_millis(50)).await;
+    }
+    panic!("the submitted scan never left `queued` — no worker owns it");
+}
+
 #[tokio::test]
 async fn test_scan_with_dalfox_rejects_out_of_range_timeout() {
     let mcp = DalfoxMcp::new();

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -643,7 +643,10 @@ pub async fn probe_dictionary_params(
         {
             eprintln!("Error initializing remote wordlists: {}", e);
         }
-        if let Some(words) = crate::payload::get_remote_words()
+        // Keyed by this scan's provider set: the cache is process-global, so a
+        // provider-less lookup in the server/MCP daemon could return whatever
+        // wordlist an earlier job with different providers had fetched.
+        if let Some(words) = crate::payload::get_remote_words_for(&args.remote_wordlists)
             && !words.is_empty()
         {
             params = words.as_ref().clone();

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -22,8 +22,15 @@ const DEFAULT_TIMEOUT_SECS: u64 = 15;
 /// `remote_payloads` / `remote_wordlists` verbatim), so the number of distinct
 /// *sets* a long-lived daemon can be asked to remember is unbounded — including
 /// sets naming providers that do not exist, which cache an empty list without
-/// ever touching the network. Past this many entries new sets simply are not
-/// cached: they refetch each time, which is slower but never wrong.
+/// ever touching the network. A real deployment uses a handful of sets, so this
+/// bound is only ever reached by someone spraying names.
+///
+/// Reaching it is reported to the caller as a fetch failure rather than
+/// silently leaving the entry uncached: the getters are keyed, so an uncached
+/// set reads back as "no remote list" and the scan would otherwise run without
+/// what it asked for and still report success. The callers already turn that
+/// error into the operator-facing "scanning without the requested remote lists"
+/// warning, which is exactly what happens.
 const MAX_CACHED_PROVIDER_SETS: usize = 64;
 
 /// A process-wide cache of fetched remote lists, keyed by provider set.
@@ -41,14 +48,17 @@ const MAX_CACHED_PROVIDER_SETS: usize = 64;
 ///
 /// Keying by the provider set fixes both: an entry can only ever be read back
 /// by a job that asked for exactly the same providers.
-struct ProviderCache(OnceLock<Mutex<HashMap<Vec<String>, Arc<Vec<String>>>>>);
+struct ProviderCache(OnceLock<Mutex<CachedLists>>);
+
+/// Fetched lists indexed by the normalized provider set that produced them.
+type CachedLists = HashMap<Vec<String>, Arc<Vec<String>>>;
 
 impl ProviderCache {
     const fn new() -> Self {
         Self(OnceLock::new())
     }
 
-    fn map(&self) -> &Mutex<HashMap<Vec<String>, Arc<Vec<String>>>> {
+    fn map(&self) -> &Mutex<CachedLists> {
         self.0.get_or_init(|| Mutex::new(HashMap::new()))
     }
 
@@ -57,14 +67,17 @@ impl ProviderCache {
         m.get(key).cloned()
     }
 
-    fn store(&self, key: Vec<String>, lines: Vec<String>) {
+    /// Cache `lines` under `key`. Returns `false` when the cache is full and
+    /// this is a new set — never evicting a live entry, which a job mid-scan
+    /// may still be reading.
+    #[must_use]
+    fn store(&self, key: Vec<String>, lines: Vec<String>) -> bool {
         let mut m = self.map().lock().unwrap_or_else(PoisonError::into_inner);
-        // Never evict a live entry to make room — a job mid-scan may still read
-        // it. Refusing the new one degrades to "refetch next time" instead.
         if m.len() >= MAX_CACHED_PROVIDER_SETS && !m.contains_key(&key) {
-            return;
+            return false;
         }
         m.insert(key, Arc::new(lines));
+        true
     }
 
     fn is_empty(&self) -> bool {
@@ -85,18 +98,33 @@ impl ProviderCache {
     }
 }
 
+/// Error returned when a fetch succeeded but the cache had no room for it. The
+/// callers already render this as "scanning without the requested remote
+/// lists", which is what the keyed getters will now report for this set.
+fn cache_full_error(kind: &str) -> Box<dyn std::error::Error> {
+    format!(
+        "remote {kind} cache is full ({MAX_CACHED_PROVIDER_SETS} distinct provider sets); \
+         this set was fetched but not cached"
+    )
+    .into()
+}
+
 /// Normalize a caller-supplied provider list into a cache key: each name
-/// trimmed and lowercased (matching how [`collect_payload_provider_urls`] looks
-/// them up), blanks dropped, then deduplicated and sorted so `["Burp","assetnote"]`
-/// and `["assetnote"," burp ","burp"]` name the same entry. A `Vec<String>` key
-/// rather than a joined string, so a provider name containing the separator
-/// cannot collide with a two-provider set.
+/// lowercased, then deduplicated and sorted, so `["Burp","assetnote"]` and
+/// `["assetnote","burp","burp"]` name the same entry. Both normalizations are
+/// safe because the fetched list is order-independent — `collect_*_provider_urls`
+/// dedupes URLs and the result is sorted before caching.
+///
+/// The lowercasing is exactly what `collect_*_provider_urls` applies when it
+/// looks a name up in the registry, and nothing more: a key normalization the
+/// lookup does not share (trimming, say) would let two provider lists that
+/// resolve to *different* URL sets share one cache entry — `[" burp "]` misses
+/// the registry and caches an empty list, which `["burp"]` would then read back.
+///
+/// A `Vec<String>` key rather than a joined string, so a provider name
+/// containing the separator cannot collide with a two-provider set.
 fn provider_cache_key(providers: &[String]) -> Vec<String> {
-    let mut names: Vec<String> = providers
-        .iter()
-        .map(|p| p.trim().to_ascii_lowercase())
-        .filter(|p| !p.is_empty())
-        .collect();
+    let mut names: Vec<String> = providers.iter().map(|p| p.to_ascii_lowercase()).collect();
     names.sort();
     names.dedup();
     names
@@ -199,7 +227,8 @@ pub async fn init_remote_payloads_with(
 
     let urls = collect_payload_provider_urls(providers);
     if urls.is_empty() {
-        REMOTE_PAYLOADS.store(key, Vec::new());
+        // No recognized providers: cache an empty list for *this* set only.
+        let _ = REMOTE_PAYLOADS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -218,7 +247,9 @@ pub async fn init_remote_payloads_with(
         return Err("remote payload fetch returned no usable entries".into());
     }
 
-    REMOTE_PAYLOADS.store(key, dedup_sorted);
+    if !REMOTE_PAYLOADS.store(key, dedup_sorted) {
+        return Err(cache_full_error("payload"));
+    }
     Ok(())
 }
 
@@ -235,7 +266,8 @@ pub async fn init_remote_wordlists_with(
 
     let urls = collect_wordlist_provider_urls(providers);
     if urls.is_empty() {
-        REMOTE_WORDS.store(key, Vec::new());
+        // No recognized providers: cache an empty list for *this* set only.
+        let _ = REMOTE_WORDS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -254,7 +286,9 @@ pub async fn init_remote_wordlists_with(
         return Err("remote wordlist fetch returned no usable entries".into());
     }
 
-    REMOTE_WORDS.store(key, dedup_sorted);
+    if !REMOTE_WORDS.store(key, dedup_sorted) {
+        return Err(cache_full_error("wordlist"));
+    }
     Ok(())
 }
 
@@ -271,7 +305,7 @@ pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn st
     let urls = collect_payload_provider_urls(providers);
     if urls.is_empty() {
         // No recognized providers – cache an empty list for *this* set only
-        REMOTE_PAYLOADS.store(key, Vec::new());
+        let _ = REMOTE_PAYLOADS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -294,7 +328,9 @@ pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn st
         return Err("remote payload fetch returned no usable entries".into());
     }
 
-    REMOTE_PAYLOADS.store(key, dedup_sorted);
+    if !REMOTE_PAYLOADS.store(key, dedup_sorted) {
+        return Err(cache_full_error("payload"));
+    }
     Ok(())
 }
 
@@ -331,7 +367,7 @@ pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn s
     let urls = collect_wordlist_provider_urls(providers);
     if urls.is_empty() {
         // No recognized providers – cache an empty list for *this* set only
-        REMOTE_WORDS.store(key, Vec::new());
+        let _ = REMOTE_WORDS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -354,7 +390,9 @@ pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn s
         return Err("remote wordlist fetch returned no usable entries".into());
     }
 
-    REMOTE_WORDS.store(key, dedup_sorted);
+    if !REMOTE_WORDS.store(key, dedup_sorted) {
+        return Err(cache_full_error("wordlist"));
+    }
     Ok(())
 }
 

--- a/src/payload/remote.rs
+++ b/src/payload/remote.rs
@@ -5,14 +5,102 @@ use std::time::Duration;
 use reqwest::Client;
 use tokio::task::JoinSet;
 
-/// Cache for remote XSS payloads (deduplicated, sorted).
-static REMOTE_PAYLOADS: OnceLock<Arc<Vec<String>>> = OnceLock::new();
+/// Cache for remote XSS payloads (deduplicated, sorted), keyed by the
+/// normalized provider set that produced them. See [`ProviderCache`].
+static REMOTE_PAYLOADS: ProviderCache = ProviderCache::new();
 
-/// Cache for remote parameter wordlists (deduplicated, sorted).
-static REMOTE_WORDS: OnceLock<Arc<Vec<String>>> = OnceLock::new();
+/// Cache for remote parameter wordlists (deduplicated, sorted), keyed by the
+/// normalized provider set that produced them. See [`ProviderCache`].
+static REMOTE_WORDS: ProviderCache = ProviderCache::new();
 
 /// Default timeout for remote fetch operations.
 const DEFAULT_TIMEOUT_SECS: u64 = 15;
+
+/// Ceiling on distinct provider sets held in one cache.
+///
+/// Provider names are caller-supplied (a REST/MCP scan request carries
+/// `remote_payloads` / `remote_wordlists` verbatim), so the number of distinct
+/// *sets* a long-lived daemon can be asked to remember is unbounded — including
+/// sets naming providers that do not exist, which cache an empty list without
+/// ever touching the network. Past this many entries new sets simply are not
+/// cached: they refetch each time, which is slower but never wrong.
+const MAX_CACHED_PROVIDER_SETS: usize = 64;
+
+/// A process-wide cache of fetched remote lists, keyed by provider set.
+///
+/// This used to be a bare `OnceLock<Arc<Vec<String>>>` — "fetch once per
+/// process", which is right for the one-scan-per-process CLI and wrong for the
+/// `dalfox server` / MCP daemon, where every job brings its own provider list:
+///
+/// * The first job to ask for *any* remote list won the cell for the life of
+///   the process. A later job asking for a different provider silently scanned
+///   with the first job's payloads and still reported `done`.
+/// * A job naming only unrecognized providers took the `urls.is_empty()` path
+///   and cached an **empty** list, poisoning every later job in the same way —
+///   they short-circuited on the already-set cell and scanned with nothing.
+///
+/// Keying by the provider set fixes both: an entry can only ever be read back
+/// by a job that asked for exactly the same providers.
+struct ProviderCache(OnceLock<Mutex<HashMap<Vec<String>, Arc<Vec<String>>>>>);
+
+impl ProviderCache {
+    const fn new() -> Self {
+        Self(OnceLock::new())
+    }
+
+    fn map(&self) -> &Mutex<HashMap<Vec<String>, Arc<Vec<String>>>> {
+        self.0.get_or_init(|| Mutex::new(HashMap::new()))
+    }
+
+    fn get(&self, key: &[String]) -> Option<Arc<Vec<String>>> {
+        let m = self.map().lock().unwrap_or_else(PoisonError::into_inner);
+        m.get(key).cloned()
+    }
+
+    fn store(&self, key: Vec<String>, lines: Vec<String>) {
+        let mut m = self.map().lock().unwrap_or_else(PoisonError::into_inner);
+        // Never evict a live entry to make room — a job mid-scan may still read
+        // it. Refusing the new one degrades to "refetch next time" instead.
+        if m.len() >= MAX_CACHED_PROVIDER_SETS && !m.contains_key(&key) {
+            return;
+        }
+        m.insert(key, Arc::new(lines));
+    }
+
+    fn is_empty(&self) -> bool {
+        let m = self.map().lock().unwrap_or_else(PoisonError::into_inner);
+        m.is_empty()
+    }
+
+    /// The single cached entry, or `None` when the cache holds zero or more
+    /// than one provider set. Backs the legacy provider-less getters, which
+    /// have no way to say *which* list they mean; see [`get_remote_payloads`].
+    fn sole_entry(&self) -> Option<Arc<Vec<String>>> {
+        let m = self.map().lock().unwrap_or_else(PoisonError::into_inner);
+        if m.len() == 1 {
+            m.values().next().cloned()
+        } else {
+            None
+        }
+    }
+}
+
+/// Normalize a caller-supplied provider list into a cache key: each name
+/// trimmed and lowercased (matching how [`collect_payload_provider_urls`] looks
+/// them up), blanks dropped, then deduplicated and sorted so `["Burp","assetnote"]`
+/// and `["assetnote"," burp ","burp"]` name the same entry. A `Vec<String>` key
+/// rather than a joined string, so a provider name containing the separator
+/// cannot collide with a two-provider set.
+fn provider_cache_key(providers: &[String]) -> Vec<String> {
+    let mut names: Vec<String> = providers
+        .iter()
+        .map(|p| p.trim().to_ascii_lowercase())
+        .filter(|p| !p.is_empty())
+        .collect();
+    names.sort();
+    names.dedup();
+    names
+}
 
 // Provider registries with default seeds and registration APIs
 static PAYLOAD_PROVIDER_REGISTRY: OnceLock<Mutex<HashMap<String, Vec<String>>>> = OnceLock::new();
@@ -104,13 +192,14 @@ pub async fn init_remote_payloads_with(
     providers: &[String],
     opts: RemoteFetchOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if REMOTE_PAYLOADS.get().is_some() {
+    let key = provider_cache_key(providers);
+    if REMOTE_PAYLOADS.get(&key).is_some() {
         return Ok(());
     }
 
     let urls = collect_payload_provider_urls(providers);
     if urls.is_empty() {
-        let _ = REMOTE_PAYLOADS.set(Arc::new(Vec::new()));
+        REMOTE_PAYLOADS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -120,18 +209,16 @@ pub async fn init_remote_payloads_with(
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
 
-    // Never cache "we got nothing" for a provider set that named real URLs.
-    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
-    // single egress blip during the *first* remote-fetch job would otherwise
-    // poison every later job for the process's lifetime: each one short-circuits
-    // on the already-set cache, scans with an empty list, and reports `done`
-    // with no indication that what it asked for was never fetched. Leaving the
-    // cell unset costs one retry and keeps the failure transient.
+    // Never cache "we got nothing" for a provider set that named real URLs: a
+    // transient egress blip would otherwise pin an empty list to this provider
+    // set for the daemon's lifetime, and every later job asking for the same
+    // providers would scan with nothing while still reporting `done`. Leaving
+    // the entry unset costs one retry and keeps the failure transient.
     if dedup_sorted.is_empty() {
         return Err("remote payload fetch returned no usable entries".into());
     }
 
-    let _ = REMOTE_PAYLOADS.set(Arc::new(dedup_sorted));
+    REMOTE_PAYLOADS.store(key, dedup_sorted);
     Ok(())
 }
 
@@ -141,13 +228,14 @@ pub async fn init_remote_wordlists_with(
     providers: &[String],
     opts: RemoteFetchOptions,
 ) -> Result<(), Box<dyn std::error::Error>> {
-    if REMOTE_WORDS.get().is_some() {
+    let key = provider_cache_key(providers);
+    if REMOTE_WORDS.get(&key).is_some() {
         return Ok(());
     }
 
     let urls = collect_wordlist_provider_urls(providers);
     if urls.is_empty() {
-        let _ = REMOTE_WORDS.set(Arc::new(Vec::new()));
+        REMOTE_WORDS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -157,18 +245,16 @@ pub async fn init_remote_wordlists_with(
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
 
-    // Never cache "we got nothing" for a provider set that named real URLs.
-    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
-    // single egress blip during the *first* remote-fetch job would otherwise
-    // poison every later job for the process's lifetime: each one short-circuits
-    // on the already-set cache, scans with an empty list, and reports `done`
-    // with no indication that what it asked for was never fetched. Leaving the
-    // cell unset costs one retry and keeps the failure transient.
+    // Never cache "we got nothing" for a provider set that named real URLs: a
+    // transient egress blip would otherwise pin an empty list to this provider
+    // set for the daemon's lifetime, and every later job asking for the same
+    // providers would scan with nothing while still reporting `done`. Leaving
+    // the entry unset costs one retry and keeps the failure transient.
     if dedup_sorted.is_empty() {
         return Err("remote wordlist fetch returned no usable entries".into());
     }
 
-    let _ = REMOTE_WORDS.set(Arc::new(dedup_sorted));
+    REMOTE_WORDS.store(key, dedup_sorted);
     Ok(())
 }
 
@@ -176,15 +262,16 @@ pub async fn init_remote_wordlists_with(
 /// - providers: case-insensitive tokens such as "portswigger", "payloadbox"
 /// - Returns Ok(()) when initialized or already initialized. Never panics.
 pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn std::error::Error>> {
-    if REMOTE_PAYLOADS.get().is_some() {
-        // Already initialized – idempotent
+    let key = provider_cache_key(providers);
+    if REMOTE_PAYLOADS.get(&key).is_some() {
+        // This provider set is already fetched – idempotent
         return Ok(());
     }
 
     let urls = collect_payload_provider_urls(providers);
     if urls.is_empty() {
-        // No recognized providers – set empty cache
-        let _ = REMOTE_PAYLOADS.set(Arc::new(Vec::new()));
+        // No recognized providers – cache an empty list for *this* set only
+        REMOTE_PAYLOADS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -198,40 +285,53 @@ pub async fn init_remote_payloads(providers: &[String]) -> Result<(), Box<dyn st
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
 
-    // Never cache "we got nothing" for a provider set that named real URLs.
-    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
-    // single egress blip during the *first* remote-fetch job would otherwise
-    // poison every later job for the process's lifetime: each one short-circuits
-    // on the already-set cache, scans with an empty list, and reports `done`
-    // with no indication that what it asked for was never fetched. Leaving the
-    // cell unset costs one retry and keeps the failure transient.
+    // Never cache "we got nothing" for a provider set that named real URLs: a
+    // transient egress blip would otherwise pin an empty list to this provider
+    // set for the daemon's lifetime, and every later job asking for the same
+    // providers would scan with nothing while still reporting `done`. Leaving
+    // the entry unset costs one retry and keeps the failure transient.
     if dedup_sorted.is_empty() {
         return Err("remote payload fetch returned no usable entries".into());
     }
 
-    let _ = REMOTE_PAYLOADS.set(Arc::new(dedup_sorted));
+    REMOTE_PAYLOADS.store(key, dedup_sorted);
     Ok(())
 }
 
+/// Public API: the cached remote XSS payloads fetched for `providers`.
+///
+/// Returns `None` when this provider set has not been initialized. Prefer this
+/// over [`get_remote_payloads`] anywhere more than one scan can run in the same
+/// process (the server and MCP daemons): the cache holds one entry per provider
+/// set, and only the caller knows which one it asked for.
+pub fn get_remote_payloads_for(providers: &[String]) -> Option<Arc<Vec<String>>> {
+    REMOTE_PAYLOADS.get(&provider_cache_key(providers))
+}
+
 /// Public API: Get a clone of the cached remote XSS payloads (if initialized).
-/// Returns None if `init_remote_payloads` has not been called yet.
+///
+/// Legacy provider-less accessor for single-scan processes (the CLI). It names
+/// no provider set, so it can only answer when exactly one has been fetched;
+/// with zero or several cached it returns `None` rather than guessing. Callers
+/// that know their provider list should use [`get_remote_payloads_for`].
 pub fn get_remote_payloads() -> Option<Arc<Vec<String>>> {
-    REMOTE_PAYLOADS.get().cloned()
+    REMOTE_PAYLOADS.sole_entry()
 }
 
 /// Public API: Initialize and cache remote parameter wordlists for the given providers.
 /// - providers: case-insensitive tokens such as "burp", "assetnote"
 /// - Returns Ok(()) when initialized or already initialized. Never panics.
 pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn std::error::Error>> {
-    if REMOTE_WORDS.get().is_some() {
-        // Already initialized – idempotent
+    let key = provider_cache_key(providers);
+    if REMOTE_WORDS.get(&key).is_some() {
+        // This provider set is already fetched – idempotent
         return Ok(());
     }
 
     let urls = collect_wordlist_provider_urls(providers);
     if urls.is_empty() {
-        // No recognized providers – set empty cache
-        let _ = REMOTE_WORDS.set(Arc::new(Vec::new()));
+        // No recognized providers – cache an empty list for *this* set only
+        REMOTE_WORDS.store(key, Vec::new());
         return Ok(());
     }
 
@@ -245,35 +345,42 @@ pub async fn init_remote_wordlists(providers: &[String]) -> Result<(), Box<dyn s
     let sanitized = sanitize_lines(&lines);
     let dedup_sorted = dedup_and_sort(sanitized);
 
-    // Never cache "we got nothing" for a provider set that named real URLs.
-    // The cache is a process-global `OnceLock`, so in the server/MCP daemon a
-    // single egress blip during the *first* remote-fetch job would otherwise
-    // poison every later job for the process's lifetime: each one short-circuits
-    // on the already-set cache, scans with an empty list, and reports `done`
-    // with no indication that what it asked for was never fetched. Leaving the
-    // cell unset costs one retry and keeps the failure transient.
+    // Never cache "we got nothing" for a provider set that named real URLs: a
+    // transient egress blip would otherwise pin an empty list to this provider
+    // set for the daemon's lifetime, and every later job asking for the same
+    // providers would scan with nothing while still reporting `done`. Leaving
+    // the entry unset costs one retry and keeps the failure transient.
     if dedup_sorted.is_empty() {
         return Err("remote wordlist fetch returned no usable entries".into());
     }
 
-    let _ = REMOTE_WORDS.set(Arc::new(dedup_sorted));
+    REMOTE_WORDS.store(key, dedup_sorted);
     Ok(())
 }
 
+/// Public API: the cached remote parameter words fetched for `providers`.
+///
+/// Returns `None` when this provider set has not been initialized. Prefer this
+/// over [`get_remote_words`] for the same reason as [`get_remote_payloads_for`].
+pub fn get_remote_words_for(providers: &[String]) -> Option<Arc<Vec<String>>> {
+    REMOTE_WORDS.get(&provider_cache_key(providers))
+}
+
 /// Public API: Get a clone of the cached remote parameter words (if initialized).
-/// Returns None if `init_remote_wordlists` has not been called yet.
+///
+/// Legacy provider-less accessor; see [`get_remote_payloads`] for the caveat.
 pub fn get_remote_words() -> Option<Arc<Vec<String>>> {
-    REMOTE_WORDS.get().cloned()
+    REMOTE_WORDS.sole_entry()
 }
 
-/// Helper: Return true if remote payloads have been initialized.
+/// Helper: Return true if any remote payload provider set has been initialized.
 pub fn has_remote_payloads() -> bool {
-    REMOTE_PAYLOADS.get().is_some()
+    !REMOTE_PAYLOADS.is_empty()
 }
 
-/// Helper: Return true if remote wordlists have been initialized.
+/// Helper: Return true if any remote wordlist provider set has been initialized.
 pub fn has_remote_wordlists() -> bool {
-    REMOTE_WORDS.get().is_some()
+    !REMOTE_WORDS.is_empty()
 }
 
 /// Collapse a provider->URL expansion to the set of distinct URLs, preserving

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -514,15 +514,17 @@ pub(crate) fn get_dynamic_payloads(
     }
 
     // Include remote payloads, but only for a scan that actually asked for
-    // them. The cache behind `get_remote_payloads` is a process-global
-    // `OnceLock`, which is fine for the one-scan-per-process CLI and wrong for
-    // the long-lived server/MCP daemon: reading it unconditionally meant a job
-    // that requested **no** remote payloads still got whatever list some
-    // earlier job had fetched appended to every parameter's catalog — thousands
-    // of requests the submitter never asked for, against a target they had
-    // scoped deliberately.
+    // them, and only the list fetched for *this* scan's provider set. The cache
+    // is process-global, which is fine for the one-scan-per-process CLI and
+    // wrong for the long-lived server/MCP daemon: reading it unconditionally
+    // meant a job that requested **no** remote payloads still got whatever list
+    // some earlier job had fetched appended to every parameter's catalog —
+    // thousands of requests the submitter never asked for, against a target
+    // they had scoped deliberately. Keying the lookup by provider set closes
+    // the other half: a job asking for provider B no longer gets provider A's
+    // payloads just because A's job ran first.
     if !args.remote_payloads.is_empty()
-        && let Some(remotes) = crate::payload::get_remote_payloads()
+        && let Some(remotes) = crate::payload::get_remote_payloads_for(&args.remote_payloads)
         && !remotes.is_empty()
     {
         base_payloads.extend(remotes.iter().cloned());

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -901,6 +901,18 @@ pub(crate) async fn preflight_handler(
         .timeout
         .unwrap_or(crate::cmd::scan::DEFAULT_TIMEOUT_SECS);
 
+    // Preflight is not a dry run in network terms: discovery and mining send
+    // real requests to the target (20+ against a two-parameter URL). Those
+    // sends go through `crate::record_outbound_request`, which acquires from
+    // whichever rate limiter is in scope — and nothing bound one here, so this
+    // route ran flat out. That silently voided both the caller's `rate_limit`
+    // *and* the operator's server-wide `--rate-limit`, which is documented as
+    // applying to "every submitted scan": a client refused a fast scan could
+    // simply hammer the same target through `/preflight`. Resolve it through
+    // the same `effective_rate_limit` ceiling the scan path uses so the
+    // operator's cap wins over the request's value.
+    let preflight_rate = effective_rate_limit(opts.rate_limit, state.rate_limit);
+
     // Bound concurrent preflights: each one pins a blocking-pool thread for the
     // full request timeout against an attacker-controlled target, so an
     // unthrottled burst could exhaust the blocking pool and stall every scan.
@@ -935,7 +947,12 @@ pub(crate) async fn preflight_handler(
                 .enable_all()
                 .build()
                 .map_err(|e| PreflightError::RuntimeUnavailable(e.to_string()))?;
-            rt.block_on(async {
+            // Everything that touches the network runs inside the per-job
+            // limiter scope (`RATE_LIMITER_JOB`), which is what
+            // `record_outbound_request` looks for. `with_job_rate_limiter` is a
+            // plain await when the effective rate is 0 (unlimited), so the
+            // default path pays nothing.
+            rt.block_on(crate::with_job_rate_limiter(preflight_rate, async {
                 let mut target = hydrate_preflight_target(&target_url, &opts, timeout_secs)
                     .map_err(PreflightError::BadUrl)?;
 
@@ -1026,7 +1043,7 @@ pub(crate) async fn preflight_handler(
                     "estimated_total_requests": estimated_requests,
                     "params": discovered_params,
                 }))
-            })
+            }))
         })
         .await
         .unwrap_or(Err(PreflightError::TaskPanicked));

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -83,8 +83,8 @@ pub(crate) async fn start_scan_handler(
     // same-target resubmission in the same nanosecond can't clobber an
     // in-flight job (see make_scan_id's nonce), and so the concurrency cap is
     // checked race-free against the live job count. 503 when at capacity.
-    let id = match try_admit_and_queue(&state, &url, callback_url).await {
-        Some(id) => id,
+    let (id, lease) = match try_admit_and_queue(&state, &url, callback_url).await {
+        Some(admitted) => admitted,
         None => {
             let resp = at_capacity_response(&state);
             return make_api_response(
@@ -105,6 +105,7 @@ pub(crate) async fn start_scan_handler(
         opts,
         include_request,
         include_response,
+        lease,
     );
 
     let resp = ApiResponse::<serde_json::Value> {
@@ -493,8 +494,8 @@ pub(crate) async fn get_scan_handler(
     let callback_url = opts.callback_url.clone();
     // Reserve a unique scan_id and enforce the concurrency cap under one lock
     // (see POST /scan). 503 when at capacity.
-    let id = match try_admit_and_queue(&state, &url, callback_url).await {
-        Some(id) => id,
+    let (id, lease) = match try_admit_and_queue(&state, &url, callback_url).await {
+        Some(admitted) => admitted,
         None => {
             let resp = at_capacity_response(&state);
             return make_api_response(
@@ -516,6 +517,7 @@ pub(crate) async fn get_scan_handler(
         opts,
         include_request,
         include_response,
+        lease,
     );
 
     let resp = ApiResponse::<serde_json::Value> {

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -11,6 +11,13 @@ use crate::job::spec::ScanRequestSpec;
 /// `JoinHandle` and leaves the job pinned in `Queued`/`Running` forever.
 /// `purge_expired_jobs` only collects terminal jobs, so the orphan also
 /// leaks the job slot indefinitely.
+///
+/// `lease` is the job's liveness handle: it is moved into the spawned task and
+/// dropped when the task ends (including on panic), which is what tells job
+/// retention this entry is finally safe to evict. Without it, cancelling a scan
+/// — which stamps the terminal state immediately while the worker drains —
+/// makes the job look collectable, and an eviction in that window drops the
+/// partial results and the terminal webhook on the floor.
 pub(crate) fn spawn_scan_task(
     state: AppState,
     job_id: String,
@@ -18,8 +25,11 @@ pub(crate) fn spawn_scan_task(
     opts: ScanOptions,
     include_request: bool,
     include_response: bool,
+    lease: WorkerLease,
 ) {
     tokio::task::spawn_blocking(move || {
+        // Held for the whole task; dropping it releases the job to retention.
+        let _lease = lease;
         let rt = match tokio::runtime::Builder::new_current_thread()
             .enable_all()
             .build()

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -543,6 +543,14 @@ pub(crate) async fn send_terminal_webhook(
     }
 }
 
+/// Worker count `/preflight` runs discovery/mining at when the request does not
+/// ask for one. Deliberately *not* [`crate::cmd::scan::DEFAULT_WORKERS`] (50):
+/// preflight has always fanned out at ten (`parse_target`'s default, matched by
+/// the hardcoded `workers: 10` in `ScanArgs::for_preflight`), and honoring an
+/// explicit `worker` must not also quintuple the load every existing caller
+/// puts on a target.
+pub(crate) const PREFLIGHT_DEFAULT_WORKERS: usize = 10;
+
 /// Build a hydrated Target from the preflight request options.
 pub(crate) fn hydrate_preflight_target(
     target_url: &str,
@@ -552,6 +560,17 @@ pub(crate) fn hydrate_preflight_target(
     let mut t = parse_target(target_url).map_err(|e| format!("parse_target failed: {}", e))?;
     t.method = opts.method.clone().unwrap_or_else(|| "GET".to_string());
     t.timeout = timeout_secs;
+    // Pacing and concurrency are read off the *target*, not off `ScanArgs`:
+    // `analyze_parameters` sizes its semaphores from `target.workers` and every
+    // discovery/mining probe sleeps `target.delay` afterwards. Leaving both at
+    // `parse_target`'s defaults meant `/preflight` accepted `delay` and
+    // `worker` (they are the same `ScanOptions` `/scan` validates) and then
+    // discarded them — so the one per-request pacing control a caller has was
+    // silently removed on this route, while the CLI's preflight honors `--delay`
+    // because it runs against a target hydrated from the same args
+    // (`cmd::scan::input` sets `target.delay`).
+    t.delay = opts.delay.unwrap_or(crate::cmd::scan::DEFAULT_DELAY_MS);
+    t.workers = opts.worker.unwrap_or(PREFLIGHT_DEFAULT_WORKERS);
     t.user_agent = opts.user_agent.clone();
     t.proxy = opts.proxy.clone();
     t.insecure = opts.insecure.unwrap_or(true);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -36,7 +36,7 @@ pub(crate) use serde::{Deserialize, Serialize};
 pub(crate) use crate::cmd::scan::ScanArgs;
 pub(crate) use crate::job::{
     JOB_RETENTION_SECS, Job, JobProgress, JobStatus, MAX_DELAY_MS, MAX_SCAN_TIMEOUT_SECS,
-    MAX_TIMEOUT_SECS, MAX_WORKERS, cap_reflection_params, effective_rate_limit,
+    MAX_TIMEOUT_SECS, MAX_WORKERS, WorkerLease, cap_reflection_params, effective_rate_limit,
     effective_scan_timeout, enforce_retention_cap, has_http_scheme, now_ms, parse_job_status,
     purge_expired_jobs as purge_jobs_map, send_reachability_probe, split_cookie_pairs,
     unreachable_error_message,

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -4496,6 +4496,124 @@ async fn test_untrusted_host_is_refused_but_ip_literals_and_localhost_pass() {
     }
 }
 
+/// End-to-end: a scan cancelled while it is still draining must survive the
+/// retention cap, and the worker must still find its entry to write results
+/// into.
+///
+/// `cancel_scan_handler` stamps `status = Cancelled` and `finished_at_ms`
+/// immediately, so `is_terminal()` is true while the worker keeps running.
+/// Retention used to evict on that alone: a few new submissions in that window
+/// removed the entry, and the worker's `jobs.get_mut(&id)` then came back
+/// `None` — partial results dropped, terminal webhook never fired, and a GET on
+/// the scan_id the client is holding 404s.
+#[tokio::test(flavor = "multi_thread", worker_threads = 4)]
+async fn test_cancelled_but_draining_scan_survives_the_retention_cap() {
+    let addr = start_slow_reflecting_target_server().await;
+    let mut state = make_state(None, None, false, false, "cb");
+    // Aggressive cap: any further admission wants to evict something.
+    state.max_retained_scans = 1;
+
+    let resp = start_scan_handler(
+        State(state.clone()),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            target: format!("http://{addr}/?q=1"),
+            options: Some(ScanOptions {
+                timeout: Some(5),
+                skip_mining: Some(true),
+                ..ScanOptions::default()
+            }),
+        })),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+    let parsed: serde_json::Value =
+        serde_json::from_str(&response_body_string(resp).await).expect("json");
+    let scan_id = parsed["data"]["scan_id"]
+        .as_str()
+        .expect("scan_id")
+        .to_string();
+
+    // Wait for the worker to claim the job.
+    for _ in 0..200 {
+        {
+            let jobs = state.jobs.lock().await;
+            if jobs.get(&scan_id).map(|j| j.status.clone()) == Some(JobStatus::Running) {
+                break;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    {
+        let jobs = state.jobs.lock().await;
+        assert_eq!(
+            jobs.get(&scan_id).map(|j| j.status.clone()),
+            Some(JobStatus::Running),
+            "the scan must be running before we cancel it"
+        );
+    }
+
+    let resp = cancel_scan_handler(
+        State(state.clone()),
+        HeaderMap::new(),
+        Path(scan_id.clone()),
+        Query(Map::new()),
+    )
+    .await
+    .into_response();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    // The window this test is about: terminal on paper, worker still running.
+    {
+        let jobs = state.jobs.lock().await;
+        let job = jobs.get(&scan_id).expect("job still present after cancel");
+        assert!(job.is_terminal(), "cancel stamps the terminal state at once");
+        assert!(
+            job.worker_alive(),
+            "the slow target guarantees the worker is still draining here"
+        );
+    }
+
+    // Three more admissions, each of which runs enforce_retention_cap against a
+    // cap of 1. Leases are held so these stay active and are never themselves
+    // candidates — the cancelled job is the only one the old code could take.
+    let mut _leases = Vec::new();
+    for i in 0..3 {
+        let (_id, lease) =
+            try_admit_and_queue(&state, &format!("http://example.com/filler{i}"), None)
+                .await
+                .expect("admission succeeds");
+        _leases.push(lease);
+    }
+
+    {
+        let jobs = state.jobs.lock().await;
+        assert!(
+            jobs.contains_key(&scan_id),
+            "a cancelled scan whose worker is still draining must not be evicted"
+        );
+    }
+
+    // And the worker still has somewhere to put what it collected.
+    for _ in 0..400 {
+        {
+            let jobs = state.jobs.lock().await;
+            let job = jobs.get(&scan_id).expect("job must remain until it settles");
+            if !job.worker_alive() {
+                assert!(
+                    job.results.is_some(),
+                    "the draining worker must have written its results back"
+                );
+                return;
+            }
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(25)).await;
+    }
+    panic!("cancelled scan never settled");
+}
+
 #[tokio::test]
 async fn test_retention_cap_evicts_oldest_finished_scans_only() {
     let mut state = make_state(None, None, false, false, "callback");
@@ -4514,7 +4632,7 @@ async fn test_retention_cap_evicts_oldest_finished_scans_only() {
         jobs.insert("running".to_string(), running);
     }
 
-    let id = try_admit_and_queue(&state, "http://example.com/new", None)
+    let (id, _lease) = try_admit_and_queue(&state, "http://example.com/new", None)
         .await
         .expect("admission succeeds");
 

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -4569,7 +4569,10 @@ async fn test_cancelled_but_draining_scan_survives_the_retention_cap() {
     {
         let jobs = state.jobs.lock().await;
         let job = jobs.get(&scan_id).expect("job still present after cancel");
-        assert!(job.is_terminal(), "cancel stamps the terminal state at once");
+        assert!(
+            job.is_terminal(),
+            "cancel stamps the terminal state at once"
+        );
         assert!(
             job.worker_alive(),
             "the slow target guarantees the worker is still draining here"
@@ -4600,7 +4603,9 @@ async fn test_cancelled_but_draining_scan_survives_the_retention_cap() {
     for _ in 0..400 {
         {
             let jobs = state.jobs.lock().await;
-            let job = jobs.get(&scan_id).expect("job must remain until it settles");
+            let job = jobs
+                .get(&scan_id)
+                .expect("job must remain until it settles");
             if !job.worker_alive() {
                 assert!(
                     job.results.is_some(),

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -3316,6 +3316,32 @@ fn test_hydrate_preflight_target_insecure_default_and_override() {
     assert!(!t.insecure, "insecure=false must propagate to the target");
 }
 
+/// `/preflight` sends real discovery/mining traffic, and `analyze_parameters`
+/// reads its pacing off the **target** (`target.delay` between probes,
+/// `target.workers` for the semaphore) — not off `ScanArgs`. Both used to be
+/// left at `parse_target`'s defaults, so the very options `/preflight`
+/// validates (`delay`, `worker`) were accepted and then discarded.
+#[test]
+fn test_hydrate_preflight_target_carries_delay_and_workers() {
+    let mut opts = ScanOptions::default();
+    let t = hydrate_preflight_target("https://example.com", &opts, 10).expect("hydrate default");
+    assert_eq!(
+        t.delay,
+        crate::cmd::scan::DEFAULT_DELAY_MS,
+        "no delay requested -> the scanner default"
+    );
+    assert_eq!(
+        t.workers, PREFLIGHT_DEFAULT_WORKERS,
+        "no worker count requested -> preflight's long-standing default"
+    );
+
+    opts.delay = Some(250);
+    opts.worker = Some(3);
+    let t = hydrate_preflight_target("https://example.com", &opts, 10).expect("hydrate paced");
+    assert_eq!(t.delay, 250, "delay must reach the discovery stage");
+    assert_eq!(t.workers, 3, "worker must reach the discovery stage");
+}
+
 // ─────────────────────────────────────────────────────────────────────────
 // job_runner.rs — analyze_external_js: Some(true) exercises the new
 // fetch_and_analyze_external_js call added in run_scan_job.
@@ -3949,6 +3975,152 @@ async fn test_preflight_handler_success_reports_params_and_consistent_estimate()
         "the total must be the sum of the per-param estimates"
     );
     assert!(summed > 0, "a scannable param must bill a nonzero estimate");
+}
+
+// ---- /preflight pacing: rate_limit, delay and worker are not cosmetic ----
+//
+// Preflight is a *network* operation — discovery and mining probe the target
+// dozens of times — but it used to run flat out: no limiter was bound around
+// `analyze_parameters`, and `hydrate_preflight_target` left `delay`/`workers`
+// at `parse_target`'s defaults. So the operator's `--rate-limit` (documented as
+// applying to every submitted scan) and the caller's own pacing options were
+// both silently void on this route.
+
+/// A reflecting target that counts every request it serves.
+async fn start_counting_reflecting_target_server()
+-> (SocketAddr, Arc<std::sync::atomic::AtomicUsize>) {
+    use std::sync::atomic::{AtomicUsize, Ordering as AtomicOrdering};
+    let hits = Arc::new(AtomicUsize::new(0));
+    let handler = {
+        let hits = hits.clone();
+        move |Query(q): Query<Map<String, String>>| {
+            let hits = hits.clone();
+            async move {
+                hits.fetch_add(1, AtomicOrdering::SeqCst);
+                let mut body = String::from("<html><body>");
+                for (k, v) in &q {
+                    body.push_str(&format!("<div>{k}={v}</div>"));
+                }
+                body.push_str("</body></html>");
+                (
+                    StatusCode::OK,
+                    [("content-type", "text/html; charset=utf-8")],
+                    body,
+                )
+            }
+        }
+    };
+    let app = Router::new()
+        .route("/", any(handler.clone()))
+        .route("/{*rest}", any(handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind counting target listener");
+    let addr = listener.local_addr().expect("counting target local addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    // These two tests assert on *timing*, so a target that is not accepting yet
+    // would both zero the request count and shorten the measured window. Wait
+    // for a real connection instead of a fixed sleep. Connecting sends no
+    // request, so `hits` is untouched.
+    for _ in 0..200 {
+        if tokio::net::TcpStream::connect(addr).await.is_ok() {
+            return (addr, hits);
+        }
+        tokio::time::sleep(std::time::Duration::from_millis(10)).await;
+    }
+    panic!("counting target server never accepted a connection");
+}
+
+/// The server-wide `--rate-limit` must bound `/preflight` traffic the way it
+/// bounds `/scan` traffic. Before the fix this exact call sent ~20 requests in
+/// under 100 ms with `state.rate_limit = Some(20)` set.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_preflight_honors_server_wide_rate_limit() {
+    const RATE: u64 = 20; // requests/second -> 50 ms apart
+    let (addr, hits) = start_counting_reflecting_target_server().await;
+    let mut state = make_state(None, None, false, false, "cb");
+    state.rate_limit = Some(RATE as u32);
+
+    let started = std::time::Instant::now();
+    let resp = preflight_handler(
+        State(state),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            target: format!("http://{addr}/?q=1&z=2"),
+            options: Some(ScanOptions {
+                timeout: Some(5),
+                skip_mining: Some(true),
+                ..ScanOptions::default()
+            }),
+        })),
+    )
+    .await
+    .into_response();
+    let elapsed = started.elapsed();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let sent = hits.load(std::sync::atomic::Ordering::SeqCst) as u64;
+    assert!(
+        sent >= 8,
+        "preflight must actually probe the target for the pacing bound to mean \
+         anything (sent {sent})"
+    );
+    // GCRA with a burst of one admits the first request immediately and spaces
+    // the rest by 1/RATE. Allow generous slack (60% of the theoretical floor)
+    // so this asserts "throttled" rather than an exact schedule.
+    let floor_ms = (sent - 1) * 1000 / RATE * 6 / 10;
+    assert!(
+        elapsed.as_millis() as u64 >= floor_ms,
+        "server-wide rate_limit={RATE} must throttle /preflight: {sent} requests \
+         in {}ms, expected at least {floor_ms}ms",
+        elapsed.as_millis()
+    );
+}
+
+/// `delay` and `worker` reach `analyze_parameters` through the target, so a
+/// single worker with a per-probe delay must serialize preflight's discovery
+/// traffic. Both options were previously dropped on the floor.
+#[tokio::test(flavor = "multi_thread", worker_threads = 2)]
+async fn test_preflight_honors_delay_and_worker_options() {
+    const DELAY_MS: u64 = 60;
+    let (addr, hits) = start_counting_reflecting_target_server().await;
+    let state = make_state(None, None, false, false, "cb");
+
+    let started = std::time::Instant::now();
+    let resp = preflight_handler(
+        State(state),
+        HeaderMap::new(),
+        Query(Map::new()),
+        Ok(Json(ScanRequest {
+            target: format!("http://{addr}/?q=1&z=2"),
+            options: Some(ScanOptions {
+                timeout: Some(5),
+                skip_mining: Some(true),
+                delay: Some(DELAY_MS),
+                worker: Some(1),
+                ..ScanOptions::default()
+            }),
+        })),
+    )
+    .await
+    .into_response();
+    let elapsed = started.elapsed();
+    assert_eq!(resp.status(), StatusCode::OK);
+
+    let sent = hits.load(std::sync::atomic::Ordering::SeqCst) as u64;
+    assert!(sent >= 8, "preflight must probe the target (sent {sent})");
+    // One worker sleeping DELAY_MS after each probe: not every send is inside a
+    // delayed loop, so hold the bound to half the sends.
+    let floor_ms = sent / 2 * DELAY_MS;
+    assert!(
+        elapsed.as_millis() as u64 >= floor_ms,
+        "delay={DELAY_MS}ms with worker=1 must pace /preflight: {sent} requests \
+         in {}ms, expected at least {floor_ms}ms",
+        elapsed.as_millis()
+    );
 }
 
 /// `encoders: ["none"]` collapses the encoder fan-out factor to 1, so the

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -231,10 +231,11 @@ pub(crate) fn parse_opt_bool_query(params: &HashMap<String, String>, key: &str) 
 /// jobs-lock, or return `None` when the server is already at its
 /// `max_concurrent_scans` capacity (`0` = unlimited). Counting active
 /// (non-terminal) jobs and inserting under the *same* lock keeps the check
-/// race-free. Returns the reserved scan_id on success. Shared by POST and GET
-/// /scan so both paths enforce the cap and build the queued job identically.
-/// Returns the reserved scan_id together with the worker lease the caller must
-/// move into the scan task (see [`crate::job::Job::is_evictable`]).
+/// race-free. Shared by POST and GET /scan so both paths enforce the cap and
+/// build the queued job identically.
+///
+/// On success returns the reserved scan_id together with the worker lease the
+/// caller must move into the scan task (see [`crate::job::Job::is_evictable`]).
 pub(crate) async fn try_admit_and_queue(
     state: &AppState,
     url: &str,

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -233,11 +233,13 @@ pub(crate) fn parse_opt_bool_query(params: &HashMap<String, String>, key: &str) 
 /// (non-terminal) jobs and inserting under the *same* lock keeps the check
 /// race-free. Returns the reserved scan_id on success. Shared by POST and GET
 /// /scan so both paths enforce the cap and build the queued job identically.
+/// Returns the reserved scan_id together with the worker lease the caller must
+/// move into the scan task (see [`crate::job::Job::is_evictable`]).
 pub(crate) async fn try_admit_and_queue(
     state: &AppState,
     url: &str,
     callback_url: Option<String>,
-) -> Option<String> {
+) -> Option<(String, WorkerLease)> {
     let mut jobs = state.jobs.lock().await;
     if state.max_concurrent_scans > 0
         && jobs.values().filter(|j| !j.is_terminal()).count() >= state.max_concurrent_scans
@@ -245,28 +247,17 @@ pub(crate) async fn try_admit_and_queue(
         return None;
     }
     let id = crate::utils::make_unique_scan_id(url, |id| jobs.contains_key(id));
-    jobs.insert(
-        id.clone(),
-        Job {
-            status: JobStatus::Queued,
-            results: None,
-            callback_url,
-            progress: JobProgress::default(),
-            cancelled: Arc::new(std::sync::atomic::AtomicBool::new(false)),
-            error_message: None,
-            target_url: url.to_string(),
-            queued_at_ms: now_ms(),
-            started_at_ms: None,
-            finished_at_ms: None,
-        },
-    );
+    let mut job = Job::new_queued(url.to_string());
+    job.callback_url = callback_url;
+    let lease = job.issue_worker_lease();
+    jobs.insert(id.clone(), job);
     // Bound retained finished scans. The admission cap above counts only active
     // jobs, so without this the map grows with every quick scan until the
     // retention TTL expires. Applied after the insert so the steady state is
     // exactly `max_retained_scans`; the job just added is non-terminal and so
     // is never a candidate for eviction.
     enforce_retention_cap(&mut jobs, state.max_retained_scans);
-    Some(id)
+    Some((id, lease))
 }
 
 /// Build the standard 503 "at capacity" response body for a rejected admission.

--- a/tests/remote_provider_cache_test.rs
+++ b/tests/remote_provider_cache_test.rs
@@ -1,0 +1,139 @@
+//! The remote payload / wordlist caches must be keyed by provider set.
+//!
+//! They used to be bare `OnceLock`s — "fetch once per process", which is right
+//! for the one-scan-per-process CLI and wrong for the `dalfox server` / MCP
+//! daemon, where every job carries its own `remote_payloads` /
+//! `remote_wordlists` list. The first job to fetch anything won the cell for
+//! the life of the process, so a later job asking for a different provider
+//! silently scanned with the first job's list and still reported `done`.
+//!
+//! This lives in its own integration binary because the caches are process
+//! globals: a separate process is what makes "the first init wins" observable
+//! without depending on the order of the whole `--lib` suite.
+
+use std::time::Duration;
+
+use dalfox::payload::{
+    RemoteFetchOptions, get_remote_payloads_for, get_remote_words_for, init_remote_payloads_with,
+    init_remote_wordlists_with, register_payload_provider, register_wordlist_provider,
+};
+use tokio::io::{AsyncReadExt, AsyncWriteExt};
+use tokio::net::TcpListener;
+
+/// Serve `body` as `text/plain` for up to `max_requests` connections.
+async fn spawn_text_server(
+    body: &'static str,
+    max_requests: usize,
+) -> (String, tokio::task::JoinHandle<()>) {
+    let listener = TcpListener::bind("127.0.0.1:0")
+        .await
+        .expect("bind local test server");
+    let addr = listener.local_addr().expect("get local addr");
+
+    let handle = tokio::spawn(async move {
+        for _ in 0..max_requests {
+            let Ok((mut stream, _)) = listener.accept().await else {
+                return;
+            };
+            let mut req_buf = [0u8; 1024];
+            let _ = stream.read(&mut req_buf).await;
+            let response = format!(
+                "HTTP/1.1 200 OK\r\nContent-Type: text/plain\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+                body.len(),
+                body
+            );
+            let _ = stream.write_all(response.as_bytes()).await;
+        }
+    });
+
+    (format!("http://{addr}/list.txt"), handle)
+}
+
+fn fetch_opts() -> RemoteFetchOptions {
+    RemoteFetchOptions {
+        timeout_secs: Some(3),
+        proxy: None,
+    }
+}
+
+/// Two jobs, two different providers: each must get back its own list.
+#[tokio::test]
+async fn test_remote_payload_cache_is_keyed_by_provider_set() {
+    let (url_a, handle_a) = spawn_text_server("alpha-payload\n", 1).await;
+    let (url_b, handle_b) = spawn_text_server("beta-payload\n", 1).await;
+    register_payload_provider("cache-key-a", vec![url_a]);
+    register_payload_provider("cache-key-b", vec![url_b]);
+
+    let a = vec!["cache-key-a".to_string()];
+    let b = vec!["cache-key-b".to_string()];
+
+    init_remote_payloads_with(&a, fetch_opts())
+        .await
+        .expect("provider A fetch");
+    // Second job, different provider set. Before the fix this short-circuited
+    // on the already-set OnceLock and never fetched provider B at all.
+    init_remote_payloads_with(&b, fetch_opts())
+        .await
+        .expect("provider B fetch");
+
+    assert_eq!(
+        get_remote_payloads_for(&a).expect("provider A cached").as_ref(),
+        &vec!["alpha-payload".to_string()],
+    );
+    assert_eq!(
+        get_remote_payloads_for(&b).expect("provider B cached").as_ref(),
+        &vec!["beta-payload".to_string()],
+        "a job asking for provider B must not be served provider A's payloads"
+    );
+
+    // The key is order- and case-insensitive and dedupes, so the same set
+    // spelled differently hits the same entry rather than refetching.
+    let b_spelled_differently = vec![
+        " CACHE-KEY-B ".to_string(),
+        "cache-key-b".to_string(),
+        String::new(),
+    ];
+    assert_eq!(
+        get_remote_payloads_for(&b_spelled_differently)
+            .expect("normalized key hits the same entry")
+            .as_ref(),
+        &vec!["beta-payload".to_string()],
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle_a).await;
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle_b).await;
+}
+
+/// A job naming only unrecognized providers takes the "no URLs" path and caches
+/// an empty list. That must not poison a later job that names a real provider —
+/// the poisoned daemon scanned with an empty wordlist and reported `done`.
+#[tokio::test]
+async fn test_unknown_provider_set_does_not_poison_a_real_one() {
+    let (url, handle) = spawn_text_server("id\nq\n", 1).await;
+    register_wordlist_provider("cache-key-real", vec![url]);
+
+    let bogus = vec!["definitely-not-a-registered-provider".to_string()];
+    let real = vec!["cache-key-real".to_string()];
+
+    init_remote_wordlists_with(&bogus, fetch_opts())
+        .await
+        .expect("unknown provider set caches an empty list");
+    assert!(
+        get_remote_words_for(&bogus)
+            .expect("unknown set is cached")
+            .is_empty()
+    );
+
+    init_remote_wordlists_with(&real, fetch_opts())
+        .await
+        .expect("real provider fetch");
+    assert_eq!(
+        get_remote_words_for(&real)
+            .expect("real provider cached")
+            .as_ref(),
+        &vec!["id".to_string(), "q".to_string()],
+        "an earlier unknown-provider job must not leave later jobs with an empty list"
+    );
+
+    let _ = tokio::time::timeout(Duration::from_secs(2), handle).await;
+}

--- a/tests/remote_provider_cache_test.rs
+++ b/tests/remote_provider_cache_test.rs
@@ -77,11 +77,15 @@ async fn test_remote_payload_cache_is_keyed_by_provider_set() {
         .expect("provider B fetch");
 
     assert_eq!(
-        get_remote_payloads_for(&a).expect("provider A cached").as_ref(),
+        get_remote_payloads_for(&a)
+            .expect("provider A cached")
+            .as_ref(),
         &vec!["alpha-payload".to_string()],
     );
     assert_eq!(
-        get_remote_payloads_for(&b).expect("provider B cached").as_ref(),
+        get_remote_payloads_for(&b)
+            .expect("provider B cached")
+            .as_ref(),
         &vec!["beta-payload".to_string()],
         "a job asking for provider B must not be served provider A's payloads"
     );

--- a/tests/remote_provider_cache_test.rs
+++ b/tests/remote_provider_cache_test.rs
@@ -90,18 +90,36 @@ async fn test_remote_payload_cache_is_keyed_by_provider_set() {
         "a job asking for provider B must not be served provider A's payloads"
     );
 
-    // The key is order- and case-insensitive and dedupes, so the same set
+    // The key is case-insensitive, order-insensitive and dedupes — exactly the
+    // normalizations the registry lookup itself applies — so the same set
     // spelled differently hits the same entry rather than refetching.
-    let b_spelled_differently = vec![
-        " CACHE-KEY-B ".to_string(),
-        "cache-key-b".to_string(),
-        String::new(),
-    ];
+    let b_spelled_differently = vec!["CACHE-KEY-B".to_string(), "cache-key-b".to_string()];
     assert_eq!(
         get_remote_payloads_for(&b_spelled_differently)
             .expect("normalized key hits the same entry")
             .as_ref(),
         &vec!["beta-payload".to_string()],
+    );
+
+    // A key normalization the *lookup* does not share would be a new bug: a
+    // name the registry cannot resolve must get its own (empty) entry rather
+    // than aliasing onto the trimmed one's fetched list.
+    let untrimmed = vec![" cache-key-a ".to_string()];
+    init_remote_payloads_with(&untrimmed, fetch_opts())
+        .await
+        .expect("unresolvable name caches an empty list");
+    assert!(
+        get_remote_payloads_for(&untrimmed)
+            .expect("untrimmed set cached")
+            .is_empty(),
+        "a name the registry cannot resolve must not alias onto another entry"
+    );
+    assert_eq!(
+        get_remote_payloads_for(&a)
+            .expect("provider A still cached")
+            .as_ref(),
+        &vec!["alpha-payload".to_string()],
+        "and it must not clobber the entry it looks similar to"
     );
 
     let _ = tokio::time::timeout(Duration::from_secs(2), handle_a).await;


### PR DESCRIPTION
Four daemon-lifecycle defects on the server / MCP / job surface, each with a
regression test that was mutation-verified (fix temporarily reverted, test
confirmed RED, fix restored).

---

## 1. `/preflight` ran flat out — no rate limit, no delay, no worker count

**Symptom.** `/preflight` is not a dry run in network terms: discovery and
mining probe the target for real. Measured against a two-parameter reflecting
target with `rate_limit: 4`, a server-wide `--rate-limit 4` **and**
`delay: 300`, it sent **20 requests in 79 ms** — every pacing control ignored.

The server-wide cap is the serious half: `--rate-limit` is documented as "applied
to every submitted scan… a request's own `rate_limit` may be lower but cannot
exceed or disable this cap", and a client refused a fast scan could simply
hammer the same target through `/preflight` instead. `delay` and `worker` are a
CLI/server divergence: the CLI's preflight honors `--delay`, because it runs
against a target hydrated from the same args.

**Root cause.**
* `src/server/handlers.rs:952` — `analyze_parameters` ran outside any
  `with_job_rate_limiter` scope. `crate::record_outbound_request` (which every
  discovery/mining probe calls) acquires from `RATE_LIMITER_JOB` / the
  process-wide limiter, and neither was set: `install_rate_limiter` is CLI-only
  and `state.rate_limit` was only read on the scan path
  (`src/server/job_runner.rs:282`).
* `src/server/job_runner.rs:558` — `hydrate_preflight_target` never set
  `t.delay` or `t.workers`. `analyze_parameters` reads pacing off the *target*
  (`target.delay` after each probe at `src/parameter_analysis/discovery.rs:396`,
  `target.workers` for its semaphores at `src/parameter_analysis/mod.rs:1206`),
  so both stayed at `parse_target`'s defaults.

**Fix.** `hydrate_preflight_target` now carries `delay` and `worker` onto the
target, and the preflight analysis future is wrapped in
`crate::with_job_rate_limiter(effective_rate_limit(opts.rate_limit,
state.rate_limit), …)` — the same ceiling helper the scan path uses, so the
operator's cap wins over the request value. The default worker count stays at
preflight's long-standing 10 (`PREFLIGHT_DEFAULT_WORKERS`) rather than the scan
default of 50, so honoring an explicit `worker` doesn't also quintuple the load
every existing caller puts on a target. `with_job_rate_limiter` is a plain
await at rate 0, so the default path pays nothing.

**Test.** `src/server/tests.rs`
* `test_hydrate_preflight_target_carries_delay_and_workers` (deterministic unit)
* `test_preflight_honors_server_wide_rate_limit` — counts the requests the
  target actually served and asserts the elapsed time against the GCRA floor
  derived from that count
* `test_preflight_honors_delay_and_worker_options` — `worker: 1` + `delay: 60`
  must serialize the probes

---

## 2. `remote_payloads` / `remote_wordlists` leaked across jobs

**Symptom.** In a `dalfox server` / MCP daemon, job A asking for provider *X*
and job B asking for provider *Y* both scanned with *X*'s list — and job B still
reported `done`, so the caller cannot tell that what they asked for was never
fetched. Worse, a job naming only unrecognized providers cached an **empty**
list and poisoned every later job the same way.

**Root cause.** `src/payload/remote.rs:9,12` — both caches were bare
`OnceLock<Arc<Vec<String>>>`: fetch once per process. Right for the
one-scan-per-process CLI, wrong for a daemon where every job carries its own
provider list. `init_remote_payloads_with` short-circuited on
`REMOTE_PAYLOADS.get().is_some()` regardless of which providers were asked for,
and the `urls.is_empty()` branch `set` an empty `Vec` unconditionally.

**Fix.** A small keyed map (`ProviderCache`) whose key is the normalized
provider set — lowercased, deduplicated, sorted, kept as a `Vec<String>` so a
provider name can't collide with a multi-provider set through a separator. The
key normalization is deliberately *exactly* what the registry lookup applies and
nothing more (no trimming): a stronger key normalization would let two lists
that resolve to different URL sets share one entry. An entry can now only be read
back by a job that asked for the same providers. Provider names are
caller-supplied, so the map is bounded at 64 sets; no live entry is ever evicted,
and hitting the bound is reported to the caller as a fetch failure (which the
callers already render as "scanning without the requested remote lists") rather
than silently leaving the set uncached.

`get_remote_payloads_for` / `get_remote_words_for` are the provider-aware
accessors. The provider-less `get_remote_payloads` / `get_remote_words` remain
for single-scan processes (the `payload` subcommand) and answer only when
exactly one provider set is cached rather than guessing.

**Test.** `tests/remote_provider_cache_test.rs` (its own binary, because the
caches are process globals):
* `test_remote_payload_cache_is_keyed_by_provider_set`
* `test_unknown_provider_set_does_not_poison_a_real_one`

---

## 3. A cancelled-but-draining job could be evicted, losing results and the webhook

**Symptom.** `cancel_scan_handler` stamps `status = Cancelled` and
`finished_at_ms` the moment the user asks, so `is_terminal()` is true while the
worker is still draining. A few submissions landing in that window let
`enforce_retention_cap` collect the entry: the worker's `jobs.get_mut(&id)` then
returned `None`, partial results were dropped, the terminal webhook never fired,
and a `GET` on the scan_id the client is holding 404s.

**Root cause.** `src/job/mod.rs:391` (`enforce_retention_cap`) filtered on
`job.is_terminal()`, and `purge_expired_jobs` (`src/job/mod.rs:369`) only looked
at `finished_at_ms`. Neither had any notion of "a worker still owns this".

**Fix.** `Job` now carries a worker lease: the spawned task holds an `Arc<()>`,
the job record a `Weak`. Dropping the task — normally, on panic, or without ever
being polled — is what makes the entry collectable, so there is no "clear the
flag" branch to forget on an error path, and cloning a `Job` for an outbound
response doesn't look like another worker. Both retention paths switch to
`Job::is_evictable()` (terminal **and** no live worker). Both front ends issue
the lease where they insert the queued job, so REST and MCP behave identically.
An explicit `DELETE /scan/{id}?purge=1` / `delete_scan_dalfox` is unchanged —
that is the caller asking for exactly this.

**Test.**
* `src/job/tests.rs`: `cancelled_job_with_a_live_worker_is_not_evictable`,
  `enforce_retention_cap_never_evicts_a_draining_job`,
  `purge_expired_jobs_keeps_a_draining_job_past_its_ttl`, and
  `a_job_with_no_worker_is_evictable_as_soon_as_it_is_terminal` (guards against
  the check degenerating into "never evict anything")
* `src/server/tests.rs::test_cancelled_but_draining_scan_survives_the_retention_cap`
  — end to end through `POST /scan` → `DELETE /scan/{id}` → three more
  admissions against `max_retained_scans = 1`, then asserts the worker still
  wrote its results back

---

## 4. MCP stranded a capacity slot on a cancelled tool call

**Symptom.** `scan_with_dalfox` inserted the queued job — which immediately
counts against `MAX_ACTIVE_SCANS_MCP` — and then awaited the remote
payload/wordlist fetch before spawning the worker. A tool call cancelled in that
window drops the future, so the worker is never spawned: nothing moves the job
out of `queued`, `purge_expired_jobs` only collects terminal jobs, and the slot
is gone for the life of the process.

**Root cause.** `src/mcp/mod.rs` — a network `.await` (up to the request timeout,
against a caller-named host) between the `jobs.insert` and the `spawn_blocking`.
REST never had this hole: `spawn_scan_task` runs synchronously right after
admission and `run_scan_job` does the fetch inside the task.

**Fix.** Moved the fetch into `run_job`, right after the job is claimed and
marked running — matching REST. Its warning now carries the `scan_id`, like the
REST side's does.

**Test.** `src/mcp/tests.rs::test_scan_with_dalfox_does_not_await_remote_fetch_in_the_tool_call`
— a provider URL pointed at a socket that accepts and never answers; the tool
call must return inside 500 ms and the job must leave `queued` on its own.

---

## REST ↔ MCP parity

* The shared `job::spec` mapping is untouched, so
  `job::tests::rest_and_mcp_requests_agree_on_scan_args` still covers it (no new
  fields).
* The worker lease is issued on both submit paths (REST `try_admit_and_queue`,
  MCP `scan_with_dalfox`) and both retention helpers are shared, so eviction
  behaves identically on the two surfaces.
* Remote-list fetch placement is now identical (inside the worker on both).

---

## Deferred

* **MCP `preflight_dalfox` has no pacing controls at all.**
  `PreflightDalfoxParams` (`src/mcp/mod.rs:728`) accepts no `delay`, `workers`
  or `rate_limit`, so MCP preflight always runs at ten workers with no delay and
  no limiter. Nothing is *discarded* there, so it is not the same bug — but it
  is now a parity gap with REST. Adding the fields expands the MCP tool schema,
  which per repo convention has to move together with `skills/dalfox/`, the
  `.well-known` SKILL.md + digest, and the EN+KO docs. Out of scope here.
* **`ScanArgs::for_preflight` still hardcodes `workers: 10`**
  (`src/cmd/scan/args.rs:1084`). Harmless today — `analyze_parameters` reads
  `target.workers`, which this PR fixes — but it is a second, divergent source of
  truth. Lives in `src/cmd/**`.
* **Cancel still frees a capacity slot while the worker runs on.**
  `try_admit_and_queue` and the MCP admission both count `!j.is_terminal()`, so a
  cancelled-but-draining job stops counting against `--max-concurrent-scans` /
  `MAX_ACTIVE_SCANS_MCP` while its thread is still burning. The `worker_lease`
  added here is exactly the primitive to fix it
  (`!j.is_terminal() || j.worker_alive()`), but that changes admission semantics
  (a cancel would no longer immediately free a slot), so it wants its own call.
* **`DELETE /scan/{id}?purge=1` can still drop a draining job's results.** Left
  deliberately: it is an explicit caller request, and turning it into a 409
  "still draining" changes documented DELETE semantics.
* **The pre-scan remote fetch is outside the `scan_timeout` budget** on both
  surfaces (`run_within_scan_budget` wraps only `execute_scan`). Pre-existing;
  moving the MCP fetch into the worker did not change it.

## Files touched outside server / mcp / job / payload::remote

The keyed getters forced two one-line call-site updates, both mechanical:
* `src/scanning/xss_common.rs:527` — `get_remote_payloads()` →
  `get_remote_payloads_for(&args.remote_payloads)`
* `src/parameter_analysis/mining.rs:649` — `get_remote_words()` →
  `get_remote_words_for(&args.remote_wordlists)`

Flagging them explicitly in case they collide with concurrent work in those
files.
