### PR TITLE
fix(server): exit non-zero when the server never came up

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -525,8 +525,14 @@ async fn main() {
                 outcome = cmd::scan::run_scan(&args).await;
             }
             Commands::Server(args) => {
-                server::run_server(args).await;
-                outcome = ScanOutcome::Clean;
+                // A server that never bound — or whose `axum::serve` failed —
+                // has to reach the exit code. A supervisor reads status, not
+                // stderr, so the hard-coded `Clean` made "the port was already
+                // in use" indistinguishable from a clean shutdown.
+                outcome = match server::run_server(args).await {
+                    Ok(()) => ScanOutcome::Clean,
+                    Err(_) => ScanOutcome::Error,
+                };
             }
             Commands::Payload(args) => {
                 outcome = cmd::payload::run_payload(args);

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,13 +63,21 @@ pub(crate) use response::*;
 pub(crate) use types::*;
 pub(crate) use util::*;
 
-pub async fn run_server(args: ServerArgs) {
+/// Run the REST API server until it shuts down gracefully.
+///
+/// Returns `Err` when the server never came up (an unparseable bind address, a
+/// port already in use) or when `axum::serve` itself failed. A supervisor —
+/// systemd, a container runtime, `dalfox server || alert` — reads the exit
+/// status, not stderr, so a failed start that exits 0 is indistinguishable from
+/// a clean shutdown.
+pub async fn run_server(args: ServerArgs) -> Result<(), String> {
     let addr_str = format!("{}:{}", args.host, args.port);
     let addr: SocketAddr = match addr_str.parse() {
         Ok(a) => a,
         Err(e) => {
-            eprintln!("Invalid bind address {}: {}", addr_str, e);
-            return;
+            let msg = format!("Invalid bind address {}: {}", addr_str, e);
+            eprintln!("{}", msg);
+            return Err(msg);
         }
     };
 
@@ -158,8 +166,9 @@ pub async fn run_server(args: ServerArgs) {
             .append(true)
             .open(path)
     {
-        eprintln!("Cannot open --log-file {}: {}", path, e);
-        return;
+        let msg = format!("Cannot open --log-file {}: {}", path, e);
+        eprintln!("{}", msg);
+        return Err(msg);
     }
 
     let state = AppState {
@@ -202,12 +211,6 @@ pub async fn run_server(args: ServerArgs) {
         // body over the limit is rejected with 413 before handler code runs.
         .layer(axum::extract::DefaultBodyLimit::max(args.max_body_bytes))
         .with_state(state.clone());
-
-    log(
-        &state,
-        "SERVER",
-        &format!("listening on http://{}", addr_str),
-    );
 
     // Loud warning for the most dangerous misconfiguration: a network-reachable
     // bind with auth disabled. The API scans any submitted URL and POSTs results
@@ -253,14 +256,19 @@ pub async fn run_server(args: ServerArgs) {
     let listener = match tokio::net::TcpListener::bind(addr).await {
         Ok(l) => l,
         Err(e) => {
-            log(
-                &state,
-                "ERR",
-                &format!("Failed to bind {}: {}", addr_str, e),
-            );
-            return;
+            let msg = format!("Failed to bind {}: {}", addr_str, e);
+            log(&state, "ERR", &msg);
+            return Err(msg);
         }
     };
+    // Announced only now: this line is the operator's "it came up" signal, and
+    // logging it before the bind made the last line before a bind error claim
+    // success.
+    log(
+        &state,
+        "SERVER",
+        &format!("listening on http://{}", addr_str),
+    );
     // Graceful shutdown on SIGINT / SIGTERM. axum drains in-flight
     // requests before returning; previously the server ignored Ctrl-C
     // outright and required SIGKILL, leaking any in-flight scans and
@@ -294,8 +302,11 @@ pub async fn run_server(args: ServerArgs) {
         .with_graceful_shutdown(shutdown_signal)
         .await
     {
-        log(&state, "ERR", &format!("server error: {}", e));
+        let msg = format!("server error: {}", e);
+        log(&state, "ERR", &msg);
+        return Err(msg);
     }
+    Ok(())
 }
 
 #[cfg(test)]

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -1898,7 +1898,7 @@ async fn test_get_scan_handler_success_plain_json_defaults() {
 
 #[tokio::test]
 async fn test_run_server_returns_on_invalid_bind_address() {
-    run_server(ServerArgs {
+    let err = run_server(ServerArgs {
         port: 6664,
         host: "not a valid host".to_string(),
         api_key: None,
@@ -1916,6 +1916,11 @@ async fn test_run_server_returns_on_invalid_bind_address() {
         cors_allow_headers: None,
     })
     .await;
+    assert!(
+        err.is_err(),
+        "an unparseable bind address must be reported to the caller so `main` \
+         can exit non-zero; a supervisor reads status, not stderr"
+    );
 }
 
 #[tokio::test]
@@ -1925,7 +1930,7 @@ async fn test_run_server_returns_on_bind_failure_after_state_build() {
         .expect("bind guard listener");
     let guard_addr = guard_listener.local_addr().expect("guard addr");
 
-    run_server(ServerArgs {
+    let err = run_server(ServerArgs {
         port: guard_addr.port(),
         host: Ipv4Addr::LOCALHOST.to_string(),
         api_key: Some("server-key".to_string()),
@@ -1945,8 +1950,47 @@ async fn test_run_server_returns_on_bind_failure_after_state_build() {
         cors_allow_headers: Some("Content-Type,X-API-KEY".to_string()),
     })
     .await;
+    let msg = err.expect_err("a port already in use must not report success");
+    assert!(
+        msg.contains("Failed to bind"),
+        "the error must name the bind failure, got {msg:?}"
+    );
 
     drop(guard_listener);
+}
+
+#[tokio::test]
+async fn test_run_server_reports_an_unwritable_log_file() {
+    // `--log-file` is proven writable before serving; that failure has to reach
+    // the exit code too, not just stderr.
+    let dir = std::env::temp_dir().join("dalfox-nonexistent-dir-for-log-file-test");
+    let _ = std::fs::remove_dir_all(&dir);
+    let path = dir.join("server.log");
+
+    let err = run_server(ServerArgs {
+        port: 6665,
+        host: Ipv4Addr::LOCALHOST.to_string(),
+        api_key: None,
+        log_file: Some(path.to_string_lossy().into_owned()),
+        rate_limit: None,
+        scan_timeout: None,
+        max_concurrent_scans: 100,
+        allowed_hosts: None,
+        max_retained_scans: 1000,
+        max_body_bytes: 1_048_576,
+        allowed_origins: None,
+        jsonp: false,
+        callback_param_name: "callback".to_string(),
+        cors_allow_methods: None,
+        cors_allow_headers: None,
+    })
+    .await;
+
+    let msg = err.expect_err("an unopenable --log-file must not report success");
+    assert!(
+        msg.contains("Cannot open --log-file"),
+        "the error must name the log-file failure, got {msg:?}"
+    );
 }
 
 // ---- Tests for new endpoints: cancel, list, preflight ----


### PR DESCRIPTION
## Symptom

Every `dalfox server` start-up failure exits **0**:

```
$ dalfox server --host 127.0.0.1 --port <busy>
2026-09-02 11:38:02 SERVER listening on http://127.0.0.1:62881     <- claims success
2026-09-02 11:38:02 ERR Failed to bind 127.0.0.1:62881: Address already in use
$ echo $?
0
```

Two things are wrong. A supervisor — systemd, a container runtime,
`dalfox server || alert` — reads the exit status, not stderr, so "the port was
already in use" is indistinguishable from a clean shutdown. And the last line
before the error announces that the server is listening.

Reported as deferred/out-of-area in #1408 (which fixed the same exit-0 bug for
`dalfox mcp`).

## Root cause

`src/server/mod.rs` — `run_server` returns `()`, so `src/main.rs` had nothing to
map and set `outcome = ScanOutcome::Clean` unconditionally. Three start-up paths
`return`ed bare:

- unparseable bind address (`addr_str.parse()`)
- unopenable `--log-file` (**this one had no test at all**)
- `TcpListener::bind` failure

A serve-loop failure had the same shape: `axum::serve` returning `Err` was logged
and then reported as success.

Separately, `SERVER listening on http://…` was logged at router-build time — about
40 lines before the bind was attempted.

## Fix

`run_server` returns `Result<(), String>`; all four failures return `Err`, and
`main.rs` maps `Err` to `ScanOutcome::Error` (exit 2). The `listening on` line
moves to just after a successful `bind`, so it prints only when it is true — after
the start-up warnings, which is also the better order.

## Verification with the release binary

| invocation | before | after |
|---|---|---|
| `--port <busy>` | exit 0, last line `listening on` | **exit 2**, last line `ERR Failed to bind …` |
| `--host 'not a host'` | exit 0 | **exit 2** |
| unwritable `--log-file` | exit 0 | **exit 2** |

## Tests

The two existing failure-path tests only asserted that `run_server` *returned*;
they now assert `Err` and that the message names the failure.
`test_run_server_reports_an_unwritable_log_file` covers the third path, which was
untested.

## Green gate

`cargo build --release`, `cargo test` (2362 lib + all integration binaries, exit 0),
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
— all clean.