### PR TITLE
fix(scan): count requests that never reached the target

### DIFF
--- a/src/cmd/scan/mod.rs
+++ b/src/cmd/scan/mod.rs
@@ -595,13 +595,16 @@ pub async fn run_scan(args: &ScanArgs) -> ScanOutcome {
     // Output results: dedupe, --only-poc filter, --limit, per-target summary,
     // and format-specific rendering to stdout or --output file.
     let scan_elapsed = __dalfox_scan_start.elapsed();
-    let total_requests = crate::REQUEST_COUNT.load(Ordering::Relaxed);
+    let requests = output::RequestTally {
+        sent: crate::REQUEST_COUNT.load(Ordering::Relaxed),
+        failed: crate::REQUEST_FAILURE_COUNT.load(Ordering::Relaxed),
+    };
     let (final_results, output_write_failed) = output::render_results(
         args,
         &state,
         &all_target_urls,
         scan_elapsed,
-        total_requests,
+        requests,
         stream_findings_enabled,
         baseline.as_ref(),
     )

--- a/src/cmd/scan/output.rs
+++ b/src/cmd/scan/output.rs
@@ -379,12 +379,42 @@ pub(super) fn apply_baseline(
     Some(block)
 }
 
+/// How many outbound requests this run made, and how many of them never got a
+/// response. Passed as one value rather than two adjacent `u64` parameters,
+/// which are trivially transposable at a call site.
+#[derive(Debug, Clone, Copy, Default)]
+pub(crate) struct RequestTally {
+    pub sent: u64,
+    pub failed: u64,
+}
+
+impl RequestTally {
+    /// Share of attempted requests that never produced a response, 0.0 when
+    /// nothing was sent.
+    fn failure_ratio(&self) -> f64 {
+        if self.sent == 0 {
+            return 0.0;
+        }
+        self.failed as f64 / self.sent as f64
+    }
+}
+
+/// A run that lost at least this share of its requests is reported
+/// `incomplete`. A scan never gets a perfect network, so a handful of resets on
+/// a long run is noise and flipping the flag on a single failure would devalue
+/// it. Losing a tenth of everything attempted is not noise: at that rate the
+/// payloads that were never delivered outnumber most targets' whole payload
+/// catalogue, and "no findings" stops meaning "nothing to find". The raw
+/// `failed_requests` count is always reported regardless, so a consumer that
+/// wants a stricter bar has the number.
+const INCOMPLETE_FAILURE_RATIO: f64 = 0.10;
+
 pub(crate) async fn render_results(
     args: &ScanArgs,
     state: &ScanState,
     all_target_urls: &[String],
     scan_elapsed: std::time::Duration,
-    total_requests: u64,
+    requests: RequestTally,
     stream_findings_enabled: bool,
     baseline: Option<&Baseline>,
 ) -> (Vec<Result>, bool) {
@@ -546,12 +576,18 @@ pub(crate) async fn render_results(
         summary
     };
 
-    // One field for "don't trust this run": true when any target's session
-    // died. Read straight off the summary we just built so the flag and the
-    // per-target statuses can't disagree.
-    let scan_incomplete = target_summary
+    // One field for "don't trust this run": a target's session died, or a
+    // significant share of this run's requests never reached the target. The
+    // session half is read straight off the summary we just built so the flag
+    // and the per-target statuses can't disagree; the transport half covers the
+    // case the summary cannot see — a target that resets or drops injection
+    // requests answers the reachability probe fine, so every per-target status
+    // stays `clean` while most payloads were never actually delivered.
+    let session_died = target_summary
         .iter()
         .any(|t| t["error_code"] == crate::cmd::error_codes::SESSION_LOST);
+    let lost_too_many_requests = requests.failure_ratio() >= INCOMPLETE_FAILURE_RATIO;
+    let scan_incomplete = session_died || lost_too_many_requests;
 
     // One envelope, built once and rendered by every format. Previously the
     // `json` and `jsonl` arms each inlined their own copy of this object next
@@ -561,7 +597,8 @@ pub(crate) async fn render_results(
         dalfox_version: env!("CARGO_PKG_VERSION").to_string(),
         targets: args.targets.clone(),
         scan_duration_ms: scan_elapsed.as_millis() as u64,
-        total_requests,
+        total_requests: requests.sent,
+        failed_requests: requests.failed,
         findings_count: display_results.len(),
         // Moved, not cloned: on a mass-URL run this vector holds one JSON
         // object per target, and nothing below needs a second copy.
@@ -633,17 +670,32 @@ pub(crate) async fn render_results(
         // A finding count printed after a session died is a half-truth — say
         // so on the same screen, next to the number the operator will quote.
         // The per-target detail already went to stderr as it happened.
-        if scan_incomplete {
-            let lost = scan_meta
-                .target_summary
-                .iter()
-                .filter(|t| t["error_code"] == crate::cmd::error_codes::SESSION_LOST)
-                .count();
+        let lost = scan_meta
+            .target_summary
+            .iter()
+            .filter(|t| t["error_code"] == crate::cmd::error_codes::SESSION_LOST)
+            .count();
+        if lost > 0 {
             log_warn(
                 args,
                 &format!(
                     "INCOMPLETE: \x1b[33m{}\x1b[0m target(s) had no usable session — those results are not a clean bill of health",
                     lost
+                ),
+            );
+        }
+        // The transport half. A target that resets or drops injection requests
+        // answers the reachability probe fine, so every per-target status stays
+        // `clean` and the finding count reads as a verdict. Say what actually
+        // happened next to the number the operator will quote.
+        if lost_too_many_requests {
+            log_warn(
+                args,
+                &format!(
+                    "INCOMPLETE: \x1b[33m{}\x1b[0m of {} requests never reached the target ({:.0}%) — payloads that were not delivered were not tested, so this is not a clean bill of health",
+                    requests.failed,
+                    requests.sent,
+                    requests.failure_ratio() * 100.0
                 ),
             );
         }

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -1276,7 +1276,10 @@ async fn render_results_to_file(
         &state,
         &urls,
         std::time::Duration::from_millis(7),
-        42,
+        crate::cmd::scan::output::RequestTally {
+            sent: 42,
+            failed: 0,
+        },
         false,
         None,
     )
@@ -1284,6 +1287,109 @@ async fn render_results_to_file(
     let content = std::fs::read_to_string(&path).expect("output file written");
     let _ = std::fs::remove_file(&path);
     content
+}
+
+/// Like `render_results_to_file`, but the caller picks the request tally so a
+/// test can describe a run that lost part of its traffic.
+async fn render_results_to_file_with_tally(
+    mut args: ScanArgs,
+    results: Vec<ScanResult>,
+    urls: Vec<String>,
+    tag: &str,
+    requests: crate::cmd::scan::output::RequestTally,
+) -> String {
+    let path = temp_out_path(tag);
+    args.output = Some(path.clone());
+    let state = make_scan_state(results);
+    let _ = render_results(
+        &args,
+        &state,
+        &urls,
+        std::time::Duration::from_millis(7),
+        requests,
+        false,
+        None,
+    )
+    .await;
+    let content = std::fs::read_to_string(&path).expect("output file written");
+    let _ = std::fs::remove_file(&path);
+    content
+}
+
+#[tokio::test]
+async fn test_a_run_that_lost_most_of_its_requests_is_not_a_clean_bill_of_health() {
+    // A target that resets or drops injection requests still answers the
+    // reachability probe, so every per-target status stays `clean` and a zero
+    // finding count reads as a verdict. The transport failures have to reach
+    // the envelope, or the run is indistinguishable from a genuinely clean one.
+    let mut args = default_scan_args();
+    args.format = "json".to_string();
+    let urls = vec!["https://example.com".to_string()];
+    let content = render_results_to_file_with_tally(
+        args,
+        vec![],
+        urls,
+        "lost_requests",
+        crate::cmd::scan::output::RequestTally {
+            sent: 170,
+            failed: 148,
+        },
+    )
+    .await;
+    let v: serde_json::Value = serde_json::from_str(&content).expect("valid json");
+    assert_eq!(v["meta"]["findings_count"], 0);
+    assert_eq!(v["meta"]["failed_requests"], 148);
+    assert_eq!(
+        v["meta"]["incomplete"], true,
+        "a run that lost 148 of 170 requests must not report a trustworthy clean, got {}",
+        v["meta"]
+    );
+}
+
+#[tokio::test]
+async fn test_a_healthy_run_is_not_marked_incomplete() {
+    // The control: no failures must never flip the flag, or it means nothing.
+    let mut args = default_scan_args();
+    args.format = "json".to_string();
+    let urls = vec!["https://example.com".to_string()];
+    let content = render_results_to_file_with_tally(
+        args,
+        vec![],
+        urls,
+        "healthy_run",
+        crate::cmd::scan::output::RequestTally {
+            sent: 170,
+            failed: 0,
+        },
+    )
+    .await;
+    let v: serde_json::Value = serde_json::from_str(&content).expect("valid json");
+    assert_eq!(v["meta"]["failed_requests"], 0);
+    assert_eq!(v["meta"]["incomplete"], false);
+}
+
+#[tokio::test]
+async fn test_a_handful_of_lost_requests_does_not_flip_incomplete() {
+    // Below the ratio the count is still reported — a consumer that wants a
+    // stricter bar has the number — but the flag stays clear so it keeps
+    // meaning something on a long run over a real network.
+    let mut args = default_scan_args();
+    args.format = "json".to_string();
+    let urls = vec!["https://example.com".to_string()];
+    let content = render_results_to_file_with_tally(
+        args,
+        vec![],
+        urls,
+        "few_lost_requests",
+        crate::cmd::scan::output::RequestTally {
+            sent: 1000,
+            failed: 3,
+        },
+    )
+    .await;
+    let v: serde_json::Value = serde_json::from_str(&content).expect("valid json");
+    assert_eq!(v["meta"]["failed_requests"], 3);
+    assert_eq!(v["meta"]["incomplete"], false);
 }
 
 #[tokio::test]
@@ -1551,7 +1657,10 @@ async fn test_render_results_baseline_filter_suppresses_known_findings() {
         &state,
         &["https://example.com/s".to_string()],
         std::time::Duration::from_millis(7),
-        42,
+        crate::cmd::scan::output::RequestTally {
+            sent: 42,
+            failed: 0,
+        },
         false,
         Some(&bl),
     )
@@ -1594,7 +1703,10 @@ async fn test_render_results_baseline_annotate_marks_every_finding() {
         &state,
         &["https://example.com/s".to_string()],
         std::time::Duration::from_millis(7),
-        42,
+        crate::cmd::scan::output::RequestTally {
+            sent: 42,
+            failed: 0,
+        },
         false,
         Some(&bl),
     )
@@ -1631,7 +1743,10 @@ async fn test_render_results_baseline_meta_survives_toml_and_markdown() {
             &state,
             &["https://example.com/s".to_string()],
             std::time::Duration::from_millis(7),
-            42,
+            crate::cmd::scan::output::RequestTally {
+                sent: 42,
+                failed: 0,
+            },
             false,
             Some(&bl),
         )
@@ -1672,7 +1787,10 @@ async fn test_render_results_baseline_counts_match_the_only_poc_filtered_set() {
         &state,
         &["https://example.com/s".to_string()],
         std::time::Duration::from_millis(7),
-        42,
+        crate::cmd::scan::output::RequestTally {
+            sent: 42,
+            failed: 0,
+        },
         false,
         Some(&bl),
     )
@@ -1704,7 +1822,10 @@ async fn test_render_results_disabled_baseline_reports_itself() {
         &state,
         &["https://example.com".to_string()],
         std::time::Duration::from_millis(7),
-        42,
+        crate::cmd::scan::output::RequestTally {
+            sent: 42,
+            failed: 0,
+        },
         false,
         Some(&bl),
     )
@@ -1837,7 +1958,7 @@ async fn test_render_results_includes_waf_summary() {
         &state,
         std::slice::from_ref(&url),
         std::time::Duration::from_millis(1),
-        3,
+        crate::cmd::scan::output::RequestTally { sent: 3, failed: 0 },
         false,
         None,
     )
@@ -1868,7 +1989,7 @@ async fn test_render_results_stdout_path_returns_results() {
         &state,
         &["https://example.com".to_string()],
         std::time::Duration::from_millis(1),
-        1,
+        crate::cmd::scan::output::RequestTally { sent: 1, failed: 0 },
         true, // stream_findings_enabled → skip per-finding re-render
         None,
     )
@@ -1897,7 +2018,7 @@ async fn test_render_results_reports_output_write_failure() {
         &state,
         &["https://example.com".to_string()],
         std::time::Duration::from_millis(1),
-        1,
+        crate::cmd::scan::output::RequestTally { sent: 1, failed: 0 },
         true,
         None,
     )

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,6 +83,10 @@ pub use std::sync::atomic::AtomicU64;
 
 pub static DEBUG: AtomicBool = AtomicBool::new(false);
 pub static REQUEST_COUNT: AtomicU64 = AtomicU64::new(0);
+/// Outbound requests that never produced a response — connection reset,
+/// refused, timed out, TLS failure — counted *after* `send_with_retry` has
+/// exhausted its budget. See [`tick_request_failure`].
+pub static REQUEST_FAILURE_COUNT: AtomicU64 = AtomicU64::new(0);
 pub(crate) static WAF_BLOCK_COUNT: AtomicU64 = AtomicU64::new(0);
 pub(crate) static WAF_CONSECUTIVE_BLOCKS: std::sync::atomic::AtomicU32 =
     std::sync::atomic::AtomicU32::new(0);
@@ -122,6 +126,12 @@ tokio::task_local! {
     /// `tick_request_count` which bumps both the global counter and this
     /// task-local when it is bound.
     pub(crate) static REQUEST_COUNT_JOB: std::sync::Arc<AtomicU64>;
+
+    /// Per-scan failed-request counter, the sibling of [`REQUEST_COUNT_JOB`].
+    /// Bound alongside it so a daemon's concurrent jobs don't inherit each
+    /// other's transport failures — the same process-global trap the remote
+    /// payload cache had.
+    pub(crate) static REQUEST_FAILURE_COUNT_JOB: std::sync::Arc<AtomicU64>;
 
     /// Per-scan consecutive-WAF-block counter. Bound by MCP and REST runners
     /// so concurrent scans don't trigger each other's adaptive backoff.
@@ -175,6 +185,7 @@ where
 #[derive(Clone, Default)]
 pub struct JobScopes {
     requests: Option<std::sync::Arc<AtomicU64>>,
+    request_failures: Option<std::sync::Arc<AtomicU64>>,
     waf: Option<std::sync::Arc<std::sync::atomic::AtomicU32>>,
     limiter: Option<std::sync::Arc<utils::rate_limit::RateLimiter>>,
 }
@@ -185,6 +196,9 @@ impl JobScopes {
     pub(crate) fn capture() -> Self {
         Self {
             requests: REQUEST_COUNT_JOB.try_with(std::sync::Arc::clone).ok(),
+            request_failures: REQUEST_FAILURE_COUNT_JOB
+                .try_with(std::sync::Arc::clone)
+                .ok(),
             waf: WAF_CONSECUTIVE_BLOCKS_JOB
                 .try_with(std::sync::Arc::clone)
                 .ok(),
@@ -194,7 +208,10 @@ impl JobScopes {
 
     /// True when no per-job scope was captured (the CLI path).
     pub(crate) fn is_empty(&self) -> bool {
-        self.requests.is_none() && self.waf.is_none() && self.limiter.is_none()
+        self.requests.is_none()
+            && self.request_failures.is_none()
+            && self.waf.is_none()
+            && self.limiter.is_none()
     }
 }
 
@@ -220,6 +237,9 @@ where
     }
     if let Some(waf) = scopes.waf {
         f = Box::pin(WAF_CONSECUTIVE_BLOCKS_JOB.scope(waf, f));
+    }
+    if let Some(failures) = scopes.request_failures {
+        f = Box::pin(REQUEST_FAILURE_COUNT_JOB.scope(failures, f));
     }
     if let Some(requests) = scopes.requests {
         f = Box::pin(REQUEST_COUNT_JOB.scope(requests, f));
@@ -265,6 +285,23 @@ pub async fn record_outbound_request() {
 pub(crate) fn tick_request_count() {
     REQUEST_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
     let _ = REQUEST_COUNT_JOB.try_with(|c| c.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
+}
+
+/// Record an outbound request that never produced a response.
+///
+/// A transport error in the injection phase means a payload was *sent but never
+/// tested*. Every send site swallowed those (`if let Ok(resp) = …`), and nothing
+/// counted them, so a target that drops or resets injection requests produced a
+/// scan indistinguishable from a genuinely clean one: `status: clean`,
+/// `incomplete: false`, exit 0, with a plausible `total_requests`.
+///
+/// Mirrors [`tick_request_count`]: always bumps the process-wide counter, and
+/// additionally the task-local one when a per-job scope is bound.
+#[inline]
+pub(crate) fn tick_request_failure() {
+    REQUEST_FAILURE_COUNT.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    let _ = REQUEST_FAILURE_COUNT_JOB
+        .try_with(|c| c.fetch_add(1, std::sync::atomic::Ordering::Relaxed));
 }
 
 /// Record a WAF-block response (403/406/429/503 on an injection request).

--- a/src/parameter_analysis/discovery.rs
+++ b/src/parameter_analysis/discovery.rs
@@ -359,7 +359,7 @@ pub async fn check_query_discovery(
                     crate::utils::build_request(&client_clone, &target_clone, m, url, data.clone());
                 crate::record_outbound_request().await;
                 let mut discovered: Option<Param> = None;
-                if let Ok(resp) = request.send().await {
+                if let Ok(resp) = crate::utils::http::send_counted(request).await {
                     // Check for redirect reflection: if the response is a 3xx redirect,
                     // the Location header may contain the reflected marker value.
                     let is_redirect = resp.status().is_redirection();
@@ -440,7 +440,7 @@ pub async fn check_query_discovery(
             let m = target.parse_method();
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
-            if let Ok(resp) = request.send().await
+            if let Ok(resp) = crate::utils::http::send_counted(request).await
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
@@ -519,7 +519,7 @@ pub async fn check_query_discovery(
             let m = target.parse_method();
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
-            if let Ok(resp) = request.send().await
+            if let Ok(resp) = crate::utils::http::send_counted(request).await
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
@@ -567,7 +567,7 @@ pub async fn check_query_discovery(
             let m = target.parse_method();
             let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
             crate::record_outbound_request().await;
-            if let Ok(resp) = request.send().await
+            if let Ok(resp) = crate::utils::http::send_counted(request).await
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && text.contains(numeric_marker)
             {
@@ -607,7 +607,7 @@ pub async fn check_query_discovery(
         let m = target.parse_method();
         let request = crate::utils::build_request(&client, target, m, url, target.data.clone());
         crate::record_outbound_request().await;
-        if let Ok(resp) = request.send().await
+        if let Ok(resp) = crate::utils::http::send_counted(request).await
             && let Ok(text) = crate::utils::http::read_body(resp).await
             && crate::scanning::markers::classify_probe_reflection(&text).detected()
         {
@@ -679,7 +679,7 @@ async fn detect_blanket_header_echo(target: &Target) -> bool {
     let overrides = vec![(guard_name, test_value.to_string())];
     let request = crate::utils::apply_header_overrides(base, &overrides);
     crate::record_outbound_request().await;
-    match request.send().await {
+    match crate::utils::http::send_counted(request).await {
         Ok(resp) => match crate::utils::http::read_body(resp).await {
             Ok(text) => crate::scanning::markers::classify_probe_reflection(&text).detected(),
             Err(_) => false,
@@ -772,7 +772,7 @@ pub async fn check_header_discovery(
                 let request = crate::utils::apply_header_overrides(base, &overrides);
                 crate::record_outbound_request().await;
                 let mut discovered: Option<Param> = None;
-                if let Ok(resp) = request.send().await
+                if let Ok(resp) = crate::utils::http::send_counted(request).await
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
@@ -895,7 +895,7 @@ pub async fn check_path_discovery(
 
                 crate::record_outbound_request().await;
                 let mut discovered: Option<Param> = None;
-                if let Ok(resp) = request.send().await {
+                if let Ok(resp) = crate::utils::http::send_counted(request).await {
                     // Pair discovery with the scan-time `should_suppress_path_*`
                     // policy so we don't pay payload-set requests for path
                     // segments the scanner would later throw away. Concretely:
@@ -949,7 +949,7 @@ pub async fn check_path_discovery(
                                     data.clone(),
                                 );
                                 crate::record_outbound_request().await;
-                                match probe.send().await {
+                                match crate::utils::http::send_counted(probe).await {
                                     Ok(r) => match crate::utils::http::read_body(r).await {
                                         Ok(t) => t.contains(&needle),
                                         Err(_) => false,
@@ -1061,7 +1061,7 @@ pub async fn check_cookie_discovery(
                 );
                 crate::record_outbound_request().await;
                 let mut discovered: Option<Param> = None;
-                if let Ok(resp) = request.send().await
+                if let Ok(resp) = crate::utils::http::send_counted(request).await
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
@@ -1117,7 +1117,7 @@ pub async fn check_form_discovery(
     let method = reqwest::Method::GET;
     let request = crate::utils::build_request(&client, target, method, target.url.clone(), None);
     crate::record_outbound_request().await;
-    let html = match request.send().await {
+    let html = match crate::utils::http::send_counted(request).await {
         Ok(resp) => match crate::utils::http::read_body(resp).await {
             Ok(text) => text,
             Err(_) => return,
@@ -1242,7 +1242,7 @@ pub async fn check_form_discovery(
                 )
                 .multipart(form);
                 crate::record_outbound_request().await;
-                if let Ok(resp) = rb.send().await
+                if let Ok(resp) = crate::utils::http::send_counted(rb).await
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
@@ -1316,7 +1316,7 @@ pub async fn check_form_discovery(
                     )],
                 );
                 crate::record_outbound_request().await;
-                if let Ok(resp) = rb.send().await
+                if let Ok(resp) = crate::utils::http::send_counted(rb).await
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
@@ -1357,7 +1357,7 @@ pub async fn check_form_discovery(
                 let m = reqwest::Method::GET;
                 let rb = crate::utils::build_request(&client, target, m, test_url.clone(), None);
                 crate::record_outbound_request().await;
-                if let Ok(resp) = rb.send().await
+                if let Ok(resp) = crate::utils::http::send_counted(rb).await
                     && let Ok(text) = crate::utils::http::read_body(resp).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {
@@ -1403,7 +1403,7 @@ pub async fn check_form_discovery(
                 &[("Content-Type".to_string(), "application/json".to_string())],
             );
             crate::record_outbound_request().await;
-            if let Ok(resp) = rb.send().await
+            if let Ok(resp) = crate::utils::http::send_counted(rb).await
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && crate::scanning::markers::classify_probe_reflection(&text).detected()
             {
@@ -1484,7 +1484,7 @@ pub async fn check_form_discovery(
                         &[("Content-Type".to_string(), "application/json".to_string())],
                     );
                     crate::record_outbound_request().await;
-                    if let Ok(resp) = rb.send().await
+                    if let Ok(resp) = crate::utils::http::send_counted(rb).await
                         && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {
@@ -1555,7 +1555,7 @@ pub async fn check_form_discovery(
                         &[("Content-Type".to_string(), "application/json".to_string())],
                     );
                     crate::record_outbound_request().await;
-                    if let Ok(resp) = rb.send().await
+                    if let Ok(resp) = crate::utils::http::send_counted(rb).await
                         && let Ok(text) = crate::utils::http::read_body(resp).await
                         && crate::scanning::markers::classify_probe_reflection(&text).detected()
                     {

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -94,7 +94,7 @@ async fn pre_collapse_query_probe(client: &reqwest::Client, target: &Target) -> 
             target.data.clone(),
         );
         crate::record_outbound_request().await;
-        let resp = req.send().await.ok()?;
+        let resp = crate::utils::http::send_counted(req).await.ok()?;
         let location_has_marker = resp.status().is_redirection()
             && resp
                 .headers()
@@ -793,7 +793,7 @@ pub async fn probe_dictionary_params(
                     );
 
                     crate::record_outbound_request().await;
-                    let resp = request.send().await;
+                    let resp = crate::utils::http::send_counted(request).await;
 
                     let mut discovered: Option<Param> = None;
                     if let Ok(r) = resp {
@@ -1038,7 +1038,7 @@ pub async fn probe_body_params(
                     let request = crate::utils::apply_header_overrides(base, &overrides);
 
                     crate::record_outbound_request().await;
-                    let resp = request.send().await;
+                    let resp = crate::utils::http::send_counted(request).await;
 
                     let mut discovered: Option<Param> = None;
                     if let Ok(r) = resp
@@ -1141,7 +1141,7 @@ pub async fn probe_response_id_params(
     );
 
     crate::record_outbound_request().await;
-    let __resp = base_request.send().await;
+    let __resp = crate::utils::http::send_counted(base_request).await;
     if let Ok(resp) = __resp
         && !resp.status().is_server_error()
         && let Ok(text) = crate::utils::http::read_body(resp).await
@@ -1266,7 +1266,7 @@ pub async fn probe_response_id_params(
                     // Prepare optional discovered Param container for batched return
                     let mut discovered: Option<Param> = None;
                     crate::record_outbound_request().await;
-                    let __resp = request.send().await;
+                    let __resp = crate::utils::http::send_counted(request).await;
                     if let Ok(resp) = __resp {
                         // Skip 5xx error responses — debug pages often reflect params
                         if resp.status().is_server_error() {
@@ -1475,7 +1475,7 @@ pub async fn probe_json_body_params(
                 let request = crate::utils::apply_header_overrides(base, &overrides);
 
                 crate::record_outbound_request().await;
-                let resp = request.send().await;
+                let resp = crate::utils::http::send_counted(request).await;
 
                 let mut discovered: Option<Param> = None;
                 if let Ok(r) = resp
@@ -1645,7 +1645,7 @@ pub async fn probe_multipart_params(
                 crate::record_outbound_request().await;
 
                 let mut discovered: Option<Param> = None;
-                if let Ok(r) = request.send().await
+                if let Ok(r) = crate::utils::http::send_counted(request).await
                     && let Ok(text) = crate::utils::http::read_body(r).await
                     && crate::scanning::markers::classify_probe_reflection(&text).detected()
                 {

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -614,7 +614,9 @@ async fn send_probe_request_for_param(
     }
 
     crate::record_outbound_request().await;
-    let resp = request_builder.send().await.ok()?;
+    let resp = crate::utils::http::send_counted(request_builder)
+        .await
+        .ok()?;
     if !ignore_return.is_empty() && ignore_return.contains(&resp.status().as_u16()) {
         return None;
     }
@@ -1177,7 +1179,7 @@ pub async fn active_probe_param(
             };
             let request_builder = client.request(target.parse_method(), url);
             crate::record_outbound_request().await;
-            if let Ok(resp) = request_builder.send().await
+            if let Ok(resp) = crate::utils::http::send_counted(request_builder).await
                 && let Ok(text) = crate::utils::http::read_body(resp).await
                 && text.contains(&raw_marker)
             {

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -896,7 +896,14 @@ async fn verify_sxss_dom(
                 crate::utils::build_request(client, target, method, sxss_url.clone(), None);
 
             crate::record_outbound_request().await;
-            if let Ok(resp) = check_request.send().await {
+            // Direct send (no `send_with_retry`): count the transport failure
+            // here so a retrieval URL that never answers is not silently read
+            // as "the payload isn't there".
+            let sent = check_request.send().await;
+            if sent.is_err() {
+                crate::tick_request_failure();
+            }
+            if let Ok(resp) = sent {
                 let headers = resp.headers().clone();
                 let ct = headers
                     .get(reqwest::header::CONTENT_TYPE)

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1976,7 +1976,14 @@ async fn fetch_injection_response_with_client(
                     crate::utils::build_request(client, target, method, sxss_url.clone(), None);
 
                 crate::record_outbound_request().await;
-                if let Ok(resp) = check_request.send().await
+                // This path sends directly (no `send_with_retry`), so count its
+                // transport failures here — a retrieval URL that never answers
+                // means the stored payload was never actually checked.
+                let sent = check_request.send().await;
+                if sent.is_err() {
+                    crate::tick_request_failure();
+                }
+                if let Ok(resp) = sent
                     && let Some(body) = gated_body(resp, param, payload, args).await
                 {
                     if classify_reflection(&body.text, payload).is_some() {

--- a/src/scanning/result.rs
+++ b/src/scanning/result.rs
@@ -481,6 +481,14 @@ pub(crate) struct ScanMetadata {
     pub targets: Vec<String>,
     pub scan_duration_ms: u64,
     pub total_requests: u64,
+    /// Outbound requests that never produced a response (connection reset,
+    /// refused, timed out) after their retry budget was spent. Reported
+    /// alongside `total_requests` because a payload that never reached the
+    /// target was never tested: a scan that sent 176 requests and lost 160 of
+    /// them is not the same scan as one that sent 176 and got 176 answers,
+    /// even though both can finish with zero findings.
+    #[serde(default)]
+    pub failed_requests: u64,
     pub findings_count: usize,
     pub target_summary: Vec<serde_json::Value>,
     /// Target-dedup mode in effect (`exact`, `signature`, or `off`).
@@ -503,8 +511,9 @@ pub(crate) struct ScanMetadata {
     /// a resumed run from a scan that mostly found nothing.
     #[serde(default, skip_serializing_if = "Option::is_none")]
     pub resumed: Option<serde_json::Value>,
-    /// At least one target was not fully tested — today that means its
-    /// authenticated session died mid-scan (see `error_codes::SESSION_LOST`).
+    /// At least one target was not fully tested: its authenticated session
+    /// died mid-scan (see `error_codes::SESSION_LOST`), or a significant share
+    /// of this run's requests never reached the target at all.
     /// Hoisted out of `target_summary` so a consumer can answer "are these
     /// results trustworthy?" with one field read instead of a scan over every
     /// entry's status. `false` on a normal run.
@@ -632,6 +641,7 @@ impl Result {
             "targets": &meta.targets,
             "scan_duration_ms": meta.scan_duration_ms,
             "total_requests": meta.total_requests,
+            "failed_requests": meta.failed_requests,
             "findings_count": meta.findings_count,
             "incomplete": meta.incomplete,
             "target_summary": &meta.target_summary,
@@ -772,6 +782,9 @@ impl Result {
             );
             let _ = writeln!(out, "| **Scan Duration** | {} ms |", m.scan_duration_ms);
             let _ = writeln!(out, "| **Total Requests** | {} |", m.total_requests);
+            if m.failed_requests > 0 {
+                let _ = writeln!(out, "| **Failed Requests** | {} |", m.failed_requests);
+            }
             let _ = writeln!(out, "| **Findings Count** | {} |", m.findings_count);
             // Only shown when dedup actually dropped something: a collapsed
             // input list must be visible in the report, but the common

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -621,6 +621,25 @@ pub(crate) fn decide_retry(
 /// Returns the final response or transport error after success or after the
 /// applicable retry budget is exhausted. If the request body was streamed
 /// (not clonable) the first response/error is returned without retrying.
+/// Send a request, counting a transport failure if it never answers.
+///
+/// The discovery and mining stages send directly rather than through
+/// [`send_with_retry`], and every one of those call sites drops the `Err`
+/// (`if let Ok(resp) = …`, `.ok()?`). A parameter whose probe was reset is
+/// then indistinguishable from a parameter that does not reflect — so a target
+/// that drops requests yields an empty finding list that reads as a verdict.
+/// Counting here keeps `failed_requests` aligned with the `total_requests`
+/// these stages already tick via `record_outbound_request`.
+pub async fn send_counted(
+    request_builder: RequestBuilder,
+) -> Result<reqwest::Response, reqwest::Error> {
+    let result = request_builder.send().await;
+    if result.is_err() {
+        crate::tick_request_failure();
+    }
+    result
+}
+
 pub async fn send_with_retry(
     request_builder: RequestBuilder,
     max_transient_retries: u32,
@@ -665,10 +684,22 @@ pub async fn send_with_retry(
             base_delay_ms,
             retry_after,
         ) {
-            RetryDecision::Stop => return result,
+            RetryDecision::Stop => {
+                // The retry budget is spent. A request that never produced a
+                // response means whatever it carried was never actually tested,
+                // and every caller drops the `Err` — so count it here, once,
+                // where the give-up decision is made.
+                if result.is_err() {
+                    crate::tick_request_failure();
+                }
+                return result;
+            }
             RetryDecision::Sleep { ms, rate_limited } => {
                 let Some(rb) = next_rb else {
                     // Body was streamed; can't replay the request.
+                    if result.is_err() {
+                        crate::tick_request_failure();
+                    }
                     return result;
                 };
                 if crate::DEBUG.load(std::sync::atomic::Ordering::Relaxed) {

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -711,3 +711,62 @@ fn build_request_keeps_inherited_content_type() {
         Some("application/json"),
     );
 }
+
+#[tokio::test]
+async fn send_counted_counts_a_request_that_never_answers() {
+    // Scoped to the per-job task-local so the assertion is isolated from the
+    // process-wide counter the rest of the suite shares.
+    let counter = std::sync::Arc::new(std::sync::atomic::AtomicU64::new(0));
+    let c = counter.clone();
+    crate::REQUEST_FAILURE_COUNT_JOB
+        .scope(counter.clone(), async move {
+            // Bind then drop a listener: the port is closed, but was definitely
+            // free, so a connection there cannot succeed.
+            let dead_listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .await
+                .expect("bind dead listener");
+            let dead_port = dead_listener.local_addr().expect("dead addr").port();
+            drop(dead_listener);
+
+            // Explicit: reqwest resolves the rustls provider when a `Client`
+            // is built, and this test must not depend on some earlier test in
+            // the binary having installed it first.
+            crate::ensure_crypto_provider();
+            let client = reqwest::Client::new();
+            let dead = format!("http://127.0.0.1:{dead_port}/");
+            assert!(
+                send_counted(client.get(&dead)).await.is_err(),
+                "a closed port must not answer"
+            );
+            assert_eq!(
+                c.load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "a request that never reached the target must be counted"
+            );
+
+            // A request that does answer must not be counted.
+            let live_listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
+                .await
+                .expect("bind live listener");
+            let live_addr = live_listener.local_addr().expect("live addr");
+            tokio::spawn(async move {
+                if let Ok((mut sock, _)) = live_listener.accept().await {
+                    use tokio::io::AsyncWriteExt;
+                    let _ = sock
+                        .write_all(
+                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
+                        )
+                        .await;
+                    let _ = sock.shutdown().await;
+                }
+            });
+            let live = format!("http://{live_addr}/");
+            assert!(send_counted(client.get(&live)).await.is_ok());
+            assert_eq!(
+                c.load(std::sync::atomic::Ordering::Relaxed),
+                1,
+                "a successful request must not bump the failure counter"
+            );
+        })
+        .await;
+}

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -744,24 +744,23 @@ async fn send_counted_counts_a_request_that_never_answers() {
                 "a request that never reached the target must be counted"
             );
 
-            // A request that does answer must not be counted.
+            // A request that does answer must not be counted. Served by axum
+            // rather than a hand-rolled socket: a raw one-shot responder races
+            // the client's connection handling differently across platforms
+            // (it failed on Windows).
             let live_listener = tokio::net::TcpListener::bind((std::net::Ipv4Addr::LOCALHOST, 0))
                 .await
                 .expect("bind live listener");
             let live_addr = live_listener.local_addr().expect("live addr");
             tokio::spawn(async move {
-                if let Ok((mut sock, _)) = live_listener.accept().await {
-                    use tokio::io::AsyncWriteExt;
-                    let _ = sock
-                        .write_all(
-                            b"HTTP/1.1 200 OK\r\nContent-Length: 2\r\nConnection: close\r\n\r\nok",
-                        )
-                        .await;
-                    let _ = sock.shutdown().await;
-                }
+                let app = axum::Router::new().route("/", axum::routing::get(|| async { "ok" }));
+                let _ = axum::serve(live_listener, app).await;
             });
             let live = format!("http://{live_addr}/");
-            assert!(send_counted(client.get(&live)).await.is_ok());
+            assert!(
+                send_counted(client.get(&live)).await.is_ok(),
+                "the live server must answer"
+            );
             assert_eq!(
                 c.load(std::sync::atomic::Ordering::Relaxed),
                 1,


### PR DESCRIPTION
## Symptom

A target that drops or resets injection requests produces a scan **indistinguishable
from a genuinely clean one**. Same trivially-vulnerable app on two ports, one RSTing
95% of everything that is not the operator's own baseline request:

| | findings | status | incomplete | total_requests | server-side dropped |
|---|---|---|---|---|---|
| healthy | 1 | `findings` | false | 167 | 0 / 168 |
| 95% dropping | **0** | **`clean`** | **false** | 170 | **150 / 171** |

`status: clean`, `incomplete: false`, exit 0, and a `total_requests` that looks like
a full scan happened. Nothing anywhere said 150 payloads were never delivered.

A payload that never reached the target was never tested, so "no findings" is not a
verdict on that run. Reported as deferred/out-of-area in #1409.

## Root cause

Every send site swallows the transport error — `if let Ok(resp) = …`, `.ok()?`,
`match … { Ok(r) => …, Err(_) => … }` — and nothing counted them. There was no
counter to report even if a caller had wanted to.

## Fix

- `REQUEST_FAILURE_COUNT` plus the `REQUEST_FAILURE_COUNT_JOB` task-local, mirroring
  the existing request counter exactly — **including the `JobScopes` plumbing**, so a
  daemon's concurrent jobs don't inherit each other's failures (the process-global
  trap #1406 just fixed for the remote payload cache).
- Counted at the give-up point in `send_with_retry` (both exits, so retried-then-
  recovered requests are *not* counted), and via a new `utils::http::send_counted`
  at the 26 discovery/mining sites that send directly. `light_verify` is left alone:
  it deliberately does not tick the request count, so counting its failures would
  skew the ratio against a denominator it never contributed to.
- `meta.failed_requests` in every rendered envelope (JSON / JSONL / SARIF / TOML,
  plus a Markdown row when non-zero).
- `incomplete` now also means "a significant share of this run never landed" —
  **10% of attempted requests**. A scan never gets a perfect network, so flipping the
  flag on a single reset would devalue it; losing a tenth of everything attempted is
  not noise. The raw count is reported regardless, so a consumer wanting a stricter
  bar has the number. The threshold is a named constant with the reasoning next to it.
- The plain-output warning is split. The existing line is session-loss-specific and
  would have printed "**0** target(s) had no usable session" once the flag could be
  set by transport failures; it now prints only when a session actually died, and the
  transport case gets its own line naming the numbers.

## Result

Same two ports, after:

| | findings | incomplete | failed_requests | server-side dropped |
|---|---|---|---|---|
| healthy | 1 | false | **0** | 0 / 168 |
| 95% dropping | 0 | **true** | **148** | 150 / 171 |

148 counted against 150 actually dropped — the gap is `light_verify`, by design.

```
WRN INCOMPLETE: 139 of 170 requests never reached the target (82%) — payloads that
    were not delivered were not tested, so this is not a clean bill of health
```

and nothing is printed on the healthy run.

## API shape

`render_results` takes a `RequestTally { sent, failed }` rather than a second bare
`u64` next to `total_requests`; two adjacent same-typed parameters are trivially
transposable at a call site.

## Tests

- a run that lost most of its requests must be `incomplete` with the count in the envelope
- a healthy run must not be marked incomplete (the control — otherwise the flag means nothing)
- a handful of failures on a long run must not flip the flag

**Mutation-verified**: dropping the transport half of the flag turns the first RED and
leaves both controls green.

## Deferred

**Per-target attribution and the exit code.** The counter is scan-wide, matching
`total_requests`. The repo's precedent for "this target can't be trusted" is a
per-target `status: "incomplete"` with an error code (`SESSION_LOST`), which is what
drives exit 2. Doing the same for transport failures needs a per-URL counter, and
changing a clean-but-incomplete run from exit 0 to exit 2 is a behaviour change that
will reach people's CI — the repo owner's call, not a side effect of this fix. The
scan-wide flag plus the stderr warning is the honest half that carries no such risk.

## Green gate

`cargo build --release`, `cargo test` (2366 lib + all integration binaries, exit 0),
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
— all clean.