### PR TITLE
fix(scan): bound nesting when parsing a payload for the sink check

### DIFF
--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -239,7 +239,11 @@ fn payload_marker_element_carries_sink(payload: &str) -> bool {
         } else {
             format!("{candidate}>")
         };
-        let frag = scraper::Html::parse_fragment(&normalized);
+        // Bounded: html5ever is O(depth^2) and this runs once per payload, so a
+        // single pathological entry in a `--custom-payload` file or a fetched
+        // `--remote-payloads` list would stall the scan. See
+        // `utils::html::parse_fragment_bounded`.
+        let frag = crate::utils::html::parse_fragment_bounded(&normalized);
         let sel = super::selectors::universal();
         let hit = frag.select(sel).any(|node| {
             let is_marker = element_class_has(node, class_marker)

--- a/src/scanning/check_dom_verification/tests.rs
+++ b/src/scanning/check_dom_verification/tests.rs
@@ -1946,3 +1946,31 @@ fn test_payload_has_handler_sink_text_ignores_embedded_on() {
     ));
     assert!(payload_has_handler_sink_text("'/onfocus=\"alert(1)\"/x='"));
 }
+
+#[test]
+fn deeply_nested_payload_does_not_stall_the_sink_check() {
+    // This gate parses once per payload, so one pathological entry in a
+    // `--custom-payload` file or a fetched `--remote-payloads` list stalls the
+    // whole scan: html5ever's tree building is O(depth^2). Measured on this
+    // shape in debug — 15.2 s unbounded vs 11 ms through the nesting guard.
+    //
+    // A wall-clock assertion is the only way to pin the call site: both parsers
+    // return the same answer for realistic payloads, which is precisely why the
+    // swap is safe. The bound is set far from both figures (≈270x the bounded
+    // time, ≈5x under the unbounded one) so it can only fail if the guard is
+    // gone, not because the machine is busy.
+    let depth = 20_000;
+    let payload = format!(
+        "{}<svg onload=alert(1) class={}>{}",
+        "<div>".repeat(depth),
+        crate::scanning::markers::class_marker(),
+        "</div>".repeat(depth)
+    );
+    let start = std::time::Instant::now();
+    let _ = payload_marker_element_carries_sink(&payload);
+    let elapsed = start.elapsed();
+    assert!(
+        elapsed.as_secs() < 3,
+        "nesting guard is not applied to the payload parse: took {elapsed:?}"
+    );
+}

--- a/src/utils/html.rs
+++ b/src/utils/html.rs
@@ -322,5 +322,25 @@ pub(crate) fn parse_document_bounded(html: &str) -> scraper::Html {
     scraper::Html::parse_document(&bound_html_nesting(html))
 }
 
+/// `scraper::Html::parse_fragment` with the same nesting guard.
+///
+/// html5ever's tree building is O(depth^2), so an unbounded parse of a deeply
+/// nested fragment is a denial of service against the scanner itself. Measured
+/// on `<div>`*N + a sink element + `</div>`*N:
+///
+/// ```text
+/// depth  1000:  46 ms unbounded,  12 ms bounded
+/// depth  5000: 995 ms unbounded,  11 ms bounded
+/// depth 20000:  15.2 s unbounded, 11 ms bounded
+/// ```
+///
+/// Payload text is not "trusted input" just because dalfox usually generates
+/// it: `--custom-payload` is a file, and `--remote-payloads` fetches a list
+/// from a third party. One pathological entry in either is enough, because the
+/// callers parse *per payload*.
+pub(crate) fn parse_fragment_bounded(html: &str) -> scraper::Html {
+    scraper::Html::parse_fragment(&bound_html_nesting(html))
+}
+
 #[cfg(test)]
 mod tests;

--- a/src/utils/html/tests.rs
+++ b/src/utils/html/tests.rs
@@ -347,3 +347,36 @@ fn unmatched_end_tags_stay_linear_with_a_deep_stack() {
         start.elapsed()
     );
 }
+
+#[test]
+fn parse_fragment_bounded_caps_nesting_like_the_document_variant() {
+    // html5ever's tree building is O(depth^2); the guard is what keeps a
+    // pathological fragment from stalling the caller. Asserted on node count
+    // rather than elapsed time so the check is deterministic on any machine.
+    let deep = format!(
+        "{}<b>x</b>{}",
+        "<div>".repeat(20_000),
+        "</div>".repeat(20_000)
+    );
+    let bounded = parse_fragment_bounded(&deep);
+    let unbounded_nodes = 20_000 + 4;
+    let bounded_nodes = bounded.tree.values().count();
+    assert!(
+        bounded_nodes < unbounded_nodes / 10,
+        "nesting was not bounded: {bounded_nodes} nodes"
+    );
+}
+
+#[test]
+fn parse_fragment_bounded_leaves_ordinary_fragments_intact() {
+    // The control: the guard must not disturb a realistic payload-sized
+    // fragment, or it would change what the DOM-verification gate sees.
+    let frag = "<svg onload=alert(1) class=dlxdeadbeef>";
+    let bounded = parse_fragment_bounded(frag);
+    let plain = scraper::Html::parse_fragment(frag);
+    assert_eq!(
+        bounded.tree.values().count(),
+        plain.tree.values().count(),
+        "an ordinary fragment must parse identically"
+    );
+}


### PR DESCRIPTION
## Symptom

`payload_marker_element_carries_sink` (`src/scanning/check_dom_verification.rs`)
called `scraper::Html::parse_fragment` directly, skipping the nesting guard every
other parse in the codebase goes through.

html5ever's tree building is O(depth²) and this runs **once per payload**, so a
single pathological entry stalls the scan. Measured in debug on
`<div>`×N + a sink element + `</div>`×N:

| depth | unbounded | bounded |
|---|---|---|
| 1 000 | 46 ms | 12 ms |
| 5 000 | 995 ms | 11 ms |
| 20 000 | **15.2 s** | 11 ms |

Reported as deferred/out-of-area in #1405, rated low risk on the grounds that the
input is a dalfox payload. That holds for the generated ones, but payload text is not
trusted just because dalfox usually writes it: `--custom-payload` is an
operator-supplied file, and `--remote-payloads` fetches a list from a **third party**
over a connection that deliberately accepts invalid certificates. One entry is enough.

## Fix

`utils::html::parse_fragment_bounded` — the fragment sibling of the existing
`parse_document_bounded` — used at that call site.

## Testing note

The call-site swap is invisible to an ordinary assertion: both parsers return the
same answer for realistic payloads, which is exactly why the swap is safe. Pinning it
needs a wall-clock bound.

Consistent with #1416, the bound is set far from the noise floor rather than just
above the passing figure: **3 s**, about 270× the bounded time and 5× under the
unbounded one. It can only fail if the guard is gone, not because the machine is busy.

**Mutation-verified**: reverting the call site fails it with
`nesting guard is not applied to the payload parse: took 15.2217425s`.

Also covers `parse_fragment_bounded` directly — node count is capped, and an ordinary
payload-sized fragment parses identically to the unbounded parser (the control, so
the guard cannot silently change what the DOM-verification gate sees).

## Green gate

`cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.