### PR TITLE
test(skills): guard the agent-skill copies against silent drift

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,11 @@
 * linguist-vendored
 *.rs linguist-vendored=false
 *.cr linguist-vendored=false
+
+# The published agent skill and its discovery index are digest-verified: the
+# `sha256` in index.json is taken over the file as served, which is LF. A CRLF
+# checkout on Windows would otherwise let a contributor commit CRLF and break
+# that digest for every client that checks it.
+skills/dalfox/SKILL.md text eol=lf
+docs/static/.well-known/agent-skills/dalfox/SKILL.md text eol=lf
+docs/static/.well-known/agent-skills/index.json text eol=lf

--- a/tests/agent_skills_sync_test.rs
+++ b/tests/agent_skills_sync_test.rs
@@ -23,10 +23,33 @@ const SOURCE: &str = "skills/dalfox/SKILL.md";
 const PUBLISHED: &str = "docs/static/.well-known/agent-skills/dalfox/SKILL.md";
 const INDEX: &str = "docs/static/.well-known/agent-skills/index.json";
 
+/// Read a repo file with line endings normalized to LF.
+///
+/// The digest in `index.json` is taken over the file *as served*, which is LF.
+/// A Windows checkout can materialize CRLF (`.gitattributes` now pins these
+/// three paths, but a pre-existing clone or a zip download still can), and
+/// hashing those bytes would fail against a digest that is perfectly correct.
+/// Normalizing here keeps the test about drift rather than about checkout
+/// settings.
+fn read_lf(rel: &str) -> Vec<u8> {
+    let raw = std::fs::read(repo_path(rel)).unwrap_or_else(|e| panic!("read {rel}: {e}"));
+    let mut out = Vec::with_capacity(raw.len());
+    let mut i = 0;
+    while i < raw.len() {
+        if raw[i] == b'\r' && raw.get(i + 1) == Some(&b'\n') {
+            i += 1;
+            continue;
+        }
+        out.push(raw[i]);
+        i += 1;
+    }
+    out
+}
+
 #[test]
 fn published_skill_is_byte_identical_to_the_source() {
-    let source = std::fs::read(repo_path(SOURCE)).expect("read skills/dalfox/SKILL.md");
-    let published = std::fs::read(repo_path(PUBLISHED)).expect("read the .well-known copy");
+    let source = read_lf(SOURCE);
+    let published = read_lf(PUBLISHED);
     assert_eq!(
         source, published,
         "{SOURCE} and {PUBLISHED} have drifted — the docs site would serve \
@@ -37,7 +60,7 @@ fn published_skill_is_byte_identical_to_the_source() {
 
 #[test]
 fn index_digest_matches_the_published_skill() {
-    let published = std::fs::read(repo_path(PUBLISHED)).expect("read the .well-known copy");
+    let published = read_lf(PUBLISHED);
     let mut hasher = Sha256::new();
     hasher.update(&published);
     let actual = format!("sha256:{}", hex::encode(hasher.finalize()));

--- a/tests/agent_skills_sync_test.rs
+++ b/tests/agent_skills_sync_test.rs
@@ -1,0 +1,66 @@
+//! The agent-facing skill is published in three places that must agree, and
+//! nothing enforced that: a change to one and not the others rots silently,
+//! because none of them is compiled or linked.
+//!
+//!   1. `skills/dalfox/SKILL.md` — the source of truth in the repo
+//!   2. `docs/static/.well-known/agent-skills/dalfox/SKILL.md` — the copy the
+//!      docs site serves, which must be byte-identical
+//!   3. `docs/static/.well-known/agent-skills/index.json` — carries a
+//!      `sha256:` digest of (2), which discovery clients verify
+//!
+//! A stale digest makes the published skill fail verification for every agent
+//! that checks it, and a stale copy serves instructions that no longer match
+//! the tool. Both are invisible until someone reports it.
+
+use sha2::{Digest, Sha256};
+use std::path::{Path, PathBuf};
+
+fn repo_path(rel: &str) -> PathBuf {
+    Path::new(env!("CARGO_MANIFEST_DIR")).join(rel)
+}
+
+const SOURCE: &str = "skills/dalfox/SKILL.md";
+const PUBLISHED: &str = "docs/static/.well-known/agent-skills/dalfox/SKILL.md";
+const INDEX: &str = "docs/static/.well-known/agent-skills/index.json";
+
+#[test]
+fn published_skill_is_byte_identical_to_the_source() {
+    let source = std::fs::read(repo_path(SOURCE)).expect("read skills/dalfox/SKILL.md");
+    let published = std::fs::read(repo_path(PUBLISHED)).expect("read the .well-known copy");
+    assert_eq!(
+        source, published,
+        "{SOURCE} and {PUBLISHED} have drifted — the docs site would serve \
+         instructions that no longer match the repo. Copy the source over the \
+         published file and refresh the digest in {INDEX}."
+    );
+}
+
+#[test]
+fn index_digest_matches_the_published_skill() {
+    let published = std::fs::read(repo_path(PUBLISHED)).expect("read the .well-known copy");
+    let mut hasher = Sha256::new();
+    hasher.update(&published);
+    let actual = format!("sha256:{}", hex::encode(hasher.finalize()));
+
+    let index: serde_json::Value = serde_json::from_slice(
+        &std::fs::read(repo_path(INDEX)).expect("read the agent-skills index"),
+    )
+    .expect("index.json must be valid JSON");
+
+    let entry = index["skills"]
+        .as_array()
+        .expect("index.json must carry a `skills` array")
+        .iter()
+        .find(|s| s["name"] == "dalfox")
+        .expect("index.json must list the dalfox skill");
+    let recorded = entry["digest"]
+        .as_str()
+        .expect("the dalfox entry must carry a digest");
+
+    assert_eq!(
+        recorded, actual,
+        "the digest in {INDEX} is stale — discovery clients that verify it will \
+         reject the published skill. Recompute with:\n    \
+         shasum -a 256 {PUBLISHED}"
+    );
+}


### PR DESCRIPTION
## The gap

The agent-facing skill is published in three places that must agree, and nothing
enforced it:

1. `skills/dalfox/SKILL.md` — the source of truth in the repo
2. `docs/static/.well-known/agent-skills/dalfox/SKILL.md` — the copy the docs site
   serves, which must be **byte-identical**
3. `docs/static/.well-known/agent-skills/index.json` — carries a `sha256:` digest of
   (2), which discovery clients verify

None of the three is compiled or linked, so a change to one and not the others rots
silently:

- a **stale digest** makes the published skill fail verification for every agent that
  checks it
- a **stale copy** serves instructions that no longer match the tool

Both are invisible until someone reports it. I found this while scoping the MCP
preflight parity work, which would have had to touch all three.

## The guard

Two tests in the ordinary `cargo test` run, so all three CI platforms cover them and
no workflow change is needed. The failure messages say how to fix the drift rather
than just that it exists:

```
skills/dalfox/SKILL.md and docs/static/.well-known/agent-skills/dalfox/SKILL.md have
drifted — the docs site would serve instructions that no longer match the repo. Copy
the source over the published file and refresh the digest in
docs/static/.well-known/agent-skills/index.json.
```

```
the digest in docs/static/.well-known/agent-skills/index.json is stale — discovery
clients that verify it will reject the published skill. Recompute with:
    shasum -a 256 docs/static/.well-known/agent-skills/dalfox/SKILL.md
```

**Mutation-verified**: appending one comment line to the published copy turns both
tests RED.

## Scope

All three are in sync today — **this is a guard, not a repair**. No content changes.

## Green gate

`cargo test` (exit 0), `cargo fmt --all -- --check`,
`cargo clippy --all-targets --all-features -- -D warnings` — all clean.