### PR TITLE
fix(mining): scope the already-discovered skip to the wire slot

### DIFF
--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -749,12 +749,15 @@ pub async fn probe_dictionary_params(
                     break 'outer;
                 }
             }
-            // Skip if already discovered
+            // Skip only when this *slot* was already discovered. Matching on
+            // the name alone let a param found at another wire location (a
+            // query `q`, a header `q`) suppress mining of the same name here,
+            // so the slot was never probed at all. See `param_slot_key`.
             let exists = reflection_params
                 .lock()
                 .await
                 .iter()
-                .any(|p| p.name == *param);
+                .any(|p| p.name == *param && p.location == Location::Query);
             if exists {
                 continue;
             }
@@ -973,12 +976,17 @@ pub async fn probe_body_params(
                     break;
                 }
             }
-            // Skip already discovered params
+            // Skip already discovered params — but only at *this* wire slot.
+            // Keying on the name alone meant an ordinary
+            // `dalfox scan '…?q=x' -d 'q=y'` never mined the body `q` at all,
+            // because Stage 1 had already discovered the query `q`: a
+            // vulnerable body parameter was not just unreported, it was never
+            // probed. See `param_slot_key`.
             let exists = reflection_params
                 .lock()
                 .await
                 .iter()
-                .any(|p| p.name == param_name);
+                .any(|p| p.name == param_name && p.location == Location::Body);
             if exists {
                 continue;
             }
@@ -1217,11 +1225,12 @@ pub async fn probe_response_id_params(
                     break;
                 }
             }
+            // Slot-scoped, not name-scoped: see `param_slot_key`.
             let existing = reflection_params
                 .lock()
                 .await
                 .iter()
-                .any(|p| p.name == param);
+                .any(|p| p.name == param && p.location == Location::Query);
             if existing {
                 continue;
             }
@@ -1397,12 +1406,13 @@ pub async fn probe_json_body_params(
                 break;
             }
         }
-        // Skip if already discovered
+        // Slot-scoped, not name-scoped: a query or form `q` must not suppress
+        // mining of the JSON body's `q`. See `param_slot_key`.
         let exists = reflection_params
             .lock()
             .await
             .iter()
-            .any(|p| p.name == param_name);
+            .any(|p| p.name == param_name && p.location == Location::JsonBody);
         if exists {
             continue;
         }

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1362,3 +1362,80 @@ fn test_detect_js_breakout_still_works_behind_a_large_inline_script() {
     let body = format!("<script>{filler}foo(\"{marker}\");</script>");
     assert_eq!(detect_js_breakout(&body).as_deref(), Some("\")"));
 }
+
+#[tokio::test]
+async fn test_probe_body_params_mines_a_name_already_discovered_in_the_query() {
+    // The ordinary `dalfox scan '…?q=x' -d 'q=y'` shape. Stage 1 discovery has
+    // already put a *query* `q` in `reflection_params`; the body `q` is a
+    // different wire slot and must still be mined. Keying the skip on the name
+    // alone meant it never was — so a vulnerable body parameter was not merely
+    // unreported, it was never probed.
+    let addr = start_body_reflect_server().await;
+    let target =
+        parse_target(&format!("http://{}:{}/b", addr.ip(), addr.port())).expect("parse target");
+    let mut args = default_scan_args();
+    args.data = Some("q=y".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(vec![Param::new(
+        "q".to_string(),
+        "x".to_string(),
+        Location::Query,
+    )]));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "q" && p.location == Location::Body),
+        "body slot `q` was not mined because the query `q` shadowed it, got {:?}",
+        params
+            .iter()
+            .map(|p| (p.name.clone(), format!("{:?}", p.location)))
+            .collect::<Vec<_>>()
+    );
+    // The pre-existing query param must survive untouched.
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "q" && p.location == Location::Query),
+        "the pre-existing query param was dropped, got {:?}",
+        params
+            .iter()
+            .map(|p| (p.name.clone(), format!("{:?}", p.location)))
+            .collect::<Vec<_>>()
+    );
+}
+
+#[tokio::test]
+async fn test_probe_json_body_params_mines_a_name_already_discovered_in_the_query() {
+    // Same shape for the JSON body stage.
+    let addr = start_json_reflect_server().await;
+    let mut target =
+        parse_target(&format!("http://{}:{}/j", addr.ip(), addr.port())).expect("parse target");
+    target.method = "POST".to_string();
+    target.data = Some("{\"q\":\"y\"}".to_string());
+    let mut args = default_scan_args();
+    args.data = Some("{\"q\":\"y\"}".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(vec![Param::new(
+        "q".to_string(),
+        "x".to_string(),
+        Location::Query,
+    )]));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_json_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "q" && p.location == Location::JsonBody),
+        "JSON body slot `q` was shadowed by the query `q`, got {:?}",
+        params
+            .iter()
+            .map(|p| (p.name.clone(), format!("{:?}", p.location)))
+            .collect::<Vec<_>>()
+    );
+}


### PR DESCRIPTION
## Symptom

The ordinary two-slot invocation never probes the body parameter:

```
dalfox scan 'http://target/?q=x' -d 'q=y'
```

Stage 1 discovery records the query `q`. `probe_body_params` then skips the body
`q` because a param *named* `q` is already in `reflection_params` — so a
vulnerable body parameter is not merely deduplicated out of the report, **it is
never probed at all**.

#1407 keyed `FoundParams` on `(location, name, wire_name)` so two slots sharing a
name both get reported. That fix cannot help when the second slot is never
discovered in the first place, which is this. It was flagged as deferred/out-of-area
in that PR.

## Root cause

`src/parameter_analysis/mining.rs` — the "already discovered" guard in each mining
stage compared names only:

```rust
let exists = reflection_params.lock().await.iter().any(|p| p.name == param_name);
if exists { continue; }
```

A name is not a parameter; a slot is. `param_slot_key` (`name|location`) has been
this file's notion of identity all along, and `probe_multipart_params` already
matched on `p.name == field && p.location == Location::MultipartBody` (from the
earlier multipart absent-param fix). The other four stages had drifted back to a
bare name compare.

## Fix

All five stages now agree, each scoped to the location it actually produces:

| stage | location |
|---|---|
| `probe_dictionary_params` | `Query` |
| `probe_body_params` | `Body` |
| `probe_response_id_params` | `Query` |
| `probe_json_body_params` | `JsonBody` |
| `probe_multipart_params` | `MultipartBody` (already correct) |

**Collapse is unaffected.** `collapse_mined_params` is already location-scoped and
guarded by the `preexisting` slot-key snapshot each caller takes before pushing, so
the extra slots a stage now mines fold exactly the way that stage's own finds
always did — the "collapse must not delete discovered params" invariant still holds.

## Test

`test_probe_body_params_mines_a_name_already_discovered_in_the_query` and the
JSON-body sibling seed `reflection_params` with a query `q`, run the stage against
a reflecting mock, and assert both that the body / JSON slot **is** mined and that
the pre-existing query param survives untouched.

**Mutation-verified**: reverting the two predicates to the bare name compare turns
both RED with `body slot 'q' was not mined because the query 'q' shadowed it, got
[("q", "Query")]`.

## Green gate

`cargo build --release`, `cargo test` (2363 lib + all integration binaries, exit 0),
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
— all clean.