### PR TITLE
fix(scan): don't verify DOM evidence on a marker whose handler was swallowed; match probe markers case-insensitively

### DIFF
--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -350,14 +350,44 @@ pub(crate) fn encoded_variants(c: char) -> Vec<&'static str> {
     }
 }
 
-/// Extract segment between first open marker and subsequent close marker
+/// Byte offset of the first ASCII-case-insensitive occurrence of `needle` in
+/// `haystack`, or `None`.
+///
+/// Markers are `dlx`/`xld` plus 8 hex digits, so case-folding them cannot
+/// collide with anything else in a response — while a server that
+/// case-normalizes reflected input (title-case, `upcase`, `downcase`) breaks an
+/// exact-case `find` and makes the marker look filtered.
+fn find_ascii_ci(haystack: &str, needle: &str) -> Option<usize> {
+    let (h, n) = (haystack.as_bytes(), needle.as_bytes());
+    if n.is_empty() {
+        return Some(0);
+    }
+    if h.len() < n.len() {
+        return None;
+    }
+    h.windows(n.len()).position(|w| w.eq_ignore_ascii_case(n))
+}
+
+/// Whether `body` carries either probe marker, matched case-insensitively.
+fn body_has_probe_marker(body: &str) -> bool {
+    contains_ascii_ci(body, crate::scanning::markers::open_marker())
+        || contains_ascii_ci(body, crate::scanning::markers::close_marker())
+}
+
+/// Extract segment between first open marker and subsequent close marker.
+///
+/// Marker matching is ASCII-case-insensitive: a server that case-normalizes the
+/// reflection (`"Dlx1234abcd'\"<>…"` from a title-casing template filter) still
+/// reflects every special character raw, and an exact-case `find` would miss the
+/// segment and hand the caller the "all specials filtered" verdict — muting the
+/// entire angle/quote-bearing payload set for a completely unfiltered sink.
 fn extract_reflected_segment(body: &str) -> Option<&str> {
     let open = crate::scanning::markers::open_marker();
     let close = crate::scanning::markers::close_marker();
-    let start = body.find(open)?;
+    let start = find_ascii_ci(body, open)?;
     let after = start + open.len();
     let rest = &body[after..];
-    let end_rel = rest.find(close)?;
+    let end_rel = find_ascii_ci(rest, close)?;
     Some(&rest[..end_rel])
 }
 
@@ -952,10 +982,9 @@ pub async fn active_probe_param(
             // reflection), and a block page that echoes the payload (e.g. a
             // reflected-block-page WAF) carries the markers too — neither is a
             // size-limited inspection window, so skip the probe for them.
-            let genuine_block = batched_response.as_deref().is_none_or(|body| {
-                !body.contains(crate::scanning::markers::open_marker())
-                    && !body.contains(crate::scanning::markers::close_marker())
-            });
+            let genuine_block = batched_response
+                .as_deref()
+                .is_none_or(|body| !body_has_probe_marker(body));
             let window = if genuine_block {
                 // One window-overflow probe: re-send the batched probe behind a
                 // benign filler prefix. If the markers + specials now reflect,

--- a/src/parameter_analysis/tests.rs
+++ b/src/parameter_analysis/tests.rs
@@ -1744,3 +1744,48 @@ fn one_analysis_applies_identically_to_many_params() {
         );
     }
 }
+
+/// A server that case-normalizes the reflection (Rails-style `titleize`,
+/// `upcase`, `downcase` template filters) still echoes every special character
+/// raw. Matching the probe markers case-sensitively made
+/// `extract_reflected_segment` return `None`, which `active_probe_param` reads
+/// as "the whole probe was filtered" and classifies every `SPECIAL_PROBE_CHARS`
+/// entry as invalid — muting the entire angle/quote-bearing payload set for a
+/// completely unfiltered sink (xssmaze `/casemanip/level2`, `/casemanip/level3`,
+/// `/casemanip/level6`, `/obfuscation/level2`).
+#[test]
+fn test_extract_reflected_segment_matches_case_folded_markers() {
+    let open = crate::scanning::markers::open_marker();
+    let close = crate::scanning::markers::close_marker();
+
+    // Whole reflection upper-cased.
+    let upper = format!(
+        "<html><body>{}{}{}</body></html>",
+        open.to_ascii_uppercase(),
+        "'\"<>();",
+        close.to_ascii_uppercase()
+    );
+    assert_eq!(
+        extract_reflected_segment(&upper),
+        Some("'\"<>();"),
+        "an upper-cased marker must still bound the reflected segment"
+    );
+
+    // First letter capitalized only (`titleize`-style filters).
+    let mut titled_open = open.to_string();
+    titled_open.replace_range(..1, &open[..1].to_ascii_uppercase());
+    let titled = format!(
+        "<html><body>{}{}{}</body></html>",
+        titled_open, "'<>", close
+    );
+    assert_eq!(extract_reflected_segment(&titled), Some("'<>"));
+}
+
+/// Case-folded markers must also count as "the probe came back", so the
+/// window-overflow probe is not spent on a server that reflected fine.
+#[test]
+fn test_body_has_probe_marker_is_case_insensitive() {
+    let open = crate::scanning::markers::open_marker();
+    assert!(body_has_probe_marker(&open.to_ascii_uppercase()));
+    assert!(!body_has_probe_marker("nothing reflected here"));
+}

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -255,6 +255,83 @@ fn payload_marker_element_carries_sink(payload: &str) -> bool {
     false
 }
 
+/// Whether `payload` can open an HTML tag of its own — a `<` followed by a
+/// tag-name start, a closing tag, or a markup declaration — in either its raw
+/// or its entity-decoded form.
+///
+/// Payloads that *cannot* are pure attribute-injection fragments
+/// (`" onmouseover=alert(1) class=… x="`): everything they contribute lands on
+/// a tag the server already wrote, so whether the handler survives depends
+/// entirely on the surrounding markup and can only be answered against the
+/// response.
+fn payload_opens_tag(payload: &str) -> bool {
+    fn opens(text: &str) -> bool {
+        text.as_bytes()
+            .windows(2)
+            .any(|w| w[0] == b'<' && (w[1].is_ascii_alphabetic() || w[1] == b'/' || w[1] == b'!'))
+    }
+    opens(payload) || opens(&decode_html_entities(payload))
+}
+
+/// Whether `payload` contains an `on<event>=` attribute whose value carries a
+/// JavaScript sink call.
+///
+/// Deliberately textual: the shapes this exists for
+/// (`'/onmouseover="{JS}"/id="{ID}"/x='`, `" onmouseover={JS} class={CLASS} x="`)
+/// form no element on their own, so an HTML fragment parse yields nothing to
+/// inspect. Only the attribute *name* is matched structurally (`on` + letters,
+/// not preceded by an identifier character, followed by optional whitespace and
+/// `=`); the sink test then runs over the remainder of the payload, which is
+/// where the handler value lives.
+fn payload_has_handler_sink_text(payload: &str) -> bool {
+    let bytes = payload.as_bytes();
+    for i in 0..bytes.len() {
+        if !(bytes[i] | 0x20).eq(&b'o') || i + 2 >= bytes.len() {
+            continue;
+        }
+        if !(bytes[i + 1] | 0x20).eq(&b'n') {
+            continue;
+        }
+        // `on` must start an attribute name, not sit inside a longer word
+        // (`button`, `session`, …).
+        if i > 0 && (bytes[i - 1].is_ascii_alphanumeric() || matches!(bytes[i - 1], b'_' | b'-')) {
+            continue;
+        }
+        let mut end = i + 2;
+        while end < bytes.len() && bytes[end].is_ascii_alphabetic() {
+            end += 1;
+        }
+        if end == i + 2 {
+            continue; // bare `on`, no event name
+        }
+        let mut eq = end;
+        while eq < bytes.len() && bytes[eq].is_ascii_whitespace() {
+            eq += 1;
+        }
+        if eq >= bytes.len() || bytes[eq] != b'=' {
+            continue;
+        }
+        if value_carries_js_sink(&payload[eq + 1..]) {
+            return true;
+        }
+    }
+    false
+}
+
+/// Whether `payload` is a bare attribute-injection fragment that attaches an
+/// `on*` handler sink: it opens no tag of its own, yet carries a handler whose
+/// value is a JS sink.
+///
+/// These payloads slip past [`payload_marker_element_carries_sink`] because
+/// parsing them as an HTML fragment yields a text node and no element at all.
+/// Their marker and their handler are always emitted onto the *same* injected
+/// attribute run (see the `ATTR_*` templates in `payload::synthesis`), so if the
+/// response shows the marker on an element that carries no surviving handler,
+/// the handler was swallowed by the surrounding markup and nothing executes.
+fn payload_is_bare_attribute_handler_injection(payload: &str) -> bool {
+    !payload_opens_tag(payload) && payload_has_handler_sink_text(payload)
+}
+
 /// Whether at least one element carrying one of the payload's markers also
 /// carries a surviving JS sink. Used to gate the marker-evidence path for
 /// payloads whose marker element's own attributes/body ARE the exploit.
@@ -398,6 +475,18 @@ fn has_marker_evidence_in_doc(payload: &str, document: &scraper::Html) -> bool {
     // evidence. Structural markers (base-href, DOM-clobbering containers) carry
     // no such sink on the marker element and keep presence-only evidence.
     if payload_marker_element_carries_sink(payload) {
+        return marker_element_carries_surviving_sink(payload, document);
+    }
+
+    // Same requirement for the attribute-injection shapes that form no element
+    // of their own, so the parse above finds nothing to inspect. When such a
+    // payload lands inside a *quoted* attribute value the server already wrote
+    // (`style="… url('HERE')"`, `content="Looking for HERE"`), the injected
+    // `on*=` is swallowed by that value while a later `id=`/`class=` still
+    // tokenizes into a real attribute — leaving the marker on a live element
+    // that executes nothing. Require the handler to have survived alongside the
+    // marker before calling that DOM-verified.
+    if payload_is_bare_attribute_handler_injection(payload) {
         return marker_element_carries_surviving_sink(payload, document);
     }
 

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1843,3 +1843,106 @@ fn test_1183_inline_breakout_on_hidden_input_not_evidence() {
         "an inline breakout on a hidden input never fires"
     );
 }
+
+// ── Bare attribute-injection payloads whose handler is swallowed ───────────
+//
+// An attribute-injection payload forms no element of its own, so the #1118
+// gate (which parses the payload) finds nothing to inspect. When the payload
+// lands inside a *quoted* attribute value the server already wrote, the
+// injected `on*=` is absorbed into that value while a later `id=`/`class=`
+// still tokenizes into a real attribute — the marker rides a live element
+// that executes nothing. Observed against xssmaze `/inlinestyle/level2`,
+// `/multicontext/level2`, `/multireflect/level2`, `/partial-encode/level1`,
+// `/data-attribute/level2`, `/tagattrmix/level6`.
+
+/// The reported shape: the payload's `onmouseover` is swallowed by the
+/// pre-existing double-quoted `style` value; only `id=` escapes as a real
+/// attribute, so the `<p>` carries the marker but no handler.
+#[test]
+fn test_bare_attr_handler_swallowed_by_quoted_value_not_evidence() {
+    let marker = crate::scanning::markers::id_marker();
+    let payload = format!("'/onmouseover=\"alert(1)\"/id=\"{}\"/x='", marker);
+    let body = format!(
+        "<html><body><p style=\"background-image: url('{}')\">text</p></body></html>",
+        payload
+    );
+    assert!(
+        !has_marker_evidence(&payload, &body),
+        "the payload's handler was absorbed into the style value; the marker alone is not evidence"
+    );
+    assert_eq!(
+        classify_dom_evidence(&payload, &body),
+        None,
+        "the reported FP must classify as no DOM evidence (downgrades V -> R)"
+    );
+}
+
+/// The `<a href="…">` variant of the same shape (xssmaze
+/// `/multicontext/level2`): `href` eats the handler, `id=` survives.
+#[test]
+fn test_bare_attr_handler_swallowed_by_href_value_not_evidence() {
+    let marker = crate::scanning::markers::id_marker();
+    let payload = format!("x/onmouseover=\"alert(1)\"/id=\"{}\"/", marker);
+    let body = format!(
+        "<html><body><a href=\"{}\">Click</a></body></html>",
+        payload
+    );
+    assert_eq!(classify_dom_evidence(&payload, &body), None);
+}
+
+/// FN guard: the same family of payload with a handler that *does* survive
+/// alongside the marker stays DOM-verified.
+#[test]
+fn test_bare_attr_handler_surviving_is_still_evidence() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\" onmouseover=alert(1) class={} x=\"", marker);
+    let body = format!(
+        "<html><body><input type=\"text\" value=\"{}\" class=\"form-control\"></body></html>",
+        payload
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "handler and marker both survive on the input; this is genuine DOM evidence"
+    );
+}
+
+/// FN guard: a bare attribute payload carrying no handler sink at all (a
+/// structural `id=`-only marker) keeps presence-only evidence.
+#[test]
+fn test_bare_attr_without_handler_keeps_presence_only_evidence() {
+    let marker = crate::scanning::markers::id_marker();
+    let payload = format!("\" id={} x=\"", marker);
+    let body = format!(
+        "<html><body><div title=\"{}\">x</div></body></html>",
+        payload
+    );
+    assert!(
+        has_marker_evidence(&payload, &body),
+        "a marker with no handler sink is a structural marker and keeps presence-only evidence"
+    );
+}
+
+/// FN guard: a tag-forming payload is untouched by the new branch — it keeps
+/// going through the #1118 element parse, which already requires co-survival.
+#[test]
+fn test_tag_forming_payload_unaffected_by_bare_attr_gate() {
+    let marker = crate::scanning::markers::class_marker();
+    let payload = format!("\"><svg onload=alert(1) class={}>", marker);
+    let body = format!(
+        "<html><body><svg onload=\"alert(1)\" class=\"{}\"></svg></body></html>",
+        marker
+    );
+    assert!(has_marker_evidence(&payload, &body));
+}
+
+/// Unit guard for the textual handler detector: `on` inside a longer word is
+/// not an event-handler attribute.
+#[test]
+fn test_payload_has_handler_sink_text_ignores_embedded_on() {
+    assert!(!payload_has_handler_sink_text("button=alert(1)"));
+    assert!(!payload_has_handler_sink_text("\" id=dlx x=\""));
+    assert!(payload_has_handler_sink_text(
+        "\" onmouseover=alert(1) x=\""
+    ));
+    assert!(payload_has_handler_sink_text("'/onfocus=\"alert(1)\"/x='"));
+}


### PR DESCRIPTION
Black-box functional hunt: the release binary was run against a local
[XSSMaze](https://github.com/hahwul/xssmaze) 0.4.0 instance (1064 endpoints,
175 categories) and **every reported PoC URL was re-fetched and re-parsed** to
check the payload really landed in an executable position. Two defects came out
of that; both are fixed here with mutation-verified regression tests.

Scored population is `exploitable=true reach=server` (n=1013), split by finding
tier rather than "did dalfox report anything".

## 1. Attribute-injection payloads were DOM-verified on the marker alone

**Symptom.** `[V] DOM verification successful` on a payload whose handler
provably never runs. Re-fetching the PoC for `/inlinestyle/level2/`:

```
payload:  '/onmouseover="alert(1)"/id="dlxb84fe5c4"/x='
response: <p style="background-image: url(''/onmouseover="alert(1)"/id="dlxb84fe5c4"/x='')">text</p>
```

The HTML tokenizer closes `style` at the second `"`, so `onmouseover` is part of
the *style value*; only `id="dlxb84fe5c4"` opens a real attribute. The `<p>`
carries the marker and executes nothing. Same shape on `/multicontext/level2/`
(`<a href="…">` eats the handler), `/multireflect/level2/` (`<meta content="…">`),
`/partial-encode/level1/` (`<input value="…">`), `/data-attribute/level2/`,
`/tagattrmix/level6/`, `/svg/level5/` (`<embed src="…">`).

**Root cause.** `src/scanning/check_dom_verification.rs:400` — the issue-#1118
co-survival gate parses the payload as an HTML fragment and requires the sink to
have survived on the marker element. `" onmouseover={JS} class={CLASS} x="` and
the slash-separated `'/onmouseover="{JS}"/id="{ID}"/x='` family (added in #1402)
form **no element at all**, so that parse finds nothing to inspect and control
falls through to presence-only evidence. #1183 patched one instance of this hole
(`<input type=hidden>`); the general case was still open.

**Fix.** `src/scanning/check_dom_verification.rs` — for a payload that opens no
tag of its own yet carries an `on*=` handler whose value is a JS sink, require
`marker_element_carries_surviving_sink` just like the tag-forming case.
Structural markers (`<base href>`, `<form id=…>` clobbering, a bare `" id=… x="`)
carry no handler and keep presence-only evidence.

**Test.** `src/scanning/check_dom_verification/tests.rs` —
`test_bare_attr_handler_swallowed_by_quoted_value_not_evidence`,
`test_bare_attr_handler_swallowed_by_href_value_not_evidence`, plus three FN
guards (surviving handler stays `[V]`; a marker with no handler keeps
presence-only evidence; tag-forming payloads take the unchanged path) and a unit
test for the textual handler detector.
Mutation-tested: with the new branch disabled (`if false && …`) the two
"not evidence" tests fail (`left: Some(Marker), right: None`); restored, all 85
module tests pass.

## 2. Probe markers were matched case-sensitively

**Symptom.** `/casemanip/level2/` reflects `<svg onload=alert(1) class=dlx…>`
**verbatim** — no filtering at all — yet dalfox only reported `[R]` with an
attribute-breakout payload. `--debug`:

```
adaptive prune (param=query): reflection 3000→2096
  (invalid_specials=['/', '\\', '\'', '{', '`', '<', '>', '"', '(', ')', ';',
                     '=', '|', '}', '[', '.', ':', ']', '+', ',', '$', '-'])
```

Every special character classified invalid, so the whole angle/quote-bearing
payload set was muted. The server only capitalises the first letter of the
reflection (`dlx1234'"<>();` → `Dlx1234'"<>();`).

**Root cause.** `src/parameter_analysis/mod.rs` — `extract_reflected_segment`
located the probe markers with `str::find`. A server that case-normalizes the
reflection (`upcase` / `downcase` / title-case template filters) breaks that
exact match, `active_probe_param` reads "no reflected segment" as "the probe was
filtered", and the `None` arm keeps the legacy all-invalid classification. The
sibling `genuine_block` check had the same problem and additionally spent a
wasted window-overflow probe.

**Fix.** ASCII-case-insensitive marker matching (`find_ascii_ci` /
`body_has_probe_marker`). Markers are `dlx`/`xld` plus 8 hex digits, so
case-folding them cannot collide — the same argument the DOM-marker path already
uses in `any_element_has_class_ascii_ci`.

**Test.** `src/parameter_analysis/tests.rs` —
`test_extract_reflected_segment_matches_case_folded_markers` (upper-cased and
title-cased markers) and `test_body_has_probe_marker_is_case_insensitive`.
Mutation-tested: reverting to `str::find` makes the first test fail
(`left: None, right: Some("'\"<>();")`); restored, all 161 module tests pass.

## Measurement

Both binaries built from this branch (`HEAD` vs `HEAD` with only these two files
reverted to v3.2.2), each run against a freshly restarted XSSMaze, same harness,
`clean` results re-confirmed serially so a dropped local connection is not
counted as a miss.

| | v3.2.2 | this PR |
|---|---|---|
| any-finding recall | 996/1013 (98.3%) | **996/1013 (98.3%)** |
| `[V]` rate | 886/1013 (87.5%) | 881/1013 (87.0%) |
| control FPs (`exploitable=false`, n=27) | 17 any / 5 `[V]` | 17 any / 5 `[V]` |
| total requests | 325 144 | 330 610 (+1.7%) |

Attributable changes (the rest is endpoint noise, see below):

* **+4 `[V]`** — `casemanip-level2/3/6`, `obfuscation-level2` go `[R]` → `[V]`
  with the correct payload, and cost *fewer* requests (541 → 171 on
  casemanip-2, 504 → 177 on obfuscation-2) because the context is now read
  correctly on the first probe.
* **−8 `[V]`** — the eight endpoints listed in §1, each demoted to `[R]`. Every
  one was verified by re-fetching the PoC and tokenizing the response: the
  marker lands, no handler survives. These endpoints are still genuinely
  exploitable via a different payload (`--deep-scan` finds real `[V]`s on
  `/inlinestyle/level2/`), so `[R]` is the honest tier for what the shallow scan
  actually proved.
* Per-class `[V]`: `reflected-html` 94.2% → **95.1%**, `reflected-attr`
  96.5% → 93.4%, others unchanged.

Endpoint noise, verified as unrelated by running each 3–6× on both binaries:
`stored-level3` swings between `[]`/`[R]`/`[V]` on both binaries with 1259–8858
requests (the stored list accumulates every posted payload);
`dragdrop-level1` and `worker-level2` are identical on both binaries when run
individually and only moved because a local connection was dropped under the
harness's own load.

## Deferred (verified, but outside this PR's file ownership)

**D1 — `--poc-type http-request` does not reproduce for header/cookie params,
and drops the port.** `src/scanning/mod.rs:889` `build_request_text` handles
`Query`/`Path`/`Body`/`JsonBody`/`MultipartBody`; `Location::Header` (which is
also where cookie-typed params land) falls to `_ => target.url.clone()`, so the
payload appears nowhere in the emitted request:

```
$ dalfox scan 'http://127.0.0.1:3031/header/level1/' -p 'Referer:header' --poc-type http-request
GET /header/level1/ HTTP/1.1
Host: 127.0.0.1                     # <- no Referer:, and the :3031 port is gone
  └── Payload: <svg onload=alert(1) class=dlx1a12bef6>
```

`--poc-type curl` gets the header right, so the two renderers disagree. Two
separate one-line-ish fixes in `src/scanning/mod.rs`:
`buf.push_str(url.host_str()…)` at ~line 990 should append `:{port}` when
`url.port()` is `Some`, and the `match param.location` should grow a
`Location::Header` arm that emits `\r\n{param.name}: {payload}` (folding into
`Cookie:` when the param is a cookie). Related: for a cookie-typed param
(`-p sid:cookie`, reported as `location: "Header"`), `render_curl_poc` in
`src/cmd/scan/poc.rs` emits `-H "sid: …"` instead of `-b "sid=…"` — its
cookie branch only triggers when the param is literally named `cookie`.

**D2 — `text/plain` without `nosniff` still mints `[V]`.**
`src/scanning/check_reflection.rs:1901` documents "`text/plain` is inert only
when the response also sends `X-Content-Type-Options: nosniff` — without it a
browser sniffs the body as HTML". Per the MIME Sniffing standard §5 that is not
right: a supplied `text/plain` sets the check-for-apache-bug flag and runs the
"text or binary" rules, whose only outcomes are `text/plain` and
`application/octet-stream` — never `text/html`, `nosniff` or not. XSSMaze's
`realworld-level6` control (`Content-Type: text/plain`, no nosniff) is reported
`[V] high`. Fix: drop the `nosniff` condition for `text/plain` in
`crate::utils::content_type_is_inert_data_with_nosniff`
(`src/utils/http.rs:407`).

**D3 — a target that drops payload requests reports a confident clean scan.**
Same trivially-vulnerable app on two ports, one RSTing 90% of injection
requests:

```
drop=0    → status "findings", 1 × [V], reqs 167
drop=0.9  → status "clean", incomplete=false, exit 0, reqs 175, 0 debug lines
             mentioning any failure
```

Transport errors in the payload phase are swallowed at every send site and
nothing counts them, so a rate-limiting or flaky target is indistinguishable
from "no XSS here". Preflight has `CONNECTION_FAILED`; the scan phase has
nothing. Plan: a `REQUEST_ERROR_COUNT` sibling of `tick_request_count`
(`src/lib.rs:265`) bumped at the request-error branches, surfaced as
`meta.incomplete` / a per-target warning once failures exceed a fraction of
requests sent. Touches `src/lib.rs`, `src/scanning/check_reflection.rs` and
`src/cmd/scan/output.rs`.

**D4 — reflected-XSS `[V]` ignores CSP.** `grade_ast_finding`
(`src/scanning/ast_integration.rs:337`) already models
`PageSecurityPosture.inline_script_allowed` for AST findings, but the reflection
path does not, so `/csp/level3/`, `/cspbypass/level3/` and `/nonce/level2/` —
controls whose inline `<script>` is blocked by an enforcing CSP with no
`unsafe-inline`, nonce or hash — are reported `[V]`. A blanket "CSP without
unsafe-inline ⇒ demote" would change the tier on most real-world targets and is
too blunt. The narrow, provably-correct version: when the reflection lands
*inside an inline `<script>`*, that element executes only under `unsafe-inline`
(with no nonce/hash present) or with a matching `nonce`/hash — both readable
from the response. Wants its own FP/FN validation pass.

**D5 — remaining recall gaps (17 endpoints, all pre-existing).** `filterchain-5`
(parens stripped), `edgefilter-6` / `encodingedge-4` (leading-pad encoding),
`callback-2` / `jf-1` (JSONP script-include, JSFuck) need new payload
primitives in `src/payload/`. A cheap one that would flip five `[R]` → `[V]`
(`fragment-2`, `recfilt-3`, `partialencode-5`, `encmix-5`,
`encoding-bypass-2`): a "duplicate the leading angle bracket" mutation
(`<<script>`) for filters that use `sub` rather than `gsub`. The eight DOM
misses (`domsink-5/6/8`, `domsource-1`, `taintflow-3/5/8`,
`modern-bypass-11`) are the known round-3 dataflow gaps.

**Robustness (no defects found).** Scanned mock servers returning: no response
at all (→ `REQUEST_TIMEOUT`, exit 2), a 1-byte-per-50 ms trickle, a 60 MB body,
60 000-deep HTML nesting, and 40 000-deep JS parenthesis nesting. No panic, no
abort, no unterminated scan; the deep-nesting and huge-body guards hold. The
slowloris target did run 170 s under `--scan-timeout 90`, consistent with the
already-known "pre-scan work sits outside the scan-timeout budget".

Green gate on this branch: `cargo build --release`, `cargo test`
(2331 lib + all integration suites, 0 failed), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.
