### PR TITLE
fix(server): anchor origin patterns, and harden the API's secret handling

### DIFF
--- a/docs/content/integrations/server.ko.md
+++ b/docs/content/integrations/server.ko.md
@@ -20,19 +20,33 @@ dalfox server
 dalfox server \
   --port 6664 \
   --host 0.0.0.0 \
-  --api-key "change-me" \
+  --api-key "8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   --log-file /var/log/dalfox.log
 ```
+
+`--log-file`은 제출된 모든 대상 URL을 기록하고, 그런 URL에는 대개 그 대상을 스캔할 이유가
+된 자격증명이 들어 있습니다. 그래서 로그 파일을 새로 만들 때는 `0600`으로 생성합니다.
+이미 있는 파일의 권한은 그대로 두며, 그룹/기타 사용자가 읽을 수 있으면 기동 시 경고합니다
+— 구버전에서 그대로 업그레이드하면 이 상태가 됩니다. 파일 권한을 넓히지 말고 로그 수집기의
+uid를 맞추세요.
 
 ### 인증
 
 `--api-key`를 설정했거나 `DALFOX_API_KEY`를 export 했다면, 모든 요청에 다음이 들어가야 합니다:
 
 ```
-X-API-KEY: change-me
+X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73
 ```
 
 API 키를 설정하지 않으면 서버는 인증 없는 요청도 받습니다. 그럴 때는 `127.0.0.1`에 바인딩하세요.
+
+틀린 키에 대한 제한이나 잠금이 없으므로, 포트에 접근할 수 있는 공격자와 유효한 키 사이를
+가로막는 것은 키 길이뿐입니다. 최소 24자의 무작위 문자열을 사용하세요 — 그보다 짧으면
+서버가 기동 시 경고합니다:
+
+```bash
+export DALFOX_API_KEY="$(openssl rand -hex 16)"
+```
 
 ### 브라우저 요청
 
@@ -78,6 +92,17 @@ dalfox server \
 
 `*`는 와일드카드로 허용됩니다. 정규식은 `regex:^https://.*\.example\.com$` 형태로 지원됩니다.
 
+두 형태 모두 `Origin` **전체**와 매칭되므로, 패턴을 부분 문자열로 포함하는 더 긴 호스트가
+통과할 수 없습니다 — `regex:https://app\.example\.com`은 `https://app.example.com.evil.com`과
+매칭되지 않습니다. 앵커(`^`, `$`)를 직접 써도 됩니다. 중복일 뿐 문제가 되지는 않습니다.
+반대로, 대상 오리진에 포트가 붙는다면 패턴도 포트를 포함해야 합니다
+(`regex:https://app\.example\.com(:8443)?`). 정확히 일치하는 항목은 대소문자를 구분하지
+않고 비교합니다.
+
+`--allowed-origins '*'`는 모든 오리진을 허용한다는 뜻이며, `--jsonp`와 마찬가지로
+크로스사이트 게이트를 꺼 버립니다. 둘 중 하나라도 API 키 없이 켜면 서버가 기동 시
+경고합니다.
+
 ### JSONP
 
 커스텀 헤더를 설정할 수 없는 브라우저 클라이언트를 위해:
@@ -110,7 +135,7 @@ JSONP는 `<script src>` 로드로 전달되는데, 스크립트 로드에는 검
 
 ```bash
 curl -X POST http://127.0.0.1:6664/scan \
-  -H "X-API-KEY: change-me" \
+  -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   -H "Content-Type: application/json" \
   -d '{
     "target": "https://target.app?q=test",
@@ -141,7 +166,7 @@ curl -X POST http://127.0.0.1:6664/scan \
 ### 상태 폴링
 
 ```bash
-curl -H "X-API-KEY: change-me" http://127.0.0.1:6664/scan/9f2c…
+curl -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" http://127.0.0.1:6664/scan/9f2c…
 ```
 
 응답 (실행 중):
@@ -171,20 +196,20 @@ curl -H "X-API-KEY: change-me" http://127.0.0.1:6664/scan/9f2c…
 ### 스캔 목록 조회
 
 ```bash
-curl -H "X-API-KEY: change-me" 'http://127.0.0.1:6664/scans?status=running'
+curl -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" 'http://127.0.0.1:6664/scans?status=running'
 ```
 
 ### 스캔 취소
 
 ```bash
-curl -X DELETE -H "X-API-KEY: change-me" http://127.0.0.1:6664/scan/9f2c…
+curl -X DELETE -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" http://127.0.0.1:6664/scan/9f2c…
 ```
 
 ### 프리플라이트 (공격 없음)
 
 ```bash
 curl -X POST http://127.0.0.1:6664/preflight \
-  -H "X-API-KEY: change-me" \
+  -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   -H "Content-Type: application/json" \
   -d '{"target":"https://target.app"}'
 ```
@@ -343,7 +368,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/local/bin/dalfox server --port 6664 --host 127.0.0.1 --log-file /var/log/dalfox.log
-Environment=DALFOX_API_KEY=change-me
+Environment=DALFOX_API_KEY=8f2b1c6d4a9e7053b8c1f4d2e6a09b73
 Restart=on-failure
 User=dalfox
 

--- a/docs/content/integrations/server.md
+++ b/docs/content/integrations/server.md
@@ -20,19 +20,34 @@ Common options:
 dalfox server \
   --port 6664 \
   --host 0.0.0.0 \
-  --api-key "change-me" \
+  --api-key "8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   --log-file /var/log/dalfox.log
 ```
+
+`--log-file` records every submitted target URL, which routinely carries the
+credential that made the target worth scanning, so a new log file is created
+mode `0600`. An existing file keeps whatever permissions it already has — the
+server warns at startup if it is readable by group or other, which is what an
+in-place upgrade from an older version leaves behind. Adjust your log shipper's
+uid rather than widening the file.
 
 ### Authentication
 
 If `--api-key` is set (or `DALFOX_API_KEY` is exported), every request must include:
 
 ```
-X-API-KEY: change-me
+X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73
 ```
 
 If you don't set an API key, the server accepts unauthenticated requests; bind to `127.0.0.1` in that case.
+
+Nothing throttles or locks out a wrong key, so its length is the only thing
+standing between an attacker who can reach the port and a valid key. Use at
+least 24 random characters — the server warns at startup for anything shorter:
+
+```bash
+export DALFOX_API_KEY="$(openssl rand -hex 16)"
+```
 
 ### Browser requests
 
@@ -79,6 +94,18 @@ dalfox server \
 
 `*` is accepted as a wildcard. Regex is supported via `regex:^https://.*\.example\.com$`.
 
+Both forms are matched against the **whole** `Origin`, so a pattern can never
+accept a longer host that merely contains it — `regex:https://app\.example\.com`
+does not match `https://app.example.com.evil.com`. Writing the anchors yourself
+is still fine; they are redundant, not wrong. The flip side is that a pattern
+has to cover the port when the origins it describes carry one
+(`regex:https://app\.example\.com(:8443)?`). Exact entries are compared
+case-insensitively.
+
+`--allowed-origins '*'` means every origin is allowed, which switches the
+cross-site gate off the same way `--jsonp` does. The server warns at startup
+when either is combined with no API key.
+
 ### JSONP
 
 For browser clients that can't set custom headers:
@@ -111,7 +138,7 @@ server prints a startup warning when `--jsonp` is enabled without an API key.
 
 ```bash
 curl -X POST http://127.0.0.1:6664/scan \
-  -H "X-API-KEY: change-me" \
+  -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   -H "Content-Type: application/json" \
   -d '{
     "target": "https://target.app?q=test",
@@ -142,7 +169,7 @@ Response:
 ### Poll status
 
 ```bash
-curl -H "X-API-KEY: change-me" http://127.0.0.1:6664/scan/9f2c…
+curl -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" http://127.0.0.1:6664/scan/9f2c…
 ```
 
 Response (while running):
@@ -172,20 +199,20 @@ When complete, `status` becomes `done` and `results` is populated.
 ### List scans
 
 ```bash
-curl -H "X-API-KEY: change-me" 'http://127.0.0.1:6664/scans?status=running'
+curl -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" 'http://127.0.0.1:6664/scans?status=running'
 ```
 
 ### Cancel a scan
 
 ```bash
-curl -X DELETE -H "X-API-KEY: change-me" http://127.0.0.1:6664/scan/9f2c…
+curl -X DELETE -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" http://127.0.0.1:6664/scan/9f2c…
 ```
 
 ### Preflight (no attack)
 
 ```bash
 curl -X POST http://127.0.0.1:6664/preflight \
-  -H "X-API-KEY: change-me" \
+  -H "X-API-KEY: 8f2b1c6d4a9e7053b8c1f4d2e6a09b73" \
   -H "Content-Type: application/json" \
   -d '{"target":"https://target.app"}'
 ```
@@ -351,7 +378,7 @@ After=network.target
 
 [Service]
 ExecStart=/usr/local/bin/dalfox server --port 6664 --host 127.0.0.1 --log-file /var/log/dalfox.log
-Environment=DALFOX_API_KEY=change-me
+Environment=DALFOX_API_KEY=8f2b1c6d4a9e7053b8c1f4d2e6a09b73
 Restart=on-failure
 User=dalfox
 

--- a/skills/dalfox/references/server-and-payload.md
+++ b/skills/dalfox/references/server-and-payload.md
@@ -11,8 +11,8 @@ Runs an async HTTP API (axum) that exposes the same scanning engine.
 | `-p, --port` | 6664 | Listen port |
 | `-H, --host` | 127.0.0.1 | Bind address (use 0.0.0.0 carefully) |
 | `--api-key` | (none) | Required value for `X-API-KEY` header (or `DALFOX_API_KEY` env) |
-| `--log-file` | (none) | Plain-text log file (no ANSI) |
-| `--allowed-origins` | (none) | Comma-separated. Supports `*`, exact origins, `regex:<pattern>` |
+| `--log-file` | (none) | Plain-text log file (no ANSI). Created `0600` on Unix; an existing file keeps its mode and is warned about if group/other-readable |
+| `--allowed-origins` | (none) | Comma-separated. Supports `*`, exact origins (case-insensitive), `regex:<pattern>`. Patterns match the whole `Origin` (anchored), so a longer host that merely contains one is refused — and a pattern must cover the port. `*` switches the cross-site gate off, like `--jsonp` |
 | `--jsonp` | false | Enable JSONP (wraps responses in callback function) |
 | `--callback-param-name` | `callback` | JSONP callback query parameter |
 | `--cors-allow-methods` | GET,POST,... | |
@@ -35,9 +35,9 @@ Jobs are in-memory only. Same `queued / running / done / error / cancelled` life
 
 **Webhook/SSRF**: `callback_url` (and the scan target itself) are dialed server-side with no host filtering — loopback/link-local/private hosts are reachable. Set `--api-key` and restrict egress on untrusted binds. `--jsonp` exposes GET endpoints cross-origin (bypasses the CORS allow-list); enable deliberately.
 
-**Authentication**: when `--api-key` is set, every mutating endpoint requires the key. Read endpoints can be open or also protected depending on deployment choice.
+**Authentication**: when `--api-key` is set, every endpoint requires it in `X-API-KEY` except `GET /health` and the `OPTIONS` CORS preflights — a browser attaches no key to a preflight. Reads (`GET /scan/{id}`, `/scans`) are included. `/health` and the preflights stay key-free but are still subject to the cross-site/`Host` gate. There is no per-caller identity: any caller holding the key can read or cancel any scan. Nothing rate-limits a wrong key, so use at least 24 random characters (the server warns below that).
 
-**JSONP**: only works for GET endpoints and requires the callback parameter. The server is strict about the callback name to avoid XSS in the JSONP wrapper itself.
+**JSONP**: only works for GET endpoints and requires the callback parameter. The server is strict about the callback name to avoid XSS in the JSONP wrapper itself. Every response with a body carries `X-Content-Type-Options: nosniff` and `Cache-Control: no-store` (the bodyless `OPTIONS` 204s do not).
 
 Use the server when:
 - You want a long-lived scan service for a team / pipeline

--- a/src/server/cors.rs
+++ b/src/server/cors.rs
@@ -1,6 +1,107 @@
-//! CORS response-header construction driven by the configured allow-lists.
+//! CORS response-header construction driven by the configured allow-lists,
+//! plus the compilation of `--allowed-origins` into the matchers `AppState`
+//! carries.
 
 use super::*;
+
+/// The `--allowed-origins` list, compiled into the three fields `AppState`
+/// holds — the raw entries (exact compares), the compiled patterns, and the
+/// `*` opt-in — plus any entry that had to be dropped.
+pub(crate) struct OriginRules {
+    pub(crate) origins: Option<Vec<String>>,
+    pub(crate) regexes: Vec<regex::Regex>,
+    pub(crate) allow_all: bool,
+    /// Entries that could not be compiled, already rendered for the operator.
+    /// Returned rather than printed because this runs before `AppState` exists
+    /// and a bare `eprintln!` never reaches `--log-file` — which is the one
+    /// place an operator running under systemd would look after their web UI
+    /// started getting 403s from a silently dropped pattern.
+    pub(crate) rejected: Vec<String>,
+}
+
+/// Anchor an origin pattern so it must match the **whole** `Origin` value.
+///
+/// `Regex::is_match` searches anywhere in the subject, and an origin has no
+/// delimiter to stop it at: an unanchored `https://app\.example\.com` is a
+/// substring of `https://app.example.com.evil.com`, a host an attacker can
+/// simply register. That is not a CORS-only leak — [`origin_allowed`] is also
+/// what `auth::check_cross_site` consults, so a matching origin lets an
+/// attacker's page drive the whole API (start scans, read results) from the
+/// operator's browser.
+///
+/// Operators write these patterns as if they described the entire origin —
+/// the wildcard form has always been anchored, and every doc example spells
+/// `^…$` — so anchoring is what makes the two forms agree instead of one
+/// silently accepting suffixes. The non-capturing group matters for
+/// alternation (`a|b` must become `^(?:a|b)$`, not `^a|b$`), and a pattern
+/// that already carries `^…$` is unaffected: the added anchors are zero-width
+/// assertions asserting the same positions.
+fn anchored_origin_pattern(pattern: &str) -> String {
+    format!("^(?:{})$", pattern)
+}
+
+/// Compile the comma-separated `--allowed-origins` value.
+///
+/// Entries are trimmed and empties dropped. `*` sets the allow-all opt-in;
+/// a `regex:` prefix supplies a pattern verbatim; anything containing `*` is
+/// a shell-style wildcard escaped into one. Both pattern forms go through
+/// [`anchored_origin_pattern`]. A pattern that fails to compile — or names no
+/// origin at all — is dropped and reported through `rejected`, which fails
+/// closed.
+pub(crate) fn compile_allowed_origins(raw: Option<&str>) -> OriginRules {
+    let origins = raw.map(|s| {
+        s.split(',')
+            .map(|x| x.trim().to_string())
+            .filter(|x| !x.is_empty())
+            .collect::<Vec<_>>()
+    });
+
+    let mut regexes = Vec::new();
+    let mut allow_all = false;
+    let mut rejected = Vec::new();
+    if let Some(list) = &origins {
+        for item in list {
+            if item == "*" {
+                allow_all = true;
+                continue;
+            }
+            // `regex:` is the operator's own pattern; a bare `*` inside an
+            // otherwise literal origin is the shell-style wildcard form, which
+            // is escaped first so only the `*` stays meta.
+            let (pattern, label) = if let Some(pat) = item.strip_prefix("regex:") {
+                if pat.trim().is_empty() {
+                    // `^(?:)$` matches the empty string, so a stray `regex:`
+                    // left behind while editing the list would quietly admit a
+                    // request carrying an empty `Origin` header — and admitting
+                    // it skips the `Sec-Fetch-Site` fallback entirely. An entry
+                    // that describes no origin is a typo, not a rule.
+                    rejected.push(format!("empty allowed-origins regex '{}'", item));
+                    continue;
+                }
+                (anchored_origin_pattern(pat), "regex")
+            } else if item.contains('*') {
+                let escaped = regex::escape(item).replace("\\*", ".*");
+                (anchored_origin_pattern(&escaped), "wildcard")
+            } else {
+                continue;
+            };
+            match regex::Regex::new(&pattern) {
+                Ok(re) => regexes.push(re),
+                Err(e) => rejected.push(format!(
+                    "invalid allowed-origins {} '{}': {}",
+                    label, item, e
+                )),
+            }
+        }
+    }
+
+    OriginRules {
+        origins,
+        regexes,
+        allow_all,
+        rejected,
+    }
+}
 
 /// Does `origin` match the configured allow-list (exact entry, compiled
 /// wildcard/regex, or the `*` opt-in)?
@@ -11,9 +112,16 @@ pub(crate) fn origin_allowed(state: &AppState, origin: &str) -> bool {
     if state.allow_all_origins {
         return true;
     }
+    // Compared case-insensitively: scheme and host are case-insensitive per
+    // RFC 6454, and `auth::check_host` already normalizes the sibling `Host`
+    // value the same way. A byte-exact compare made an allow-list entry the
+    // operator typed as `https://App.Corp.Local` silently dead — browsers
+    // always send the lowercased form, so their web UI got a
+    // `refused: cross-site browser request` 403 with nothing pointing at the
+    // capitalization.
     let exact = state.allowed_origins.as_ref().is_some_and(|v| {
         v.iter()
-            .any(|o| !o.starts_with("regex:") && o != "*" && o == origin)
+            .any(|o| !o.starts_with("regex:") && o != "*" && o.eq_ignore_ascii_case(origin))
     });
     exact
         || state

--- a/src/server/handlers.rs
+++ b/src/server/handlers.rs
@@ -244,10 +244,21 @@ pub(crate) async fn get_result_handler(
     }
 }
 
+/// CORS preflight. No API key is checked — a browser never attaches one to a
+/// preflight — but the source gate still applies, for the same reason
+/// `/health` carries it: without it a page the operator visits can use a 204
+/// to fingerprint a dalfox server on their machine, and a rebound `Host` gets
+/// an answer here that it is refused everywhere else. A genuine preflight from
+/// an allowed origin passes on the `Origin` branch; one from a disallowed
+/// origin is refused instead of getting a 204 with no `Access-Control-Allow-Origin`,
+/// which fails the browser's preflight either way.
 pub(crate) async fn options_scan_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
 ) -> impl IntoResponse {
+    if let Err(denied) = check_request_source(&state, &headers) {
+        return (denied.status(), HeaderMap::new());
+    }
     let cors = build_cors_headers(&state, &headers);
     (StatusCode::NO_CONTENT, cors)
 }
@@ -576,11 +587,16 @@ pub(crate) async fn health_handler(
     make_api_response(&state, &headers, &params, StatusCode::OK, &resp)
 }
 
+/// CORS preflight for the id-bearing routes. Source-gated exactly like
+/// [`options_scan_handler`].
 pub(crate) async fn options_result_handler(
     State(state): State<AppState>,
     headers: HeaderMap,
     Path(_id): Path<String>,
 ) -> impl IntoResponse {
+    if let Err(denied) = check_request_source(&state, &headers) {
+        return (denied.status(), HeaderMap::new());
+    }
     let cors = build_cors_headers(&state, &headers);
     (StatusCode::NO_CONTENT, cors)
 }

--- a/src/server/mod.rs
+++ b/src/server/mod.rs
@@ -63,6 +63,12 @@ pub(crate) use response::*;
 pub(crate) use types::*;
 pub(crate) use util::*;
 
+/// Shortest `--api-key` the server will not warn about. The API-key check has
+/// no throttle or lockout, so key length is the entire cost of a brute-force
+/// attempt; 24 random characters is comfortably past what an attacker can walk
+/// over a network.
+const MIN_RECOMMENDED_API_KEY_LEN: usize = 24;
+
 /// Run the REST API server until it shuts down gracefully.
 ///
 /// Returns `Err` when the server never came up (an unparseable bind address, a
@@ -89,43 +95,10 @@ pub async fn run_server(args: ServerArgs) -> Result<(), String> {
         api_key = Some(v);
     }
 
-    // Parse allowed origins, build regex list and wildcard flag
-    let allowed_origins_vec = args.allowed_origins.as_ref().map(|s| {
-        s.split(',')
-            .map(|x| x.trim().to_string())
-            .filter(|x| !x.is_empty())
-            .collect::<Vec<_>>()
-    });
-
-    let mut allowed_origin_regexes = Vec::new();
-    let mut allow_all_origins = false;
-    if let Some(list) = &allowed_origins_vec {
-        for item in list {
-            if item == "*" {
-                allow_all_origins = true;
-            } else if let Some(pat) = item.strip_prefix("regex:") {
-                match regex::Regex::new(pat) {
-                    Ok(re) => allowed_origin_regexes.push(re),
-                    Err(e) => eprintln!(
-                        "[WRN] ignoring invalid allowed-origins regex '{}': {}",
-                        pat, e
-                    ),
-                }
-            } else if item.contains('*') {
-                // Convert simple wildcard to regex
-                let mut pattern = regex::escape(item);
-                pattern = pattern.replace("\\*", ".*");
-                let anchored = format!("^{}$", pattern);
-                match regex::Regex::new(&anchored) {
-                    Ok(re) => allowed_origin_regexes.push(re),
-                    Err(e) => eprintln!(
-                        "[WRN] ignoring invalid allowed-origins wildcard '{}': {}",
-                        item, e
-                    ),
-                }
-            }
-        }
-    }
+    // Parse allowed origins into the exact list, the compiled (anchored)
+    // patterns, and the `*` opt-in. See `cors::compile_allowed_origins`.
+    let origin_rules = compile_allowed_origins(args.allowed_origins.as_deref());
+    let origin_rejections = origin_rules.rejected;
 
     let allow_methods = args
         .cors_allow_methods
@@ -161,10 +134,7 @@ pub async fn run_server(args: ServerArgs) -> Result<(), String> {
     // for. Creating it up front also means the file exists immediately, so
     // `tail -F` works from before the first request.
     if let Some(path) = &args.log_file
-        && let Err(e) = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
+        && let Err(e) = open_log_file(path)
     {
         let msg = format!("Cannot open --log-file {}: {}", path, e);
         eprintln!("{}", msg);
@@ -175,9 +145,9 @@ pub async fn run_server(args: ServerArgs) -> Result<(), String> {
         api_key,
         jobs: Arc::new(Mutex::new(HashMap::new())),
         log_file: args.log_file.clone(),
-        allowed_origins: allowed_origins_vec,
-        allowed_origin_regexes,
-        allow_all_origins,
+        allowed_origins: origin_rules.origins,
+        allowed_origin_regexes: origin_rules.regexes,
+        allow_all_origins: origin_rules.allow_all,
         allow_methods,
         allow_headers,
         jsonp_enabled: args.jsonp,
@@ -239,18 +209,95 @@ pub async fn run_server(args: ServerArgs) -> Result<(), String> {
         );
     }
 
-    // JSONP is served to `<script src>` loads, which carry no Origin to check,
-    // so turning it on necessarily switches off the cross-site gate (see
-    // `auth::check_cross_site`). Combined with no API key, that means any page
-    // the operator visits can both launch scans and read their results.
-    if state.jsonp_enabled && auth_disabled {
+    // A short key is not a boundary. Nothing here throttles or locks out a
+    // wrong `X-API-KEY`, so the only cost of a guess is one request — an
+    // attacker who can reach the port walks a small keyspace at line rate.
+    // Warn rather than refuse: the key may be a deployment-generated value the
+    // operator cannot lengthen, and refusing to start would be worse than
+    // running with a weak one they were told about.
+    //
+    // Counted in characters, matching what the message and the docs promise —
+    // `len()` would let a 12-character non-ASCII key past a byte comparison.
+    // The exact count stays out of the message: `constant_time_eq` deliberately
+    // confines key length to a timing difference, and this line is written to
+    // stdout and to `--log-file`, where it would become a durable one.
+    if !auth_disabled
+        && let Some(key) = state.api_key.as_deref()
+        && key.chars().count() < MIN_RECOMMENDED_API_KEY_LEN
+    {
         log(
             &state,
             "WRN",
-            "--jsonp is enabled with NO API key — any website the operator visits can \
-             launch scans through this API and read the results cross-origin. Set \
-             --api-key (or DALFOX_API_KEY), or drop --jsonp.",
+            &format!(
+                "--api-key is shorter than the recommended {} characters — nothing \
+                 rate-limits a wrong key, so a short one is guessable at line rate.",
+                MIN_RECOMMENDED_API_KEY_LEN
+            ),
         );
+    }
+
+    // Two flags switch the cross-site gate off outright — `check_cross_site`
+    // returns `Ok` for `jsonp_enabled || allow_all_origins` before it looks at
+    // anything. JSONP is served to `<script src>` loads, which carry no Origin
+    // to validate; `--allowed-origins '*'` says every origin is allowed, which
+    // is the same statement spelled differently. Combined with no API key,
+    // either one means any page the operator visits can launch scans through
+    // this API and read the results.
+    let gate_disabled_by = match (state.jsonp_enabled, state.allow_all_origins) {
+        (true, true) => Some("--jsonp and --allowed-origins '*' are"),
+        (true, false) => Some("--jsonp is"),
+        (false, true) => Some("--allowed-origins '*' is"),
+        (false, false) => None,
+    };
+    if let Some(flags) = gate_disabled_by
+        && auth_disabled
+    {
+        log(
+            &state,
+            "WRN",
+            &format!(
+                "{} enabled with NO API key — the cross-site gate is off, so any website \
+                 the operator visits can launch scans through this API and read the \
+                 results. Set --api-key (or DALFOX_API_KEY), or name the specific web UI \
+                 with --allowed-origins.",
+                flags
+            ),
+        );
+    }
+
+    // An origin pattern that could not be compiled is dropped, which fails
+    // closed: the web UI it described starts getting 403s from the cross-site
+    // gate. Reported here rather than at compile time so it lands in
+    // `--log-file` alongside the other startup warnings — under systemd a bare
+    // stderr line is exactly what nobody reads.
+    for rejection in &origin_rejections {
+        log(&state, "WRN", &format!("ignoring {}", rejection));
+    }
+
+    // `open_log_file` creates the file 0600, but the mode only applies at
+    // creation — a server upgraded in place keeps the world-readable file the
+    // previous version made, and every target URL in it (with whatever token
+    // made the target worth scanning) stays readable by every local account.
+    // Chmod-ing a file the operator may deliberately have opened up to a log
+    // group would be worse than saying so.
+    #[cfg(unix)]
+    if let Some(path) = &state.log_file {
+        use std::os::unix::fs::PermissionsExt;
+        if let Ok(meta) = std::fs::metadata(path) {
+            let mode = meta.permissions().mode() & 0o777;
+            if mode & 0o077 != 0 {
+                log(
+                    &state,
+                    "WRN",
+                    &format!(
+                        "--log-file {} is mode {:o} — it records every submitted target \
+                         URL, so any local account can read them. New log files are \
+                         created 0600; run `chmod 600 {}` on this one.",
+                        path, mode, path
+                    ),
+                );
+            }
+        }
     }
 
     let listener = match tokio::net::TcpListener::bind(addr).await {

--- a/src/server/response.rs
+++ b/src/server/response.rs
@@ -100,5 +100,17 @@ pub(crate) fn make_api_response<T: Serialize>(
         "X-Content-Type-Options",
         "nosniff".parse().expect("static nosniff header"),
     );
+    // Every response with a body is per-caller and sensitive: `GET /scan/{id}`
+    // and `/scans` return findings — including full request/response bodies
+    // when the submitter asked for them — and all of it is gated on a header
+    // (`X-API-KEY`) that no cache keys on. Without an explicit directive a
+    // shared cache or a reverse proxy may store a 200 under heuristic freshness
+    // and replay it to a caller who never presented the key, and the browser
+    // disk cache keeps a JSONP result around for whoever reads the profile
+    // next. `no-store` is the only directive that keeps it out of both.
+    cors.insert(
+        "Cache-Control",
+        "no-store".parse().expect("static cache-control header"),
+    );
     (status, cors, body)
 }

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -5267,3 +5267,88 @@ async fn test_options_preflights_are_source_gated() {
         Some("https://ui.example")
     );
 }
+
+/// The startup warnings are the only signal an operator gets for four
+/// misconfigurations that all fail silently at runtime: a log file the previous
+/// version left world-readable, an origin pattern that could not compile (its
+/// web UI just starts getting 403s), an API key short enough to guess, and a
+/// cross-site gate switched off by `--allowed-origins '*'`. They run once, at
+/// boot, on a path no other test reaches — so drive `run_server` far enough to
+/// emit them and read them back out of the log file they must reach.
+#[cfg(unix)]
+#[tokio::test]
+async fn test_run_server_warns_about_misconfiguration_before_serving() {
+    use std::os::unix::fs::PermissionsExt;
+
+    // Occupy a port so `run_server` returns right after the warnings.
+    let guard = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind guard listener");
+    let addr = guard.local_addr().expect("guard addr");
+
+    // `api_key` splits the warnings into two runs: the short-key warning needs
+    // a key, and the gate warning only fires when there is none.
+    let boot = async |api_key: Option<&str>, label: &str| -> String {
+        // Pre-create the log file world-readable, the way an in-place upgrade
+        // from a version without `open_log_file` leaves it.
+        let path = temp_log_path(label);
+        std::fs::write(&path, "").expect("seed log file");
+        std::fs::set_permissions(&path, std::fs::Permissions::from_mode(0o644))
+            .expect("seed log file mode");
+
+        let err = run_server(ServerArgs {
+            port: addr.port(),
+            host: Ipv4Addr::LOCALHOST.to_string(),
+            api_key: api_key.map(str::to_string),
+            log_file: Some(path.to_string_lossy().into_owned()),
+            rate_limit: None,
+            scan_timeout: None,
+            max_concurrent_scans: 100,
+            allowed_hosts: None,
+            max_retained_scans: 1000,
+            max_body_bytes: 1_048_576,
+            allowed_origins: Some("*,regex:https://(unclosed,regex:".to_string()),
+            jsonp: false,
+            callback_param_name: "callback".to_string(),
+            cors_allow_methods: None,
+            cors_allow_headers: None,
+        })
+        .await;
+        assert!(err.is_err(), "the occupied port must still surface");
+
+        let logged = std::fs::read_to_string(&path).expect("read back the log file");
+        let _ = std::fs::remove_file(&path);
+        logged
+    };
+
+    let with_key = boot(Some("short-key"), "startup-warnings-keyed").await;
+    assert!(
+        with_key.contains("--api-key is shorter than the recommended"),
+        "nothing rate-limits a wrong key, so a short one has to be called out, \
+         got:\n{with_key}"
+    );
+    assert!(
+        !with_key.contains("9 characters"),
+        "the exact key length is what constant_time_eq confines to a timing \
+         difference; it must not become a durable record, got:\n{with_key}"
+    );
+    assert!(
+        with_key.contains("unclosed") && with_key.contains("empty allowed-origins regex"),
+        "a dropped pattern fails closed, so the report has to reach --log-file \
+         rather than a bare stderr line, got:\n{with_key}"
+    );
+    assert!(
+        with_key.contains("is mode 644"),
+        "an upgraded-in-place log file keeps its old mode, which is the case \
+         `open_log_file` cannot fix on its own, got:\n{with_key}"
+    );
+
+    let no_key = boot(None, "startup-warnings-open").await;
+    assert!(
+        no_key.contains("--allowed-origins '*' is enabled with NO API key"),
+        "'*' switches the cross-site gate off exactly like --jsonp and must be \
+         flagged the same way, got:\n{no_key}"
+    );
+
+    drop(guard);
+}

--- a/src/server/tests.rs
+++ b/src/server/tests.rs
@@ -5014,3 +5014,256 @@ fn test_callback_url_validation_and_dispatch_agree_on_the_scheme() {
         );
     }
 }
+
+/// Build the state a real `run_server` would from an `--allowed-origins`
+/// value, so the gate is exercised through the same compilation path the
+/// binary uses rather than through hand-placed regexes.
+fn state_from_allowed_origins(spec: &str) -> AppState {
+    let rules = compile_allowed_origins(Some(spec));
+    let mut state = make_state(None, None, false, false, "callback");
+    state.allowed_origins = rules.origins;
+    state.allowed_origin_regexes = rules.regexes;
+    state.allow_all_origins = rules.allow_all;
+    state
+}
+
+/// `regex:` patterns must match the **whole** `Origin`.
+///
+/// `Regex::is_match` searches anywhere in the subject, so an unanchored
+/// `https://app\.example\.com` was also a substring of
+/// `https://app.example.com.evil.com` — a host anyone can register. That is
+/// not a CORS-header-only problem: `origin_allowed` is what the cross-site
+/// gate consults, so the attacker's page got a pass through it and could
+/// drive the whole API (launch scans, read results) from the operator's
+/// browser — the one boundary `auth.rs` exists to hold.
+#[test]
+fn test_allowed_origins_regex_is_anchored_to_the_whole_origin() {
+    let state = state_from_allowed_origins(r"regex:https://app\.example\.com");
+
+    assert!(
+        origin_allowed(&state, "https://app.example.com"),
+        "the origin the operator described must still be allowed"
+    );
+    // The reachable forgery: an `Origin` is `scheme://host[:port]`, so the only
+    // way an attacker gets the pattern to appear inside one is to register a
+    // host that extends it.
+    for forged in [
+        "https://app.example.com.evil.com",
+        "https://app.example.com.evil.com:8443",
+    ] {
+        assert!(
+            !origin_allowed(&state, forged),
+            "'{forged}' merely contains the pattern; matching it hands an \
+             attacker-registered host a pass through the cross-site gate"
+        );
+    }
+
+    // The gate itself, not just the matcher, must refuse it.
+    let mut headers = HeaderMap::new();
+    headers.insert(
+        "Origin",
+        HeaderValue::from_static("https://app.example.com.evil.com"),
+    );
+    let denied = check_request_source(&state, &headers)
+        .expect_err("a suffix-forged origin must not pass the cross-site gate");
+    assert_eq!(denied.status(), StatusCode::FORBIDDEN);
+}
+
+/// Anchoring must not break the patterns operators already write: an
+/// explicitly anchored pattern keeps working (the added anchors assert the
+/// same positions), and a top-level alternation must be wrapped rather than
+/// split — `^a|b$` would accept anything ending in `b`.
+#[test]
+fn test_anchoring_preserves_explicit_anchors_and_alternation() {
+    let already = state_from_allowed_origins(r"regex:^https://.*\.example\.com$");
+    assert!(origin_allowed(&already, "https://api.example.com"));
+    assert!(!origin_allowed(
+        &already,
+        "https://api.example.com.evil.com"
+    ));
+
+    let alt = state_from_allowed_origins(r"regex:https://a\.test|https://b\.test");
+    assert!(origin_allowed(&alt, "https://a.test"));
+    assert!(origin_allowed(&alt, "https://b.test"));
+    assert!(
+        !origin_allowed(&alt, "https://evil.test/https://b.test"),
+        "the alternation must be anchored as a whole, not just its last branch"
+    );
+}
+
+#[test]
+fn test_compile_allowed_origins_handles_star_wildcards_and_bad_patterns() {
+    let star = compile_allowed_origins(Some("*, https://app.example.com"));
+    assert!(star.allow_all);
+
+    let wild = state_from_allowed_origins("https://*.corp.local");
+    assert!(origin_allowed(&wild, "https://ui.corp.local"));
+    assert!(
+        !origin_allowed(&wild, "https://ui.corp.local.evil.com"),
+        "the wildcard form has always been anchored and must stay that way"
+    );
+
+    // An uncompilable pattern is dropped, which fails closed: nothing matches
+    // it rather than everything.
+    let broken = compile_allowed_origins(Some("regex:https://(unclosed"));
+    assert!(broken.regexes.is_empty());
+    assert!(!broken.allow_all);
+
+    // No flag at all leaves the exact list unset, which `build_cors_headers`
+    // reads as "emit no CORS headers".
+    assert!(compile_allowed_origins(None).origins.is_none());
+}
+
+/// Findings — including full request/response bodies when the submitter asked
+/// for them — are authorized by a header no cache keys on, so every response
+/// has to opt out of storage explicitly.
+#[tokio::test]
+async fn test_api_responses_are_never_cacheable() {
+    let state = make_state(Some("k"), None, false, false, "callback");
+    let resp = ApiResponse::<serde_json::Value> {
+        code: 200,
+        msg: "ok".to_string(),
+        data: None,
+    };
+    let (_, headers, _) = make_api_response(
+        &state,
+        &HeaderMap::new(),
+        &Map::new(),
+        StatusCode::OK,
+        &resp,
+    );
+    assert_eq!(
+        headers.get("Cache-Control").and_then(|v| v.to_str().ok()),
+        Some("no-store"),
+        "a shared cache or the browser disk cache must not retain scan results"
+    );
+}
+
+/// The log records every submitted target URL verbatim, and a scan target
+/// routinely carries the credential that made it worth scanning. Creating the
+/// file `0644` published all of it to every local account on the host.
+#[cfg(unix)]
+#[test]
+fn test_log_file_is_created_private_to_the_owner() {
+    use std::os::unix::fs::PermissionsExt;
+
+    let path = temp_log_path("perms");
+    let _ = std::fs::remove_file(&path);
+    let state = AppState {
+        log_file: Some(path.to_string_lossy().into_owned()),
+        ..make_state(None, None, false, false, "callback")
+    };
+    log(
+        &state,
+        "JOB",
+        "queued id=x url=https://example.com/?token=secret",
+    );
+
+    let mode = std::fs::metadata(&path)
+        .expect("the log file must exist after a log line")
+        .permissions()
+        .mode()
+        & 0o777;
+    assert_eq!(
+        mode, 0o600,
+        "the log file must not be readable by other local accounts, got {mode:o}"
+    );
+    let _ = std::fs::remove_file(&path);
+}
+
+/// Scheme and host are case-insensitive per RFC 6454, and `check_host` already
+/// treats the sibling `Host` value that way. A byte-exact compare turned an
+/// allow-list entry with any capitalization into a silently dead rule: the
+/// browser sends the lowercased origin, so the operator's own web UI got a 403
+/// with nothing pointing at the cause.
+#[test]
+fn test_exact_origin_entries_are_matched_case_insensitively() {
+    let state = state_from_allowed_origins("https://App.Corp.Local");
+    assert!(origin_allowed(&state, "https://app.corp.local"));
+    assert!(origin_allowed(&state, "https://APP.CORP.LOCAL"));
+    assert!(!origin_allowed(&state, "https://other.corp.local"));
+}
+
+/// `regex:` with nothing after it anchors to `^(?:)$`, which matches the empty
+/// string — so a stray prefix left while editing the list would admit a request
+/// carrying an empty `Origin`, and admitting it skips the `Sec-Fetch-Site`
+/// fallback entirely.
+#[test]
+fn test_empty_regex_entry_is_rejected_rather_than_matching_an_empty_origin() {
+    let rules = compile_allowed_origins(Some("regex:"));
+    assert!(rules.regexes.is_empty());
+    assert_eq!(rules.rejected.len(), 1, "the operator must be told");
+
+    let state = state_from_allowed_origins("regex:");
+    assert!(!origin_allowed(&state, ""));
+}
+
+/// A dropped pattern fails closed, so the only way an operator learns why their
+/// web UI started getting 403s is this report — which has to reach `--log-file`,
+/// not just stderr.
+#[test]
+fn test_uncompilable_origin_patterns_are_reported_for_logging() {
+    let rules = compile_allowed_origins(Some("regex:https://(unclosed, https://ok.example"));
+    assert!(rules.regexes.is_empty());
+    assert_eq!(rules.rejected.len(), 1);
+    assert!(
+        rules.rejected[0].contains("unclosed"),
+        "the report must name the offending entry, got {:?}",
+        rules.rejected
+    );
+}
+
+/// `check_cross_site` returns `Ok` for `allow_all_origins` before it looks at
+/// anything, exactly as it does for `jsonp_enabled` — so `--allowed-origins '*'`
+/// switches the gate off just as completely and has to be flagged the same way.
+#[test]
+fn test_wildcard_star_disables_the_cross_site_gate_like_jsonp() {
+    let state = state_from_allowed_origins("*");
+    assert!(state.allow_all_origins);
+
+    let mut headers = HeaderMap::new();
+    headers.insert("Origin", HeaderValue::from_static("https://evil.example"));
+    headers.insert("Sec-Fetch-Site", HeaderValue::from_static("cross-site"));
+    assert!(
+        check_request_source(&state, &headers).is_ok(),
+        "'*' is an explicit opt-out of the gate; the startup warning is what \
+         makes that visible to the operator"
+    );
+}
+
+/// The CORS preflights answer before any handler auth, so without the source
+/// gate they hand a page the operator visits — or a rebound `Host` — a 204 that
+/// confirms a dalfox server is listening, which is the fingerprint `/health`'s
+/// own gate exists to deny.
+#[tokio::test]
+async fn test_options_preflights_are_source_gated() {
+    let state = make_state(None, Some(vec!["https://ui.example"]), false, false, "cb");
+
+    let mut rebound = HeaderMap::new();
+    rebound.insert("Host", HeaderValue::from_static("evil.example"));
+    let resp = options_scan_handler(State(state.clone()), rebound)
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    let mut cross = HeaderMap::new();
+    cross.insert("Origin", HeaderValue::from_static("https://evil.example"));
+    let resp = super::options_result_handler(State(state.clone()), cross, Path("id".to_string()))
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::FORBIDDEN);
+
+    // The configured web UI's own preflight still gets its 204 + ACAO.
+    let mut allowed = HeaderMap::new();
+    allowed.insert("Origin", HeaderValue::from_static("https://ui.example"));
+    let resp = options_scan_handler(State(state), allowed)
+        .await
+        .into_response();
+    assert_eq!(resp.status(), StatusCode::NO_CONTENT);
+    assert_eq!(
+        resp.headers()
+            .get("access-control-allow-origin")
+            .and_then(|v| v.to_str().ok()),
+        Some("https://ui.example")
+    );
+}

--- a/src/server/types.rs
+++ b/src/server/types.rs
@@ -19,7 +19,11 @@ pub struct ServerArgs {
     #[arg(long = "api-key")]
     pub api_key: Option<String>,
 
-    /// Path to a log file to also write logs (plain text, no ANSI colors)
+    /// Path to a log file to also write logs (plain text, no ANSI colors).
+    /// Created mode 0600 on Unix — the log records every submitted target URL,
+    /// which routinely carries the credential that made it worth scanning. An
+    /// existing file keeps its current permissions; the server warns at startup
+    /// if it is readable by group or other.
     #[clap(help_heading = "SERVER")]
     #[arg(long = "log-file")]
     pub log_file: Option<String>,
@@ -73,14 +77,16 @@ pub struct ServerArgs {
     pub max_body_bytes: usize,
 
     /// Comma-separated list of allowed origins for CORS. Supports:
-    /// - "*" (match all)
-    /// - exact origins (http://localhost:3000)
+    /// - "*" (match all; also switches the cross-site gate off)
+    /// - exact origins (http://localhost:3000), compared case-insensitively
     /// - "regex:<pattern>" for regex
+    ///
+    /// Both pattern forms are anchored to the whole `Origin`.
     #[clap(help_heading = "CORS")]
     #[arg(
         long = "allowed-origins",
-        help = "Comma-separated list of allowed origins for CORS.\nSupports:\n  - \"*\" wildcard (match all)\n  - exact origins (http://localhost:3000)\n  - \"regex:<pattern>\" for regex",
-        long_help = "Comma-separated list of allowed origins for CORS.\nSupports:\n  - \"*\" wildcard (match all)\n  - exact origins (http://localhost:3000)\n  - \"regex:<pattern>\" for regex"
+        help = "Comma-separated list of allowed origins for CORS.\nSupports:\n  - \"*\" wildcard (match all, and switches the cross-site gate off)\n  - exact origins (http://localhost:3000), compared case-insensitively\n  - \"regex:<pattern>\" for regex\nPatterns match the whole Origin, so they must cover the port too.",
+        long_help = "Comma-separated list of allowed origins for CORS.\nSupports:\n  - \"*\" wildcard (match all, and switches the cross-site gate off)\n  - exact origins (http://localhost:3000), compared case-insensitively\n  - \"regex:<pattern>\" for regex\n\nBoth pattern forms are anchored to the whole Origin, so a longer host that\nmerely contains one is refused — and a pattern must cover the port when the\norigins it describes carry one (https://app.example.com:8443)."
     )]
     pub allowed_origins: Option<String>,
 

--- a/src/server/util.rs
+++ b/src/server/util.rs
@@ -273,6 +273,25 @@ pub(crate) fn at_capacity_response(state: &AppState) -> ApiResponse<serde_json::
     }
 }
 
+/// Open (creating if needed) the `--log-file` for appending.
+///
+/// On Unix the file is created `0600`. The log records target URLs verbatim,
+/// and a scan target routinely carries the credential that made it worth
+/// scanning — a session id, a signed URL, an `?api_key=` — so the default
+/// `0644` published every submitted URL to every local account on the host.
+/// The mode only applies at creation, so an existing file keeps whatever
+/// permissions the operator gave it.
+pub(crate) fn open_log_file(path: &str) -> std::io::Result<std::fs::File> {
+    let mut opts = std::fs::OpenOptions::new();
+    opts.create(true).append(true);
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::OpenOptionsExt;
+        opts.mode(0o600);
+    }
+    opts.open(path)
+}
+
 /// Emit a structured server log line — gray `{ts}` + colored `{level}` token +
 /// message — to stdout and, when `--log-file` is set, append it to that file.
 /// The message is run through [`sanitize_log_message`](crate::utils::log::sanitize_log_message)
@@ -295,13 +314,9 @@ pub(crate) fn log(state: &AppState, level: &str, message: &str) {
 
     if let Some(path) = &state.log_file {
         let line = format!("[{}] [{}] {}\n", ts, lvl, message);
-        let _ = std::fs::OpenOptions::new()
-            .create(true)
-            .append(true)
-            .open(path)
-            .and_then(|mut f| {
-                use std::io::Write;
-                f.write_all(line.as_bytes())
-            });
+        let _ = open_log_file(path).and_then(|mut f| {
+            use std::io::Write;
+            f.write_all(line.as_bytes())
+        });
     }
 }


### PR DESCRIPTION
## The bug

`--allowed-origins 'regex:<pattern>'` compiled the operator's pattern verbatim and matched it with `Regex::is_match`, which searches **anywhere** in the subject. An `Origin` has no delimiter to stop that at:

```
--allowed-origins 'regex:https://app\.example\.com'
→ Origin: https://app.example.com.evil.com   ← accepted
```

That host is one an attacker simply registers. And it is not a CORS-header-only leak — `origin_allowed` is what `auth::check_cross_site` consults, so the forged origin took the **allow** branch of the cross-site gate and let an attacker's page drive the whole API from the operator's browser: launch scans, read findings, ship them to any `callback_url`. `SECURITY.md` names exactly this as in scope ("a browser page driving the local server past the cross-site gate").

The sibling wildcard form (`https://*.corp.local`) was already anchored, and every doc example spells `^…$`, so the two forms disagreed on the one thing that mattered.

## The fix

Origin compilation moves out of `run_server` into `cors::compile_allowed_origins`, where **both** forms go through `^(?:…)$`. The non-capturing group is load-bearing: a top-level alternation must be wrapped, not split (`^a|b$` accepts anything ending in `b`). A pattern that already carries `^…$` is unaffected — the added anchors assert the same positions.

Reverting just the anchoring makes three of the new tests fail, so they are real regression guards.

## Alongside it

The surrounding secret-handling gaps in the same command:

| | |
|---|---|
| `--log-file` mode | Created `0600`. It records every submitted target URL, and a target routinely carries the credential that made it worth scanning; `0644` published all of it to every local account. An existing file keeps its mode, so the server warns when an in-place upgrade leaves a group/other-readable log behind. |
| `Cache-Control: no-store` | Findings are authorized by a header no cache keys on, so a shared cache could store a 200 under heuristic freshness and replay it to a caller with no key. |
| `--allowed-origins '*'` warning | `check_cross_site` returns `Ok` for `jsonp_enabled \|\| allow_all_origins` before it looks at anything. Only `--jsonp` was warned about; `*` switches the gate off just as completely. |
| `OPTIONS` source gate | The preflights answered before any check, so a rebound `Host` got a 204 confirming a dalfox server is listening — the fingerprint `/health`'s own gate exists to deny. A real preflight from an allowed origin still gets its 204 + ACAO. |
| Short `--api-key` warning | Nothing throttles a wrong key, so its length is the whole cost of a guess. The message omits the exact count, which `constant_time_eq` deliberately confines to a timing difference. |
| Dropped patterns reported | An uncompilable pattern — or an empty `regex:` left behind while editing the list, which anchored to `^(?:)$` and matched an empty `Origin` — is dropped and logged through `log()` rather than a bare `eprintln!` that never reaches `--log-file`. |
| Case-insensitive exact origins | RFC 6454 and the sibling `Host` gate both normalize case; a byte-exact compare made `https://App.Corp.Local` a silently dead rule that 403'd the operator's own web UI. |

## Deliberately not changed

- **Webhook / target / remote-payload SSRF** — `SECURITY.md` declares this out of scope by design ("We deliberately do not filter target or callback hosts").
- **`Sec-Fetch-Site` absent → allowed** — closes a `<img src>` CSRF only on Safari < 16.4, and the obvious alternative (a `Referer` check) is defeated by the attacker setting `referrer-policy: no-referrer` on their own page. Net zero, at the cost of complexity in an auth gate.
- **Scan-id predictability** (`SHA-256(url:nanos)`) — auth is global, so the id is not a capability and crosses no boundary the operator chose.
- **`*` expanding to `.*`** — `https://evil.com@ui.corp.local` and `https://evil.com/…` are not values a browser can put in an `Origin`, and tightening to `[^/@:]*` would regress `https://*` against origins carrying a port.

## Verification

- `cargo test` — 2393 + integration, all green; `clippy --all-targets` and `fmt` clean.
- Live smoke test against a real `dalfox server`: forged suffix origin → `403`, the configured origin → `200` + ACAO, `nosniff` + `no-store` on both, log file created `-rw-------`, and all four startup warnings firing.

Docs (en/ko), `--help`, and the agent skill bundle move with the behavior; the `change-me` examples become a key that would not itself trip the new length warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01XCpH7WWo9Zc6iY8gxMfPES