### PR TITLE
test(payload): give the synthesis blowup canary real headroom

### DIFF
--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -648,7 +648,8 @@ fn synthesis_closes_catalog_coverage_gaps() {
 fn synthesis_is_fast_and_bounded() {
     // Performance guard: synthesis runs once per parameter inside the scan loop,
     // so it must be cheap. 20k calls across a mix of contexts/filters should be
-    // far under a second even in debug; we assert a generous ceiling to stay
+    // well under a second even in debug on an idle machine; we assert a
+    // deliberately loose ceiling (see below) to stay
     // non-flaky in CI while still catching pathological regressions.
     let contexts = [
         InjectionContext::Html(None),
@@ -680,8 +681,18 @@ fn synthesis_is_fast_and_bounded() {
         elapsed,
         elapsed.as_nanos() as f64 / calls as f64
     );
+    // A blowup canary, not a performance gate. The real boundedness contract
+    // is the deterministic `out.len() <= MAX_SYNTHESIZED` asserted on every
+    // call above; this only has to notice a per-call regression of the kind
+    // that turns 20k calls into minutes.
+    //
+    // The bound therefore belongs far above the noise floor, not just above the
+    // idle figure. Measured on this workload: ~0.3s idle, 2.75s on a machine at
+    // load 34 — and 7.7-9.4s at load 120, which turned the old 5s ceiling red
+    // during a run where nothing about synthesis had changed. A test that fails
+    // because the machine is busy teaches people to ignore it.
     assert!(
-        elapsed.as_secs() < 5,
+        elapsed.as_secs() < 60,
         "synthesis unexpectedly slow: {:?} for {} calls",
         elapsed,
         calls


### PR DESCRIPTION
## Symptom

`payload::synthesis::tests::synthesis_is_fast_and_bounded` fails on a busy machine
while nothing about synthesis has changed:

```
thread '...synthesis_is_fast_and_bounded' panicked at src/payload/synthesis/tests.rs:683:
synthesis unexpectedly slow: 9.05s for 20000 calls
```

It cost this repo's own agents time twice in one session — once as a suspected
regression in an unrelated PR, once as a suspected regression on `main`.

## Why the bound was wrong

The assertion is a **blowup canary, not a performance gate**. The real boundedness
contract is the deterministic `out.len() <= MAX_SYNTHESIZED` checked on every one of
the 20 000 calls; the wall clock only has to notice a per-call regression of the kind
that turns those calls into minutes.

A canary belongs far above the noise floor. `< 5s` sat just above the idle figure:

| machine state | measured |
|---|---|
| idle | ~0.3s |
| load average 34 | **2.75s** (1.8× headroom) |
| load average 120 | **7.7–9.4s** (red) |

Raised to 60s, with those measurements recorded next to the assertion so the next
person does not have to re-derive them. An order-of-magnitude regression still trips it.

## The other five wall-clock assertions were measured and left alone

Checking whether this was a pattern rather than assuming it:

| test | measured | bound |
|---|---|---|
| `parameter_analysis` 15 MiB breakout scan | 0.79s | 10s |
| `js_breakout` 1M-deep cap | <0.1s | 500ms |
| `utils::html` quadratic end-tag lookback | <0.1s | 500ms |
| `utils::html` prompt termination | <0.1s | 200ms |
| `utils::html` unmatched end tags, deep stack | <0.1s | 1s |

All have 12×–1000× headroom. Only the synthesis one was tight, so only it changed —
no blanket churn.

## Green gate

`cargo test --lib` 2369 passed / 0 failed, `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — clean.