### PR TITLE
fix(scan): make the http-request PoC reproduce header and cookie findings

### DIFF
--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1016,23 +1016,65 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
     }
     buf.push_str(" HTTP/1.1\r\nHost: ");
     buf.push_str(url.host_str().unwrap_or(""));
+    // `Host` is host *and port*. Dropping it made every PoC against a
+    // non-default port replay to :80/:443 — a different service, or nothing.
+    // `Url::port()` is already `None` for the scheme's default port, which is
+    // exactly when the Host header should omit it.
+    if let Some(port) = url.port() {
+        buf.push(':');
+        buf.push_str(&port.to_string());
+    }
+
+    // A `Location::Header` param is injected into the request itself, not the
+    // URL — as a header of its own name, or, when the name is one of the
+    // target's cookies, into `Cookie` (see `url_inject::build_header_request`,
+    // which this must mirror or the PoC does not reproduce what was sent).
+    let header_param = matches!(param.location, Location::Header);
+    let cookie_param = header_param && crate::scanning::url_inject::param_is_cookie(target, param);
+    let injected_header = header_param && !cookie_param;
 
     let has_ct_header = target
         .headers
         .iter()
         .any(|(k, _)| k.eq_ignore_ascii_case("content-type"));
     for (k, v) in &target.headers {
+        // The wire path applies the injected header as an *override*, so a
+        // same-named original must not also be emitted.
+        if injected_header && k.eq_ignore_ascii_case(&param.name) {
+            continue;
+        }
         buf.push_str("\r\n");
         buf.push_str(k);
         buf.push_str(": ");
         buf.push_str(v);
+    }
+    if injected_header {
+        buf.push_str("\r\n");
+        buf.push_str(&param.name);
+        buf.push_str(": ");
+        buf.push_str(payload);
     }
     if !has_ct_header && let Some(ct) = content_type {
         buf.push_str("\r\nContent-Type: ");
         buf.push_str(ct);
     }
 
-    if !target.cookies.is_empty() {
+    // Cookies. For a cookie param the injected value is written first and the
+    // target's other cookies follow, matching `build_header_request` — those
+    // neighbours often carry the session state the sink needs to render at all.
+    if cookie_param {
+        buf.push_str("\r\nCookie: ");
+        buf.push_str(&param.name);
+        buf.push('=');
+        buf.push_str(payload);
+        if let Some(rest) =
+            crate::utils::compose_cookie_header_excluding(&target.cookies, Some(&param.name))
+            && !rest.is_empty()
+        {
+            buf.push_str("; ");
+            buf.push_str(&rest);
+        }
+    } else if !target.cookies.is_empty() {
         buf.push_str("\r\nCookie: ");
         for (i, (k, v)) in target.cookies.iter().enumerate() {
             if i > 0 {

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -3149,3 +3149,88 @@ async fn test_sxss_path_injection_drops_url_echo_only_reflections() {
         "an empty response body carries no evidence"
     );
 }
+
+#[test]
+fn test_build_request_text_host_carries_a_non_default_port() {
+    // `Host` is host *and* port. Dropping it replayed every PoC against a
+    // non-default port to :80/:443 — a different service, or nothing at all.
+    let target = parse_target("http://127.0.0.1:3031/x?q=1").unwrap();
+    let param = Param::new("q".to_string(), "1".to_string(), Location::Query);
+    let request = build_request_text(&target, &param, "PAYLOAD");
+    assert!(
+        request.contains("Host: 127.0.0.1:3031"),
+        "port missing from Host, got:\n{request}"
+    );
+}
+
+#[test]
+fn test_build_request_text_omits_the_schemes_default_port() {
+    // The flip side: :443 on https is implicit and must not be spelled out.
+    let target = parse_target("https://example.com/x?q=1").unwrap();
+    let param = Param::new("q".to_string(), "1".to_string(), Location::Query);
+    let request = build_request_text(&target, &param, "PAYLOAD");
+    assert!(request.contains("Host: example.com\r\n"));
+    assert!(!request.contains("example.com:443"));
+}
+
+#[test]
+fn test_build_request_text_injects_a_header_param() {
+    // A `Location::Header` param is injected into the request, not the URL.
+    // Emitting only the target's original headers left the payload nowhere in
+    // the PoC, so it reproduced nothing.
+    let mut target = parse_target("http://127.0.0.1:3031/h").unwrap();
+    target.method = "GET".to_string();
+    target.headers = vec![("X-Keep".to_string(), "1".to_string())];
+
+    let param = Param::new("Referer".to_string(), String::new(), Location::Header);
+    let request = build_request_text(&target, &param, "<svg onload=alert(1)>");
+    assert!(
+        request.contains("Referer: <svg onload=alert(1)>"),
+        "injected header missing, got:\n{request}"
+    );
+    assert!(request.contains("X-Keep: 1"), "original header dropped");
+}
+
+#[test]
+fn test_build_request_text_header_param_overrides_a_same_named_original() {
+    // The wire path applies the injected header via `apply_header_overrides`,
+    // which replaces. Emitting both would show a request that was never sent.
+    let mut target = parse_target("http://127.0.0.1:3031/h").unwrap();
+    target.headers = vec![("Referer".to_string(), "https://original/".to_string())];
+
+    let param = Param::new("Referer".to_string(), String::new(), Location::Header);
+    let request = build_request_text(&target, &param, "PAYLOAD");
+    assert!(request.contains("Referer: PAYLOAD"));
+    assert!(
+        !request.contains("https://original/"),
+        "the overridden original was emitted too, got:\n{request}"
+    );
+}
+
+#[test]
+fn test_build_request_text_cookie_param_goes_into_the_cookie_header() {
+    // Per-cookie discovery files cookies as `Location::Header` named after the
+    // cookie. `build_header_request` routes those into `Cookie` — injected
+    // first, the target's other cookies preserved after it. Emitting
+    // `sid: <payload>` instead would be a header the application never reads.
+    let mut target = parse_target("http://127.0.0.1:3031/c").unwrap();
+    target.cookies = vec![
+        ("sid".to_string(), "abc".to_string()),
+        ("theme".to_string(), "dark".to_string()),
+    ];
+
+    let param = Param::new("sid".to_string(), "abc".to_string(), Location::Header);
+    let request = build_request_text(&target, &param, "PAYLOAD");
+    assert!(
+        request.contains("Cookie: sid=PAYLOAD"),
+        "cookie param not injected into Cookie, got:\n{request}"
+    );
+    assert!(
+        request.contains("theme=dark"),
+        "neighbouring cookies dropped — they often carry the session the sink needs, got:\n{request}"
+    );
+    assert!(
+        !request.contains("\r\nsid: PAYLOAD"),
+        "cookie emitted as a header of its own name, got:\n{request}"
+    );
+}


### PR DESCRIPTION
## Symptom

`--poc-type http-request` emitted a request that cannot reproduce the finding it is
attached to:

```
$ dalfox scan 'http://127.0.0.1:3031/header/level1/' -p 'Referer:header' --poc-type http-request
GET /header/level1/ HTTP/1.1
Host: 127.0.0.1                    <- the :3031 port is gone
  ├── Issue: XSS payload DOM object identified
  ├── Payload: <svg onload=alert(1) class=dlx4b46f711>
                                   <- and no Referer: anywhere
```

`--poc-type curl` gets the same finding right, so the two renderers disagree:

```
curl -X GET -H "Referer: <svg onload=alert(1) class=dlxda1a76b4>" "http://127.0.0.1:3031/header/level1/"
```

Reported as deferred/out-of-area in #1409.

## Root cause

`src/scanning/mod.rs`, `build_request_text`:

1. `Host` was built from `url.host_str()` alone. A non-default port was dropped, so
   the PoC replays against :80/:443 — a different service, or nothing.
2. `match param.location` had no `Location::Header` arm. Header params — and cookie
   params, which per-cookie discovery files as `Location::Header` named after the
   cookie — fell to `_ => target.url.clone()`, and the header block emitted only the
   target's **original** headers. The payload appeared nowhere.

## Fix

Mirrors `url_inject::build_header_request`, which is what actually goes on the wire:

- **Port**: appended when `Url::port()` is `Some` — already `None` for the scheme's
  default port, which is exactly when `Host` should omit it.
- **Header param**: emitted as `name: payload`, and a same-named original is
  suppressed, because the wire path applies it as an *override* (`apply_header_overrides`).
  Emitting both would show a request that was never sent.
- **Cookie param**: routed into `Cookie` with the injected value **first** and the
  target's other cookies preserved after it — matching `build_header_request`, whose
  own doc explains those neighbours often carry the session state the sink needs to
  render at all.

## Verification

The emitted request, replayed verbatim over a raw socket:

```
GET /header/level1/ HTTP/1.1
Host: 127.0.0.1:3031
Referer: <svg onload=alert(1) class=dlx3011bdce>
--- reproduces: YES (marker dlx3011bdce)
```

Query PoCs are unchanged apart from now carrying the port.

## Tests

Port present / default port omitted / header injected alongside originals / header
override suppresses the same-named original / cookie routed into `Cookie` with
neighbours kept.

**Mutation-verified**: reverting each half turns exactly the four new tests RED and
leaves the four existing `build_request_text` tests green.

## Not fixed here

`render_curl_poc` and `render_httpie_poc` treat a param as a cookie only when it is
literally *named* `cookie`, so a cookie-typed param named `sid` still renders as
`-H "sid: …"` (a header the application never reads) instead of `-b "sid=…"`. Those
renderers receive only a `Result`, whose `location` is `"Header"` for both kinds —
telling them apart needs a new field on the finding model, which is a wider change
than this fix.

## Green gate

`cargo build --release`, `cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.