### PR TITLE
fix(server,mcp): run the remote payload fetch inside the scan budget

### DIFF
--- a/src/job/runner.rs
+++ b/src/job/runner.rs
@@ -160,6 +160,31 @@ pub(crate) async fn execute_scan(
         crate::REQUEST_COUNT_JOB.scope(progress.requests_sent.clone(), async {
             crate::WAF_CONSECUTIVE_BLOCKS_JOB
                 .scope(job_waf_consecutive.clone(), async {
+                    // Remote payload / wordlist fetch. Inside the budget on
+                    // purpose: `scan_timeout` is a promise about the whole job,
+                    // and both front ends used to do this fetch *before*
+                    // `run_within_scan_budget`, so a slow provider stretched a
+                    // job past a bound the caller had set. Each request is
+                    // capped by `--timeout`, but N provider URLs are not.
+                    //
+                    // A failure is not cosmetic: the scan proceeds without the
+                    // list the caller explicitly asked for and still settles
+                    // `done`, which reads as "scanned, found nothing" — so it
+                    // goes through `warn` rather than being swallowed.
+                    if (!args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty())
+                        && let Err(e) = crate::utils::init_remote_resources_with_options(
+                            &args.remote_payloads,
+                            &args.remote_wordlists,
+                            Some(args.timeout),
+                            args.proxy.clone(),
+                        )
+                        .await
+                    {
+                        warn(&format!(
+                            "remote resource fetch failed ({e}); scanning without the requested remote lists"
+                        ));
+                    }
+
                     if let Some(callback_url) = &args.blind_callback_url {
                         crate::scanning::blind_scanning(
                             target,

--- a/src/mcp/mod.rs
+++ b/src/mcp/mod.rs
@@ -285,33 +285,6 @@ impl DalfoxMcp {
             }
         };
 
-        // Load any requested remote payload/wordlist providers into the caches
-        // before the scan reads them. Mirrors the REST server (`run_scan_job`)
-        // and the CLI; without this the `remote_payloads`/`remote_wordlists`
-        // fields would be silently inert on the MCP path. It runs *here*, inside
-        // the spawned worker, rather than in the tool call — see the note at the
-        // spawn site in `scan_with_dalfox`.
-        //
-        // A failure is logged rather than swallowed: the scan otherwise runs
-        // without the list the caller asked for and still reports success,
-        // which an agent reads as "scanned, found nothing".
-        if (!scan_args.remote_payloads.is_empty() || !scan_args.remote_wordlists.is_empty())
-            && let Err(e) = crate::utils::init_remote_resources_with_options(
-                &scan_args.remote_payloads,
-                &scan_args.remote_wordlists,
-                Some(scan_args.timeout),
-                scan_args.proxy.clone(),
-            )
-            .await
-        {
-            Self::log(
-                "WRN",
-                &format!(
-                    "scan_id={scan_id} remote resource fetch failed ({e}); scanning without the requested remote lists"
-                ),
-            );
-        }
-
         let url = scan_args
             .targets
             .first()

--- a/src/server/job_runner.rs
+++ b/src/server/job_runner.rs
@@ -300,28 +300,6 @@ pub(crate) async fn run_scan_job(
         .into_scan_args(),
     );
 
-    // Initialize remote resources if requested (honor timeout/proxy).
-    // A failure here is not cosmetic: the scan proceeds without the payload or
-    // wordlist the caller explicitly asked for and still settles `done`, which
-    // reads as "scanned, found nothing". Log it so the difference is visible.
-    if (!args.remote_payloads.is_empty() || !args.remote_wordlists.is_empty())
-        && let Err(e) = crate::utils::init_remote_resources_with_options(
-            &args.remote_payloads,
-            &args.remote_wordlists,
-            Some(args.timeout),
-            args.proxy.clone(),
-        )
-        .await
-    {
-        log(
-            &state,
-            "WRN",
-            &format!(
-                "job {}: remote resource fetch failed ({}); scanning without the requested remote lists",
-                job_id, e
-            ),
-        );
-    }
     let mut target = match crate::job::runner::hydrate_target(&url, &args) {
         Ok(t) => t,
         Err(msg) => {

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -136,6 +136,24 @@ async fn target_reflect_handler(Query(q): Query<Map<String, String>>) -> impl In
     )
 }
 
+/// A server that accepts the connection and then never answers. Used to stand
+/// in for a remote payload provider that trickles or hangs.
+async fn start_stalling_server() -> SocketAddr {
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind stalling listener");
+    let addr = listener.local_addr().expect("stalling local addr");
+    tokio::spawn(async move {
+        let mut held = Vec::new();
+        while let Ok((sock, _)) = listener.accept().await {
+            // Hold the socket open without writing a response.
+            held.push(sock);
+        }
+    });
+    tokio::time::sleep(std::time::Duration::from_millis(20)).await;
+    addr
+}
+
 async fn start_reflecting_target_server() -> SocketAddr {
     let app = Router::new()
         .route("/", any(target_reflect_handler))
@@ -1542,6 +1560,68 @@ async fn test_run_scan_job_scan_timeout_marks_cancelled_with_partial_results() {
         "partial results vector should be attached even on timeout"
     );
     assert!(job.finished_at_ms.is_some());
+}
+
+#[tokio::test]
+async fn test_scan_timeout_bounds_a_slow_remote_payload_fetch() {
+    // `scan_timeout` is a promise about the whole job. Both front ends used to
+    // fetch `remote_payloads` / `remote_wordlists` *before*
+    // `run_within_scan_budget`, so a provider that trickles bytes stretched the
+    // job past the bound the caller set. Each request is capped by `--timeout`,
+    // but N provider URLs are not, and the caller asked for a job-level bound.
+    //
+    // A provider that never answers, a 1s budget, and a generous outer guard:
+    // the job must come back inside the budget, not inside the outer guard.
+    let stall = start_stalling_server().await;
+    let target = start_reflecting_target_server().await;
+    crate::payload::register_payload_provider(
+        "stall-test-provider",
+        vec![format!("http://{}/never", stall)],
+    );
+    let state = make_state(None, None, false, false, "callback");
+    let id = "remote-fetch-budget".to_string();
+    {
+        let mut jobs = state.jobs.lock().await;
+        jobs.insert(id.clone(), test_job(JobStatus::Queued, None, ""));
+    }
+
+    let opts = ScanOptions {
+        encoders: Some(vec!["none".to_string()]),
+        worker: Some(1),
+        skip_mining: Some(true),
+        // The discriminating pair: a long per-request timeout (which is all
+        // that used to bound the fetch) and a short job budget. Before the fix
+        // the job ran for ~`timeout`; after it, the budget trips first.
+        timeout: Some(20),
+        scan_timeout: Some(1),
+        remote_payloads: Some(vec!["stall-test-provider".to_string()]),
+        ..ScanOptions::default()
+    };
+
+    let started = std::time::Instant::now();
+    let run = tokio::time::timeout(
+        std::time::Duration::from_secs(60),
+        run_scan_job(
+            state.clone(),
+            id.clone(),
+            format!("http://{}/?q=test", target),
+            opts,
+            false,
+            false,
+        ),
+    )
+    .await;
+    assert!(run.is_ok(), "the job must settle, not hang on the provider");
+    assert!(
+        started.elapsed() < std::time::Duration::from_secs(10),
+        "job took {:?} — the remote fetch ran outside the scan budget \
+         (it was bounded only by the 20s per-request timeout)",
+        started.elapsed()
+    );
+
+    let jobs = state.jobs.lock().await;
+    let job = jobs.get(&id).expect("job should remain");
+    assert!(job.finished_at_ms.is_some(), "the job must settle");
 }
 
 #[tokio::test]


### PR DESCRIPTION
## Symptom

`scan_timeout` is a promise about the whole job, and it did not hold. Both front ends
fetched `remote_payloads` / `remote_wordlists` **before** calling `execute_scan`,
which is what wraps `run_within_scan_budget` — so a provider that hangs stretched the
job past the bound the caller set.

Each request is capped by `--timeout`, but N provider URLs are not, and a per-request
cap is not the guarantee `scan_timeout` makes.

Measured against a provider that accepts the connection and never answers, with
`timeout: 20` and `scan_timeout: 1`:

| | job duration |
|---|---|
| before | **20.05 s** — bounded only by the per-request timeout |
| after | **1.07 s** — the budget trips, as asked |

Reported as deferred/out-of-area in #1406.

## Fix

The fetch moves into `execute_scan`, inside the future the budget wraps, and reports
failure through the existing `warn` sink — the callback that exists precisely because
this warning is the one line that differed between the two front ends.

The duplicated blocks in `src/server/job_runner.rs` and `src/mcp/mod.rs` are deleted,
so the two surfaces can no longer drift on it. (They already had subtly different
messages — this is the `parallel builders drift` shape that has bitten this repo
before.)

**Failure behaviour is unchanged**: the scan still proceeds without the list the
caller asked for, and the warning still says so, because settling `done` silently
would read as "scanned, found nothing".

## Test

`test_scan_timeout_bounds_a_slow_remote_payload_fetch` registers a payload provider
pointing at a stalling local server and asserts the job settles well inside the
budget. The **long per-request timeout paired with the short job budget** is what
makes it discriminating — with the two close together the test would pass either way.

**Mutation-verified**: restoring the pre-fix shape (fetch hoisted back out of the
budget) fails it with
`job took 20.046162125s — the remote fetch ran outside the scan budget`.

## Green gate

`cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.