### PR TITLE
test(scan): pin the shared injection-response and --sxss gates

### DIFF
--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -2370,3 +2370,154 @@ fn url_attr_backwalk_verdicts_are_unchanged_for_normal_markup() {
         "the same bytes in body text are not"
     );
 }
+
+/// `injection_response_suppressed` is the single copy of the status/header gates
+/// that the normal reflection branch and the `--sxss` branch both run. The
+/// `--sxss` branch previously had no gates at all, so these cases pin the shared
+/// contract directly rather than only through one branch's integration test.
+mod injection_response_gates {
+    use super::*;
+    use reqwest::header::{CONTENT_TYPE, HeaderMap, HeaderValue};
+
+    fn headers(pairs: &[(&str, &str)]) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        for (k, v) in pairs {
+            h.insert(
+                reqwest::header::HeaderName::from_bytes(k.as_bytes()).expect("header name"),
+                HeaderValue::from_str(v).expect("header value"),
+            );
+        }
+        h
+    }
+
+    fn param(location: Location) -> Param {
+        Param::new("q", "seed", location)
+    }
+
+    fn ct(value: &str) -> HeaderMap {
+        let mut h = HeaderMap::new();
+        h.insert(CONTENT_TYPE, HeaderValue::from_str(value).expect("value"));
+        h
+    }
+
+    #[test]
+    fn ignore_return_suppresses_whatever_the_body_says() {
+        let mut args = default_scan_args();
+        args.ignore_return = vec![404];
+        assert!(injection_response_suppressed(
+            404,
+            &ct("text/html"),
+            &param(Location::Query),
+            &args
+        ));
+        // A status the operator did not exclude still goes through.
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("text/html"),
+            &param(Location::Query),
+            &args
+        ));
+    }
+
+    #[test]
+    fn inert_data_content_types_are_suppressed_for_non_path_locations() {
+        let args = default_scan_args();
+        for location in [Location::Query, Location::Body, Location::Header] {
+            assert!(
+                injection_response_suppressed(
+                    200,
+                    &ct("application/json"),
+                    &param(location.clone()),
+                    &args
+                ),
+                "a JSON body renders as data, never markup ({:?})",
+                location
+            );
+        }
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("text/html; charset=utf-8"),
+            &param(Location::Query),
+            &args
+        ));
+        // JSONP stays detectable — `application/javascript` is deliberately not
+        // treated as inert data.
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("application/javascript"),
+            &param(Location::Query),
+            &args
+        ));
+    }
+
+    #[test]
+    fn text_plain_is_inert_only_with_nosniff() {
+        let args = default_scan_args();
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("text/plain"),
+            &param(Location::Query),
+            &args
+        ));
+        assert!(injection_response_suppressed(
+            200,
+            &headers(&[
+                ("content-type", "text/plain"),
+                ("x-content-type-options", "nosniff"),
+            ]),
+            &param(Location::Query),
+            &args
+        ));
+    }
+
+    #[test]
+    fn redirects_skip_the_inert_check_so_the_location_header_is_still_read() {
+        let args = default_scan_args();
+        // The body content-type describes the (usually empty) redirect body, not
+        // the redirect target, so it must not veto the caller's Location check.
+        assert!(!injection_response_suppressed(
+            302,
+            &ct("application/json"),
+            &param(Location::Query),
+            &args
+        ));
+    }
+
+    #[test]
+    fn path_injection_drops_redirects_and_non_markup_bodies() {
+        let args = default_scan_args();
+        let path = param(Location::Path);
+        assert!(injection_response_suppressed(
+            302,
+            &ct("text/html"),
+            &path,
+            &args
+        ));
+        assert!(injection_response_suppressed(
+            200,
+            &ct("application/json"),
+            &path,
+            &args
+        ));
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("text/html; charset=utf-8"),
+            &path,
+            &args
+        ));
+        // A generated SVG executes inline scripts on top-level navigation.
+        assert!(!injection_response_suppressed(
+            200,
+            &ct("image/svg+xml"),
+            &path,
+            &args
+        ));
+        // No content-type at all: nothing to judge, let the body checks decide.
+        assert!(!injection_response_suppressed(
+            200,
+            &HeaderMap::new(),
+            &path,
+            &args
+        ));
+    }
+}

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -3052,3 +3052,100 @@ async fn test_run_scanning_limit_abort_keeps_already_confirmed_findings() {
         params
     );
 }
+
+/// The other half of the `--sxss` gate parity: the Path-injection drops.
+///
+/// A path segment echoed back by an error page is only a finding when it lands
+/// somewhere a browser parses as markup. Pure URL echo — a canonical `<link>`,
+/// `<a href>` breadcrumbs — is noise, and the plain reflection path drops it via
+/// `should_suppress_path_reflection_with_body`. The `--sxss` branch never ran
+/// that check, so stored runs reported every 404 that prints the requested URI.
+#[tokio::test]
+async fn test_sxss_path_injection_drops_url_echo_only_reflections() {
+    use axum::extract::Path as AxumPath;
+    use axum::http::{StatusCode, header};
+    use axum::{Router, response::IntoResponse, routing::get};
+
+    /// 404 that echoes the requested path *only* inside a canonical link.
+    async fn url_echo(AxumPath(rest): AxumPath<String>) -> impl IntoResponse {
+        (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            format!(
+                "<html><head><link rel=\"canonical\" href=\"/{}\"></head><body>Not found</body></html>",
+                rest
+            ),
+        )
+    }
+
+    /// 404 that renders the requested path into the document body — genuine
+    /// error-page XSS, and it must survive the gate.
+    async fn body_echo(AxumPath(rest): AxumPath<String>) -> impl IntoResponse {
+        (
+            StatusCode::NOT_FOUND,
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            format!("<html><body><table><td>{}</td></table></body></html>", rest),
+        )
+    }
+
+    /// An empty body carries no evidence at all.
+    async fn empty() -> impl IntoResponse {
+        (
+            [(header::CONTENT_TYPE, "text/html; charset=utf-8")],
+            String::new(),
+        )
+    }
+
+    let addr = spawn_regression_app(
+        Router::new()
+            .route("/url-echo/{*rest}", get(url_echo))
+            .route("/body-echo/{*rest}", get(body_echo))
+            .route("/empty/{*rest}", get(empty)),
+    )
+    .await;
+
+    async fn scan_path(addr: std::net::SocketAddr, prefix: &str) -> usize {
+        let url = format!("http://{}/{}/seg", addr, prefix);
+        let mut target = parse_target(&url).expect("parse_target");
+        target.workers = 2;
+        // `Location::Path` params are addressed by segment index (see
+        // `url_inject`); index 1 is the `seg` component.
+        target.reflection_params = vec![Param {
+            injection_context: Some(InjectionContext::Html(None)),
+            ..Param::new(
+                "path_segment_1".to_string(),
+                "seg".to_string(),
+                Location::Path,
+            )
+        }];
+
+        let mut raw_args = integration_scan_args(false);
+        raw_args.sxss = true;
+        raw_args.max_payloads_per_param = 8;
+        let results = Arc::new(Mutex::new(Vec::new()));
+        run_scanning(
+            &target,
+            Arc::new(raw_args),
+            ScanRunHandles::new(results.clone(), Arc::new(AtomicUsize::new(0))),
+        )
+        .await;
+        results.lock().await.len()
+    }
+
+    assert!(
+        scan_path(addr, "body-echo").await > 0,
+        "control: a 404 that renders the path segment into the document body is \
+         real error-page XSS and must still be reported under --sxss"
+    );
+    assert_eq!(
+        scan_path(addr, "url-echo").await,
+        0,
+        "a path segment echoed only inside a canonical <link> is URL noise; \
+         --sxss must apply the same body-level Path gate the plain path applies"
+    );
+    assert_eq!(
+        scan_path(addr, "empty").await,
+        0,
+        "an empty response body carries no evidence"
+    );
+}


### PR DESCRIPTION
Follow-up to #1407, which extracted the status/header suppression gates the
normal reflection branch and the `--sxss` branch both run into a single
`injection_response_suppressed`, and added a `gated_body` helper applying the
body-level Path drop on both SXSS candidate paths. That PR exercised the shared
copies only indirectly, through one branch's mock scan; `codecov/patch` flagged
the gap.

Two test-only commits pin those contracts directly.

**`injection_response_suppressed`** (`src/scanning/check_reflection/tests.rs`)
- `--ignore-return` status suppression
- inert-data content-types (`application/json`, `text/csv`, …)
- the nosniff-only `text/plain` rule
- the redirect carve-out that deliberately lets the caller still read `Location:`
- the Path-only redirect / non-markup drops

**`--sxss` body-level gates** (`src/scanning/tests.rs`)
- a path segment echoed only inside a canonical `<link>` is URL noise the plain
  path drops, and must drop under `--sxss` too
- an empty body carries no evidence on either path
- a `<td>`-rendering 404 is the recall control, so an empty result means
  "gated", not "nothing reached the scanner"

No production code changes — two test files, 248 lines added.

Verified: `cargo test --lib check_reflection` 150 passed / 0 failed,
`cargo test --lib scanning::tests` 118 passed / 0 failed, `cargo fmt --check`
and `cargo clippy --all-targets --all-features -- -D warnings` clean.