### PR TITLE
fix(scan): key found-params per wire slot, honor cancel in probe/HPP, gate --sxss responses

### DIFF
--- a/src/cmd/scan/analysis.rs
+++ b/src/cmd/scan/analysis.rs
@@ -285,76 +285,67 @@ pub(crate) async fn preflight_and_analyze_target(
     )
     .await?;
 
-    // Pretty start log per target (plain only)
+    // Pretty start log per target (plain only). Multi-target runs deliberately
+    // render a single overall progress line instead of this per-target block,
+    // so the whole block is gated on `total_targets_copy == 1`.
     if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
-        if total_targets_copy > 1 {
-            let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(target.url.as_ref()));
-            let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-            crate::cprintln!(
-                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} start scan to {}",
-                ts,
-                sid,
-                target.url
-            );
-        } else {
-            let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-            crate::cprintln!(
-                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m start scan to {}",
-                ts,
-                target.url
-            );
-            if __preflight_csp_present {
-                crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m CSP: enabled", ts);
-                if let Some((hn, hv)) = &__preflight_csp_header {
+        let ts = chrono::Local::now().format("%-I:%M%p").to_string();
+        crate::cprintln!(
+            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m start scan to {}",
+            ts,
+            target.url
+        );
+        if __preflight_csp_present {
+            crate::cprintln!("\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m CSP: enabled", ts);
+            if let Some((hn, hv)) = &__preflight_csp_header {
+                crate::cprintln!(
+                    "  \x1b[90m└──\x1b[0m \x1b[38;5;247m{}:\x1b[0m \x1b[38;5;247m{}\x1b[0m",
+                    hn,
+                    hv
+                );
+            }
+        }
+        // Log WAF detection
+        if let Some(ref waf_info) = target.waf_info {
+            for fp in &waf_info.detected {
+                crate::cprintln!(
+                    "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m {} detected (confidence: {:.0}%, evidence: {})",
+                    ts,
+                    fp.waf_type,
+                    fp.confidence * 100.0,
+                    fp.evidence
+                );
+            }
+            if args_clone.waf_bypass != "off" {
+                let waf_types: Vec<&crate::waf::WafType> = waf_info.waf_types();
+                let strategy = crate::waf::bypass::merge_strategies(&waf_types);
+                if !strategy.extra_encoders.is_empty() {
                     crate::cprintln!(
-                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247m{}:\x1b[0m \x1b[38;5;247m{}\x1b[0m",
-                        hn,
-                        hv
+                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass encoders: {}\x1b[0m",
+                        strategy.extra_encoders.join(", ")
+                    );
+                }
+                if !strategy.mutations.is_empty() {
+                    crate::cprintln!(
+                        "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass mutations: {} types\x1b[0m",
+                        strategy.mutations.len()
                     );
                 }
             }
-            // Log WAF detection
-            if let Some(ref waf_info) = target.waf_info {
-                for fp in &waf_info.detected {
-                    crate::cprintln!(
-                        "\x1b[90m{}\x1b[0m \x1b[33mWAF\x1b[0m {} detected (confidence: {:.0}%, evidence: {})",
-                        ts,
-                        fp.waf_type,
-                        fp.confidence * 100.0,
-                        fp.evidence
-                    );
-                }
-                if args_clone.waf_bypass != "off" {
-                    let waf_types: Vec<&crate::waf::WafType> = waf_info.waf_types();
-                    let strategy = crate::waf::bypass::merge_strategies(&waf_types);
-                    if !strategy.extra_encoders.is_empty() {
-                        crate::cprintln!(
-                            "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass encoders: {}\x1b[0m",
-                            strategy.extra_encoders.join(", ")
-                        );
-                    }
-                    if !strategy.mutations.is_empty() {
-                        crate::cprintln!(
-                            "  \x1b[90m└──\x1b[0m \x1b[38;5;247mbypass mutations: {} types\x1b[0m",
-                            strategy.mutations.len()
-                        );
-                    }
-                }
-            }
-            // Log detected technologies
-            if let Some(ref tech_info) = target.tech_info {
-                let tech_names: Vec<String> = tech_info
-                    .detected
-                    .iter()
-                    .map(|d| format!("{}", d.tech))
-                    .collect();
-                if !tech_names.is_empty() {
-                    crate::cprintln!(
-                        "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m tech: {}",
-                        ts,
-                        tech_names.join(", ")
-                    );
-                }
+        }
+        // Log detected technologies
+        if let Some(ref tech_info) = target.tech_info {
+            let tech_names: Vec<String> = tech_info
+                .detected
+                .iter()
+                .map(|d| format!("{}", d.tech))
+                .collect();
+            if !tech_names.is_empty() {
+                crate::cprintln!(
+                    "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m tech: {}",
+                    ts,
+                    tech_names.join(", ")
+                );
             }
         }
     }
@@ -362,19 +353,14 @@ pub(crate) async fn preflight_and_analyze_target(
     // Silence parameter analysis logs and progress; show spinner for single-target runs.
     // When multi_pb_clone is active, analyze_parameters renders its own indicatif
     // spinner via that MultiProgress — skip the stdout spinner so we don't double up.
-    let current = analyze_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
+    analyze_idx_clone.fetch_add(1, Ordering::Relaxed);
+    // Single-target only: multi-target runs render the overall progress bar
+    // instead, so there is no `[n/total]` variant of this label to build.
     let __analyze_spinner = if total_targets_copy == 1 && multi_pb_clone.is_none() {
         start_spinner(
             spinner_allowed,
             !args_clone.silence,
-            if total_targets_copy > 1 {
-                format!(
-                    "[{}/{}] analyzing: {}",
-                    current, total_targets_copy, target.url
-                )
-            } else {
-                format!("analyzing: {}", target.url)
-            },
+            format!("analyzing: {}", target.url),
         )
     } else {
         None
@@ -470,21 +456,11 @@ pub(crate) async fn preflight_and_analyze_target(
     if args_clone.format == "plain" && !args_clone.silence && total_targets_copy == 1 {
         let n = target.reflection_params.len();
         let ts = chrono::Local::now().format("%-I:%M%p").to_string();
-        if total_targets_copy > 1 {
-            let sid = crate::utils::short_scan_id(&crate::utils::make_scan_id(target.url.as_ref()));
-            crate::cprintln!(
-                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m {} found reflected \x1b[33m{}\x1b[0m params",
-                ts,
-                sid,
-                n
-            );
-        } else {
-            crate::cprintln!(
-                "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m found reflected \x1b[33m{}\x1b[0m params",
-                ts,
-                n
-            );
-        }
+        crate::cprintln!(
+            "\x1b[90m{}\x1b[0m \x1b[36mINF\x1b[0m found reflected \x1b[33m{}\x1b[0m params",
+            ts,
+            n
+        );
         for (i, p) in target.reflection_params.iter().enumerate() {
             let bullet = if i + 1 == n { "└──" } else { "├──" };
             let valid = p
@@ -594,18 +570,15 @@ async fn run_target_preflight(
     // and the initial-response AST DOM analysis under `--deep-scan`,
     // making the "more thorough" mode strictly weaker.
     {
-        let current = preflight_idx_clone.fetch_add(1, Ordering::Relaxed) + 1;
-        // Print an ephemeral spinner and auto-clear when finished
-        let label = if total_targets_copy > 1 {
-            format!(
-                "[{}/{}] preflight: {}",
-                current, total_targets_copy, target.url
-            )
-        } else {
-            format!("preflight: {}", target.url)
-        };
+        preflight_idx_clone.fetch_add(1, Ordering::Relaxed);
+        // Print an ephemeral spinner and auto-clear when finished. Single-target
+        // only, for the same reason as the analysis spinner above.
         let __preflight_spinner = if total_targets_copy == 1 {
-            start_spinner(spinner_allowed, !args_clone.silence, label)
+            start_spinner(
+                spinner_allowed,
+                !args_clone.silence,
+                format!("preflight: {}", target.url),
+            )
         } else {
             None
         };

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1727,6 +1727,103 @@ impl ReflectionBody {
     }
 }
 
+/// Status/header-level suppression gates every injection response must pass
+/// before a reflection may be recorded from it.
+///
+/// Shared by the normal reflection branch and the `--sxss` branch of
+/// [`fetch_injection_response_with_client`]. The `--sxss` branch used to apply
+/// none of them, so a stored-XSS run reported reflections the plain run drops:
+/// echoes into `application/json` / `text/csv` / nosniff `text/plain` bodies,
+/// responses whose status the operator excluded with `--ignore-return`, and
+/// path-injection echoes on redirects or non-markup content-types.
+///
+/// Returns `true` when the response must not produce a finding. Body-level
+/// suppression (`should_suppress_path_reflection_with_body`) is applied
+/// separately by the callers, once the body has been read.
+fn injection_response_suppressed(
+    status_code: u16,
+    headers: &reqwest::header::HeaderMap,
+    param: &Param,
+    args: &crate::cmd::scan::ScanArgs,
+) -> bool {
+    // Skip processing if the status code is in the ignore_return list
+    if !args.ignore_return.is_empty() && args.ignore_return.contains(&status_code) {
+        return true;
+    }
+    let content_type = headers
+        .get(reqwest::header::CONTENT_TYPE)
+        .and_then(|v| v.to_str().ok())
+        .unwrap_or("");
+
+    // Inert-data content-type suppression for ALL non-Path locations.
+    // When the response declares a structured-data / binary type
+    // (`application/json`, `text/csv`, raster image, …), a browser
+    // navigating to it renders the body as data — never as markup —
+    // so a payload reflected into it is not exploitable as reflected
+    // XSS even when the body happens to contain HTML-looking text.
+    // This removes the false positives where a query/body param is
+    // echoed into a JSON API response (e.g. `{"q":"<svg onload=…>"}`).
+    // Path has its own stricter markup-only gate just below; JSONP
+    // (`application/javascript`) is intentionally NOT treated as inert
+    // here (see `content_type_is_inert_data`), preserving those
+    // detections. `text/plain` is inert only when the response also
+    // sends `X-Content-Type-Options: nosniff` — without it a browser
+    // sniffs the body as HTML, with it the body can never be markup.
+    //
+    // Skip redirects: a 3xx carries the reflection in its `Location`
+    // header, and the body content-type describes the (usually empty)
+    // redirect body, not the redirect target — so it says nothing about
+    // whether the Location reflection is exploitable. Let those fall
+    // through to the Location-header check in the caller.
+    if !matches!(param.location, Location::Path) && !(300..400).contains(&status_code) {
+        let nosniff = crate::utils::headers_declare_nosniff(headers);
+        if crate::utils::content_type_is_inert_data_with_nosniff(content_type, nosniff) {
+            crate::dbg_log!(
+                "suppressing reflection on inert-data content-type (param={}, content-type={}, nosniff={})",
+                param.name,
+                content_type,
+                nosniff
+            );
+            return true;
+        }
+    }
+
+    // Hard suppressions for Path that don't need to read the body:
+    //   * 3xx redirects: any reflection lives in the Location header,
+    //     not a rendered HTML sink. Browsers don't execute Location
+    //     bodies, so there's nothing exploitable here regardless of
+    //     marker context — keep the old blanket drop.
+    //   * non-HTML content-types: response is JSON / JS / image and
+    //     browsers render it as data, not markup.
+    if matches!(param.location, Location::Path) {
+        if (300..400).contains(&status_code) {
+            crate::dbg_log!(
+                "suppressing path reflection on 3xx redirect (param={}, status={})",
+                param.name,
+                status_code
+            );
+            return true;
+        }
+        // `image/svg+xml` executes inline <script>/event handlers on
+        // top-level navigation, so a dynamically-generated SVG that
+        // reflects a path segment is a real sink — allow it alongside
+        // the HTML-ish types (don't open up JSON/JS/raster, which render
+        // as data).
+        let executes_as_markup = crate::utils::is_htmlish_content_type(content_type)
+            || crate::utils::content_type_primary(content_type).as_deref() == Some("image/svg+xml");
+        if !content_type.is_empty() && !executes_as_markup {
+            crate::dbg_log!(
+                "suppressing path-injection reflection on non-HTML content-type (param={}, content-type={})",
+                param.name,
+                content_type
+            );
+            return true;
+        }
+    }
+
+    false
+}
+
 async fn fetch_injection_response(
     target: &Target,
     param: &Param,
@@ -1801,11 +1898,51 @@ async fn fetch_injection_response_with_client(
     // from the injection request. If retrieval URLs don't surface the
     // payload, classify the inject body before giving up.
     if args.sxss {
-        // Eagerly consume the injection response body so we can use it as
-        // an inline-rendered fallback. We drop status/headers because the
-        // retrieval-URL path doesn't gate on them either, and we want
-        // consistent SXSS evidence semantics.
-        let inject_body: Option<String> = match inject_resp {
+        // Read a candidate body — the injection response (usable as an
+        // inline-rendered fallback) or a retrieval-URL response — applying the
+        // same status/header gates and the same body-level Path gate the normal
+        // branch applies, then tag it with whether it was served as executable
+        // JavaScript. Both SXSS paths previously skipped all of that, so a
+        // stored run reported reflections into JSON APIs, into statuses the
+        // operator excluded with `--ignore-return`, and path echoes on
+        // non-markup responses — every false positive the plain path removes.
+        async fn gated_body(
+            resp: reqwest::Response,
+            param: &Param,
+            payload: &str,
+            args: &crate::cmd::scan::ScanArgs,
+        ) -> Option<ReflectionBody> {
+            let status_code = resp.status().as_u16();
+            if injection_response_suppressed(status_code, resp.headers(), param, args) {
+                return None;
+            }
+            let is_js_content_type = crate::utils::is_javascript_content_type(
+                resp.headers()
+                    .get(reqwest::header::CONTENT_TYPE)
+                    .and_then(|v| v.to_str().ok())
+                    .unwrap_or(""),
+            );
+            let text = crate::utils::http::read_body(resp).await.ok()?;
+            if text.is_empty() {
+                return None;
+            }
+            if should_suppress_path_reflection_with_body(
+                &param.location,
+                status_code,
+                &text,
+                payload,
+            ) {
+                crate::dbg_log!(
+                    "suppressing url-echo-only path reflection (param={}, status={})",
+                    param.name,
+                    status_code
+                );
+                return None;
+            }
+            Some(ReflectionBody::rendered(text).with_js_content_type(is_js_content_type))
+        }
+
+        let inject_body: Option<ReflectionBody> = match inject_resp {
             Ok(resp) => {
                 // Mirror the normal path's WAF accounting on the stored-write
                 // response before consuming the body: a 403/406/503 stored-write
@@ -1815,17 +1952,14 @@ async fn fetch_injection_response_with_client(
                 // target_summary.waf.bypass is always empty.
                 let status_code = resp.status().as_u16();
                 apply_injection_waf_accounting(status_code, target, args, streak).await;
-                crate::utils::http::read_body(resp)
-                    .await
-                    .ok()
-                    .filter(|t| !t.is_empty())
+                gated_body(resp, param, payload, args).await
             }
             Err(_) => None,
         };
 
         let check_urls = resolve_sxss_check_urls(target, param, args);
         let retries = args.sxss_retries.max(1) as u64;
-        let mut fallback_body: Option<String> = None;
+        let mut fallback_body: Option<ReflectionBody> = None;
         for sxss_url in &check_urls {
             // Retry with delay to handle session / content propagation
             for attempt in 0u64..retries {
@@ -1843,14 +1977,13 @@ async fn fetch_injection_response_with_client(
 
                 crate::record_outbound_request().await;
                 if let Ok(resp) = check_request.send().await
-                    && let Ok(text) = crate::utils::http::read_body(resp).await
-                    && !text.is_empty()
+                    && let Some(body) = gated_body(resp, param, payload, args).await
                 {
-                    if classify_reflection(&text, payload).is_some() {
-                        return Some(ReflectionBody::rendered(text));
+                    if classify_reflection(&body.text, payload).is_some() {
+                        return Some(body);
                     }
                     if fallback_body.is_none() {
-                        fallback_body = Some(text);
+                        fallback_body = Some(body);
                     }
                 }
             }
@@ -1860,11 +1993,11 @@ async fn fetch_injection_response_with_client(
         // /comments page). Without this check we'd miss the entire class
         // of sinks where the write-response is the rendered view.
         if let Some(body) = inject_body.as_ref()
-            && classify_reflection(body, payload).is_some()
+            && classify_reflection(&body.text, payload).is_some()
         {
-            return inject_body.map(ReflectionBody::rendered);
+            return inject_body;
         }
-        fallback_body.or(inject_body).map(ReflectionBody::rendered)
+        fallback_body.or(inject_body)
     } else {
         // Normal reflection check
         if let Ok(resp) = inject_resp {
@@ -1883,83 +2016,10 @@ async fn fetch_injection_response_with_client(
             // Adaptive WAF accounting (per-worker streak + cooldown + telemetry).
             apply_injection_waf_accounting(status_code, target, args, streak).await;
 
-            // Skip processing if the status code is in the ignore_return list
-            if !args.ignore_return.is_empty() && args.ignore_return.contains(&status_code) {
+            // `--ignore-return`, inert-data content-types, and the Path-only
+            // redirect / non-markup drops. Shared with the `--sxss` branch above.
+            if injection_response_suppressed(status_code, resp.headers(), param, args) {
                 return None;
-            }
-            // Inert-data content-type suppression for ALL non-Path locations.
-            // When the response declares a structured-data / binary type
-            // (`application/json`, `text/csv`, raster image, …), a browser
-            // navigating to it renders the body as data — never as markup —
-            // so a payload reflected into it is not exploitable as reflected
-            // XSS even when the body happens to contain HTML-looking text.
-            // This removes the false positives where a query/body param is
-            // echoed into a JSON API response (e.g. `{"q":"<svg onload=…>"}`).
-            // Path has its own stricter markup-only gate just below; JSONP
-            // (`application/javascript`) is intentionally NOT treated as inert
-            // here (see `content_type_is_inert_data`), preserving those
-            // detections. `text/plain` is inert only when the response also
-            // sends `X-Content-Type-Options: nosniff` — without it a browser
-            // sniffs the body as HTML, with it the body can never be markup.
-            //
-            // Skip redirects: a 3xx carries the reflection in its `Location`
-            // header, and the body content-type describes the (usually empty)
-            // redirect body, not the redirect target — so it says nothing about
-            // whether the Location reflection is exploitable. Let those fall
-            // through to the Location-header check below.
-            if !matches!(param.location, Location::Path) && !(300..400).contains(&status_code) {
-                let ct = resp
-                    .headers()
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("");
-                let nosniff = crate::utils::headers_declare_nosniff(resp.headers());
-                if crate::utils::content_type_is_inert_data_with_nosniff(ct, nosniff) {
-                    crate::dbg_log!(
-                        "suppressing reflection on inert-data content-type (param={}, content-type={}, nosniff={})",
-                        param.name,
-                        ct,
-                        nosniff
-                    );
-                    return None;
-                }
-            }
-            // Hard suppressions for Path that don't need to read the body:
-            //   * 3xx redirects: any reflection lives in the Location header,
-            //     not a rendered HTML sink. Browsers don't execute Location
-            //     bodies, so there's nothing exploitable here regardless of
-            //     marker context — keep the old blanket drop.
-            //   * non-HTML content-types: response is JSON / JS / image and
-            //     browsers render it as data, not markup.
-            if matches!(param.location, Location::Path) {
-                if (300..400).contains(&status_code) {
-                    crate::dbg_log!(
-                        "suppressing path reflection on 3xx redirect (param={}, status={})",
-                        param.name,
-                        status_code
-                    );
-                    return None;
-                }
-                let ct = resp
-                    .headers()
-                    .get(reqwest::header::CONTENT_TYPE)
-                    .and_then(|v| v.to_str().ok())
-                    .unwrap_or("");
-                // `image/svg+xml` executes inline <script>/event handlers on
-                // top-level navigation, so a dynamically-generated SVG that
-                // reflects a path segment is a real sink — allow it alongside
-                // the HTML-ish types (don't open up JSON/JS/raster, which render
-                // as data).
-                let executes_as_markup = crate::utils::is_htmlish_content_type(ct)
-                    || crate::utils::content_type_primary(ct).as_deref() == Some("image/svg+xml");
-                if !ct.is_empty() && !executes_as_markup {
-                    crate::dbg_log!(
-                        "suppressing path-injection reflection on non-HTML content-type (param={}, content-type={})",
-                        param.name,
-                        ct
-                    );
-                    return None;
-                }
             }
             // Check for redirect context: if the response is a 3xx redirect,
             // the Location header may contain the reflected payload in either

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -163,9 +163,36 @@ pub(crate) fn count_matching_results(
         .count()
 }
 
+/// Per-target "a finding already landed for this injection point" sets, keyed
+/// by [`found_param_key`].
 struct FoundParams {
     reflection: HashSet<String>,
     dom: HashSet<String>,
+}
+
+/// Identity of a parameter *slot* for the [`FoundParams`] sets.
+///
+/// Keyed on the wire location and the wire-level name, not just the display
+/// name: the same name routinely names two independent injection points on one
+/// request — `?q=` in the query string *and* `q` in the POST body, or a `q`
+/// cookie — and a finding at one says nothing about the other. Keying on
+/// `Param::name` alone let the first slot that produced a finding suppress
+/// every sibling slot: the reflection/DOM phases short-circuited and the
+/// dispatch loop skipped the sibling's worker outright, so a vulnerable body
+/// parameter was silently never reported (false negative).
+///
+/// `wire_name` is part of the key so nested-field synthetic params
+/// (`qs[move_url]`, whose wire name is the parent `qs`) stay distinct from one
+/// another exactly as they were under the old name-only key.
+fn found_param_key(param: &Param) -> String {
+    // `\u{1}` separator: not producible by a URL/header parameter name, so
+    // concatenation cannot alias two different slots onto one key.
+    format!(
+        "{:?}\u{1}{}\u{1}{}",
+        param.location,
+        param.name,
+        param.effective_wire_name()
+    )
 }
 
 /// Label written to `Result.inject_type` for findings produced by the scan
@@ -1542,7 +1569,7 @@ fn log_waf_block_stats(target: &Target) {
 }
 
 /// Collapse this target's R findings that are already proven by one of its
-/// own V findings on the same `(param, inject_type)`, adjusting
+/// own V findings on the same `(param, location, inject_type)`, adjusting
 /// `findings_count` for any dropped duplicates. Multiple per-param payload
 /// variants typically surface the same logical issue twice — keep the
 /// strongest evidence and drop weaker R duplicates. See
@@ -1573,12 +1600,22 @@ async fn collapse_target_results(
     }
 }
 
-/// Outcome of a per-parameter scan phase. `Abort` mirrors the pre-refactor
-/// `return` out of the worker task: a global `--limit` was reached mid-phase,
-/// so the worker stops immediately and drops any results batched so far (the
-/// limit is already hit and the scan is winding down). A `break`-style early
-/// exit (cancellation) instead yields `Continue`, so later phases run their
-/// own cancellation checks and the batched results are still flushed.
+/// Outcome of a per-parameter scan phase. `Abort` means a global `--limit` was
+/// reached mid-phase, so the worker stops immediately without running the
+/// remaining phases. A `break`-style early exit (cancellation) instead yields
+/// `Continue`, so later phases run their own cancellation checks.
+///
+/// Either way the caller flushes whatever the worker already batched. The
+/// pre-refactor `return` discarded that batch instead, on the reasoning that
+/// "the limit is already hit, the scan is winding down" — but `--limit` is a
+/// *stop condition*, not an instruction to destroy evidence already confirmed
+/// against the target, and the worker that aborts is rarely the one that
+/// reached the cap. The discard is observable whenever the surviving tally
+/// falls back under the limit before rendering, which `collapse_target_results`
+/// does routinely (it decrements `findings_count` for every `R` a `V` covers):
+/// the report then has room for the findings the abort threw away. Flushing
+/// cannot overshoot the cap either, because `--limit` truncation is applied
+/// once more at render time (`cmd::scan::output`).
 enum PhaseFlow {
     Continue,
     Abort,
@@ -1808,6 +1845,15 @@ impl ScanWorkerCtx {
 
         let mut state = ParamScanState::default();
 
+        // Every parameter's worker is spawned up front (the dispatch loop only
+        // gates *spawning* on cancellation), so on a cancelled scan the workers
+        // still queued behind this semaphore would each go on to fire the Stage-0
+        // probe and the HPP phase — thousands of requests at a target the user
+        // already asked us to stop hitting. Bail before the first request.
+        if self.cancelled() {
+            return;
+        }
+
         // Stage 0: fast probe to avoid large payload blasts on non-reflective
         // params (also runs one-shot AST DOM analysis on the probe response).
         let probe_reflected = self.probe_param(&param, &mut state).await;
@@ -1834,9 +1880,11 @@ impl ScanWorkerCtx {
             .run_reflection_phase(&param, reflection_payloads, &mut state)
             .await
         {
+            self.flush_results(&mut state.local_results).await;
             return;
         }
         if let PhaseFlow::Abort = self.run_dom_phase(&param, dom_payloads, &mut state).await {
+            self.flush_results(&mut state.local_results).await;
             return;
         }
         self.run_hpp_phase(&param, hpp_payloads, &mut state).await;
@@ -1860,6 +1908,9 @@ impl ScanWorkerCtx {
         let mut probe_reflected = false;
         let mut probe_response_text: Option<String> = None;
         for pp in probe_payloads {
+            if self.cancelled() {
+                break;
+            }
             let (kind, response_text) = check_reflection_with_response_tracked(
                 Some(client),
                 &self.target,
@@ -1911,8 +1962,9 @@ impl ScanWorkerCtx {
         }
 
         // If probe found no reflection, try a numeric-only probe to detect
-        // letter-stripping filters (e.g., /[a-zA-Z]/ removal).
-        if !probe_reflected {
+        // letter-stripping filters (e.g., /[a-zA-Z]/ removal). Skipped once the
+        // scan is cancelled — it is a second HTTP request per parameter.
+        if !probe_reflected && !self.cancelled() {
             let numeric_probe = crate::scanning::check_reflection::NUMERIC_PROBE_MARKER;
             let (kind, _) = check_reflection_with_response_tracked(
                 Some(client),
@@ -1976,7 +2028,7 @@ impl ScanWorkerCtx {
                     .read()
                     .await
                     .reflection
-                    .contains(&param.name);
+                    .contains(&found_param_key(param));
                 if already {
                     state.reflection_found_locally = true;
                     (None, None)
@@ -2067,7 +2119,7 @@ impl ScanWorkerCtx {
                 if body_is_javascript && dom_evidence_kind.is_none() {
                     if !self.args.deep_scan {
                         let mut found = self.found_params.write().await;
-                        found.reflection.insert(param.name.clone());
+                        found.reflection.insert(found_param_key(param));
                         state.reflection_found_locally = true;
                     }
                     continue;
@@ -2077,8 +2129,9 @@ impl ScanWorkerCtx {
                     true
                 } else {
                     let mut found = self.found_params.write().await;
-                    if !found.reflection.contains(&param.name) {
-                        found.reflection.insert(param.name.clone());
+                    let key = found_param_key(param);
+                    if !found.reflection.contains(&key) {
+                        found.reflection.insert(key);
                         state.reflection_found_locally = true;
                         true
                     } else {
@@ -2139,7 +2192,7 @@ impl ScanWorkerCtx {
                             // Mark dom_found so we skip redundant DOM verification
                             {
                                 let mut found = self.found_params.write().await;
-                                found.dom.insert(param.name.clone());
+                                found.dom.insert(found_param_key(param));
                             }
                             state.dom_found_locally = true;
                             let evidence_label = kind.label();
@@ -2261,7 +2314,12 @@ impl ScanWorkerCtx {
             let already_dom_found = if state.dom_found_locally {
                 true
             } else {
-                let is_found = self.found_params.read().await.dom.contains(&param.name);
+                let is_found = self
+                    .found_params
+                    .read()
+                    .await
+                    .dom
+                    .contains(&found_param_key(param));
                 if is_found {
                     state.dom_found_locally = true;
                 }
@@ -2294,8 +2352,9 @@ impl ScanWorkerCtx {
                     true
                 } else {
                     let mut found = self.found_params.write().await;
-                    if !found.dom.contains(&param.name) {
-                        found.dom.insert(param.name.clone());
+                    let key = found_param_key(param);
+                    if !found.dom.contains(&key) {
+                        found.dom.insert(key);
                         state.dom_found_locally = true;
                         true
                     } else {
@@ -2422,10 +2481,18 @@ impl ScanWorkerCtx {
         let hpp_positions = [HppPosition::Last, HppPosition::First, HppPosition::Both];
 
         'hpp_outer: for hpp_payload in &hpp_payloads {
-            if self.limit_reached() {
+            // Cancellation is checked here *and* in the inner position loop:
+            // this phase runs after the reflection/DOM phases have already
+            // broken out on cancel, and without its own check a cancelled
+            // `--hpp` scan kept firing up to `payloads x positions` requests
+            // per parameter after the user stopped it.
+            if self.limit_reached() || self.cancelled() {
                 break;
             }
             for &position in &hpp_positions {
+                if self.cancelled() {
+                    break 'hpp_outer;
+                }
                 if let Some(hpp_url) = build_hpp_url(&self.target.url, param, hpp_payload, position)
                 {
                     let (kind, response_text) =
@@ -2695,8 +2762,9 @@ pub async fn run_scanning(
             break;
         }
         let already_found = {
+            let key = found_param_key(&param_clone);
             let fp = found_params.read().await;
-            fp.reflection.contains(&param_clone.name) || fp.dom.contains(&param_clone.name)
+            fp.reflection.contains(&key) || fp.dom.contains(&key)
         };
         if already_found && !args.deep_scan {
             // Skip further testing for this param if reflection or DOM XSS
@@ -2762,8 +2830,8 @@ pub async fn run_scanning(
     log_waf_block_stats(target);
 
     // Collapse this target's R findings that are already proven by one of
-    // its own V findings on the same (param, inject_type), scoped to the
-    // current target so other targets' findings are never affected.
+    // its own V findings on the same (param, location, inject_type), scoped
+    // to the current target so other targets' findings are never affected.
     collapse_target_results(&results, &findings_count, &limit_result_type, target).await;
 
     if let Some(pb) = pb {
@@ -2781,24 +2849,32 @@ pub async fn run_scanning(
 }
 
 /// Drop Reflected findings on the *current target* that are already covered
-/// by a Verified finding on the same `(param, inject_type)` for that same
-/// target. Verified and AST findings are preserved.
+/// by a Verified finding on the same `(param, location, inject_type)` for
+/// that same target. Verified and AST findings are preserved.
 ///
 /// Scope is critical: this runs at the end of each target's scan against
 /// the shared cross-target results vector. Without scoping, a V finding on
 /// one target would silently drop every later R finding on different
 /// targets that share the same reflection shape (param + inject_type) —
 /// which on benchmarks like xssmaze is the common case.
+///
+/// `location` is part of the key for the same reason it is part of
+/// [`found_param_key`]: a `q` in the query string and a `q` in the request
+/// body are different injection points, so proving one exploitable says
+/// nothing about the other and must not delete the other's evidence.
 fn collapse_redundant_reflected(
     results: Vec<crate::scanning::result::Result>,
     target_url: &str,
 ) -> Vec<crate::scanning::result::Result> {
     use std::collections::HashSet;
     let belongs = |data: &str| crate::utils::finding_belongs_to_target(target_url, data);
-    let verified_keys: HashSet<(String, String)> = results
+    let key = |r: &crate::scanning::result::Result| {
+        (r.param.clone(), r.location.clone(), r.inject_type.clone())
+    };
+    let verified_keys: HashSet<(String, String, String)> = results
         .iter()
         .filter(|r| r.result_type == FindingType::Verified && belongs(&r.data))
-        .map(|r| (r.param.clone(), r.inject_type.clone()))
+        .map(key)
         .collect();
     if verified_keys.is_empty() {
         return results;
@@ -2808,7 +2884,7 @@ fn collapse_redundant_reflected(
         .filter(|r| {
             !(r.result_type == FindingType::Reflected
                 && belongs(&r.data)
-                && verified_keys.contains(&(r.param.clone(), r.inject_type.clone())))
+                && verified_keys.contains(&key(r)))
         })
         .collect()
 }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -217,6 +217,36 @@ fn test_collapse_keeps_r_when_no_v_for_that_param() {
     assert_eq!(after.len(), 2, "no V to cover, keep R findings");
 }
 
+/// A `q` in the query string and a `q` in the request body are different
+/// injection points (see `found_param_key`), so proving the body one
+/// exploitable must not delete the query one's evidence.
+#[test]
+fn test_collapse_keeps_r_when_the_v_is_at_a_different_wire_location() {
+    let mut verified_body = make_typed_param_result(FindingType::Verified, "q", "inHTML");
+    verified_body.location = "Body".to_string();
+    let mut reflected_query = make_typed_param_result(FindingType::Reflected, "q", "inHTML");
+    reflected_query.location = "Query".to_string();
+
+    let after = collapse_redundant_reflected(
+        vec![verified_body, reflected_query],
+        "https://example.com/?x=1",
+    );
+    assert_eq!(
+        after.len(),
+        2,
+        "the query-string reflection is a separate injection point from the \
+         verified body parameter and must survive the collapse"
+    );
+
+    // Same location: the R really is the weaker evidence for the same finding.
+    let mut verified = make_typed_param_result(FindingType::Verified, "q", "inHTML");
+    verified.location = "Query".to_string();
+    let mut reflected = make_typed_param_result(FindingType::Reflected, "q", "inHTML");
+    reflected.location = "Query".to_string();
+    let after = collapse_redundant_reflected(vec![verified, reflected], "https://example.com/?x=1");
+    assert_eq!(after.len(), 1);
+}
+
 #[test]
 fn test_collapse_keeps_r_for_different_param_or_inject_type() {
     let results = vec![
@@ -2644,4 +2674,381 @@ fn test_estimate_param_requests_caps_each_phase_separately() {
     // the estimate.
     let unlimited = |n: usize| n;
     assert!(estimate_param_requests(&html, &args, 1, &unlimited) > 2 * cap);
+}
+
+// ---------------------------------------------------------------------------
+// Scan-core defect regressions (A1)
+// ---------------------------------------------------------------------------
+
+/// Bind an axum app on an ephemeral loopback port and return its base address.
+async fn spawn_regression_app(app: axum::Router) -> std::net::SocketAddr {
+    use std::net::Ipv4Addr;
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind test listener");
+    let addr = listener.local_addr().expect("local addr");
+    tokio::spawn(async move {
+        axum::serve(listener, app).await.expect("serve test app");
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    addr
+}
+
+/// `FoundParams` used to be keyed by parameter *name* alone, so the first wire
+/// slot to produce a finding suppressed every sibling slot with the same name:
+/// the reflection/DOM phases short-circuited and the dispatch loop skipped the
+/// sibling's worker outright.
+///
+/// Here `q` names two genuinely independent injection points on one request —
+/// `?q=` in the query string and `q` in the urlencoded POST body — and the mock
+/// reflects **both** raw. Both are exploitable, so both must be reported;
+/// before the fix whichever worker won the race silenced the other and the scan
+/// reported exactly one finding (a false negative on a real vulnerability).
+#[tokio::test]
+async fn test_run_scanning_reports_same_name_query_and_body_params_separately() {
+    use axum::{Router, extract::Query, response::Html, routing::post};
+    use std::collections::HashMap;
+
+    async fn handler(Query(q): Query<HashMap<String, String>>, body: String) -> Html<String> {
+        let from_query = q.get("q").cloned().unwrap_or_default();
+        let from_body = url::form_urlencoded::parse(body.as_bytes())
+            .find(|(k, _)| k == "q")
+            .map(|(_, v)| v.to_string())
+            .unwrap_or_default();
+        Html(format!(
+            "<html><body><div id=q>{}</div><div id=b>{}</div></body></html>",
+            from_query, from_body
+        ))
+    }
+
+    let addr = spawn_regression_app(Router::new().route("/", post(handler))).await;
+
+    let url = format!("http://{}/?q=a", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.method = "POST".to_string();
+    target.data = Some("q=b".to_string());
+    target.workers = 4;
+    target.reflection_params = vec![
+        Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new("q".to_string(), "a".to_string(), Location::Query)
+        },
+        Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new("q".to_string(), "b".to_string(), Location::Body)
+        },
+    ];
+
+    let args = Arc::new(integration_scan_args(false));
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        args,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
+    )
+    .await;
+
+    let guard = results.lock().await;
+    let locations: Vec<&str> = guard
+        .iter()
+        .filter(|r| r.param == "q")
+        .map(|r| r.location.as_str())
+        .collect();
+    assert!(
+        locations.contains(&"Query"),
+        "the vulnerable query-string `q` must be reported; got {:?}",
+        locations
+    );
+    assert!(
+        locations.contains(&"Body"),
+        "the vulnerable body `q` is a different injection point and must be \
+         reported too; got {:?}",
+        locations
+    );
+}
+
+/// Cancellation used to be honoured only inside the reflection and DOM payload
+/// loops. Every parameter's worker is spawned up front, so on a cancelled scan
+/// the workers still queued behind the concurrency semaphore each went on to
+/// fire the Stage-0 probe and then the whole `--hpp` phase — thousands of
+/// requests at a target the operator had already asked us to stop hitting.
+///
+/// The mock flips the cancel flag once it has served a handful of requests and
+/// counts everything it receives afterwards. `--hpp` is on and duplicate-
+/// parameter requests are answered without a reflection, so the HPP phase runs
+/// its full `payloads x positions` fan-out when it is not stopped.
+#[tokio::test]
+async fn test_run_scanning_cancel_stops_probe_and_hpp_requests() {
+    use axum::{Router, extract::RawQuery, extract::State, response::Html, routing::get};
+    use std::sync::atomic::AtomicBool;
+
+    #[derive(Clone)]
+    struct AppState {
+        requests: Arc<AtomicUsize>,
+        cancel: Arc<AtomicBool>,
+    }
+
+    /// Requests served before the scan is cancelled.
+    const CANCEL_AFTER: usize = 6;
+
+    async fn handler(State(st): State<AppState>, RawQuery(q): RawQuery) -> Html<String> {
+        let n = st.requests.fetch_add(1, Ordering::SeqCst) + 1;
+        if n >= CANCEL_AFTER {
+            st.cancel.store(true, Ordering::SeqCst);
+        }
+        let raw = q.unwrap_or_default();
+        let pairs: Vec<(String, String)> = url::form_urlencoded::parse(raw.as_bytes())
+            .map(|(k, v)| (k.to_string(), v.to_string()))
+            .collect();
+        // HPP probes send the same name twice. Answer those without echoing
+        // anything so the HPP phase never short-circuits on a first hit and
+        // instead spends its full per-parameter budget.
+        let mut names: Vec<&str> = pairs.iter().map(|(k, _)| k.as_str()).collect();
+        names.sort_unstable();
+        let deduped = {
+            let mut d = names.clone();
+            d.dedup();
+            d.len()
+        };
+        if deduped != names.len() {
+            return Html("<html><body>no</body></html>".to_string());
+        }
+        let echoed: String = pairs.iter().map(|(_, v)| v.as_str()).collect();
+        Html(format!("<html><body><div>{}</div></body></html>", echoed))
+    }
+
+    let requests = Arc::new(AtomicUsize::new(0));
+    let cancel = Arc::new(AtomicBool::new(false));
+    let state = AppState {
+        requests: requests.clone(),
+        cancel: cancel.clone(),
+    };
+    let addr = spawn_regression_app(
+        Router::new()
+            .route("/", get(handler))
+            .with_state(state.clone()),
+    )
+    .await;
+
+    // 40 parameters, 2 workers: 38 of them are queued behind the semaphore when
+    // the cancel flag flips, which is exactly the population the fix protects.
+    const PARAMS: usize = 40;
+    let query: String = (0..PARAMS)
+        .map(|i| format!("p{}=a", i))
+        .collect::<Vec<_>>()
+        .join("&");
+    let url = format!("http://{}/?{}", addr, query);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.workers = 2;
+    target.reflection_params = (0..PARAMS)
+        .map(|i| Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new(format!("p{}", i), "a".to_string(), Location::Query)
+        })
+        .collect();
+
+    let mut raw_args = integration_scan_args(false);
+    raw_args.hpp = true;
+    // One reflection payload per param keeps the *pre*-cancel traffic tiny; the
+    // HPP subset is taken from this same list, so the post-cancel fan-out this
+    // test measures stays attributable to the probe + HPP phases.
+    raw_args.max_payloads_per_param = 1;
+    let args = Arc::new(raw_args);
+
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        args,
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))).with_cancel(cancel),
+    )
+    .await;
+
+    let total = requests.load(Ordering::SeqCst);
+    // Before the fix each of the ~38 queued workers still ran a probe and the
+    // full HPP fan-out after cancellation, which lands in the hundreds. The
+    // small allowance covers the two workers that were already mid-flight.
+    assert!(
+        total < 60,
+        "a cancelled scan must stop issuing requests; the queued workers sent \
+         {} requests in total (cancel fired at request {})",
+        total,
+        CANCEL_AFTER
+    );
+}
+
+/// The `--sxss` branch of `fetch_injection_response_with_client` used to return
+/// candidate bodies without applying any of the response gates the normal
+/// reflection branch applies. An `application/json` echo is inert — a browser
+/// renders it as data, never as markup — so the plain path suppresses it, while
+/// `--sxss` reported it as a stored-XSS reflection.
+///
+/// The HTML half of the test is the control: it proves the mock is otherwise
+/// detectable, so an empty result on the JSON half means "gated", not
+/// "nothing reached the scanner".
+#[tokio::test]
+async fn test_sxss_applies_the_same_response_gates_as_the_normal_path() {
+    use axum::http::header;
+    use axum::{Router, extract::Query, response::IntoResponse, routing::get};
+    use std::collections::HashMap;
+
+    async fn json_echo(Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
+        let v = q.get("q").cloned().unwrap_or_default();
+        (
+            [(header::CONTENT_TYPE, "application/json")],
+            format!("{{\"q\":\"{}\"}}", v),
+        )
+    }
+    async fn html_echo(Query(q): Query<HashMap<String, String>>) -> impl IntoResponse {
+        let v = q.get("q").cloned().unwrap_or_default();
+        (
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            format!("<html><body><div>{}</div></body></html>", v),
+        )
+    }
+
+    let addr = spawn_regression_app(
+        Router::new()
+            .route("/json", get(json_echo))
+            .route("/html", get(html_echo)),
+    )
+    .await;
+
+    async fn scan_path(addr: std::net::SocketAddr, path: &str) -> usize {
+        let url = format!("http://{}{}?q=a", addr, path);
+        let mut target = parse_target(&url).expect("parse_target");
+        target.workers = 2;
+        target.reflection_params = vec![Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new("q".to_string(), "a".to_string(), Location::Query)
+        }];
+
+        let mut raw_args = integration_scan_args(false);
+        raw_args.sxss = true;
+        raw_args.max_payloads_per_param = 8;
+        let results = Arc::new(Mutex::new(Vec::new()));
+        run_scanning(
+            &target,
+            Arc::new(raw_args),
+            ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
+        )
+        .await;
+        results.lock().await.len()
+    }
+
+    assert!(
+        scan_path(addr, "/html").await > 0,
+        "control: an HTML echo must still be reported under --sxss"
+    );
+    assert_eq!(
+        scan_path(addr, "/json").await,
+        0,
+        "an application/json echo is inert markup-wise; --sxss must apply the \
+         same inert-content-type gate the plain reflection path applies"
+    );
+}
+
+/// `PhaseFlow::Abort` (a global `--limit` reached mid-phase) used to `return`
+/// out of the per-parameter worker *before* `flush_results`, silently
+/// discarding every finding that worker had already confirmed and batched.
+///
+/// The scan below has two vulnerable parameters and `--limit 1`. `victim`
+/// reflects entity-escaped, so it records an `R` on its first reflection
+/// payload and then grinds through the (never-verifying) DOM payload set;
+/// `trigger` reflects raw and is held back by the mock until `victim` has
+/// confirmed its finding, at which point it verifies and flushes, tripping the
+/// limit while `victim` is still mid-DOM-phase. `victim`'s already-confirmed
+/// finding must survive that: `--limit` is a stop condition, not an instruction
+/// to destroy evidence, and the report truncates to the limit on its own
+/// (`cmd::scan::output`), so flushing here cannot overshoot the cap.
+#[tokio::test]
+async fn test_run_scanning_limit_abort_keeps_already_confirmed_findings() {
+    use axum::{Router, extract::Query, extract::State, response::Html, routing::get};
+    use std::collections::HashMap;
+
+    #[derive(Clone)]
+    struct AppState {
+        victim_requests: Arc<AtomicUsize>,
+    }
+
+    /// `victim` requests to wait for before letting `trigger` verify. High
+    /// enough that `victim` has certainly recorded its `R` and moved on to the
+    /// (never-verifying) DOM payload set, so the limit trips while its worker
+    /// is mid-loop with a batched finding.
+    const VICTIM_REQUESTS_BEFORE_TRIGGER: usize = 60;
+
+    fn escape(s: &str) -> String {
+        s.replace('&', "&amp;")
+            .replace('<', "&lt;")
+            .replace('>', "&gt;")
+            .replace('"', "&quot;")
+    }
+
+    async fn handler(
+        State(st): State<AppState>,
+        Query(q): Query<HashMap<String, String>>,
+    ) -> Html<String> {
+        let victim = q.get("victim").cloned().unwrap_or_default();
+        let trigger = q.get("trigger").cloned().unwrap_or_default();
+        if trigger != "b" {
+            // A `trigger` injection: hold it until `victim` has gone past its
+            // reflection phase (probe + first payload) and into the DOM phase,
+            // so the limit trips while `victim` still has a batched finding.
+            while st.victim_requests.load(Ordering::SeqCst) < VICTIM_REQUESTS_BEFORE_TRIGGER {
+                tokio::time::sleep(std::time::Duration::from_millis(2)).await;
+            }
+        } else {
+            st.victim_requests.fetch_add(1, Ordering::SeqCst);
+        }
+        Html(format!(
+            "<html><body><div id=v>{}</div><div id=t>{}</div></body></html>",
+            escape(&victim),
+            trigger
+        ))
+    }
+
+    let addr = spawn_regression_app(Router::new().route("/", get(handler)).with_state(AppState {
+        victim_requests: Arc::new(AtomicUsize::new(0)),
+    }))
+    .await;
+
+    let url = format!("http://{}/?victim=a&trigger=b", addr);
+    let mut target = parse_target(&url).expect("parse_target");
+    target.workers = 2;
+    target.reflection_params = vec![
+        Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new("victim".to_string(), "a".to_string(), Location::Query)
+        },
+        Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new("trigger".to_string(), "b".to_string(), Location::Query)
+        },
+    ];
+
+    let mut raw_args = integration_scan_args(false);
+    raw_args.limit = Some(1);
+    let results = Arc::new(Mutex::new(Vec::new()));
+    run_scanning(
+        &target,
+        Arc::new(raw_args),
+        ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
+    )
+    .await;
+
+    let guard = results.lock().await;
+    let params: Vec<(String, String)> = guard
+        .iter()
+        .map(|r| (r.param.clone(), r.result_type.short().to_string()))
+        .collect();
+    assert!(
+        params.iter().any(|(p, _)| p == "trigger"),
+        "sanity: the limit-tripping finding must be present; got {:?}",
+        params
+    );
+    assert!(
+        params.iter().any(|(p, _)| p == "victim"),
+        "a finding confirmed before the --limit stop must not be discarded by \
+         the abort path; got {:?}",
+        params
+    );
 }


### PR DESCRIPTION
Five scan-core defects that were verified during the 2026-08-31 hunt and deliberately deferred out of #1404 so each could get its own PR + functional run. Every one was re-verified against `HEAD` before fixing, and every fix was mutation-tested (fix reverted, new test confirmed RED, fix restored).

---

## 1. `FoundParams` was keyed by parameter name only — false negative

**Symptom.** A parameter name that appears at two wire locations on the same request (`?q=` in the query string *and* `q` in the urlencoded body, or a `q` cookie) is reported at most once. Whichever worker wins the race silences the other, so a genuinely vulnerable body parameter is never reported.

Reproduced against a local mock that reflects both slots raw. Each slot alone is `V`:

```
$ dalfox scan 'http://127.0.0.1:3010/x?q=FUZZ' --inject-marker FUZZ --format json
  n=1   V q Query GET
$ dalfox scan 'http://127.0.0.1:3010/x' -d 'q=FUZZ' -X POST --inject-marker FUZZ --format json
  n=1   V q Body POST
```

Both together, before the fix:

```
$ dalfox scan 'http://127.0.0.1:3010/x?q=FUZZ' -d 'q=FUZZ' -X POST --inject-marker FUZZ --format json
  n=1   V q Body POST          <-- the vulnerable query parameter is gone
```

After:

```
  n=2   V q Body POST
        V q Query POST
```

**Root cause.** `src/scanning/mod.rs:166` — `FoundParams { reflection, dom }` held bare `param.name` strings, and all seven read/write sites used `param.name`: the reflection short-circuit (`:2002`), the JS-body lock (`:2097`), the R record (`:2107`), the static-V upgrade (`:2169`), the DOM short-circuit (`:2291`), the DOM record (`:2324`), and the dispatch-loop `already_found` skip (`:2726`).

**Fix.** New `found_param_key(param)` keyed on `(location, name, wire_name)`, used at all seven sites. `wire_name` is in the key so nested-field synthetic params (`qs[move_url]`, wire name `qs`) stay distinct exactly as they were before.

`collapse_redundant_reflected` had the same name-only key, so with (1) fixed a verified body `q` would have deleted the query `q`'s `R` at the end of the target's scan. It now keys on `(param, location, inject_type)`. All four scan-loop finding builders already set `Result.location` from `param.location`, so same-slot collapse is unchanged.

**Test.** `scanning::tests::test_run_scanning_reports_same_name_query_and_body_params_separately` — mock reflects query `q` and body `q` raw, asserts both a `Query` and a `Body` finding. Mutation (key reverted to `param.name.clone()`): `got ["Query"]` → RED.
Plus `test_collapse_keeps_r_when_the_v_is_at_a_different_wire_location` for the collapse key.

---

## 2. Cancellation not honored in the Stage-0 probe or the HPP phase — request flood after cancel

**Symptom.** A cancelled `--hpp` scan keeps firing hundreds to thousands of requests at the target.

**Root cause.** `src/scanning/mod.rs` — the dispatch loop gates only *spawning* on cancellation, but every parameter's worker is spawned up front and then queues on the concurrency semaphore. Each queued worker, once it gets a permit, ran `probe_param` (no cancel check anywhere in it, up to 2 requests) and then `run_hpp_phase` (`:2481`, no cancel check, up to `5 payloads x 3 positions`). The reflection/DOM phases *do* `break` on cancel, but a `break` yields `PhaseFlow::Continue`, which falls straight through into HPP.

Measured with a counting mock (40 params, 2 workers, cancel flipped at request 6): **162 requests total** before the fix, **&lt;60** after.

**Fix.** Cancel checks at the top of `scan_param` (before the first request), inside the probe payload loop, before the numeric fallback probe, and in both HPP loops.

**Test.** `scanning::tests::test_run_scanning_cancel_stops_probe_and_hpp_requests`. The mock answers duplicate-parameter (HPP-shaped) requests without a reflection so the HPP phase spends its full budget instead of short-circuiting on the first hit. Mutation (all four checks removed): `sent 162 requests` → RED.

---

## 3. `--sxss` skipped every response gate — false positives the plain path removes

**Symptom.** `--sxss` reports reflections into `application/json` (and `text/csv`, nosniff `text/plain`, …) bodies, into statuses the operator excluded with `--ignore-return`, and path echoes on redirects / non-markup content-types. The plain reflection path drops all of these.

**Root cause.** `src/scanning/check_reflection.rs` — the `if args.sxss` branch consumed `inject_resp` with a bare `read_body(...).filter(|t| !t.is_empty())`, and the retrieval-URL loop did the same. All of `--ignore-return`, `content_type_is_inert_data_with_nosniff`, the Path 3xx / non-markup drops and `should_suppress_path_reflection_with_body` lived inline in the `else` branch only. The SXSS bodies also never carried the `js_content_type` tag that keeps R→V upgraders off JavaScript bodies.

**Fix.** Extracted the status/header gates into `injection_response_suppressed(status_code, headers, param, args)` and made the normal branch call it (identical logic, moved not rewritten). Added a local `gated_body` helper in the SXSS branch that applies that gate, the body-level Path gate, and the JS-content-type tag; it is used for both the inject response and every retrieval-URL response, so the two SXSS candidate paths cannot drift apart again.

**Test.** `scanning::tests::test_sxss_applies_the_same_response_gates_as_the_normal_path` — an `application/json` echo must yield 0 findings under `--sxss`, with a `text/html` control asserting the mock is otherwise detectable (so an empty result means "gated", not "nothing reached the scanner"). Mutation (both gates removed from `gated_body`): `left: 1, right: 0` → RED.

---

## 4. `PhaseFlow::Abort` discarded already-confirmed findings

**The stated symptom is NOT real, and I want to flag that explicitly.** The brief described this as "findings already streamed and printed to stdout are dropped from the JSON/file output". That cannot happen: `cmd::scan::mod.rs:178` `stream_findings_enabled` returns `false` whenever `args.limit.is_some()`, and `PhaseFlow::Abort` is only ever produced by `limit_reached()`, which requires `--limit`. So no finding is ever both streamed and dropped, and the "streaming printer post-dates the comment" reasoning does not apply.

**What is real.** `scan_param` `return`ed on `Abort` without `flush_results`, throwing away every finding that worker had already confirmed and batched (including the `[A]` findings from its probe). That is observable whenever the surviving tally falls back under `--limit` before rendering — which `collapse_target_results` does routinely, since it decrements `findings_count` for every `R` a `V` covers. The report then has room for exactly the findings the abort destroyed. It is also just wrong on its own terms: `--limit` is a stop condition, not an instruction to destroy evidence, and the worker that aborts is rarely the one that reached the cap.

**Fix.** Flush on both `Abort` paths. This cannot overshoot the user-visible cap, because `--limit` truncation is applied once more at render time (`cmd::scan::output.rs:427`). The `PhaseFlow` doc comment was rewritten to say this rather than the streaming claim.

**Test.** `scanning::tests::test_run_scanning_limit_abort_keeps_already_confirmed_findings` — two vulnerable parameters, `--limit 1`; the mock holds `trigger` back until `victim` has recorded its `R` and moved into the (never-verifying) DOM payload set, so the limit trips while `victim`'s worker is mid-loop with a batched finding. Asserts on the `results` vector directly (before output truncation). Mutation (both flushes removed): `got [("trigger", "V")]` → RED.

---

## 5. Unreachable multi-target log branches (cosmetic)

`src/cmd/scan/analysis.rs` had `if total_targets_copy > 1 { … } else { … }` nested inside `if … && total_targets_copy == 1`, at the start-scan log, the analysis spinner label and the reflection summary — so the scan-id-prefixed multi-target variants could never run. The preflight spinner label (`:599`) had the same shape: the `[n/total]` label was computed unconditionally but only ever used under `total == 1`.

`902d8209` ("Add global progress ticker for multi-target scans") is where the `== 1` guards were added; suppressing the per-target block on multi-target runs is the intent, and the `> 1` arms are just leftovers. Removed the dead arms and kept the surviving one verbatim.

**No test.** This is dead-branch removal with no observable behavior change, so a regression test could not go RED. Verified by hand that single-target and multi-target plain output are byte-identical to before.

---

## Deferred / out of my area

* **`probe_body_params` has the same name-only-key bug** — `src/parameter_analysis/mining.rs:973`:
  ```rust
  let exists = reflection_params.lock().await.iter().any(|p| p.name == param_name);
  if exists { continue; }
  ```
  A query parameter already discovered as `q` blocks body mining of `q` entirely, so for the ordinary `dalfox scan '…?q=x' -d 'q=y'` invocation the body slot is never even *discovered* — the `FoundParams` fix in this PR cannot help there. That is why the regression test and the CLI repro above use `--inject-marker`, which builds both slots directly (`cmd/scan/analysis.rs:392-425`, no name dedup). The fix is the same shape as (1): compare `(name, location)`, not `name`. `src/parameter_analysis/` is outside my file ownership, so I have not touched it — please route it.

* **The streaming printer ignores `--limit`** — noted while disproving (4). It is currently unreachable because `stream_findings_enabled` refuses to turn streaming on under `--limit`, so it is latent, not a live bug. Worth knowing if anyone relaxes that guard.

## Green gate

`cargo build --release`, `cargo test` (2328 lib + all integration suites, exit 0), `cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings` — all clean.

Note on flakes: `payload::synthesis::tests::synthesis_is_fast_and_bounded` fails under machine load on this hardware (a 5s wall-clock budget on a debug build; measured 7.7-9.4s). I confirmed it fails the same way on `origin/main` in a scratch worktree (`9.05s`), so it is pre-existing and untouched here. It passes on an idle run, which is what the green-gate run above was.
