### PR TITLE
fix(scan): a supplied text/plain is never HTML-parsed, nosniff or not

### DIFF
--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -2451,9 +2451,13 @@ mod injection_response_gates {
     }
 
     #[test]
-    fn text_plain_is_inert_only_with_nosniff() {
+    fn text_plain_is_inert_with_or_without_nosniff() {
+        // `nosniff` is not what makes `text/plain` inert: a *supplied*
+        // `text/plain` can never be sniffed into `text/html` (see
+        // `content_type_is_inert_data_with_nosniff`). Both spellings must
+        // suppress.
         let args = default_scan_args();
-        assert!(!injection_response_suppressed(
+        assert!(injection_response_suppressed(
             200,
             &ct("text/plain"),
             &param(Location::Query),
@@ -2465,6 +2469,13 @@ mod injection_response_gates {
                 ("content-type", "text/plain"),
                 ("x-content-type-options", "nosniff"),
             ]),
+            &param(Location::Query),
+            &args
+        ));
+        // The carve-out stays: a typeless response IS sniffed, so it stays live.
+        assert!(!injection_response_suppressed(
+            200,
+            &headers(&[]),
             &param(Location::Query),
             &args
         ));

--- a/src/utils/http.rs
+++ b/src/utils/http.rs
@@ -393,23 +393,33 @@ pub(crate) fn content_type_is_inert_data(ct: &str) -> bool {
 /// sniffable — and therefore only exploitable — when the server has *not* sent
 /// `X-Content-Type-Options: nosniff`.
 ///
-/// The plain-content-type version cannot make this call: its exclusion of
-/// `text/plain` is justified by "browsers content-sniff it as HTML when nosniff
-/// is absent", but it only receives the content-type string and so can never
-/// observe that nosniff is present. That gap reported a `[V]` for a
-/// `text/plain; charset=utf-8` + `nosniff` response echoing a payload — a
-/// document no browser will ever HTML-parse.
+/// The plain-content-type version cannot add `text/plain` on its own, because
+/// that list is also consulted where the caller has no headers to inspect.
 ///
-/// Only `text/plain` is added. An absent or empty content-type is deliberately
-/// still treated as live: `nosniff` constrains MIME *checking* for scripts and
-/// styles, and a navigation to a typeless response is still sniffed, so the
-/// same reasoning does not carry over.
-pub(crate) fn content_type_is_inert_data_with_nosniff(ct: &str, nosniff: bool) -> bool {
+/// `nosniff` is *not* what makes `text/plain` inert. Per the MIME Sniffing
+/// standard, sniffing can only produce `text/html` when the supplied type is
+/// absent or one of `unknown/unknown` / `application/unknown` / `*/*`. A
+/// supplied `text/plain` either trips the check-for-apache-bug flag — whose
+/// "text or binary" rules yield only `text/plain` or
+/// `application/octet-stream` — or is returned unchanged. There is no path
+/// from a supplied `text/plain` to an HTML parse, with or without the header.
+///
+/// Confirmed against real Chrome (headless, `--dump-dom`) serving the same
+/// `<h1 id=marker>` + `<script>` body five ways: `text/html` parsed it;
+/// `text/plain`, `text/plain; charset=utf-8`,
+/// `text/plain; charset=windows-1252`, and `text/plain` + `nosniff` all did
+/// not. XSSMaze's three `text/plain` endpoints are all `exploitable: false`
+/// controls, and `realworld-level6` — which reflects markup raw — says the
+/// same thing in its own metadata: "no modern browser sniffs [it] into HTML,
+/// so it never parses; reporting no XSS here is the correct result". Before
+/// this, dalfox reported `[V] High` on it.
+///
+/// An absent or empty content-type is deliberately still treated as live: that
+/// is exactly the case the standard *does* sniff, so the same reasoning does
+/// not carry over.
+pub(crate) fn content_type_is_inert_data_with_nosniff(ct: &str, _nosniff: bool) -> bool {
     if content_type_is_inert_data(ct) {
         return true;
-    }
-    if !nosniff {
-        return false;
     }
     matches!(content_type_primary(ct).as_deref(), Some("text/plain"))
 }

--- a/src/utils/http/tests.rs
+++ b/src/utils/http/tests.rs
@@ -568,22 +568,37 @@ async fn test_read_body_capped_handles_utf8_split_at_cap() {
 
 #[test]
 fn test_content_type_is_inert_data_with_nosniff_covers_text_plain() {
-    // `text/plain` is excluded from the plain deny-list because a browser
-    // sniffs it as HTML — but only when the server has *not* said not to.
-    // With `nosniff` present the body can never be markup, so a reflection in
-    // it is not exploitable. This is the FP the replay corpus caught: a
-    // `text/plain; charset=utf-8` + `nosniff` response echoing a payload was
-    // reported `[V]`.
+    // `text/plain` stays out of the plain deny-list (that list is consulted
+    // where the caller has no headers), but it is inert here whether or not the
+    // server sent `nosniff`. Per the MIME Sniffing standard a *supplied*
+    // `text/plain` can never become `text/html`: sniffing to HTML requires an
+    // absent or `unknown`/`*/*` type. Confirmed against real Chrome — the same
+    // `<h1 id=marker>` + `<script>` body was HTML-parsed as `text/html` and not
+    // parsed under any `text/plain` spelling, with or without the header.
     assert!(!content_type_is_inert_data("text/plain"));
-    assert!(!content_type_is_inert_data_with_nosniff(
-        "text/plain",
-        false
-    ));
-    assert!(content_type_is_inert_data_with_nosniff("text/plain", true));
-    assert!(content_type_is_inert_data_with_nosniff(
-        "text/plain; charset=utf-8",
-        true
-    ));
+    for nosniff in [true, false] {
+        for ct in [
+            "text/plain",
+            "text/plain; charset=utf-8",
+            "text/plain; charset=windows-1252",
+            "TEXT/PLAIN",
+        ] {
+            assert!(
+                content_type_is_inert_data_with_nosniff(ct, nosniff),
+                "{ct} must be inert (nosniff={nosniff}) — no browser HTML-parses a supplied text/plain"
+            );
+        }
+    }
+}
+
+#[test]
+fn test_a_typeless_response_is_still_treated_as_live() {
+    // The carve-out: an absent or empty content-type is exactly the case the
+    // standard *does* sniff, and sniffing an unknown type can produce
+    // `text/html`. Widening `text/plain` must not widen this.
+    for nosniff in [true, false] {
+        assert!(!content_type_is_inert_data_with_nosniff("", nosniff));
+    }
 }
 
 #[test]


### PR DESCRIPTION
## Symptom

A confirmed high-severity false positive. XSSMaze's `realworld/level6` reflects markup
raw over `Content-Type: text/plain` with no `nosniff`:

```
$ dalfox scan 'http://127.0.0.1:3031/realworld/level6/?query=a' -f json
1 findings [('V', 'High')]
```

Its own endpoint metadata calls it a `non-xss-control` and says why:

> the markup is reflected raw, but the response is served as text/plain, which no
> modern browser sniffs into HTML, so it never parses; reporting no XSS here is the
> correct result

## Root cause

`src/utils/http.rs` — `content_type_is_inert_data_with_nosniff` treated `text/plain`
as inert **only** when the response also sent `X-Content-Type-Options: nosniff`, on
the documented reasoning that "browsers content-sniff it as HTML when nosniff is
absent". That reasoning is wrong.

Per the [MIME Sniffing standard](https://mimesniff.spec.whatwg.org/), sniffing can
only produce `text/html` when the supplied type is **absent** or one of
`unknown/unknown` / `application/unknown` / `*/*`. A supplied `text/plain` either
trips the check-for-apache-bug flag — whose "text or binary" rules yield only
`text/plain` or `application/octet-stream` — or is returned unchanged. There is no
path from a supplied `text/plain` to an HTML parse, header or no header.

## Verified against a real browser

Rather than argue from the spec alone, one `<h1 id=marker>` + `<script>` body served
five ways, loaded in headless Chrome with `--dump-dom`:

| Content-Type | HTML-parsed? |
|---|---|
| `text/html` | **yes** |
| `text/plain` | no |
| `text/plain; charset=utf-8` | no |
| `text/plain; charset=windows-1252` | no |
| `text/plain` + `nosniff` | no |

## Recall impact: none

All three of XSSMaze's `text/plain` endpoints are `exploitable: false` controls, so
there is nothing to lose. Measured anyway — A/B on 120 `exploitable=true reach=server`
endpoints, two release binaries differing only in this file:

| | any-finding | `[V]` |
|---|---|---|
| before | 119 / 120 | 105 / 120 |
| after | 119 / 120 | 105 / 120 |

**0 endpoints differ.** And the control goes `[V] High` → no finding.

## Tests

- the gate test is extended to all four `text/plain` spellings × both `nosniff` values
- `test_a_typeless_response_is_still_treated_as_live` pins the carve-out: an absent or
  empty content-type is exactly the case the standard *does* sniff, so widening
  `text/plain` must not widen that
- `text_plain_is_inert_only_with_nosniff` (added in #1410) pinned the old rule — it is
  rewritten and renamed rather than deleted, since it is the assertion that caught the
  behaviour change

## Green gate

`cargo build --release`, `cargo test` (2365 lib + all integration binaries, exit 0),
`cargo fmt --all -- --check`, `cargo clippy --all-targets --all-features -- -D warnings`
— all clean.