### PR TITLE
fix(cli,config): close six silent CLI / config / output-surface defects

### DIFF
--- a/src/cmd/scan/input.rs
+++ b/src/cmd/scan/input.rs
@@ -66,6 +66,27 @@ const MAX_TARGET_LIST_BYTES: u64 = crate::utils::fs::MAX_FILE_READ_BYTES;
 // the budget can still be forced with `--input-type har`.
 const SNIFF_PREFIX_BYTES: u64 = 8 * 1024;
 
+/// The target lines of a URL list, in the shape every input path shares: a
+/// leading UTF-8 BOM is dropped, each line is trimmed, and blank lines and `#`
+/// comments are skipped (the nuclei / ffuf / httpx convention).
+///
+/// The BOM is why this is one helper rather than the four near-identical loops
+/// it replaces. `str::trim` does not remove U+FEFF — it is not `White_Space` —
+/// so a list written by Notepad, Excel, or PowerShell's `Out-File` (all of which
+/// emit a BOM by default) handed its **first** line to the target parser as
+/// `\u{feff}http://host/…`. That has no parseable scheme, the fallback
+/// re-prefixed the whole string, and dalfox scanned `http://http//host/…`: a
+/// bogus host, a DNS failure recorded as `skipped`, and — as long as any later
+/// line resolved — exit code 0. The one target the operator put first was
+/// silently never scanned.
+pub(crate) fn target_list_lines(content: &str) -> impl Iterator<Item = &str> {
+    content
+        .trim_start_matches('\u{feff}')
+        .lines()
+        .map(str::trim)
+        .filter(|l| !l.is_empty() && !l.starts_with('#'))
+}
+
 pub(crate) async fn resolve_targets(
     args: &ScanArgs,
 ) -> std::result::Result<ResolvedTargets, ScanOutcome> {
@@ -117,12 +138,9 @@ pub(crate) async fn resolve_targets(
             ) {
                 Ok(crate::utils::fs::StdinRead::Data(buffer)) => {
                     let mut stdin_count = 0;
-                    for line in buffer.lines() {
-                        let trimmed = line.trim();
-                        if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                            target_strings.push(trimmed.to_string());
-                            stdin_count += 1;
-                        }
+                    for line in target_list_lines(&buffer) {
+                        target_strings.push(line.to_string());
+                        stdin_count += 1;
                     }
                     if stdin_count > 0 && !args.targets.is_empty() && !args.silence {
                         eprintln!(
@@ -200,18 +218,10 @@ pub(crate) async fn resolve_targets(
                         target_strings.push(target.clone());
                         continue;
                     }
-                    for line in content.lines() {
-                        let line = line.trim();
-                        // Industry-standard target-list shape: skip
-                        // blank lines *and* `#` comments (nuclei, ffuf,
-                        // httpx all behave this way). Previously a
-                        // commented line would be sent to parse_target
-                        // and surface as a confusing "empty host"
-                        // error.
-                        if !line.is_empty() && !line.starts_with('#') {
-                            target_strings.push(line.to_string());
-                        }
-                    }
+                    // Industry-standard target-list shape (blank lines and
+                    // `#` comments skipped, leading BOM dropped) — see
+                    // `target_list_lines`.
+                    target_strings.extend(target_list_lines(&content).map(ToString::to_string));
                 }
                 Some(Err(e)) => {
                     // The file exists but `read_bounded` refused it
@@ -259,13 +269,9 @@ pub(crate) async fn resolve_targets(
                         MAX_TARGET_LIST_BYTES,
                         "target list",
                     ) {
-                        Ok(content) => collected.extend(
-                            content
-                                .lines()
-                                .map(str::trim)
-                                .filter(|l| !l.is_empty() && !l.starts_with('#'))
-                                .map(ToString::to_string),
-                        ),
+                        Ok(content) => {
+                            collected.extend(target_list_lines(&content).map(ToString::to_string))
+                        }
                         Err(e) => {
                             if !args.silence {
                                 emit_error(
@@ -319,15 +325,10 @@ pub(crate) async fn resolve_targets(
                         }
                     }
                 };
-                for line in buffer.lines() {
-                    let trimmed = line.trim();
-                    // Same comment-skipping convention as the auto/file paths
-                    // above so `cat targets.txt | dalfox` and `dalfox scan
-                    // targets.txt` behave identically.
-                    if !trimmed.is_empty() && !trimmed.starts_with('#') {
-                        piped_targets.push(trimmed.to_string());
-                    }
-                }
+                // Same line shape as the auto/file paths above (shared helper)
+                // so `cat targets.txt | dalfox` and `dalfox scan targets.txt`
+                // behave identically.
+                piped_targets.extend(target_list_lines(&buffer).map(ToString::to_string));
                 if !args.targets.is_empty() {
                     let before_merge = piped_targets.len();
                     for target in &args.targets {
@@ -481,9 +482,10 @@ pub(crate) async fn resolve_targets(
                             Some((name.to_string(), value.to_string()))
                         })
                         .collect();
-                    // Only override method if explicitly provided via CLI (not the default)
-                    if args.method != DEFAULT_METHOD {
-                        target.method = args.method.clone();
+                    // Only override the method the target carries when the
+                    // operator actually asked for one. See `method_override`.
+                    if let Some(m) = method_override(args) {
+                        target.method = m.to_string();
                     }
                     // An empty `--user-agent ""` must not become a literal
                     // `User-Agent:` header on every request (the server/MCP path
@@ -870,6 +872,27 @@ fn load_request_source(
     }
 }
 
+/// The HTTP method to force onto a target that already carries one of its own —
+/// a `POST https://host/` target line, a raw-HTTP request file, a HAR entry —
+/// or `None` to leave the imported method alone.
+///
+/// The guard used to be `args.method != DEFAULT_METHOD`, which is the
+/// value-comparison anti-pattern `Config::apply_to_scan_args_if_default`
+/// documents: it cannot tell "the operator said nothing" from "the operator
+/// typed the value that happens to be the default". So `-X GET` — the one
+/// method a `ScanArgs` also holds by default — was silently discarded, and
+/// `dalfox scan -i raw-http captured.req -X GET` kept replaying the captured
+/// `POST`. For a scanner that means writing to an endpoint the operator
+/// explicitly asked to only read.
+///
+/// `was_explicit` answers it for the command line; the `!= DEFAULT_METHOD` half
+/// is kept so a config-file `method` (which never passes through clap, so it is
+/// never "explicit") and the server / MCP runners — which build `ScanArgs`
+/// directly with an empty `ExplicitArgs` — behave exactly as before.
+fn method_override(args: &ScanArgs) -> Option<&str> {
+    (args.was_explicit("method") || args.method != DEFAULT_METHOD).then_some(args.method.as_str())
+}
+
 /// Apply CLI overrides to a Target parsed from a request-bearing source
 /// (`raw-http` or `har`). Request-content fields (method, body, headers,
 /// cookies, User-Agent) are only touched when the user explicitly set the
@@ -878,8 +901,8 @@ fn load_request_source(
 /// already carries its own. Network/runtime fields are always taken from the
 /// args. This is the shared override path for both raw-HTTP and HAR inputs.
 fn apply_request_cli_overrides(target: &mut Target, args: &ScanArgs) {
-    if args.method != DEFAULT_METHOD {
-        target.method = args.method.clone();
+    if let Some(m) = method_override(args) {
+        target.method = m.to_string();
     }
     if let Some(d) = &args.data {
         target.data = Some(d.clone());

--- a/src/cmd/scan/input/tests.rs
+++ b/src/cmd/scan/input/tests.rs
@@ -754,3 +754,125 @@ async fn explicit_dedup_urls_flag_beats_an_unset_default() {
     ]);
     assert_eq!(args.dedup_urls.as_deref(), Some("exact"));
 }
+
+// ── target-list line shape (`target_list_lines`) ────────────────────
+
+#[test]
+fn target_list_lines_skips_blanks_and_comments() {
+    let content = "https://a.example/\n\n   \n# a comment\n  https://b.example/  \n";
+    assert_eq!(
+        target_list_lines(content).collect::<Vec<_>>(),
+        vec!["https://a.example/", "https://b.example/"]
+    );
+}
+
+#[test]
+fn target_list_lines_strips_a_leading_utf8_bom() {
+    // `str::trim` leaves U+FEFF alone (it is not `White_Space`), so without an
+    // explicit strip the first entry reaches the target parser as
+    // `\u{feff}https://…` — a string with no parseable scheme.
+    let content = "\u{feff}https://a.example/\nhttps://b.example/\n";
+    assert_eq!(
+        target_list_lines(content).collect::<Vec<_>>(),
+        vec!["https://a.example/", "https://b.example/"]
+    );
+}
+
+#[tokio::test]
+async fn file_mode_ignores_a_leading_utf8_bom_in_the_list() {
+    // A URL list saved by Notepad / Excel / PowerShell `Out-File` starts with a
+    // BOM. It used to corrupt the *first* target only: the byte defeated the
+    // scheme check, the fallback re-prefixed the whole string, and dalfox
+    // scanned `http://http//a.example/…`. Every later line was fine, so the run
+    // still exited 0 and the operator never heard that the first target was
+    // never reached.
+    let p = tmp_file(
+        "bom-list",
+        "\u{feff}https://a.example/?q=1\r\nhttps://b.example/?q=2\r\n",
+    );
+    let args = args_from(&["-i", "file", "-S", p.to_str().unwrap()]);
+    let targets = resolve(&args).await.expect("resolves");
+    let _ = std::fs::remove_file(&p);
+
+    assert_eq!(targets.len(), 2);
+    assert_eq!(targets[0].url.as_str(), "https://a.example/?q=1");
+    assert_eq!(targets[1].url.as_str(), "https://b.example/?q=2");
+}
+
+// ── `-X/--method` against a target that carries its own method ──────
+
+/// Like [`args_from`], but also records which flags the operator actually
+/// typed, the way `main.rs` does from clap's `ArgMatches`. Needed by anything
+/// that reads [`ScanArgs::was_explicit`]: the plain derive parse leaves
+/// `explicit` empty (it is an `#[arg(skip)]` field), so a test built with
+/// `args_from` can never tell an explicit flag from its default.
+fn args_from_explicit(argv: &[&str]) -> ScanArgs {
+    use clap::{CommandFactory, FromArgMatches};
+    let mut full = Vec::with_capacity(argv.len() + 1);
+    full.push("dalfox");
+    full.extend_from_slice(argv);
+    let matches = TestCli::command()
+        .try_get_matches_from(full)
+        .expect("test args should parse");
+    let mut args = TestCli::from_arg_matches(&matches)
+        .expect("test args should map")
+        .scan;
+    args.explicit = crate::cmd::scan::ExplicitArgs::from_matches(&matches);
+    args
+}
+
+#[tokio::test]
+async fn explicit_get_overrides_a_captured_raw_http_method() {
+    // `-X GET` is the one method a `ScanArgs` also holds by default, so the old
+    // `args.method != DEFAULT_METHOD` guard read it as "the operator said
+    // nothing" and kept replaying the captured POST — writing to an endpoint the
+    // operator explicitly asked to only read.
+    let raw = "POST /login HTTP/1.1\r\nHost: raw.example\r\n\r\nu=a";
+    let args = args_from_explicit(&["-i", "raw-http", "-S", "-X", "GET", raw]);
+    let targets = resolve(&args).await.expect("raw http resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].method, "GET");
+}
+
+#[tokio::test]
+async fn explicit_get_overrides_a_method_embedded_in_the_target_line() {
+    let args = args_from_explicit(&[
+        "-i",
+        "url",
+        "-S",
+        "-X",
+        "GET",
+        "POST https://example.com/?q=1",
+    ]);
+    let targets = resolve(&args).await.expect("resolves");
+    assert_eq!(targets.len(), 1);
+    assert_eq!(targets[0].method, "GET");
+}
+
+#[tokio::test]
+async fn absent_method_flag_keeps_a_captured_raw_http_method() {
+    // The other half of the contract: without `-X`, an imported request keeps
+    // the method it was captured with.
+    let raw = "POST /login HTTP/1.1\r\nHost: raw.example\r\n\r\nu=a";
+    let args = args_from_explicit(&["-i", "raw-http", "-S", raw]);
+    let targets = resolve(&args).await.expect("raw http resolves");
+    assert_eq!(targets[0].method, "POST");
+}
+
+#[tokio::test]
+async fn non_cli_scan_args_still_override_with_a_non_default_method() {
+    // Server / MCP build `ScanArgs` directly, so `explicit` is empty there. The
+    // `!= DEFAULT_METHOD` half of the guard is what keeps their `method: "PUT"`
+    // applying, and must not regress.
+    let raw = "POST /login HTTP/1.1\r\nHost: raw.example\r\n\r\nu=a";
+    let args = ScanArgs {
+        input_type: "raw-http".to_string(),
+        method: "PUT".to_string(),
+        silence: true,
+        targets: vec![raw.to_string()],
+        ..Default::default()
+    };
+    assert!(args.explicit.is_empty());
+    let targets = resolve(&args).await.expect("raw http resolves");
+    assert_eq!(targets[0].method, "PUT");
+}

--- a/src/cmd/scan/startup.rs
+++ b/src/cmd/scan/startup.rs
@@ -30,6 +30,40 @@ use super::{ScanOutcome, emit_error, session};
 /// are emitted here and do not stop the scan. The order of the checks is
 /// load-bearing for what reaches stderr first, so it is preserved exactly as it
 /// ran inline.
+/// Refuse `-H/--headers`, `--user-agent` and `--cookies` values that cannot do
+/// what the operator asked. All three end up as HTTP header values, and both
+/// ways they can be wrong used to be silent on the CLI:
+///
+/// * a spec with no `:` (`-H 'Authorization Bearer eyJ…'` — one missing
+///   keystroke) or with an empty name is dropped by the `filter_map` in
+///   [`super::input::resolve_targets`], so the scan runs *unauthenticated*
+///   against a protected endpoint, finds nothing, and exits clean. That is the
+///   same false all-clear `--proxy` and `--custom-payload` are already gated
+///   against here.
+/// * a byte reqwest cannot put in a header (a pasted CR/LF, a NUL) fails the
+///   request *builder* for every request in the run, so the reachability probe
+///   fails and a live target is reported `CONNECTION_FAILED` — the scanner
+///   blaming the target for the operator's input.
+///
+/// REST and MCP have refused both at submission since #1404, through these
+/// exact helpers (`server::util::validate_scan_options`, the MCP tools); the
+/// CLI was the front end that never got the gate. Sharing the validators keeps
+/// the three surfaces refusing the same inputs. The helpers build and sanitize
+/// the message themselves, so a credential-bearing value cannot leak into a log
+/// or forge a line in it; only the flag name is added here.
+fn validate_header_inputs(args: &ScanArgs) -> Result<(), String> {
+    crate::job::validate_header_list(&args.headers).map_err(|e| format!("--headers: {e}"))?;
+    // An empty `--user-agent ""` means "no override" (see `resolve_targets`),
+    // not an empty header — the same exemption the REST/MCP validator makes.
+    if let Some(ua) = args.user_agent.as_deref().filter(|s| !s.is_empty()) {
+        crate::job::validate_header_value("--user-agent", ua)?;
+    }
+    for cookie in args.cookies.iter().filter(|c| !c.is_empty()) {
+        crate::job::validate_header_value("--cookies", cookie)?;
+    }
+    Ok(())
+}
+
 pub(crate) fn prepare_and_validate(args: &ScanArgs) -> Result<(), super::ScanOutcome> {
     // Validate numeric args up front so misconfigurations (workers: 0,
     // max_targets_per_host: 0, absurd timeouts) fail fast with a clear
@@ -38,6 +72,17 @@ pub(crate) fn prepare_and_validate(args: &ScanArgs) -> Result<(), super::ScanOut
         if !args.silence {
             emit_error(&args.format, code, &msg);
         }
+        return Err(ScanOutcome::Error);
+    }
+
+    // Header-shaped inputs, refused before the first request rather than
+    // discovered as a scan result. See [`validate_header_inputs`].
+    if let Err(msg) = validate_header_inputs(args) {
+        emit_error(
+            &args.format,
+            crate::cmd::error_codes::INVALID_INPUT_TYPE,
+            &msg,
+        );
         return Err(ScanOutcome::Error);
     }
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -284,20 +284,23 @@ async fn main() {
         &cli.command,
         Some(Commands::Payload(args)) if args.selector.is_some()
     );
-    let is_machine_format = {
-        let scan_format = match &cli.command {
-            Some(Commands::Scan(args)) => Some(args.format.as_str()),
-            _ => None,
-        };
-        // Also check raw args for the default-scan path (no subcommand)
-        let raw_format = __args
-            .windows(2)
-            .find(|w| w[0] == "--format" || w[0] == "-f")
-            .map(|w| w[1].as_str());
-        scan_format
-            .or(raw_format)
-            .is_some_and(dalfox::cmd::scan::format_is_machine)
+    // Read `--format` from the parsed args of *every* scan-bearing subcommand.
+    // All four flatten a `ScanArgs`, so the value is already there; only `scan`
+    // used to be consulted, and the compat subcommands fell back to a raw-argv
+    // `["--format", "json"]` window scan. That window only ever matched the
+    // space-separated spelling, so `dalfox url -u URL --format=json` (and
+    // `-f=json`, and `-fjson`) prepended the ASCII banner to the JSON document
+    // on stdout while `-f json` came out clean. The no-subcommand path needs no
+    // fallback: the root `Cli` declares no `--format`/`-f` at all, so
+    // `dalfox URL -f json` is a clap parse error, not a scan.
+    let cli_scan_format = match &cli.command {
+        Some(Commands::Scan(args)) => Some(args.format.as_str()),
+        Some(Commands::Url(args)) => Some(args.scan_args.format.as_str()),
+        Some(Commands::File(args)) => Some(args.scan_args.format.as_str()),
+        Some(Commands::Pipe(args)) => Some(args.scan_args.format.as_str()),
+        _ => None,
     };
+    let is_machine_format = cli_scan_format.is_some_and(dalfox::cmd::scan::format_is_machine);
     // Banner emission is deferred until after the config file has been
     // loaded (further down) so a `silence = true` in the config file
     // suppresses it the same way the `--silence` CLI flag does.
@@ -418,13 +421,27 @@ async fn main() {
     // explicit-`--config` path only — the implicit default-path init
     // (`load_or_init`, `cli.config == None`) stays quiet on purpose so a
     // first-time user isn't nagged about their bootstrapped config.
+    //
+    // The write itself is best-effort (`let _ = std::fs::write(..)`), so the
+    // notice checks the path instead of assuming success: `--config` pointing
+    // into a directory that does not exist, or one the process cannot write,
+    // used to report "created it with a default template" for a file that was
+    // never written — sending the operator to look at a path with nothing in
+    // it. Report what actually happened on disk.
     if let (Some(cfg_path), Ok(lr)) = (&cli.config, &config_load)
         && lr.created
     {
-        eprintln!(
-            "Notice: --config {} did not exist — created it with a default template and ran with built-in defaults (check the path if you meant to load an existing config)",
-            cfg_path
-        );
+        if lr.path.exists() {
+            eprintln!(
+                "Notice: --config {} did not exist — created it with a default template and ran with built-in defaults (check the path if you meant to load an existing config)",
+                cfg_path
+            );
+        } else {
+            eprintln!(
+                "Warning: --config {} did not exist and could not be created — ran with built-in defaults (check the path if you meant to load an existing config)",
+                cfg_path
+            );
+        }
     }
 
     // Config values are deserialized straight into `Config` and never pass
@@ -515,11 +532,19 @@ async fn main() {
                 outcome = cmd::payload::run_payload(args);
             }
             Commands::Mcp => {
-                // Run MCP stdio server (no banner already)
-                if let Err(e) = mcp::run_mcp_server().await {
-                    eprintln!("MCP server error: {e}");
-                }
-                outcome = ScanOutcome::Clean;
+                // Run MCP stdio server (no banner already). A failed handshake
+                // or transport error has to reach the exit code: an MCP host or
+                // a supervisor (systemd, a process manager, `dalfox mcp || …`)
+                // reads status, not stderr, and a hard-coded `Clean` made "the
+                // server never came up" indistinguishable from a clean
+                // shutdown.
+                outcome = match mcp::run_mcp_server().await {
+                    Ok(()) => ScanOutcome::Clean,
+                    Err(e) => {
+                        eprintln!("MCP server error: {e}");
+                        ScanOutcome::Error
+                    }
+                };
             }
 
             Commands::Completion { .. } => unreachable!(),

--- a/tests/e2e/cli_smoke_test.rs
+++ b/tests/e2e/cli_smoke_test.rs
@@ -683,3 +683,207 @@ fn test_man_writes_only_roff_to_stdout() {
         );
     }
 }
+
+/// `█` is unique to the ASCII-art banner; its absence is how these tests assert
+/// stdout stayed a clean machine-readable document.
+const BANNER_GLYPH: char = '█';
+
+/// A target that is rejected without any network round trip, so the machine
+/// document is produced instantly and deterministically.
+const UNREACHABLE_TARGET: &str = "http://127.0.0.1:1/?q=1";
+
+/// Flags that keep a run to target resolution + one reachability probe.
+const NO_SCAN_FLAGS: [&str; 3] = ["--skip-xss-scanning", "--skip-discovery", "--skip-mining"];
+
+/// Every scan-bearing subcommand flattens a `ScanArgs`, so `--format` has to be
+/// read from *its* parsed args. Only `scan` was consulted; `url` / `file` /
+/// `pipe` fell back to a raw-argv scan for the literal two-token
+/// `["--format", "json"]` window, which no `--format=json` / `-f=json` /
+/// `-fjson` spelling ever matches. The banner was then prepended to the JSON /
+/// SARIF / TOML document on stdout — the exact breakage
+/// `test_config_set_machine_format_suppresses_banner_on_stdout` guards for the
+/// config path.
+#[test]
+fn test_machine_format_suppresses_banner_for_every_subcommand_and_spelling() {
+    let list = std::env::temp_dir().join(format!("dalfox-fmt-list-{}.txt", std::process::id()));
+    std::fs::write(&list, format!("{UNREACHABLE_TARGET}\n")).expect("write target list");
+    let list_path = list.to_str().expect("utf8 path").to_string();
+
+    // (subcommand args, format flag spelling) — the space-separated form is the
+    // control that always worked.
+    let subcommands: [Vec<String>; 4] = [
+        vec!["scan".into(), UNREACHABLE_TARGET.into()],
+        vec!["url".into(), "-u".into(), UNREACHABLE_TARGET.into()],
+        vec!["file".into(), list_path.clone()],
+        vec!["pipe".into()],
+    ];
+    let spellings: [Vec<&str>; 4] = [
+        vec!["--format", "json"],
+        vec!["--format=json"],
+        vec!["-f", "json"],
+        vec!["-fjson"],
+    ];
+
+    for sub in &subcommands {
+        for spelling in &spellings {
+            let mut cmd = Command::new(env!("CARGO_BIN_EXE_dalfox"));
+            cmd.args(sub)
+                .args(spelling)
+                .args(NO_SCAN_FLAGS)
+                .stdin(Stdio::piped())
+                .stdout(Stdio::piped())
+                .stderr(Stdio::piped());
+            let mut child = cmd.spawn().expect("failed to execute dalfox");
+            {
+                let stdin = child.stdin.as_mut().expect("child stdin should be piped");
+                let _ = stdin.write_all(format!("{UNREACHABLE_TARGET}\n").as_bytes());
+            }
+            let output = child.wait_with_output().expect("failed waiting for dalfox");
+            let stdout = String::from_utf8_lossy(&output.stdout);
+            let label = format!("{} {}", sub.join(" "), spelling.join(" "));
+
+            assert!(
+                !stdout.contains(BANNER_GLYPH),
+                "`dalfox {label}` leaked the banner into the JSON document; stdout was:\n{stdout}"
+            );
+            serde_json::from_str::<serde_json::Value>(stdout.trim())
+                .unwrap_or_else(|e| panic!("`dalfox {label}` stdout is not JSON ({e}):\n{stdout}"));
+        }
+    }
+
+    let _ = std::fs::remove_file(&list);
+}
+
+/// `-H`, `--user-agent` and `--cookies` all end up as HTTP header values, and
+/// both ways they can be wrong used to be silent on the CLI:
+///
+///  * a spec with no `:` (`-H 'Authorization Bearer …'`) was dropped by a
+///    `filter_map`, so the scan ran unauthenticated and reported clean;
+///  * a byte reqwest cannot put in a header failed the request *builder*, so a
+///    live target came back `CONNECTION_FAILED` — the scanner blaming the target
+///    for the operator's input.
+///
+/// REST and MCP have refused both at submission since #1404 through the shared
+/// `job::validate_header_list` / `validate_header_value`; this pins the CLI to
+/// the same answer.
+#[test]
+fn test_malformed_header_inputs_are_refused_before_the_scan() {
+    for (flag, value, needle) in [
+        ("-H", "Authorization Bearer TOKEN", "--headers"),
+        ("-H", ": novalue", "--headers"),
+        ("-H", "X-Bad: va\nlue", "--headers"),
+        ("--user-agent", "Bad\nUA", "--user-agent"),
+        ("--cookies", "a=b\nc", "--cookies"),
+    ] {
+        let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+            .args(["scan", UNREACHABLE_TARGET])
+            .args(NO_SCAN_FLAGS)
+            .args([flag, value])
+            .stdin(Stdio::null())
+            .output()
+            .expect("failed to execute dalfox");
+
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        assert_eq!(
+            output.status.code(),
+            Some(2),
+            "`{flag} {value:?}` should be rejected as a configuration error; stderr:\n{stderr}"
+        );
+        assert!(
+            stderr.contains(needle),
+            "the error should name `{needle}`; stderr was:\n{stderr}"
+        );
+    }
+}
+
+/// Control for the check above: a well-formed header set still runs.
+#[test]
+fn test_wellformed_header_inputs_are_accepted() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .args(["scan", UNREACHABLE_TARGET])
+        .args(NO_SCAN_FLAGS)
+        .args([
+            "-H",
+            "Authorization: Bearer TOKEN",
+            "-H",
+            "X-Empty:",
+            "--user-agent",
+            "Dalfox/3 (테스트)",
+            "--cookies",
+            "a=1; b=2",
+            "--format",
+            "json",
+            "-S",
+        ])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to execute dalfox");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        !stderr.contains("--headers") && !stderr.contains("--user-agent"),
+        "valid header inputs must not be rejected; stderr:\n{stderr}"
+    );
+    serde_json::from_str::<serde_json::Value>(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected a JSON document ({e}):\n{stdout}"));
+}
+
+/// A URL list written on Windows starts with a UTF-8 BOM. `str::trim` leaves
+/// U+FEFF alone, so the *first* target used to reach the parser as
+/// `\u{feff}http://host/…`, get re-prefixed to `http://http//host/…`, and fail
+/// DNS — while every later line scanned fine and the run still exited 0.
+#[test]
+fn test_bom_prefixed_target_list_scans_the_first_target() {
+    let list = std::env::temp_dir().join(format!("dalfox-bom-list-{}.txt", std::process::id()));
+    std::fs::write(&list, "\u{feff}http://127.0.0.1:1/?q=1\r\n").expect("write BOM target list");
+
+    let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .args(["scan", "-i", "file", list.to_str().expect("utf8 path")])
+        .args(NO_SCAN_FLAGS)
+        .args(["--format", "json", "-S"])
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to execute dalfox");
+
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let _ = std::fs::remove_file(&list);
+
+    let doc: serde_json::Value = serde_json::from_str(stdout.trim())
+        .unwrap_or_else(|e| panic!("expected JSON ({e}):\n{stdout}"));
+    let targets: Vec<&str> = doc["meta"]["target_summary"]
+        .as_array()
+        .expect("target_summary array")
+        .iter()
+        .map(|t| t["target"].as_str().unwrap_or_default())
+        .collect();
+    assert_eq!(
+        targets,
+        vec!["http://127.0.0.1:1/?q=1"],
+        "a leading BOM must not mangle the first target; stdout was:\n{stdout}"
+    );
+}
+
+/// `dalfox mcp` used to hard-code a clean exit, so a supervisor or MCP host
+/// could not tell "the stdio server never came up" from "it shut down cleanly".
+/// With stdin closed the handshake cannot complete, which is the cheapest
+/// deterministic form of that failure.
+#[test]
+fn test_mcp_startup_failure_exits_nonzero() {
+    let output = Command::new(env!("CARGO_BIN_EXE_dalfox"))
+        .arg("mcp")
+        .stdin(Stdio::null())
+        .output()
+        .expect("failed to execute dalfox mcp");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("MCP server error"),
+        "a failed MCP start should say so on stderr, got:\n{stderr}"
+    );
+    assert_eq!(
+        output.status.code(),
+        Some(2),
+        "a failed MCP start must not exit 0; stderr:\n{stderr}"
+    );
+}

--- a/tests/e2e/config_path_smoke_test.rs
+++ b/tests/e2e/config_path_smoke_test.rs
@@ -311,3 +311,33 @@ fn test_default_load_or_init_prefers_toml_over_json() {
         "toml config should be preferred over json when both exist"
     );
 }
+
+#[test]
+fn test_uncreatable_config_path_warns_instead_of_claiming_creation() {
+    // The scaffold write is best-effort (`let _ = std::fs::write(..)`), so the
+    // notice has to describe what actually landed on disk. A `--config` path
+    // whose parent is a regular file cannot be created on any platform, and it
+    // used to still report "created it with a default template" — sending the
+    // operator to inspect a path with nothing at it.
+    let dir = unique_temp_dir("cfg-uncreatable");
+    let blocker = dir.join("not-a-directory");
+    std::fs::write(&blocker, b"x").expect("write blocking regular file");
+    let config_path = blocker.join("config.toml");
+
+    let output = run_payload_with_config(&config_path);
+    assert!(
+        output.status.success(),
+        "an uncreatable config path should still run on built-in defaults"
+    );
+    assert!(!config_path.exists(), "nothing should have been created");
+
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    assert!(
+        stderr.contains("could not be created"),
+        "a failed scaffold must say so; stderr was:\n{stderr}"
+    );
+    assert!(
+        !stderr.contains("created it with a default template"),
+        "a failed scaffold must not claim the file was created; stderr was:\n{stderr}"
+    );
+}


### PR DESCRIPTION
Six defects found by driving the built binary across the CLI, config and
output surfaces. Every one of them produced a plausible-looking run that was
quietly doing something other than what the operator asked for, and two of them
turn a healthy target into a false clean bill of health.

Each fix has a regression test that was **mutation-tested**: the fix was
temporarily reverted, the new test confirmed RED, then the fix restored.

---

## 1. Malformed `-H` / `--user-agent` / `--cookies` are silently accepted

**Symptom.** Two shapes, both silent:

```
$ dalfox scan http://target/?q=1 -H 'Authorization Bearer TOKEN123' -f json --include-request -S
  request headers: ['Host: 127.0.0.1']          # header gone, no warning, exit 0/1
$ dalfox scan http://target/?q=1 -H 'Authorization: Bearer TOKEN123' ...
  request headers: ['Host: 127.0.0.1', 'Authorization: Bearer TOKEN123']
```

A one-keystroke typo (missing `:`) or an empty name (`-H ': v'`) drops the
header, so a scan of a protected endpoint runs **unauthenticated**, finds
nothing, and exits clean — exactly the false all-clear `--proxy` and
`--custom-payload` are already gated against.

Separately, a byte reqwest cannot put in a header fails the request *builder*
for every request, so a live target is reported as unreachable:

```
$ dalfox scan http://127.0.0.1:3041/?q=1 --user-agent $'Bad\nUA' -f json -S
  [('http://127.0.0.1:3041/?q=1', 'skipped', 'CONNECTION_FAILED')]   # the server is up
```

**Root cause.** `src/cmd/scan/input.rs:471` (and the parallel loop in
`apply_request_cli_overrides`) drops any spec `filter_map` cannot split, and the
CLI has no startup gate at all. REST and MCP have refused both since #1404
through the shared `job::validate_header_list` / `job::validate_header_value`
(`src/server/util.rs:91-103`, `src/mcp/mod.rs:913-925`) — the CLI is the front
end that never got the gate.

**Fix.** `validate_header_inputs` in `src/cmd/scan/startup.rs`, called from the
existing startup gate, wired to those same shared helpers. Empty
`--user-agent \"\"` keeps meaning \"no override\", matching the REST/MCP
exemption. The helpers build and sanitize their own messages, so a
credential-bearing value cannot leak into a log or forge a line in it.

**Test.** `test_malformed_header_inputs_are_refused_before_the_scan` (five
shapes across all three flags → exit 2, message names the flag) plus
`test_wellformed_header_inputs_are_accepted` as the control.

---

## 2. `-X GET` cannot override a method the target already carries

**Symptom.**

```
$ dalfox scan -i raw-http captured.req -X GET --include-request -f json -S
  POST /?q=… HTTP/1.1     # -X GET discarded; -X PUT works
$ dalfox scan 'POST http://target/?q=1' -X GET ...
  POST /?q=… HTTP/1.1
```

Affects the embedded `METHOD url` target-line form, `-i raw-http`, and HAR
import. For a scanner this means writing to an endpoint the operator explicitly
asked to only read.

**Root cause.** `src/cmd/scan/input.rs:485` and `:881` guarded on
`args.method != DEFAULT_METHOD` — the value-comparison anti-pattern
`Config::apply_to_scan_args_if_default` documents at `src/config.rs:226`. It
cannot tell \"the operator said nothing\" from \"the operator typed the value that
happens to be the default\", and `GET` *is* the default.

**Fix.** One `method_override` helper keyed on `args.was_explicit(\"method\")`.
The `!= DEFAULT_METHOD` half is kept so a config-file `method` (never
\"explicit\", since config bypasses clap) and the server / MCP runners — which
build `ScanArgs` directly with an empty `ExplicitArgs` — behave exactly as
before.

**Test.** `explicit_get_overrides_a_captured_raw_http_method`,
`explicit_get_overrides_a_method_embedded_in_the_target_line`, plus two
non-regression controls (`absent_method_flag_keeps_a_captured_raw_http_method`,
`non_cli_scan_args_still_override_with_a_non_default_method`).

---

## 3. A UTF-8 BOM silently mangles the first target in a list

**Symptom.**

```
$ printf '\xef\xbb\xbfhttp://127.0.0.1:3041/?q=1\r\nhttp://…\r\n' > list.txt
$ dalfox scan -i file list.txt -f json -S
  [('http://http//127.0.0.1:3041/?q=1', 'skipped', 'DNS_RESOLUTION_FAILED'), …]
```

Affects `-i file`, `-i pipe`, and the `auto` path. The BOM defeats the scheme
check, the fallback re-prefixes the whole string, and the run still exits 0 as
long as any later line resolves — so the one target the operator put first is
never scanned and nothing says so. URL lists written by Notepad, Excel, or
PowerShell's `Out-File` all start with a BOM.

**Root cause.** `str::trim` does not remove U+FEFF (it is not `White_Space`),
and each of the four line loops in `src/cmd/scan/input.rs` trimmed only.

**Fix.** One `target_list_lines` helper (BOM strip + trim + blank/`#` skip)
replacing all four loops, so the shape can no longer drift between input paths.

**Test.** `target_list_lines_strips_a_leading_utf8_bom`,
`target_list_lines_skips_blanks_and_comments`,
`file_mode_ignores_a_leading_utf8_bom_in_the_list` (through `resolve_targets`),
and the end-to-end `test_bom_prefixed_target_list_scans_the_first_target`.

---

## 4. The banner leaks into machine-readable stdout on `url` / `file` / `pipe`

**Symptom.**

```
$ dalfox url -u http://target/?q=1 --format=json
<17 lines of ASCII banner>
{ \"findings\": [], …          # -f json (space form) is clean
```

Every spelling except the space-separated one leaks: `--format=json`, `-f=json`,
`-fjson`, on all three compat subcommands. Any pipeline that parses the
JSON / SARIF / TOML document breaks — the same failure
`test_config_set_machine_format_suppresses_banner_on_stdout` already guards for
the config path.

**Root cause.** `src/main.rs:287-300`: only `Commands::Scan` had its parsed
`format` read; the compat subcommands fell back to a raw-argv
`windows(2).find(|w| w[0] == \"--format\" || w[0] == \"-f\")` scan, which no
`=`/attached spelling ever matches.

**Fix.** Read `format` from the parsed args of all four scan-bearing
subcommands (they all flatten a `ScanArgs`) and drop the argv scan. The
no-subcommand path needs no fallback — the root `Cli` declares no `--format`,
so `dalfox URL -f json` is a clap parse error, verified.

**Test.** `test_machine_format_suppresses_banner_for_every_subcommand_and_spelling`
— 4 subcommands × 4 spellings, each asserting no banner glyph and parseable JSON.

---

## 5. `dalfox mcp` exits 0 after failing to start

**Symptom.**

```
$ dalfox mcp < /dev/null
MCP server error: connection closed: initialize request
$ echo $?
0
```

An MCP host or supervisor reads status, not stderr, so \"the stdio server never
came up\" was indistinguishable from a clean shutdown.

**Root cause.** `src/main.rs:517-523` logged the error and then hard-coded
`outcome = ScanOutcome::Clean`.

**Fix.** Map the `Err` arm to `ScanOutcome::Error` (exit 2).

**Test.** `test_mcp_startup_failure_exits_nonzero`.

---

## 6. `--config` claims it created a file it could not write

**Symptom.** `--config` pointing into a directory that does not exist or cannot
be written still printed `Notice: … created it with a default template`, sending
the operator to inspect a path with nothing at it.

**Root cause.** The scaffold write is best-effort (`let _ = std::fs::write(..)`)
but `src/main.rs:421` reported success unconditionally.

**Fix.** Check the path before choosing the message; a failed scaffold now warns
instead. Behaviour otherwise unchanged (the run still proceeds on built-in
defaults).

**Test.** `test_uncreatable_config_path_warns_instead_of_claiming_creation`.

---

## Deferred / out of this area

- **`dalfox server` exits 0 when it cannot start.** `server --port <busy>` logs
  `ERR Failed to bind …` and exits **0**; `server --host 'not a host'` likewise.
  Worse, `SERVER listening on http://…` is logged *before* the bind is
  attempted, so the last line before the error claims success. Root cause:
  `src/server/mod.rs:66` `run_server` returns `()`, and `src/main.rs` therefore
  has nothing to map — `outcome = ScanOutcome::Clean` unconditionally.
  Plan: change `run_server` to `-> Result<(), String>` (or a bool), return `Err`
  from the two early-return arms (`addr_str.parse()` at :68 and
  `TcpListener::bind` at :253), move the `listening on` log after a successful
  bind, and map to `ScanOutcome::Error` in `main.rs`. Left alone here because
  `src/server/**` is another agent's area.

- **`--dry-run` / `--only-discovery` ignore the non-JSON machine formats.**
  `output::render_dry_run` and `render_only_discovery` special-case `json` and
  `jsonl` only, so `-f sarif --dry-run` / `-f toml --dry-run` /
  `-f markdown --dry-run` emit the *plain-text* summary while the banner is
  suppressed — a consumer that asked for a document gets prose. Not fixed here:
  a faithful fix means SARIF/TOML/markdown renderers for the preview envelopes,
  which is more than a surgical change.

- **`dalfox payload --json` with no selector ignores `--json`** and prints the
  human summary. Cosmetic; a warning or a JSON summary would both be defensible.

- **A config-file `no_color = true` does not decolour the banner.** `main.rs`
  folds config `silence` and config `format` into the banner decision but not
  config `no_color`, so on a TTY the banner still prints with ANSI. Cosmetic
  only — `run_scan` sets the global `NO_COLOR` from the merged args, so
  everything after the banner is correct.

- **A BOM also defeats `raw-http` / HAR auto-detection** (`is_raw_http_request`
  and `is_har_content` both use `trim_start`, which leaves U+FEFF). Unlike the
  target-list case this surfaces as a clear parse error rather than a silently
  wrong target, and both predicates live in `src/target_parser/`.

## Checked and found sound

Config precedence (every `ScanArgs` field has a `ScanConfig` counterpart and is
read by `apply_to_scan_args_if_default`; CLI beats config at runtime for
`format`/`method`/`user_agent`/`headers`), `Config::normalize_and_validate`
(12 invalid values each warned and reset), the numeric range gate (every absurd
value rejected with a clear message), all six output formats (valid JSON /
JSONL / SARIF / TOML, no ANSI, no banner), `-S` (POC only), `--config` against a
missing / malformed / >1 MiB / `/dev/zero` path, `completion` for all five
shells + `man` (hidden-subcommand filter intact), and the target-file edge cases
(empty, CRLF, comments, duplicates, non-UTF-8, garbage line).

## Green gate

`cargo build --release`, `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` all clean.
`cargo test`: 2329 lib + 266 integration/e2e pass. The one failure,
`payload::synthesis::tests::synthesis_is_fast_and_bounded`, is a wall-clock
assertion (`elapsed.as_secs() < 5` over 20 000 debug-build calls) that is
flaky on a loaded machine — it passes in isolation on this same build, and it
fails identically with this branch's source changes reverted to `main`'s
content, so it is not a regression from these changes.