### PR TITLE
fix(server,mcp): don't free a capacity slot while the worker runs on

### DIFF
--- a/src/job/mod.rs
+++ b/src/job/mod.rs
@@ -404,6 +404,23 @@ impl Job {
         self.is_terminal() && !self.worker_alive()
     }
 
+    /// Whether this job still occupies a concurrency slot.
+    ///
+    /// Not the same question as `!is_terminal()`. `cancel_scan_handler` stamps
+    /// a terminal status the moment the user asks, but the worker keeps running
+    /// until it notices the flag — still holding a blocking-pool thread and
+    /// still sending requests. Counting only non-terminal jobs let a client
+    /// submit-then-cancel in a loop and keep an unbounded number of workers
+    /// alive against `--max-concurrent-scans` of 1, because every one of them
+    /// had already stopped counting.
+    ///
+    /// The slot is released when the worker's [`WorkerLease`] drops, which is
+    /// the same signal [`Job::is_evictable`] uses — so admission and retention
+    /// agree on what "still running" means.
+    pub(crate) fn occupies_capacity(&self) -> bool {
+        !self.is_terminal() || self.worker_alive()
+    }
+
     /// Total elapsed ms from `started_at_ms` to `finished_at_ms` (or now, for
     /// still-running jobs). `None` if the scan never started.
     pub(crate) fn duration_ms(&self) -> Option<i64> {

--- a/src/job/tests.rs
+++ b/src/job/tests.rs
@@ -581,3 +581,56 @@ fn validate_header_value_matches_reqwest_builder_semantics() {
     assert!(validate_header_value("user_agent", "Mozilla\nX: 1").is_err());
     assert!(validate_header_value("cookie", "sid=a\0b").is_err());
 }
+
+#[test]
+fn a_cancelled_job_keeps_its_capacity_slot_until_the_worker_stops() {
+    // `!is_terminal()` is not the same question as "is a worker running".
+    // Cancel stamps the terminal status immediately, but the worker keeps a
+    // blocking-pool thread and keeps sending requests until it notices. If the
+    // slot is released at that moment, a submit-then-cancel loop keeps an
+    // unbounded number of workers alive against a cap of 1.
+    let mut job = Job::new_queued("http://a".to_string());
+    let lease = job.issue_worker_lease();
+    assert!(job.occupies_capacity(), "a queued job holds a slot");
+
+    job.status = JobStatus::Cancelled;
+    job.finished_at_ms = Some(now_ms());
+    assert!(
+        job.is_terminal(),
+        "cancel stamps the terminal state at once"
+    );
+    assert!(
+        job.occupies_capacity(),
+        "the worker is still running — the slot is not free yet"
+    );
+
+    drop(lease);
+    assert!(
+        !job.occupies_capacity(),
+        "once the worker's lease drops the slot is free"
+    );
+}
+
+#[test]
+fn a_finished_job_without_a_worker_holds_no_slot() {
+    // The control: ordinary completion must still free the slot, or the cap
+    // would never let anything through after the first N scans.
+    let mut job = Job::new_queued("http://a".to_string());
+    let lease = job.issue_worker_lease();
+    job.status = JobStatus::Done;
+    job.finished_at_ms = Some(now_ms());
+    drop(lease);
+    assert!(!job.occupies_capacity());
+    assert!(job.is_evictable());
+}
+
+#[test]
+fn a_job_that_never_got_a_worker_holds_no_slot_once_terminal() {
+    // A job rejected or errored before any task was spawned has no lease at
+    // all; `occupies_capacity` must not treat the absent lease as "alive".
+    let mut job = Job::new_queued("http://a".to_string());
+    assert!(job.occupies_capacity(), "queued and not yet terminal");
+    job.status = JobStatus::Error;
+    job.finished_at_ms = Some(now_ms());
+    assert!(!job.occupies_capacity());
+}

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -1053,7 +1053,7 @@ browser execution; only detection_method=oob observes a real browser."
         // blocking pool without bound.
         let (scan_id, worker_lease) = {
             let mut jobs = self.lock_jobs();
-            let active = jobs.values().filter(|j| !j.is_terminal()).count();
+            let active = jobs.values().filter(|j| j.occupies_capacity()).count();
             if active >= MAX_ACTIVE_SCANS_MCP {
                 // Transient capacity shedding, not a malformed request: signal it
                 // with internal_error (-32603) so it matches the preflight path

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -243,7 +243,7 @@ pub(crate) async fn try_admit_and_queue(
 ) -> Option<(String, WorkerLease)> {
     let mut jobs = state.jobs.lock().await;
     if state.max_concurrent_scans > 0
-        && jobs.values().filter(|j| !j.is_terminal()).count() >= state.max_concurrent_scans
+        && jobs.values().filter(|j| j.occupies_capacity()).count() >= state.max_concurrent_scans
     {
         return None;
     }


### PR DESCRIPTION
## Symptom

A client can hold an unbounded number of live scan workers against a configured cap
of 1, by submitting and immediately cancelling in a loop.

Both admission checks counted `!j.is_terminal()`:

- `src/server/util.rs` — `try_admit_and_queue`
- `src/mcp/mod.rs` — `scan_with_dalfox` admission

`cancel_scan_handler` stamps the terminal status the moment the user asks, but the
worker keeps a blocking-pool thread and keeps sending requests until it notices the
flag. So a cancelled-but-draining job stops counting against
`--max-concurrent-scans` / `MAX_ACTIVE_SCANS_MCP` **while it is still burning the
resource the cap exists to bound**.

Called out as deferred in #1406, which added the primitive for it.

## Fix

`Job::occupies_capacity()` = `!is_terminal() || worker_alive()`, used by both front
ends. The slot is released when the worker's `WorkerLease` drops — the same signal
`Job::is_evictable` already uses, so admission and retention now agree on what "still
running" means rather than answering it two different ways.

## On the semantics change

A cancel no longer frees the slot instantly; it frees it when the work actually
stops. That is deliberate, and it is why #1406 left it out of that PR.

It does **not** create a new way to wedge admission: a job whose worker hangs already
held its slot, because it was never terminal. What changes is only the window between
the cancel and the worker noticing — which #1407 shortened by adding cancel checks to
the Stage-0 probe and the HPP phase, the two places that previously ran to completion
after a cancel.

## Tests

- a cancelled job keeps its slot until the lease drops
- ordinary completion frees it — the control, otherwise the cap would never let
  anything through after the first N scans
- a job that never got a worker holds no slot once terminal, so an absent lease is
  not misread as "alive"

**Mutation-verified**: reverting `occupies_capacity` to `!is_terminal()` turns exactly
the first RED and leaves both controls green.

## Green gate

`cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.