### PR TITLE
fix(target_parser): a UTF-8 BOM must not break raw-http import

### DIFF
--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -290,8 +290,23 @@ pub fn parse_target_with_method(s: &str) -> Result<Target, Box<dyn std::error::E
 }
 
 /// Detect if the provided text looks like a raw HTTP request (starts with METHOD SP URI SP HTTP/x.y)
+/// Drop a leading UTF-8 BOM.
+///
+/// `str::trim_start` leaves U+FEFF in place — it is not `White_Space` — so
+/// every text entry point that inspects the first bytes has to remove it
+/// explicitly, or a file saved by Notepad, Excel or PowerShell parses wrong.
+fn strip_bom(s: &str) -> &str {
+    s.strip_prefix('\u{feff}').unwrap_or(s)
+}
+
 pub fn is_raw_http_request(s: &str) -> bool {
-    let first = s.lines().next().unwrap_or("").trim_start();
+    // Strip a UTF-8 BOM before looking at the method: `str::trim_start` does not
+    // remove U+FEFF (it is not `White_Space`), and Notepad / Excel /
+    // PowerShell's `Out-File` all write one. Without this the method reads as
+    // `\u{feff}GET`, detection fails, and the request file is handed to the
+    // URL-list path — which tries to parse `Host: example.com:8080` as a URL
+    // and aborts the run. `is_har_content` already strips it.
+    let first = strip_bom(s).lines().next().unwrap_or("").trim_start();
     let mut it = first.split_whitespace();
     if let Some(method) = it.next()
         && is_known_http_method(method)
@@ -403,7 +418,10 @@ fn raw_http_body(raw: &str) -> Option<&str> {
 /// - Cookies collected from Cookie header
 /// - Body captured after the first blank line
 pub fn parse_raw_http_request(raw: &str) -> Result<Target, Box<dyn std::error::Error>> {
-    let mut lines = raw.lines();
+    // Same BOM strip as `is_raw_http_request`. Forcing `-i raw-http` on a
+    // BOM-prefixed file used to parse the method as `\u{feff}GET` — accepted
+    // silently here, then rejected by every request built from it.
+    let mut lines = strip_bom(raw).lines();
 
     // 1) Request line
     let request_line = lines.next().ok_or("empty raw http request")?.trim();

--- a/src/target_parser/raw_http_tests.rs
+++ b/src/target_parser/raw_http_tests.rs
@@ -289,3 +289,37 @@ fn raw_http_drops_headers_reqwest_cannot_send() {
     assert!(!t.headers.iter().any(|(k, _)| k == "X Foo"));
     assert!(!t.headers.iter().any(|(k, _)| k == "X-Ctl"));
 }
+
+#[test]
+fn raw_http_detection_survives_a_utf8_bom() {
+    // `str::trim_start` does not remove U+FEFF, so a request file saved by
+    // Notepad / Excel / PowerShell's `Out-File` failed detection and was then
+    // handed to the URL-list path, which tried to parse `Host: …:3031` as a URL
+    // and aborted the whole run. `is_har_content` already stripped it.
+    let raw = "\u{feff}GET /x?q=1 HTTP/1.1\r\nHost: example.com:8080\r\n\r\n";
+    assert!(
+        is_raw_http_request(raw),
+        "a BOM must not defeat raw-http detection"
+    );
+    // Control: the same content without a BOM was always detected.
+    assert!(is_raw_http_request(
+        "GET /x?q=1 HTTP/1.1\r\nHost: example.com:8080\r\n\r\n"
+    ));
+    // Control: a BOM must not make a URL list look like a request.
+    assert!(!is_raw_http_request("\u{feff}https://example.com/?q=1\n"));
+}
+
+#[test]
+fn raw_http_parse_does_not_carry_a_bom_into_the_method() {
+    // Worse than the detection miss: forcing `-i raw-http` on the same file
+    // parsed the method as `\u{feff}GET`, which was accepted silently here and
+    // then rejected by every request built from the target.
+    let t = parse_raw_http_request("\u{feff}GET /x?q=1 HTTP/1.1\r\nHost: example.com:8080\r\n\r\n")
+        .expect("should parse");
+    assert_eq!(t.method, "GET", "the BOM leaked into the method");
+    assert_eq!(
+        t.url.host_str(),
+        Some("example.com"),
+        "host must still come from the Host header"
+    );
+}


### PR DESCRIPTION
## Symptom

A raw HTTP request file saved by Notepad, Excel or PowerShell's `Out-File` carries a
UTF-8 BOM. `str::trim_start` does not remove U+FEFF (it is not `White_Space`), and
two things go wrong.

**1. Auto-detection fails, and the file is then read as a URL list.**

```
$ dalfox scan -i auto bom.req
Error: Error parsing target 'Host: 127.0.0.1:3031': invalid port number
```

`is_raw_http_request` sees the method as `\u{feff}GET`, so the file falls through to
the URL-list path, which parses each *line* as a URL and aborts the run (exit 2)
instead of scanning.

**2. Worse — forcing the type does not fail, it silently corrupts the method.**

```
$ dalfox scan -i raw-http bom.req --dry-run -f json
method: "\u{feff}GET"
```

That target is accepted and every request built from it goes out with an invalid
method. A silent misparse is worse than a rejection.

Reported as deferred/out-of-area in #1408 (which fixed the same BOM class for URL
lists, via `target_list_lines`).

## Fix

One `strip_bom` helper, applied in both `is_raw_http_request` and
`parse_raw_http_request`. `is_har_content` already stripped the BOM, so the HAR half
of the import surface was correct — this brings raw-http into line with it.

| | before | after |
|---|---|---|
| `-i raw-http` (forced) | method `"\u{feff}GET"` | method `"GET"` |
| `-i auto` | fell through to the URL-list path, exit 2 | `targets_scannable: 1`, method `"GET"` |

No-BOM behaviour is byte-identical.

## Tests

- detection survives a BOM
- **control**: the same content without a BOM was always detected
- **control**: a BOM-prefixed *URL list* must still not look like a request — the
  strip must not widen detection
- the parsed method is `GET`, with the host still taken from the `Host` header

**Mutation-verified**: removing either strip turns exactly those two tests RED.

## Green gate

`cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.