### PR TITLE
feat(xss): expand coverage — GraphQL/XML injection, DOM dataflow gaps, filter bypass

### DIFF
--- a/src/cmd/scan/poc.rs
+++ b/src/cmd/scan/poc.rs
@@ -40,6 +40,8 @@ fn poc_location_tag(location: &str, param: &str) -> Option<&'static str> {
         // Header location with the literal `Cookie` name folds to a cookie POC.
         "Header" if param.eq_ignore_ascii_case("cookie") => Some("cookie"),
         "Header" => Some("hdr"),
+        "GraphqlBody" => Some("graphql"),
+        "XmlBody" => Some("xml"),
         "Body" | "JsonBody" | "MultipartBody" => Some("body"),
         "Path" => Some("path"),
         "Fragment" => Some("frag"),
@@ -216,8 +218,43 @@ fn render_curl_poc(result: &crate::scanning::result::Result, attack_url: &str) -
             escaped(&result.payload),
             attack_url
         ),
+        // GraphQL / XML carry a full structured document as the body — a
+        // faithful one-liner can't be rebuilt from (param, payload) alone, so
+        // replay the exact recorded request body (rebuilt from the param's
+        // pipeline in `build_request_text`). Falls back to a plain-URL curl if
+        // the request text wasn't recorded.
+        "GraphqlBody" | "XmlBody" => match request_content_type_and_body(result.request.as_deref())
+        {
+            Some((ct, body)) => format!(
+                "curl -X {} -H \"Content-Type: {}\" --data \"{}\" \"{}\"\n",
+                method,
+                escaped(&ct),
+                escaped(body),
+                attack_url
+            ),
+            None => format!("curl -X {} \"{}\"\n", method, attack_url),
+        },
         _ => format!("curl -X {} \"{}\"\n", method, attack_url),
     }
+}
+
+/// Extract `(Content-Type, body)` from a recorded raw HTTP request text
+/// (`build_request_text` output). The body is everything after the blank line
+/// that separates headers from body (`\r\n\r\n`); the Content-Type is read
+/// from the headers. Returns `None` when there is no body section.
+fn request_content_type_and_body(request: Option<&str>) -> Option<(String, &str)> {
+    let request = request?;
+    let (head, body) = request.split_once("\r\n\r\n")?;
+    let ct = head
+        .lines()
+        .find_map(|line| {
+            let (k, v) = line.split_once(':')?;
+            k.trim()
+                .eq_ignore_ascii_case("content-type")
+                .then(|| v.trim().to_string())
+        })
+        .unwrap_or_else(|| "application/octet-stream".to_string());
+    Some((ct, body))
 }
 
 /// `httpie` mirror of [`render_curl_poc`].
@@ -240,6 +277,19 @@ fn render_httpie_poc(result: &crate::scanning::result::Result, attack_url: &str)
             "http {} \"{}\" \"{}={}\"\n",
             method, attack_url, result.param, result.payload
         ),
+        // Feed the exact recorded structured body to httpie via stdin — its
+        // `key=value` field syntax can't express a full GraphQL/XML document.
+        "GraphqlBody" | "XmlBody" => match request_content_type_and_body(result.request.as_deref())
+        {
+            Some((ct, body)) => format!(
+                "http {} \"{}\" \"Content-Type:{}\" <<< '{}'\n",
+                method,
+                attack_url,
+                ct,
+                body.replace('\'', "'\\''")
+            ),
+            None => format!("http {} \"{}\"\n", method, attack_url),
+        },
         _ => format!("http {} \"{}\"\n", method, attack_url),
     }
 }

--- a/src/cmd/scan/poc/tests.rs
+++ b/src/cmd/scan/poc/tests.rs
@@ -100,3 +100,54 @@ fn poc_location_in_url_false_for_side_channel_locations() {
     assert!(!poc_location_in_url("JsonBody"));
     assert!(!poc_location_in_url("MultipartBody"));
 }
+
+#[test]
+fn poc_location_tag_graphql_and_xml() {
+    assert_eq!(poc_location_tag("GraphqlBody", "variables.n"), Some("graphql"));
+    assert_eq!(poc_location_tag("XmlBody", "msg"), Some("xml"));
+}
+
+#[test]
+fn poc_location_in_url_false_for_graphql_and_xml() {
+    // Structured bodies are side-channel deliveries — never synthesize a
+    // `?param=payload` query for them.
+    assert!(!poc_location_in_url("GraphqlBody"));
+    assert!(!poc_location_in_url("XmlBody"));
+}
+
+#[test]
+fn request_ct_and_body_splits_headers_from_body() {
+    let req = "POST /graphql HTTP/1.1\r\nHost: x\r\nContent-Type: application/json\r\nContent-Length: 9\r\n\r\n{\"a\":\"b\"}";
+    let (ct, body) = request_content_type_and_body(Some(req)).expect("has body");
+    assert_eq!(ct, "application/json");
+    assert_eq!(body, "{\"a\":\"b\"}");
+}
+
+#[test]
+fn request_ct_and_body_none_when_no_body_section() {
+    // A request with no blank-line separator yields no body.
+    assert!(request_content_type_and_body(Some("GET / HTTP/1.1\r\nHost: x")).is_none());
+    assert!(request_content_type_and_body(None).is_none());
+}
+
+#[test]
+fn graphql_curl_poc_reproduces_full_recorded_body() {
+    let req = "POST /graphql HTTP/1.1\r\nHost: h:8899\r\nContent-Type: application/json\r\nContent-Length: 5\r\n\r\n{\"query\":\"mutation($n:String){a(n:$n)}\",\"variables\":{\"n\":\"<svg onload=alert(1)>\"}}";
+    let r = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("POST")
+        .data("http://h:8899/graphql")
+        .param("variables.n")
+        .payload("<svg onload=alert(1)>")
+        .message_str("x")
+        .build();
+    let mut r = r;
+    r.location = "GraphqlBody".to_string();
+    r.request = Some(req.to_string());
+    let out = render_curl_poc(&r, "http://h:8899/graphql");
+    assert!(out.contains("-H \"Content-Type: application/json\""), "{out}");
+    // The full structured body (query + the injected variable) is present,
+    // not a lossy `{"variables.n":"payload"}` fragment.
+    assert!(out.contains("mutation($n:String)"), "{out}");
+    assert!(out.contains("\\\"variables\\\":{\\\"n\\\":\\\"<svg onload=alert(1)>\\\"}"), "{out}");
+}

--- a/src/encoding/pipeline.rs
+++ b/src/encoding/pipeline.rs
@@ -44,6 +44,15 @@ pub enum EncodingStep {
     /// Single-round percent encoding. Useful when an outer layer (e.g. JSON
     /// stringify) preserves characters that a query value cannot carry.
     Url,
+    /// Reconstruct a body around the payload by concatenating a fixed
+    /// `prefix`, the payload, and a fixed `suffix`. Used for structured text
+    /// bodies (XML/SOAP element text and attribute values) where the payload
+    /// occupies one exact byte range and the rest of the document must survive
+    /// byte-for-byte. Splitting the original body at the injection point and
+    /// re-gluing it around the raw payload avoids the lossy parse-and-reserialize
+    /// round-trip (and the `str::replace` "replace every occurrence" garble the
+    /// JSON builder was bitten by).
+    Splice { prefix: String, suffix: String },
     /// Assemble a JWT/JWS by gluing the supplied (already base64url-encoded)
     /// header and signature segments around the input. The input is treated
     /// as the already-encoded payload segment, so this step is normally
@@ -65,6 +74,7 @@ impl EncodingStep {
             EncodingStep::Base64 => Ok(STANDARD.encode(payload)),
             EncodingStep::Base64Url => Ok(URL_SAFE_NO_PAD.encode(payload)),
             EncodingStep::Url => Ok(urlencoding::encode(payload).to_string()),
+            EncodingStep::Splice { prefix, suffix } => Ok(format!("{prefix}{payload}{suffix}")),
             EncodingStep::JsonField { pointer, template } => {
                 let mut value = template.clone();
                 set_by_pointer(
@@ -366,6 +376,87 @@ fn infer_url_json(value: &str) -> Vec<NestedField> {
             pointer,
             template: json.clone(),
         }])
+    })
+}
+
+/// Detect a GraphQL-over-JSON request body and return one injection field per
+/// string leaf inside its `variables` object.
+///
+/// A body qualifies only when it is a JSON object carrying BOTH:
+///   * a `query` (or `mutation`) *string* whose text begins with a GraphQL
+///     operation (`query` / `mutation` / `subscription`, or the anonymous
+///     `{` shorthand), and
+///   * a `variables` object with at least one string leaf.
+///
+/// Requiring the `variables` object keeps ordinary JSON APIs that merely carry
+/// a field literally named `query` (a search box: `{"query":"laptop"}`) on the
+/// existing `JsonBody` path — they yield no fields here. Each returned field
+/// carries a `JsonField` pipeline that rebuilds the *entire* request with only
+/// that one variable replaced by the payload, so the server always receives a
+/// complete, parseable GraphQL request (query source + every other variable
+/// intact).
+///
+/// Scalar (non-string) variables are skipped: injection only targets values
+/// that are already strings, matching the minimal, false-positive-safe scope.
+pub(crate) fn infer_graphql_variable_fields(data: &str) -> Vec<NestedField> {
+    let Some(root) = parse_json_object_or_array(data) else {
+        return Vec::new();
+    };
+    let serde_json::Value::Object(map) = &root else {
+        return Vec::new();
+    };
+
+    // `query` is the GraphQL-spec transport field name; some clients send the
+    // operation under `mutation`. Either way it must be a string that reads as
+    // an operation.
+    let op_src = map.get("query").or_else(|| map.get("mutation"));
+    let Some(serde_json::Value::String(op)) = op_src else {
+        return Vec::new();
+    };
+    if !looks_like_graphql_operation(op) {
+        return Vec::new();
+    }
+
+    let Some(vars) = map.get("variables") else {
+        return Vec::new();
+    };
+    if !vars.is_object() {
+        return Vec::new();
+    }
+
+    // Walk string leaves under `variables`, then re-root each pointer/path at
+    // `/variables` and attach a whole-request rebuild pipeline.
+    let mut leaves = collect_leaves(vars);
+    if leaves.is_empty() {
+        return Vec::new();
+    }
+    for nf in &mut leaves {
+        nf.pointer = format!("/variables{}", nf.pointer);
+        let mut path = vec!["variables".to_string()];
+        path.extend(std::mem::take(&mut nf.path));
+        nf.path = path;
+    }
+    attach_pipelines(leaves, move |pointer| {
+        EncodingPipeline::new(vec![EncodingStep::JsonField {
+            pointer,
+            template: root.clone(),
+        }])
+    })
+}
+
+/// True when a string reads as the start of a GraphQL operation: the
+/// `query` / `mutation` / `subscription` keyword (followed by whitespace, `{`,
+/// or `(`), or the anonymous-query `{` shorthand. Rejects a bare field value
+/// like `"queryable"` so a search API is not mistaken for GraphQL.
+fn looks_like_graphql_operation(s: &str) -> bool {
+    let t = s.trim_start();
+    if t.starts_with('{') {
+        return true;
+    }
+    ["query", "mutation", "subscription"].iter().any(|kw| {
+        t.strip_prefix(kw).is_some_and(|rest| {
+            rest.starts_with(|c: char| c.is_whitespace() || c == '{' || c == '(')
+        })
     })
 }
 

--- a/src/encoding/pipeline/tests.rs
+++ b/src/encoding/pipeline/tests.rs
@@ -473,3 +473,115 @@ fn jwt_alg_none_empty_signature_is_discovered() {
         "alg=none JWT must yield nested-field leaves, got none"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Splice step
+// ---------------------------------------------------------------------------
+
+#[test]
+fn step_splice_reglues_prefix_and_suffix() {
+    let step = EncodingStep::Splice {
+        prefix: "<a>".to_string(),
+        suffix: "</a>".to_string(),
+    };
+    let out = step.apply("<svg onload=alert(1)>").expect("splice");
+    assert_eq!(out, "<a><svg onload=alert(1)></a>");
+}
+
+#[test]
+fn step_splice_preserves_rest_of_document_byte_for_byte() {
+    // The whole document minus the injected span survives verbatim — the point
+    // of `Splice` over parse-and-reserialize.
+    let original = "<note><to>Bob</to><body>hi</body></note>";
+    // Inject at the <to> text node "Bob" (bytes 10..13).
+    let (prefix, rest) = original.split_at(10);
+    let suffix = &rest[3..];
+    let step = EncodingStep::Splice {
+        prefix: prefix.to_string(),
+        suffix: suffix.to_string(),
+    };
+    let out = step.apply("PAY").expect("splice");
+    assert_eq!(out, "<note><to>PAY</to><body>hi</body></note>");
+}
+
+// ---------------------------------------------------------------------------
+// GraphQL variable-field detection
+// ---------------------------------------------------------------------------
+
+#[test]
+fn graphql_variables_string_leaf_is_detected() {
+    let data = r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#;
+    let fields = infer_graphql_variable_fields(data);
+    assert_eq!(fields.len(), 1);
+    assert_eq!(fields[0].pointer, "/variables/n");
+    assert_eq!(fields[0].path, vec!["variables", "n"]);
+    // The pipeline rebuilds the whole request with the payload in that slot.
+    let body = fields[0].pipeline.apply("<svg/onload=alert(1)>").expect("apply");
+    let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid json");
+    assert_eq!(parsed["variables"]["n"], "<svg/onload=alert(1)>");
+    // Query source is preserved intact.
+    assert!(
+        parsed["query"].as_str().unwrap().contains("mutation"),
+        "query source must survive the rebuild"
+    );
+}
+
+#[test]
+fn graphql_nested_variables_object_is_walked() {
+    let data = r#"{"query":"query($f:Filter){search(f:$f){id}}","variables":{"f":{"title":"a","tag":"b"}}}"#;
+    let fields = infer_graphql_variable_fields(data);
+    let mut ptrs: Vec<&str> = fields.iter().map(|f| f.pointer.as_str()).collect();
+    ptrs.sort_unstable();
+    assert_eq!(ptrs, vec!["/variables/f/tag", "/variables/f/title"]);
+}
+
+#[test]
+fn graphql_anonymous_query_shorthand_is_detected() {
+    let data = r#"{"query":"{ me { name } }","variables":{"x":"y"}}"#;
+    assert_eq!(infer_graphql_variable_fields(data).len(), 1);
+}
+
+#[test]
+fn graphql_query_under_mutation_key_is_detected() {
+    let data = r#"{"mutation":"mutation Go($p:String){go(p:$p)}","variables":{"p":"z"}}"#;
+    assert_eq!(infer_graphql_variable_fields(data).len(), 1);
+}
+
+// --- FP controls: plain JSON must NOT be treated as GraphQL ---
+
+#[test]
+fn fp_control_search_api_with_query_field_is_not_graphql() {
+    // A REST search box literally named `query` and no `variables` object.
+    // Must produce zero GraphQL fields so it stays on the JsonBody path.
+    let data = r#"{"query":"laptop","page":1}"#;
+    assert!(infer_graphql_variable_fields(data).is_empty());
+}
+
+#[test]
+fn fp_control_query_field_without_variables_is_not_graphql() {
+    // Even a GraphQL-looking operation string is ignored without a `variables`
+    // object — nothing to inject, and requiring it blocks the search-box class.
+    let data = r#"{"query":"query { me { name } }"}"#;
+    assert!(infer_graphql_variable_fields(data).is_empty());
+}
+
+#[test]
+fn fp_control_queryable_field_value_is_not_graphql() {
+    // `queryable` starts with `query` but is a plain word, not an operation.
+    let data = r#"{"query":"queryable results","variables":{"x":"y"}}"#;
+    assert!(infer_graphql_variable_fields(data).is_empty());
+}
+
+#[test]
+fn fp_control_scalar_variables_are_skipped() {
+    // Only string leaves are injectable; a request whose variables are all
+    // numeric/bool yields no fields (no string to break out of).
+    let data = r#"{"query":"query($n:Int){f(n:$n)}","variables":{"n":5,"ok":true}}"#;
+    assert!(infer_graphql_variable_fields(data).is_empty());
+}
+
+#[test]
+fn fp_control_variables_not_object_is_ignored() {
+    let data = r#"{"query":"query{a}","variables":"oops"}"#;
+    assert!(infer_graphql_variable_fields(data).is_empty());
+}

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -1380,6 +1380,16 @@ pub async fn probe_json_body_params(
     if !base_json.is_object() {
         return;
     }
+    // A GraphQL request is JSON too, but its injection points live inside the
+    // `variables` object (handled by `probe_graphql_params`, which rebuilds the
+    // whole request per variable). Mining the top-level `query`/`variables`
+    // keys here would replace the `variables` object with a bare marker string
+    // and garble the request, so hand GraphQL bodies off entirely.
+    if let Some(data) = &args.data
+        && !crate::encoding::pipeline::infer_graphql_variable_fields(data).is_empty()
+    {
+        return;
+    }
 
     // Collect top-level keys to mutate
     let Some(obj) = base_json.as_object() else {
@@ -1551,6 +1561,138 @@ pub async fn probe_json_body_params(
     }
 }
 
+/// Seed GraphQL injection points from an `-d` GraphQL-over-JSON body.
+///
+/// Detects the GraphQL request shape (see
+/// [`crate::encoding::pipeline::infer_graphql_variable_fields`]) and probes each
+/// string value inside the `variables` object by rebuilding the whole request
+/// with a marker in that one slot. A field is seeded as a
+/// [`Location::GraphqlBody`] param — carrying the whole-request rebuild
+/// pipeline — only when the marker reflects, so an ordinary JSON API can never
+/// produce GraphQL params.
+///
+/// No-op unless `-d` parses as a GraphQL request, so REST/JSON/GET targets are
+/// unaffected. Bounded by the pipeline walker's leaf cap (≤32 fields).
+pub async fn probe_graphql_params(
+    target: &Target,
+    args: &ScanArgs,
+    reflection_params: Arc<Mutex<Vec<Param>>>,
+    semaphore: Arc<Semaphore>,
+    pb: Option<ShimmerSpinner>,
+) {
+    let Some(data) = &args.data else {
+        return;
+    };
+    let fields = crate::encoding::pipeline::infer_graphql_variable_fields(data);
+    if fields.is_empty() {
+        return;
+    }
+
+    if let Some(ref pb) = pb {
+        pb.set_length(fields.len() as u64);
+        pb.set_message("Probing GraphQL variables");
+    }
+
+    let arc_target = Arc::new(target.clone());
+    let client = target.build_client_or_default();
+    let silence = args.silence;
+    let marker = crate::scanning::markers::bracketed_marker();
+
+    let mut handles: Vec<tokio::task::JoinHandle<Option<Param>>> = Vec::new();
+    for nf in fields {
+        // Display name: `variables.<path>` (e.g. `variables.input.title`).
+        let name = nf.path.join(".");
+        // Slot-scoped skip: only suppress a GraphQL field already seeded here.
+        let exists = reflection_params
+            .lock()
+            .await
+            .iter()
+            .any(|p| p.name == name && p.location == Location::GraphqlBody);
+        if exists {
+            continue;
+        }
+
+        let client_clone = client.clone();
+        let url = target.url.clone();
+        let target_clone = arc_target.clone();
+        let semaphore_clone = semaphore.clone();
+        let delay = target.delay;
+        let pb_clone = pb.clone();
+        let pipeline = nf.pipeline.clone();
+        let original_value = nf.original_value.clone();
+        let name_for_task = name.clone();
+
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+
+                // Rebuild the full request with the marker in this one variable.
+                let body = match pipeline.apply(marker) {
+                    Ok(b) => b,
+                    Err(_) => {
+                        drop(permit);
+                        return None;
+                    }
+                };
+
+                let base = crate::utils::build_body_request_base(
+                    &client_clone,
+                    &target_clone,
+                    crate::scanning::url_inject::body_location_method(&target_clone.method),
+                    url,
+                    Some(body),
+                );
+                let request = crate::utils::apply_header_overrides(
+                    base,
+                    &[("Content-Type".to_string(), "application/json".to_string())],
+                );
+
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(r) = crate::utils::http::send_counted(request).await
+                    && let Ok(text) = crate::utils::http::read_body(r).await
+                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                {
+                    if !silence {
+                        eprintln!("Discovered GraphQL variable: {}", name_for_task);
+                    }
+                    discovered = Some(
+                        Param {
+                            pre_encoding_pipeline: Some(pipeline),
+                            ..Param::new(name_for_task, original_value, Location::GraphqlBody)
+                        }
+                        .with_reflection_analysis(&text),
+                    );
+                }
+
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                if let Some(ref pb) = pb_clone {
+                    pb.inc(1);
+                }
+                discovered
+            },
+        ));
+        handles.push(handle);
+    }
+
+    let mut batch: Vec<Param> = Vec::new();
+    for h in handles {
+        if let Ok(Some(p)) = h.await {
+            batch.push(p);
+        }
+    }
+    if !batch.is_empty() {
+        reflection_params.lock().await.extend(batch);
+    }
+}
+
 /// Seed multipart form-field params the operator named via `-p name:multipart`.
 ///
 /// Like [`probe_body_params`], these come from explicit `-d` input rather than
@@ -1698,6 +1840,16 @@ pub async fn mine_parameters(
     )
     .await;
     probe_json_body_params(
+        target,
+        args,
+        reflection_params.clone(),
+        semaphore.clone(),
+        pb.clone(),
+    )
+    .await;
+    // GraphQL variables: own path for GraphQL-over-JSON bodies (no-op on plain
+    // JSON, which `probe_json_body_params` already handled).
+    probe_graphql_params(
         target,
         args,
         reflection_params.clone(),

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -1693,6 +1693,169 @@ pub async fn probe_graphql_params(
     }
 }
 
+/// Whether the target's request body should be treated as XML for injection:
+/// its declared `Content-Type` is an XML-family type, or the body opens with an
+/// `<?xml` prolog. Deliberately strict so JSON / form / HTML bodies are not
+/// mistaken for XML.
+fn request_is_xml(target: &Target, data: &str) -> bool {
+    let ct_is_xml = target
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .map(|(_, v)| {
+            matches!(
+                crate::utils::content_type_primary(v).as_deref(),
+                Some("text/xml")
+                    | Some("application/xml")
+                    | Some("application/soap+xml")
+                    | Some("application/xhtml+xml")
+            )
+        })
+        .unwrap_or(false);
+    ct_is_xml || data.trim_start().starts_with("<?xml")
+}
+
+/// Seed XML / SOAP injection points from an `-d` XML body.
+///
+/// Runs only when the request body is XML (see [`request_is_xml`]). Tokenizes
+/// the document into element text nodes and attribute values (see
+/// [`crate::parameter_analysis::xml_inject::xml_injection_points`]) and probes
+/// each by splicing a marker into that one leaf — the rest of the document
+/// survives byte-for-byte. A leaf is seeded as a [`Location::XmlBody`] param,
+/// carrying the exact-byte-range `Splice` pipeline, only when the marker
+/// reflects, so a benign XML body that echoes nothing produces no params.
+///
+/// No-op on JSON / form / GET targets. Bounded by the tokenizer's point cap.
+pub async fn probe_xml_body_params(
+    target: &Target,
+    args: &ScanArgs,
+    reflection_params: Arc<Mutex<Vec<Param>>>,
+    semaphore: Arc<Semaphore>,
+    pb: Option<ShimmerSpinner>,
+) {
+    let Some(data) = &args.data else {
+        return;
+    };
+    if !request_is_xml(target, data) {
+        return;
+    }
+    let points = crate::parameter_analysis::xml_inject::xml_injection_points(data);
+    if points.is_empty() {
+        return;
+    }
+
+    if let Some(ref pb) = pb {
+        pb.set_length(points.len() as u64);
+        pb.set_message("Probing XML body");
+    }
+
+    let arc_target = Arc::new(target.clone());
+    let client = target.build_client_or_default();
+    let silence = args.silence;
+    let marker = crate::scanning::markers::bracketed_marker();
+    let content_type = crate::scanning::url_inject::xml_request_content_type(target);
+
+    let mut handles: Vec<tokio::task::JoinHandle<Option<Param>>> = Vec::new();
+    for point in points {
+        let name = point.name.clone();
+        let exists = reflection_params
+            .lock()
+            .await
+            .iter()
+            .any(|p| p.name == name && p.location == Location::XmlBody);
+        if exists {
+            continue;
+        }
+
+        // Exact-byte-range splice: prefix + payload + suffix rebuilds the whole
+        // document with only this leaf replaced.
+        let pipeline =
+            crate::encoding::pipeline::EncodingPipeline::new(vec![
+                crate::encoding::pipeline::EncodingStep::Splice {
+                    prefix: data[..point.start].to_string(),
+                    suffix: data[point.end..].to_string(),
+                },
+            ]);
+
+        let client_clone = client.clone();
+        let url = target.url.clone();
+        let target_clone = arc_target.clone();
+        let semaphore_clone = semaphore.clone();
+        let delay = target.delay;
+        let pb_clone = pb.clone();
+        let ct = content_type.clone();
+        let original_value = point.value.clone();
+        let name_for_task = name.clone();
+        let pipeline_for_task = pipeline.clone();
+
+        let handle = tokio::spawn(crate::with_job_scopes(
+            crate::JobScopes::capture(),
+            async move {
+                let permit = semaphore_clone
+                    .acquire()
+                    .await
+                    .expect("acquire semaphore permit");
+
+                let body = match pipeline_for_task.apply(marker) {
+                    Ok(b) => b,
+                    Err(_) => {
+                        drop(permit);
+                        return None;
+                    }
+                };
+
+                let base = crate::utils::build_body_request_base(
+                    &client_clone,
+                    &target_clone,
+                    crate::scanning::url_inject::body_location_method(&target_clone.method),
+                    url,
+                    Some(body),
+                );
+                let request =
+                    crate::utils::apply_header_overrides(base, &[("Content-Type".to_string(), ct)]);
+
+                crate::record_outbound_request().await;
+                let mut discovered: Option<Param> = None;
+                if let Ok(r) = crate::utils::http::send_counted(request).await
+                    && let Ok(text) = crate::utils::http::read_body(r).await
+                    && crate::scanning::markers::classify_probe_reflection(&text).detected()
+                {
+                    if !silence {
+                        eprintln!("Discovered XML injection point: {}", name_for_task);
+                    }
+                    discovered = Some(
+                        Param {
+                            pre_encoding_pipeline: Some(pipeline_for_task),
+                            ..Param::new(name_for_task, original_value, Location::XmlBody)
+                        }
+                        .with_reflection_analysis(&text),
+                    );
+                }
+
+                if delay > 0 {
+                    sleep(Duration::from_millis(delay)).await;
+                }
+                drop(permit);
+                if let Some(ref pb) = pb_clone {
+                    pb.inc(1);
+                }
+                discovered
+            },
+        ));
+        handles.push(handle);
+    }
+
+    let mut batch: Vec<Param> = Vec::new();
+    for h in handles {
+        if let Ok(Some(p)) = h.await {
+            batch.push(p);
+        }
+    }
+    if !batch.is_empty() {
+        reflection_params.lock().await.extend(batch);
+    }
+}
+
 /// Seed multipart form-field params the operator named via `-p name:multipart`.
 ///
 /// Like [`probe_body_params`], these come from explicit `-d` input rather than
@@ -1850,6 +2013,15 @@ pub async fn mine_parameters(
     // GraphQL variables: own path for GraphQL-over-JSON bodies (no-op on plain
     // JSON, which `probe_json_body_params` already handled).
     probe_graphql_params(
+        target,
+        args,
+        reflection_params.clone(),
+        semaphore.clone(),
+        pb.clone(),
+    )
+    .await;
+    // XML / SOAP element text + attribute values (no-op on non-XML bodies).
+    probe_xml_body_params(
         target,
         args,
         reflection_params.clone(),

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1439,3 +1439,109 @@ async fn test_probe_json_body_params_mines_a_name_already_discovered_in_the_quer
             .collect::<Vec<_>>()
     );
 }
+
+// --- GraphQL variable mining ---
+
+async fn graphql_reflect_handler(body: String) -> Html<String> {
+    // Reflect every string value inside `variables` into the HTML body raw.
+    let mut echo = String::new();
+    if let Ok(v) = serde_json::from_str::<serde_json::Value>(&body)
+        && let Some(vars) = v.get("variables")
+    {
+        fn walk(v: &serde_json::Value, out: &mut String) {
+            match v {
+                serde_json::Value::String(s) => {
+                    out.push_str(s);
+                    out.push(' ');
+                }
+                serde_json::Value::Object(m) => m.values().for_each(|x| walk(x, out)),
+                serde_json::Value::Array(a) => a.iter().for_each(|x| walk(x, out)),
+                _ => {}
+            }
+        }
+        walk(vars, &mut echo);
+    }
+    Html(format!("<html><body><div>{}</div></body></html>", echo))
+}
+
+async fn start_graphql_server() -> SocketAddr {
+    use axum::routing::post;
+    let app = Router::new().route("/graphql", post(graphql_reflect_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+#[tokio::test]
+async fn probe_graphql_params_seeds_reflected_variable() {
+    let addr = start_graphql_server().await;
+    let target = parse_target(&format!("http://{}:{}/graphql", addr.ip(), addr.port()))
+        .expect("parse target");
+    let mut args = default_scan_args();
+    args.data =
+        Some(r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#.to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_graphql_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    let gql: Vec<_> = params
+        .iter()
+        .filter(|p| p.location == Location::GraphqlBody)
+        .collect();
+    assert_eq!(gql.len(), 1, "expected one GraphQL variable param, got {params:?}");
+    assert_eq!(gql[0].name, "variables.n");
+    assert!(
+        gql[0].pre_encoding_pipeline.is_some(),
+        "GraphQL param must carry a whole-request rebuild pipeline"
+    );
+}
+
+#[tokio::test]
+async fn probe_graphql_params_noop_on_plain_json_body() {
+    // FP control: a non-GraphQL JSON body seeds zero GraphQL params even
+    // against a reflecting server.
+    let addr = start_graphql_server().await;
+    let target = parse_target(&format!("http://{}:{}/graphql", addr.ip(), addr.port()))
+        .expect("parse target");
+    let mut args = default_scan_args();
+    args.data = Some(r#"{"name":"seed","page":2}"#.to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_graphql_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    assert!(
+        reflection_params.lock().await.is_empty(),
+        "plain JSON body must not seed GraphQL params"
+    );
+}
+
+#[tokio::test]
+async fn probe_json_body_params_defers_graphql_body() {
+    // The JSON body probe must hand off GraphQL bodies to `probe_graphql_params`
+    // rather than mining the top-level `query`/`variables` keys (which would
+    // garble the request by replacing the `variables` object with a marker).
+    let addr = start_graphql_server().await;
+    let target = parse_target(&format!("http://{}:{}/graphql", addr.ip(), addr.port()))
+        .expect("parse target");
+    let mut args = default_scan_args();
+    args.data =
+        Some(r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#.to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_json_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    assert!(
+        reflection_params.lock().await.is_empty(),
+        "JSON body probe must skip GraphQL bodies (no top-level query/variables mining)"
+    );
+}

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1545,3 +1545,120 @@ async fn probe_json_body_params_defers_graphql_body() {
         "JSON body probe must skip GraphQL bodies (no top-level query/variables mining)"
     );
 }
+
+// --- XML / SOAP body mining ---
+
+async fn xml_reflect_handler(body: String) -> Html<String> {
+    // Reflect the first <msg>…</msg> text raw into an HTML page.
+    let echo = body
+        .split_once("<msg>")
+        .and_then(|(_, rest)| rest.split_once("</msg>"))
+        .map(|(inner, _)| inner.to_string())
+        .unwrap_or_default();
+    Html(format!("<html><body><p>{}</p></body></html>", echo))
+}
+
+async fn start_xml_server() -> SocketAddr {
+    use axum::routing::post;
+    let app = Router::new().route("/xml", post(xml_reflect_handler));
+    let listener = tokio::net::TcpListener::bind((Ipv4Addr::LOCALHOST, 0))
+        .await
+        .expect("bind listener");
+    let addr = listener.local_addr().expect("listener addr");
+    tokio::spawn(async move {
+        let _ = axum::serve(listener, app).await;
+    });
+    sleep(Duration::from_millis(20)).await;
+    addr
+}
+
+fn xml_target(addr: &SocketAddr) -> Target {
+    let mut t = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
+        .expect("parse target");
+    t.headers
+        .push(("Content-Type".to_string(), "application/xml".to_string()));
+    t
+}
+
+#[tokio::test]
+async fn probe_xml_body_params_seeds_reflected_text_node() {
+    let addr = start_xml_server().await;
+    let target = xml_target(&addr);
+    let mut args = default_scan_args();
+    args.data = Some("<req><item id=\"1\">x</item><msg>seed</msg></req>".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_xml_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+
+    let params = reflection_params.lock().await.clone();
+    let msg = params
+        .iter()
+        .find(|p| p.name == "msg" && p.location == Location::XmlBody)
+        .expect("msg text node seeded");
+    assert!(
+        msg.pre_encoding_pipeline.is_some(),
+        "XML param must carry a Splice pipeline"
+    );
+    // The pipeline rebuilds the whole document with the payload in <msg>.
+    let body = msg
+        .pre_encoding_pipeline
+        .as_ref()
+        .unwrap()
+        .apply("<svg/onload=alert(1)>")
+        .expect("apply");
+    assert_eq!(body, "<req><item id=\"1\">x</item><msg><svg/onload=alert(1)></msg></req>");
+}
+
+#[tokio::test]
+async fn probe_xml_body_params_noop_without_xml_content_type() {
+    // FP control: an XML-looking body but no XML content-type and no `<?xml`
+    // prolog must not be treated as XML.
+    let addr = start_xml_server().await;
+    let target = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
+        .expect("parse target"); // no Content-Type header
+    let mut args = default_scan_args();
+    args.data = Some("<req><msg>seed</msg></req>".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_xml_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+    assert!(reflection_params.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn probe_xml_body_params_noop_on_json_body() {
+    // FP control: a JSON body with an (incorrect) XML content-type still
+    // tokenizes to no XML leaves, so nothing is seeded.
+    let addr = start_xml_server().await;
+    let target = xml_target(&addr);
+    let mut args = default_scan_args();
+    args.data = Some(r#"{"msg":"seed"}"#.to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_xml_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+    assert!(reflection_params.lock().await.is_empty());
+}
+
+#[tokio::test]
+async fn probe_xml_body_params_fires_on_xml_prolog_without_content_type() {
+    // An `<?xml` prolog is a strong enough signal to probe even when the user
+    // forgot the Content-Type header.
+    let addr = start_xml_server().await;
+    let target = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
+        .expect("parse target");
+    let mut args = default_scan_args();
+    args.data = Some("<?xml version=\"1.0\"?><req><msg>seed</msg></req>".to_string());
+
+    let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
+    let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
+    probe_xml_body_params(&target, &args, reflection_params.clone(), semaphore, None).await;
+    assert!(
+        reflection_params
+            .lock()
+            .await
+            .iter()
+            .any(|p| p.name == "msg" && p.location == Location::XmlBody)
+    );
+}

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -24,6 +24,7 @@
 
 pub mod discovery;
 pub mod mining;
+pub(crate) mod xml_inject;
 
 pub(crate) use mining::detect_injection_context;
 

--- a/src/parameter_analysis/mod.rs
+++ b/src/parameter_analysis/mod.rs
@@ -57,6 +57,18 @@ pub enum Location {
     Body,
     JsonBody,
     MultipartBody,
+    /// A GraphQL request whose payload is injected into one string value inside
+    /// the `variables` object. The whole request body (query + all variables)
+    /// is rebuilt from the param's `pre_encoding_pipeline` (`JsonField` at the
+    /// variable's JSON pointer) and sent as `application/json`. Distinct from
+    /// `JsonBody`, whose builder substitutes at a *top-level* key.
+    GraphqlBody,
+    /// An XML / SOAP request whose payload is injected into one element text
+    /// node or attribute value. The whole body is rebuilt from the param's
+    /// `pre_encoding_pipeline` (a `Splice` of the original document around the
+    /// injection point) and sent with the request's XML content-type. The
+    /// non-target bytes of the document survive verbatim.
+    XmlBody,
     Header,
     Path,
     Fragment,
@@ -421,7 +433,11 @@ async fn send_probe_request_for_param(
     // params preserve body-capable methods (POST/PUT/PATCH/QUERY/…). See
     // `body_location_method_for_param`.
     let req_method = match location {
-        Location::Body | Location::JsonBody | Location::MultipartBody => {
+        Location::Body
+        | Location::JsonBody
+        | Location::MultipartBody
+        | Location::GraphqlBody
+        | Location::XmlBody => {
             crate::scanning::url_inject::body_location_method_for_param(&target.method, param)
         }
         _ => parsed_method,
@@ -565,6 +581,26 @@ async fn send_probe_request_for_param(
             request_builder = client
                 .request(req_method, action_resolved_url.clone())
                 .multipart(form);
+        }
+        Location::GraphqlBody => {
+            // `payload` is the full rebuilt request body: the param's
+            // `JsonField` pipeline already spliced the value into the GraphQL
+            // request template, so it ships verbatim as JSON.
+            request_builder = client
+                .request(req_method, action_resolved_url.clone())
+                .header("Content-Type", "application/json")
+                .body(payload.to_string());
+        }
+        Location::XmlBody => {
+            // `payload` is the full rebuilt XML document (the `Splice` pipeline
+            // re-glued the original body around the injection point). Preserve
+            // the request's declared XML content-type so SOAP endpoints still
+            // frame it correctly.
+            let ct = crate::scanning::url_inject::xml_request_content_type(target);
+            request_builder = client
+                .request(req_method, action_resolved_url.clone())
+                .header("Content-Type", ct)
+                .body(payload.to_string());
         }
         Location::Fragment => {
             let inject_url_str = crate::scanning::url_inject::build_injected_url(
@@ -1358,6 +1394,8 @@ fn param_type_label(p: &Param, target: &Target) -> &'static str {
         Location::Body => "body",
         Location::JsonBody => "json",
         Location::MultipartBody => "multipart",
+        Location::GraphqlBody => "graphql",
+        Location::XmlBody => "xml",
         Location::Path => "path",
         Location::Fragment => "fragment",
         Location::Header => {

--- a/src/parameter_analysis/xml_inject.rs
+++ b/src/parameter_analysis/xml_inject.rs
@@ -1,0 +1,283 @@
+//! XML / SOAP request-body injection-point discovery.
+//!
+//! Locates the exact byte range of every element **text node** and **attribute
+//! value** in an XML document so the scanner can splice a payload into one leaf
+//! and leave the rest of the document byte-for-byte intact. This is a
+//! deliberately small, self-contained tokenizer — it is NOT a conforming XML
+//! parser (no namespace resolution, entity expansion, or DTD handling), and it
+//! never rewrites the document. Injection is a `Splice` of the original bytes
+//! around the located range (see [`crate::encoding::pipeline::EncodingStep::Splice`]),
+//! which sidesteps the lossy parse-and-reserialize round-trip that garbled the
+//! JSON builder.
+//!
+//! False-positive safety: a body that does not tokenize into any text/attribute
+//! leaf yields an empty result, and every caller treats "no points" as "not an
+//! XML injection target" (silent fall-back to the original body). Discovery
+//! itself is still gated on the marker actually reflecting, so a benign XML
+//! body that echoes nothing seeds no params.
+
+/// One injectable leaf inside an XML document, addressed by an exact byte range
+/// in the original body.
+#[derive(Debug, Clone, PartialEq)]
+pub(crate) struct XmlInjectionPoint {
+    /// Human-readable name, e.g. `note/to` for a text node or `item@id` for an
+    /// attribute value. De-duplicated across the document (`_2`, `_3`, …).
+    pub name: String,
+    /// The original leaf text (attribute value, or trimmed element text).
+    pub value: String,
+    /// Byte offset (inclusive) where the payload replaces the leaf.
+    pub start: usize,
+    /// Byte offset (exclusive) where the replacement ends.
+    pub end: usize,
+}
+
+/// Upper bound on discovered points, mirroring the JSON walker's leaf cap so a
+/// pathological document can't fan out into thousands of probe requests.
+const MAX_POINTS: usize = 64;
+
+/// Tokenize `data` as XML and return every element text node and attribute
+/// value as an [`XmlInjectionPoint`]. Comments, CDATA, the XML declaration,
+/// processing instructions, and DOCTYPE are skipped. Returns an empty vec when
+/// the body is not XML-shaped or yields no leaves.
+pub(crate) fn xml_injection_points(data: &str) -> Vec<XmlInjectionPoint> {
+    let bytes = data.as_bytes();
+    let n = bytes.len();
+    // Cheap shape gate: an XML body must open with a `<` (after leading
+    // whitespace/BOM). Anything else (JSON, form-urlencoded, plain text) is not
+    // ours.
+    let first_non_ws = data.trim_start();
+    if !first_non_ws.starts_with('<') {
+        return Vec::new();
+    }
+
+    let mut points: Vec<XmlInjectionPoint> = Vec::new();
+    let mut raw: Vec<(String, String, usize, usize)> = Vec::new(); // (name, value, start, end)
+    let mut i = 0usize;
+
+    while i < n {
+        if bytes[i] == b'<' {
+            // Dispatch on the bytes right after '<'.
+            if starts_with(bytes, i, b"<!--") {
+                i = find_after(bytes, i + 4, b"-->").unwrap_or(n);
+                continue;
+            }
+            if starts_with(bytes, i, b"<![CDATA[") {
+                i = find_after(bytes, i + 9, b"]]>").unwrap_or(n);
+                continue;
+            }
+            if starts_with(bytes, i, b"<?") {
+                i = find_after(bytes, i + 2, b"?>").unwrap_or(n);
+                continue;
+            }
+            if starts_with(bytes, i, b"<!") {
+                // DOCTYPE / other markup declaration. Skip to the matching '>'
+                // (internal subset '[...]' is not handled — rare, and the
+                // whole-body fallback stays correct if we over-skip).
+                i = skip_to_gt(bytes, i + 2).map(|g| g + 1).unwrap_or(n);
+                continue;
+            }
+            if starts_with(bytes, i, b"</") {
+                // End tag: no attributes, no injectable content.
+                i = skip_to_gt(bytes, i + 2).map(|g| g + 1).unwrap_or(n);
+                continue;
+            }
+            // Start tag or empty-element tag: parse name + attributes, honoring
+            // quotes so a '>' inside an attribute value doesn't end the tag.
+            match parse_tag(bytes, i) {
+                Some((tag_name, attrs, tag_end)) => {
+                    for (attr_name, vstart, vend) in attrs {
+                        if vend > vstart {
+                            let value = data[vstart..vend].to_string();
+                            raw.push((format!("{tag_name}@{attr_name}"), value, vstart, vend));
+                        }
+                    }
+                    // After the tag, element content (text) runs until the next
+                    // '<'. Record it as a text node when non-whitespace.
+                    let content_start = tag_end + 1;
+                    let mut j = content_start;
+                    while j < n && bytes[j] != b'<' {
+                        j += 1;
+                    }
+                    let run = &data[content_start..j];
+                    let trimmed = run.trim();
+                    if !trimmed.is_empty() {
+                        // Byte range of the trimmed content, so surrounding
+                        // indentation/newlines are preserved.
+                        let lead = run.len() - run.trim_start().len();
+                        let ts = content_start + lead;
+                        let te = ts + trimmed.len();
+                        raw.push((tag_name.clone(), trimmed.to_string(), ts, te));
+                    }
+                    i = content_start; // continue scanning from element content
+                }
+                None => {
+                    // Malformed start tag — bail on this '<' and move on.
+                    i += 1;
+                }
+            }
+        } else {
+            i += 1;
+        }
+    }
+
+    // De-duplicate display names (`to`, `to_2`, `item@id`, `item@id_2`, …) so
+    // each probe/param slot is addressable and unambiguous.
+    let mut seen: std::collections::HashMap<String, usize> = std::collections::HashMap::new();
+    for (name, value, start, end) in raw {
+        if points.len() >= MAX_POINTS {
+            break;
+        }
+        let count = seen.entry(name.clone()).or_insert(0);
+        *count += 1;
+        let display = if *count == 1 {
+            name
+        } else {
+            format!("{name}_{count}")
+        };
+        points.push(XmlInjectionPoint {
+            name: display,
+            value,
+            start,
+            end,
+        });
+    }
+    points
+}
+
+/// Whether `bytes[at..]` begins with `needle`.
+fn starts_with(bytes: &[u8], at: usize, needle: &[u8]) -> bool {
+    bytes.len() >= at + needle.len() && &bytes[at..at + needle.len()] == needle
+}
+
+/// Index one past the end of the first `needle` found at or after `from`.
+fn find_after(bytes: &[u8], from: usize, needle: &[u8]) -> Option<usize> {
+    if needle.is_empty() || from > bytes.len() {
+        return None;
+    }
+    let end = bytes.len();
+    let mut i = from;
+    while i + needle.len() <= end {
+        if &bytes[i..i + needle.len()] == needle {
+            return Some(i + needle.len());
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Index of the next unquoted `>` at or after `from` (quote-aware).
+fn skip_to_gt(bytes: &[u8], from: usize) -> Option<usize> {
+    let mut i = from;
+    let mut quote: Option<u8> = None;
+    while i < bytes.len() {
+        let b = bytes[i];
+        match quote {
+            Some(q) => {
+                if b == q {
+                    quote = None;
+                }
+            }
+            None => match b {
+                b'"' | b'\'' => quote = Some(b),
+                b'>' => return Some(i),
+                _ => {}
+            },
+        }
+        i += 1;
+    }
+    None
+}
+
+/// Parse a start/empty-element tag beginning at `bytes[start] == '<'`. Returns
+/// `(tag_name, attributes, tag_end_index)` where `tag_end_index` points at the
+/// closing `>` and each attribute is `(name, value_start, value_end)` with the
+/// value range excluding the surrounding quotes. `None` on a malformed tag.
+#[allow(clippy::type_complexity)]
+fn parse_tag(bytes: &[u8], start: usize) -> Option<(String, Vec<(String, usize, usize)>, usize)> {
+    let n = bytes.len();
+    let mut i = start + 1; // past '<'
+    // Element name: up to whitespace, '>', or '/'.
+    let name_start = i;
+    while i < n && !is_space(bytes[i]) && bytes[i] != b'>' && bytes[i] != b'/' {
+        i += 1;
+    }
+    if i == name_start {
+        return None; // no name
+    }
+    let tag_name = std::str::from_utf8(&bytes[name_start..i]).ok()?.to_string();
+
+    let mut attrs: Vec<(String, usize, usize)> = Vec::new();
+    loop {
+        // Skip whitespace between attributes.
+        while i < n && is_space(bytes[i]) {
+            i += 1;
+        }
+        if i >= n {
+            return None; // unterminated tag
+        }
+        match bytes[i] {
+            b'>' => return Some((tag_name, attrs, i)),
+            b'/' => {
+                // Empty-element tag: expect '/>' (tolerate stray whitespace).
+                let mut j = i + 1;
+                while j < n && is_space(bytes[j]) {
+                    j += 1;
+                }
+                if j < n && bytes[j] == b'>' {
+                    return Some((tag_name, attrs, j));
+                }
+                return None;
+            }
+            _ => {
+                // Attribute name up to '=', whitespace, '>', or '/'.
+                let an_start = i;
+                while i < n
+                    && bytes[i] != b'='
+                    && !is_space(bytes[i])
+                    && bytes[i] != b'>'
+                    && bytes[i] != b'/'
+                {
+                    i += 1;
+                }
+                let attr_name = std::str::from_utf8(&bytes[an_start..i]).ok()?.to_string();
+                // Skip whitespace before '='.
+                while i < n && is_space(bytes[i]) {
+                    i += 1;
+                }
+                if i < n && bytes[i] == b'=' {
+                    i += 1; // past '='
+                    while i < n && is_space(bytes[i]) {
+                        i += 1;
+                    }
+                    if i < n && (bytes[i] == b'"' || bytes[i] == b'\'') {
+                        let quote = bytes[i];
+                        i += 1;
+                        let vstart = i;
+                        while i < n && bytes[i] != quote {
+                            i += 1;
+                        }
+                        if i >= n {
+                            return None; // unterminated attribute value
+                        }
+                        let vend = i;
+                        i += 1; // past closing quote
+                        if std::str::from_utf8(&bytes[vstart..vend]).is_ok() {
+                            attrs.push((attr_name, vstart, vend));
+                        }
+                    }
+                    // Unquoted / valueless attribute: not an injectable string.
+                } else if attr_name.is_empty() {
+                    // No progress and no '=': malformed.
+                    return None;
+                }
+            }
+        }
+    }
+}
+
+fn is_space(b: u8) -> bool {
+    matches!(b, b' ' | b'\t' | b'\r' | b'\n')
+}
+
+#[cfg(test)]
+mod tests;

--- a/src/parameter_analysis/xml_inject/tests.rs
+++ b/src/parameter_analysis/xml_inject/tests.rs
@@ -1,0 +1,197 @@
+use super::*;
+
+/// Every point's byte range must exactly cover its reported `value`.
+fn assert_ranges_match_values(data: &str, points: &[XmlInjectionPoint]) {
+    for p in points {
+        assert_eq!(
+            &data[p.start..p.end],
+            p.value,
+            "range [{}, {}) does not cover value {:?} in {:?}",
+            p.start,
+            p.end,
+            p.value,
+            data
+        );
+    }
+}
+
+/// Splicing a payload at a point preserves every other byte of the document.
+fn splice(data: &str, p: &XmlInjectionPoint, payload: &str) -> String {
+    format!("{}{}{}", &data[..p.start], payload, &data[p.end..])
+}
+
+#[test]
+fn finds_text_node() {
+    let xml = "<note><to>Bob</to></note>";
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    let to = pts.iter().find(|p| p.name == "to").expect("to text node");
+    assert_eq!(to.value, "Bob");
+    assert_eq!(
+        splice(xml, to, "<svg onload=alert(1)>"),
+        "<note><to><svg onload=alert(1)></to></note>"
+    );
+}
+
+#[test]
+fn finds_attribute_value() {
+    let xml = r#"<item id="42">x</item>"#;
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    let id = pts.iter().find(|p| p.name == "item@id").expect("id attr");
+    assert_eq!(id.value, "42");
+    assert_eq!(
+        splice(xml, id, "\"><svg>"),
+        r#"<item id=""><svg>">x</item>"#
+    );
+}
+
+#[test]
+fn single_quoted_attribute() {
+    let xml = "<a href='http://x'>t</a>";
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    assert!(pts.iter().any(|p| p.name == "a@href" && p.value == "http://x"));
+}
+
+#[test]
+fn nested_elements_and_multiple_leaves() {
+    let xml = "<r><a>1</a><b><c>2</c></b></r>";
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    let names: Vec<&str> = pts.iter().map(|p| p.name.as_str()).collect();
+    assert!(names.contains(&"a"));
+    assert!(names.contains(&"c"));
+    // The `<r>`/`<b>` wrappers hold only child elements (whitespace-free),
+    // so they contribute no text leaves.
+    assert!(!names.contains(&"r"));
+    assert!(!names.contains(&"b"));
+}
+
+#[test]
+fn preserves_indentation_whitespace() {
+    let xml = "<r>\n  <a>hi</a>\n</r>";
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    // Only "hi" is a text node; the newlines/indentation between elements are
+    // whitespace-only runs and are skipped.
+    assert_eq!(pts.len(), 1);
+    assert_eq!(pts[0].value, "hi");
+    assert_eq!(splice(xml, &pts[0], "P"), "<r>\n  <a>P</a>\n</r>");
+}
+
+#[test]
+fn self_closing_tag_attribute() {
+    let xml = r#"<root><img src="x"/><p>hey</p></root>"#;
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    assert!(pts.iter().any(|p| p.name == "img@src" && p.value == "x"));
+    assert!(pts.iter().any(|p| p.name == "p" && p.value == "hey"));
+}
+
+#[test]
+fn gt_inside_attribute_value_does_not_end_tag() {
+    let xml = r#"<a title="x>y">body</a>"#;
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    assert!(pts.iter().any(|p| p.name == "a@title" && p.value == "x>y"));
+    assert!(pts.iter().any(|p| p.name == "a" && p.value == "body"));
+}
+
+#[test]
+fn skips_comment_cdata_pi_doctype() {
+    let xml = concat!(
+        "<?xml version=\"1.0\"?>\n",
+        "<!DOCTYPE note>\n",
+        "<note><!-- hi -->",
+        "<data><![CDATA[<raw>not injected</raw>]]></data>",
+        "<to>Bob</to></note>"
+    );
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    // Only the real <to> text node is injectable — comment/CDATA/PI/DOCTYPE
+    // content is skipped.
+    assert_eq!(pts.len(), 1, "got {pts:?}");
+    assert_eq!(pts[0].name, "to");
+    assert_eq!(pts[0].value, "Bob");
+}
+
+#[test]
+fn soap_envelope_leaf() {
+    let xml = concat!(
+        "<soap:Envelope xmlns:soap=\"http://schemas.xmlsoap.org/soap/envelope/\">",
+        "<soap:Body><m:echo><m:text>hello</m:text></m:echo></soap:Body>",
+        "</soap:Envelope>"
+    );
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts);
+    // The xmlns attribute value and the <m:text> leaf are both injectable.
+    assert!(pts.iter().any(|p| p.value == "hello"));
+}
+
+#[test]
+fn duplicate_names_are_disambiguated() {
+    let xml = "<r><i>a</i><i>b</i><i>c</i></r>";
+    let pts = xml_injection_points(xml);
+    let names: Vec<&str> = pts.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, vec!["i", "i_2", "i_3"]);
+}
+
+// --- FP / fallback safety ---
+
+#[test]
+fn non_xml_bodies_yield_nothing() {
+    assert!(xml_injection_points("q=1&b=2").is_empty());
+    assert!(xml_injection_points(r#"{"a":"b"}"#).is_empty());
+    assert!(xml_injection_points("plain text").is_empty());
+    assert!(xml_injection_points("").is_empty());
+}
+
+#[test]
+fn malformed_xml_is_safe() {
+    // Unterminated tag / attribute must not panic and must not fabricate a
+    // point with a bogus range.
+    for bad in [
+        "<a href=\"unterminated",
+        "<<>>",
+        "<a><b>",
+        "<a b=",
+        "<",
+        "< notatag",
+    ] {
+        let pts = xml_injection_points(bad);
+        assert_ranges_match_values(bad, &pts); // any point that IS produced is valid
+    }
+}
+
+#[test]
+fn empty_text_nodes_are_not_points() {
+    let xml = "<a></a><b>   </b>";
+    let pts = xml_injection_points(xml);
+    assert!(pts.is_empty(), "whitespace-only/empty text nodes: {pts:?}");
+}
+
+#[test]
+fn point_count_is_bounded() {
+    // A pathological wide document can't fan out past the cap.
+    let mut xml = String::from("<r>");
+    for _ in 0..500 {
+        xml.push_str("<i>x</i>");
+    }
+    xml.push_str("</r>");
+    let pts = xml_injection_points(&xml);
+    assert!(pts.len() <= MAX_POINTS, "exceeded cap: {}", pts.len());
+}
+
+#[test]
+fn multibyte_utf8_text_and_attribute_ranges_are_char_aligned() {
+    // Byte-range indexing must land on char boundaries even with multi-byte
+    // content (é = 2 bytes, 世 = 3 bytes, 😀 = 4 bytes) — otherwise slicing panics.
+    let xml = "<r><t title=\"héllo\">wörld😀世</t></r>";
+    let pts = xml_injection_points(xml);
+    assert_ranges_match_values(xml, &pts); // slices here; panics if misaligned
+    assert!(pts.iter().any(|p| p.name == "t@title" && p.value == "héllo"));
+    assert!(pts.iter().any(|p| p.name == "t" && p.value == "wörld😀世"));
+    let t = pts.iter().find(|p| p.name == "t").unwrap();
+    assert_eq!(splice(xml, t, "X"), "<r><t title=\"héllo\">X</t></r>");
+}

--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -36,6 +36,35 @@ const MAX_SYNTHESIZED: usize = 48;
 /// `confirm`/`print` alternates survive a denylist on the literal `alert`.
 const JS_FUNCS: &[&str] = &["alert(1)", "alert`1`", "confirm(1)"];
 
+/// Leading-window ("positional") filter bypass — see [`positional_pad_payloads`].
+///
+/// Digit run prepended to a tag payload so the real vector lands past a filter
+/// that only entity-encodes / strips a fixed *leading window* of the reflected
+/// value. Digits are never in [`crate::parameter_analysis::SPECIAL_PROBE_CHARS`]
+/// (always "allowed") and are inert in every HTML context — they cannot form a
+/// tag name, close a quote, or start an entity — so the pad shifts the payload's
+/// byte offset without changing how the tail parses.
+///
+/// Two lengths: 24 covers the common small windows (10 / 20) with a compact
+/// PoC, 64 covers larger ones. A window wider than the longest pad simply misses
+/// (nothing is emitted that could be a false positive).
+const POSITIONAL_PAD_LENGTHS: &[usize] = &[24, 64];
+
+/// Minimum leading-digit run that marks a payload as a positional-pad bypass.
+/// The shortest [`POSITIONAL_PAD_LENGTHS`] entry is well above this, and no
+/// genuine payload begins with this many digits, so it cleanly identifies the
+/// pad shape for the raw-angle prune exemption ([`is_positional_pad_bypass`])
+/// without a sentinel shared across modules.
+const POSITIONAL_PAD_MIN_RUN: usize = 12;
+
+/// Self-firing tag shapes a leading-window angle filter would otherwise defeat.
+/// A fresh injected tag carries a `class` marker safely — the duplicate-`class`
+/// drop only bites when breaking out of an existing `class="…"` attribute.
+const POSITIONAL_PAD_SHAPES: &[&str] = &[
+    "<svg onload=alert(1) class={CLASS}>",
+    "<img src=x onerror=alert(1) class={CLASS}>",
+];
+
 /// What a parameter's server-side filter permits.
 struct FilterProfile<'a> {
     invalid: &'a [char],
@@ -435,6 +464,71 @@ pub(crate) fn synthesize_payloads(
     }
 
     out
+}
+
+/// Leading-window ("positional") filter bypass payloads.
+///
+/// Some server-side filters entity-encode or strip only a fixed *leading window*
+/// of the reflected value (e.g. "the first 20 characters are entity-encoded, the
+/// rest is raw" or "alphabetic characters in the first 10 are hex-encoded").
+/// Active probing places its per-character probe near the start of the value, so
+/// such a filter makes the tag-forming characters (`<` / `>`) look
+/// unconditionally blocked in `invalid_specials` when they are in fact usable
+/// past the window. Both [`synthesize_payloads`] and the broad catalog then obey
+/// that (mis)classification and drop every tag payload, so the reflection is
+/// missed entirely even though it is exploitable.
+///
+/// This emits a small, fixed set of *padded* tag payloads: a run of inert digits
+/// (see [`POSITIONAL_PAD_LENGTHS`]) followed by a self-firing tag carrying the
+/// class marker, so the real vector lands past the leading window. It is only
+/// meaningful for an HTML-text reflection, which needs a tag injection — an
+/// attribute-context reflection already breaks out angle-free and gains nothing.
+///
+/// Emitted for **every** HTML-text reflection, not gated on `invalid_specials`,
+/// because a leading-window filter is invisible to the per-character probe: the
+/// probe places its `<` past the window, so it reflects raw and `<` is recorded
+/// *valid* — yet the real payload puts `<` at offset 0, inside the window, where
+/// it is encoded. There is thus no filter-profile signal to gate on. The cost is
+/// nil on an easily-exploitable parameter: the ordinary tag payloads run first
+/// (see the caller's ordering) and the DOM phase stops at the first `[V]`, so
+/// these padded variants are only ever *sent* when the plain tags all failed —
+/// exactly the positional-filter case they exist for.
+///
+/// FP-safe by the same DOM-marker verification as everything else: if there is
+/// no positional window (an unfiltered param already verified above, or a proper
+/// filter encodes `<` everywhere), the padded `<` is either redundant or still
+/// encoded, so the marker element never materializes and nothing promotes to
+/// `[V]`; the encoded echo is inert and adds no `[R]` either.
+///
+/// These payloads deliberately carry raw `<` / `>` even when those characters
+/// are in `invalid_specials`, so the caller's raw-angle prune must exempt them
+/// via [`is_positional_pad_bypass`].
+pub(crate) fn positional_pad_payloads(context: &InjectionContext) -> Vec<String> {
+    // Only HTML-text reflections need a tag injection; attribute/JS/CSS contexts
+    // break out without `<`, so a positional angle filter never blocks them.
+    if !matches!(context, InjectionContext::Html(_)) {
+        return Vec::new();
+    }
+    let class = crate::scanning::markers::class_marker();
+    let mut out = Vec::with_capacity(POSITIONAL_PAD_LENGTHS.len() * POSITIONAL_PAD_SHAPES.len());
+    for &pad_len in POSITIONAL_PAD_LENGTHS {
+        let pad = "0".repeat(pad_len);
+        for shape in POSITIONAL_PAD_SHAPES {
+            out.push(format!("{pad}{}", shape.replace("{CLASS}", class)));
+        }
+    }
+    out
+}
+
+/// Whether `payload` is a [`positional_pad_payloads`] leading-window bypass: it
+/// begins with a run of at least [`POSITIONAL_PAD_MIN_RUN`] ASCII digits
+/// immediately followed by a `<`. The raw-angle prune (which drops any payload
+/// carrying a `<`/`>` the filter reports blocked) must keep these — their whole
+/// premise is that the block is positional, so the raw `<` *can* pass once the
+/// pad pushes it past the window.
+pub(crate) fn is_positional_pad_bypass(payload: &str) -> bool {
+    let digits = payload.bytes().take_while(u8::is_ascii_digit).count();
+    digits >= POSITIONAL_PAD_MIN_RUN && payload.as_bytes().get(digits) == Some(&b'<')
 }
 
 #[cfg(test)]

--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -141,6 +141,19 @@ const ATTR_SQ_TEMPLATES: &[&str] = &[
     "' ontoggle={JS} popover class={CLASS} x='",
     "' onbeforeinput={JS} contenteditable class={CLASS} x='",
     "' onmouseover={JS} id={ID} x='",
+    // Paren-free / backtick-free handler, for a filter that strips `(` `)` and
+    // backticks — which neutralises every `{JS}` primitive above (`alert(1)`,
+    // `` alert`1` ``, `confirm(1)`), so those templates are all char-gated out
+    // and this is the only surviving executor. `throw onerror=alert,1` sets
+    // `window.onerror = alert` then throws, invoking it with the error;
+    // `onerror=alert;throw 1` is the `;`-based mirror for a filter that also
+    // strips `,`. Each handler value is quoted (double-quote inside this
+    // single-quote breakout) so its inner spaces stay in one attribute, and
+    // carries an `id` marker (dup-`class` safe). Verifiable: the value carries
+    // the literal `alert` sink token. Not gated on a filter result — when parens
+    // survive, the `{JS}` forms above verify first and these are never reached.
+    "' onmouseover=\"throw onerror=alert,1\" id={ID} x='",
+    "' onmouseover=\"onerror=alert;throw 1\" id={ID} x='",
     // Slash-separated mirrors of the stay-in-tag shapes above, for a server that
     // strips literal spaces from the reflection (which collapses the space-
     // separated shapes into one merged attribute). These are always emitted, not
@@ -172,6 +185,11 @@ const ATTR_DQ_TEMPLATES: &[&str] = &[
     "\" ontoggle={JS} popover class={CLASS} x=\"",
     "\" onbeforeinput={JS} contenteditable class={CLASS} x=\"",
     "\" onmouseover={JS} id={ID} x=\"",
+    // Paren-free / backtick-free handler (inner values single-quoted to nest in
+    // the double-quote breakout); see the `ATTR_SQ_TEMPLATES` note. The only
+    // executor left when a filter strips `(` `)` and backticks.
+    "\" onmouseover='throw onerror=alert,1' id={ID} x=\"",
+    "\" onmouseover='onerror=alert;throw 1' id={ID} x=\"",
     // Slash-separated mirrors — survive space-stripping filters; see the
     // `ATTR_SQ_TEMPLATES` note for the quoting and `id`-marker reasoning (inner
     // values single-quoted here so they nest inside the double-quote breakout).

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -903,3 +903,85 @@ fn positional_pad_is_fp_safe_against_a_non_positional_filter() {
         "a filter that encodes `<` everywhere must yield NO marker element (no false [V])"
     );
 }
+
+// ===================================================================
+// Paren-free / backtick-free execution — for filters that strip `(` `)` and
+// backticks, neutralising every standard `alert(1)` / `alert`1`` primitive.
+// ===================================================================
+
+/// Parse `payload` dropped into a `delim`-quoted attribute (the injection point)
+/// and return whether the id-marker element carries an on* handler holding a
+/// recognised sink — i.e. whether the DOM-verification stage would confirm it.
+fn attr_breakout_verifies(payload: &str, open: char) -> bool {
+    let id = crate::scanning::markers::id_marker();
+    let reflected = format!("<div class={open}{payload}{open}>x</div>");
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!("#{id}")).unwrap();
+    doc.select(&sel).next().is_some_and(|el| {
+        el.value()
+            .attrs()
+            .any(|(n, v)| n.len() >= 3 && n.starts_with("on") && v.contains("alert"))
+    })
+}
+
+#[test]
+fn paren_and_backtick_blocked_still_synthesizes_a_verifiable_handler() {
+    // filterchain-5 shape: `(` `)` and backtick stripped (so alert(1) / alert`1`
+    // / confirm(1) are all char-gated out), reflection in a double-quoted
+    // attribute. A paren-free handler must survive and, when reflected, parse to
+    // a marker element carrying an executing on* handler.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    let blocked = &['(', ')', '`'];
+    let payloads = synthesize_payloads(&ctx, blocked, &[], &[], None);
+    assert_obeys_filter(&payloads, blocked);
+    let pf = payloads
+        .iter()
+        .find(|p| !p.contains('<') && attr_breakout_verifies(p, '"'))
+        .unwrap_or_else(|| {
+            panic!("no paren-free verifiable handler survived `(`/`)`/backtick strip: {payloads:?}")
+        });
+    // It must be genuinely paren/backtick-free (not a smuggled call).
+    assert!(
+        !pf.contains('(') && !pf.contains(')') && !pf.contains('`'),
+        "the surviving handler must be paren/backtick-free: {pf:?}"
+    );
+}
+
+#[test]
+fn paren_free_handler_present_for_single_quote_attr_too() {
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::SingleQuote));
+    let payloads = synthesize_payloads(&ctx, &['(', ')', '`'], &[], &[], None);
+    assert!(
+        payloads
+            .iter()
+            .any(|p| !p.contains('<') && attr_breakout_verifies(p, '\'')),
+        "single-quote attribute must also offer a paren-free verifiable handler: {payloads:?}"
+    );
+}
+
+#[test]
+fn paren_free_handler_is_fp_safe_when_quote_is_blocked() {
+    // FP control: the paren-free handler still needs its breakout quote. When the
+    // delimiter quote is ALSO stripped, no template survives (all attribute
+    // shapes lead with the quote), so synthesis emits nothing that could land an
+    // inert handler as a false positive.
+    let ctx = InjectionContext::Attribute(Some(DelimiterType::DoubleQuote));
+    // Block the breakout quote plus parens/backtick: nothing can break out.
+    let payloads = synthesize_payloads(&ctx, &['"', '(', ')', '`'], &[], &[], None);
+    assert!(
+        payloads.iter().all(|p| !p.contains("throw onerror")),
+        "no paren-free handler may be emitted once its breakout quote is blocked: {payloads:?}"
+    );
+    // And a benign reflection that entity-encodes the breakout quote yields no
+    // marker element (the handler lands inert inside the value).
+    let id = crate::scanning::markers::id_marker();
+    let inert = format!(
+        "<div class=\"&quot; onmouseover='throw onerror=alert,1' id={id} x=&quot;\">x</div>"
+    );
+    let doc = scraper::Html::parse_document(&inert);
+    let sel = scraper::Selector::parse(&format!("#{id}")).unwrap();
+    assert!(
+        doc.select(&sel).next().is_none(),
+        "an escaped breakout quote must yield no marker element (no false [V])"
+    );
+}

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -765,3 +765,141 @@ fn raw_js_context_offers_regex_literal_breakout() {
         "angle-bracket filter must drop the </script> template"
     );
 }
+
+// ===================================================================
+// Leading-window ("positional") filter bypass — issue: partial-encoding
+// filters that only entity-encode / strip a fixed leading window of the value.
+// ===================================================================
+
+#[test]
+fn positional_pad_emitted_only_for_html_context() {
+    // A leading-window angle filter can only be defeated by pushing an injected
+    // *tag* past the window, so the pad set is HTML-text-only. Attribute / JS /
+    // CSS reflections break out without `<` and gain nothing.
+    assert!(
+        !positional_pad_payloads(&html()).is_empty(),
+        "HTML context must offer positional-pad payloads"
+    );
+    for ctx in [
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Css(None),
+    ] {
+        assert!(
+            positional_pad_payloads(&ctx).is_empty(),
+            "non-HTML context must not offer positional-pad payloads: {ctx:?}"
+        );
+    }
+}
+
+#[test]
+fn positional_pad_payloads_are_padded_verifiable_tags() {
+    // Every pad payload is a run of inert digits followed by a self-firing tag
+    // carrying the class marker, and is recognised by the prune-exemption
+    // predicate. The class marker rides a *fresh* injected tag, so a class (not
+    // id) marker is safe (no pre-existing `class="…"` to collide with).
+    let class = crate::scanning::markers::class_marker();
+    let payloads = positional_pad_payloads(&html());
+    assert!(!payloads.is_empty());
+    for p in &payloads {
+        assert!(
+            is_positional_pad_bypass(p),
+            "pad payload must be recognised by the prune exemption: {p:?}"
+        );
+        assert!(p.contains(class), "pad payload must carry the class marker: {p:?}");
+        assert!(p.contains("alert(1)"), "pad payload must carry an executor: {p:?}");
+        let digits = p.bytes().take_while(u8::is_ascii_digit).count();
+        assert!(digits >= 20, "pad prefix must exceed common leading windows: {p:?}");
+        assert!(p.as_bytes()[digits] == b'<', "digits must run right up to the tag: {p:?}");
+    }
+}
+
+#[test]
+fn positional_pad_bypass_predicate_rejects_ordinary_payloads() {
+    // The prune exemption must fire ONLY for the pad shape, never for an
+    // ordinary payload — otherwise a genuinely blocked raw-angle payload would
+    // wrongly survive the raw-angle prune and waste requests.
+    for p in [
+        "<svg onload=alert(1) class=x>",
+        "1<svg onload=alert(1)>",             // short digit run, not a pad
+        "0000000000<svg>",                     // 10 digits < MIN_RUN(12)
+        "'><svg onload=alert(1)>",
+        "\" onmouseover=alert(1) x=\"",
+        "000000000000000000000000alert(1)",    // digits but no tag
+    ] {
+        assert!(
+            !is_positional_pad_bypass(p),
+            "predicate must reject ordinary payload: {p:?}"
+        );
+    }
+    // ...and accept a real pad payload.
+    assert!(is_positional_pad_bypass("000000000000<svg onload=alert(1) class=x>"));
+}
+
+#[test]
+fn positional_pad_verifies_a_real_leading_window_bypass() {
+    // Behavioural proof (not shape-only): a filter that entity-encodes the first
+    // 20 characters and passes the rest raw (edgefilter-6 shape) leaves the pad
+    // payload's tag intact past the window, so it parses to a REAL marker
+    // element carrying the executing handler. Model the server transform, then
+    // parse the reflection the way the DOM-verification stage does.
+    let class = crate::scanning::markers::class_marker();
+    let payloads = positional_pad_payloads(&html());
+    // Pick a pad long enough to clear a 20-char window (all our lengths are).
+    let payload = payloads
+        .iter()
+        .find(|p| p.contains("svg"))
+        .expect("an svg pad payload");
+
+    // Server: entity-encode `<>&\"'` in the first 20 chars only, rest raw.
+    let encode_head = |s: &str| -> String {
+        let mut out = String::new();
+        for (i, c) in s.chars().enumerate() {
+            if i < 20 {
+                match c {
+                    '<' => out.push_str("&lt;"),
+                    '>' => out.push_str("&gt;"),
+                    '&' => out.push_str("&amp;"),
+                    '"' => out.push_str("&quot;"),
+                    '\'' => out.push_str("&#39;"),
+                    _ => out.push(c),
+                }
+            } else {
+                out.push(c);
+            }
+        }
+        out
+    };
+    let reflected = format!("<div>{}</div>", encode_head(payload));
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!(".{class}")).unwrap();
+    let el = doc
+        .select(&sel)
+        .next()
+        .expect("pad tag must parse to a real marker element past the window");
+    assert!(
+        el.value()
+            .attrs()
+            .any(|(n, v)| n.len() >= 3 && n.starts_with("on") && v.contains("alert")),
+        "marker element must carry the surviving on* handler, got {:?}",
+        el.value().attrs().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn positional_pad_is_fp_safe_against_a_non_positional_filter() {
+    // FP control: a proper filter that entity-encodes angle brackets EVERYWHERE
+    // (not just a leading window) leaves the pad payload's `<` encoded, so no
+    // element materialises and nothing can promote to [V]. This is the exact
+    // shape that would be a false positive if the pad "worked" unconditionally.
+    let class = crate::scanning::markers::class_marker();
+    let payload = &positional_pad_payloads(&html())[0];
+    let encoded_everywhere = payload.replace('<', "&lt;").replace('>', "&gt;");
+    let reflected = format!("<div>{encoded_everywhere}</div>");
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!(".{class}")).unwrap();
+    assert!(
+        doc.select(&sel).next().is_none(),
+        "a filter that encodes `<` everywhere must yield NO marker element (no false [V])"
+    );
+}

--- a/src/scanning/ast_dom_analysis/async_flow.rs
+++ b/src/scanning/ast_dom_analysis/async_flow.rs
@@ -84,6 +84,37 @@ impl<'a> DomXssVisitor<'a> {
             .contains(&callee.as_str())
             .then_some(callee)
     }
+    /// Recognise a `Promise` *static* combinator whose settled value carries
+    /// taint from its argument — `Promise.resolve(x)`, and the array
+    /// combinators `Promise.all/allSettled/race/any([… x …])`.
+    ///
+    /// These are not sources of their own: the taint has to already be in the
+    /// argument, so a `Promise.resolve('static')` chain stays clean. What they
+    /// add is the *link*, so the value survives the microtask hop into the
+    /// `.then` callback's parameter — the `Promise.all([a, tainted, b])
+    /// .then(parts => sink(parts.join('')))` shape, where the tainted element is
+    /// identified only by its index in the settled array.
+    ///
+    /// The array combinators resolve to a container (an array, or for
+    /// `allSettled` an array of result wrappers) rather than the value itself;
+    /// treating the container as tainted is the same over-approximation the
+    /// analysis already makes for `arr.push(tainted)` and object literals.
+    pub(super) fn promise_combinator_source(&self, call: &CallExpression<'a>) -> Option<String> {
+        const PROMISE_COMBINATORS: &[&str] = &[
+            "Promise.resolve",
+            "Promise.all",
+            "Promise.allSettled",
+            "Promise.race",
+            "Promise.any",
+        ];
+        let callee = self.get_expr_string(&call.callee)?;
+        if !PROMISE_COMBINATORS.contains(&callee.as_str()) {
+            return None;
+        }
+        let arg = call.arguments.first()?;
+        let (tainted, source) = self.argument_taint_and_source(arg);
+        tainted.then(|| source.unwrap_or(callee))
+    }
     /// If `call` invokes a Promise combinator (`.then` / `.catch` / `.finally`),
     /// return the method name.
     pub(super) fn promise_method_name(call: &CallExpression<'a>) -> Option<&'static str> {
@@ -113,7 +144,9 @@ impl<'a> DomXssVisitor<'a> {
             match current {
                 Expression::ParenthesizedExpression(p) => current = &p.expression,
                 Expression::CallExpression(inner) => {
-                    if self.is_fetch_call(inner) || self.async_tainted_source_call(inner).is_some()
+                    if self.is_fetch_call(inner)
+                        || self.async_tainted_source_call(inner).is_some()
+                        || self.promise_combinator_source(inner).is_some()
                     {
                         return true;
                     }
@@ -165,6 +198,17 @@ impl<'a> DomXssVisitor<'a> {
         // An async source call (`navigator.clipboard.readText()`) resolves
         // straight to the untrusted string, so the chain is tainted at its root.
         if let Some(source) = self.async_tainted_source_call(call) {
+            for arg in &call.arguments {
+                if let Some(expr) = arg.as_expression() {
+                    self.walk_expression(expr);
+                }
+            }
+            return PromiseValueKind::Tainted(source);
+        }
+
+        // `Promise.resolve(tainted)` / `Promise.all([… tainted …])` settle to a
+        // value that carries the argument's taint into the next `.then`.
+        if let Some(source) = self.promise_combinator_source(call) {
             for arg in &call.arguments {
                 if let Some(expr) = arg.as_expression() {
                     self.walk_expression(expr);

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -53,6 +53,14 @@ impl<'a> DomXssVisitor<'a> {
         {
             self.instance_classes
                 .insert(var_name.to_string(), class_id.name.to_string());
+            // `const m = new Message(tainted)` — record the accessor reads that
+            // now hand the tainted constructor argument back out, so a later
+            // `m.body` resolves without re-deriving the construction.
+            self.seed_instance_field_taints(
+                var_name,
+                class_id.name.as_str(),
+                &new_expr.arguments,
+            );
             assigned_instance_class = true;
         }
         if !assigned_instance_class {
@@ -281,6 +289,9 @@ impl<'a> DomXssVisitor<'a> {
                 if let Some(source) = self.url_search_params_source_for_member(member) {
                     return Some(source);
                 }
+                if let Some(source) = self.class_accessor_taint_source(member) {
+                    return Some(source);
+                }
                 if let Some(source) = self.xhr_response_source_for_member(member) {
                     return Some(source);
                 }
@@ -421,6 +432,53 @@ impl<'a> DomXssVisitor<'a> {
                 .taint_forwarding_new_argument(new_expr)
                 .and_then(|arg| self.find_source_in_expr(arg)),
             _ => None,
+        }
+    }
+
+    /// Mark the properties of `var_name` that read back a tainted constructor
+    /// argument of `class_name` — the stored fields themselves, and every
+    /// getter that aliases one.
+    pub(super) fn seed_instance_field_taints(
+        &mut self,
+        var_name: &str,
+        class_name: &str,
+        args: &[Argument<'a>],
+    ) {
+        let prefix = format!("{class_name}.");
+        let fields: Vec<(String, usize)> = self
+            .class_ctor_param_fields
+            .iter()
+            .filter_map(|(key, idx)| key.strip_prefix(&prefix).map(|f| (f.to_string(), *idx)))
+            .collect();
+        if fields.is_empty() {
+            return;
+        }
+        let getters: Vec<(String, String)> = self
+            .class_getter_fields
+            .iter()
+            .filter_map(|(key, field)| {
+                key.strip_prefix(&prefix)
+                    .map(|g| (g.to_string(), field.clone()))
+            })
+            .collect();
+
+        for (field, idx) in &fields {
+            let Some(arg) = args.get(*idx) else {
+                continue;
+            };
+            let (tainted, source) = self.argument_taint_and_source(arg);
+            if !tainted {
+                continue;
+            }
+            let source = source.unwrap_or_else(|| "unknown source".to_string());
+            self.field_taints
+                .insert(format!("{var_name}.{field}"), source.clone());
+            for (getter, getter_field) in &getters {
+                if getter_field == field {
+                    self.field_taints
+                        .insert(format!("{var_name}.{getter}"), source.clone());
+                }
+            }
         }
     }
 }

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -416,6 +416,7 @@ impl<'a> DomXssVisitor<'a> {
             Expression::AwaitExpression(await_expr) => {
                 self.find_source_in_expr(&await_expr.argument)
             }
+            Expression::TaggedTemplateExpression(tagged) => self.tagged_template_source(tagged),
             _ => None,
         }
     }

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -417,6 +417,9 @@ impl<'a> DomXssVisitor<'a> {
                 self.find_source_in_expr(&await_expr.argument)
             }
             Expression::TaggedTemplateExpression(tagged) => self.tagged_template_source(tagged),
+            Expression::NewExpression(new_expr) => self
+                .taint_forwarding_new_argument(new_expr)
+                .and_then(|arg| self.find_source_in_expr(arg)),
             _ => None,
         }
     }

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -98,6 +98,17 @@ impl<'a> DomXssVisitor<'a> {
             self.url_object_sources.remove(var_name);
         }
 
+        // `const req = store.get(key)` — remember the request so its
+        // `onsuccess` handler is walked with the stored record treated as
+        // untrusted, and so a direct `req.result` read resolves.
+        if self.expr_is_idb_value_request(init) {
+            self.idb_request_vars.insert(var_name.to_string());
+            self.field_taints
+                .insert(format!("{var_name}.result"), "indexedDB".to_string());
+        } else {
+            self.idb_request_vars.remove(var_name);
+        }
+
         // `let s = document.createElement('script')` — remember the
         // variable so a later `s.text = tainted` is recognised as a
         // sink even though `text` is a benign property on every

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -19,6 +19,10 @@ impl<'a> DomXssVisitor<'a> {
     ) {
         let var_name = id.name.as_str();
         self.clear_url_search_params_field_sources(var_name);
+        // Rebinding the name drops whatever the *previous* instance's accessors
+        // read back, or a stale `m.body` would stay tainted after
+        // `m = new Message('static')`.
+        self.clear_instance_field_taints(var_name);
 
         // Register summaries for function expressions assigned to variables.
         if let Expression::FunctionExpression(func_expr) = init
@@ -96,6 +100,14 @@ impl<'a> DomXssVisitor<'a> {
         }
         if !assigned_url_object_source {
             self.url_object_sources.remove(var_name);
+        }
+
+        // `const store = tx.objectStore('notes')` — remember the store so a
+        // `store.get(key)` on the next line still resolves as a record read.
+        if self.expr_is_idb_object_store(init) {
+            self.idb_object_store_vars.insert(var_name.to_string());
+        } else {
+            self.idb_object_store_vars.remove(var_name);
         }
 
         // `const req = store.get(key)` — remember the request so its
@@ -490,6 +502,30 @@ impl<'a> DomXssVisitor<'a> {
                         .insert(format!("{var_name}.{getter}"), source.clone());
                 }
             }
+        }
+    }
+
+    /// Drop the accessor field taints [`seed_instance_field_taints`] recorded
+    /// for `var_name` under the class it was previously bound to.
+    ///
+    /// [`seed_instance_field_taints`]: Self::seed_instance_field_taints
+    pub(super) fn clear_instance_field_taints(&mut self, var_name: &str) {
+        let Some(class_name) = self.instance_classes.get(var_name).cloned() else {
+            return;
+        };
+        let prefix = format!("{class_name}.");
+        let mut properties: Vec<String> = self
+            .class_ctor_param_fields
+            .keys()
+            .filter_map(|key| key.strip_prefix(&prefix).map(str::to_string))
+            .collect();
+        properties.extend(
+            self.class_getter_fields
+                .keys()
+                .filter_map(|key| key.strip_prefix(&prefix).map(str::to_string)),
+        );
+        for property in properties {
+            self.field_taints.remove(&format!("{var_name}.{property}"));
         }
     }
 }

--- a/src/scanning/ast_dom_analysis/events.rs
+++ b/src/scanning/ast_dom_analysis/events.rs
@@ -191,4 +191,51 @@ impl<'a> DomXssVisitor<'a> {
             _ => {}
         }
     }
+
+    /// `request.onsuccess = function (ev) { … }` on an IndexedDB value request:
+    /// walk the handler with its event parameter treated as untrusted, so the
+    /// `ev.target.result` read inside resolves to the stored record.
+    ///
+    /// Reached from the assignment walk, which does not otherwise bind
+    /// anything to a handler's parameter — the handler body *is* walked
+    /// (it is the assignment's right-hand side), but with `ev` clean, so every
+    /// flow out of the record was lost.
+    pub(super) fn analyze_idb_success_assignment(
+        &mut self,
+        receiver: &Expression<'a>,
+        property_name: &str,
+        right: &Expression<'a>,
+    ) {
+        if property_name != "onsuccess" {
+            return;
+        }
+        let is_value_request = match receiver {
+            Expression::Identifier(id) => self.idb_request_vars.contains(id.name.as_str()),
+            other => self.expr_is_idb_value_request(other),
+        };
+        if !is_value_request {
+            return;
+        }
+
+        let (param, statements) = match right {
+            Expression::FunctionExpression(func) => {
+                let Some(body) = &func.body else {
+                    return;
+                };
+                (func.params.items.first(), &body.statements)
+            }
+            Expression::ArrowFunctionExpression(arrow) => {
+                (arrow.params.items.first(), &arrow.body.statements)
+            }
+            _ => return,
+        };
+        let Some(BindingPattern::BindingIdentifier(id)) = param.map(|p| &p.pattern) else {
+            return;
+        };
+        let param_name = id.name.to_string();
+        // A cursor request hands the record one level deeper, on
+        // `ev.target.result.value`; both spellings resolve through the
+        // parameter binding `walk_event_handler_body` installs.
+        self.walk_event_handler_body(&param_name, "indexedDB", statements);
+    }
 }

--- a/src/scanning/ast_dom_analysis/mod.rs
+++ b/src/scanning/ast_dom_analysis/mod.rs
@@ -384,6 +384,11 @@ struct DomXssVisitor<'a> {
     /// into stays clean. Standard CSS properties are deliberately excluded:
     /// the CSSOM normalizes those, so what comes back is not the input.
     css_custom_property_sources: HashMap<String, String>,
+    /// Variables bound to an IndexedDB object store or index
+    /// (`tx.objectStore('notes')`). Real code names the store before reading
+    /// from it, so without this only the fully-chained
+    /// `…objectStore(…).get(k)` spelling would resolve.
+    idb_object_store_vars: HashSet<String>,
     /// Variables bound to an IndexedDB *value* request — the object an
     /// `objectStore(...).get(...)` / `.getAll()` / `.openCursor()` call
     /// returns. Its `onsuccess` handler receives the stored record, which is
@@ -692,6 +697,7 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_objects: HashSet::new(),
             url_search_params_field_sources: HashMap::new(),
             css_custom_property_sources: HashMap::new(),
+            idb_object_store_vars: HashSet::new(),
             idb_request_vars: HashSet::new(),
             script_element_vars: HashSet::new(),
             script_element_ids: HashSet::new(),

--- a/src/scanning/ast_dom_analysis/mod.rs
+++ b/src/scanning/ast_dom_analysis/mod.rs
@@ -335,6 +335,22 @@ struct DomXssVisitor<'a> {
     function_summaries: HashMap<String, FunctionSummary>,
     /// Track `instanceVar -> ClassName` for class instance method summary resolution.
     instance_classes: HashMap<String, String>,
+    /// `"Class.field" -> constructor parameter index`, for fields a class
+    /// constructor stores straight from one of its parameters
+    /// (`constructor(v) { this._value = v; }`). Together with
+    /// [`class_getter_fields`] this is what connects `new C(tainted).accessor`
+    /// back to the argument, since the accessor read is a function call that
+    /// never mentions the constructor argument.
+    ///
+    /// Only a *bare parameter* right-hand side is recorded: a constructor that
+    /// stores `escapeHtml(v)` has no entry, so the accessor reads clean.
+    ///
+    /// [`class_getter_fields`]: DomXssVisitor::class_getter_fields
+    class_ctor_param_fields: HashMap<String, usize>,
+    /// `"Class.getter" -> field name` for `get x() { return this.field; }`
+    /// accessors — the indirection between the property the sink reads and the
+    /// field the constructor wrote.
+    class_getter_fields: HashMap<String, String>,
     /// Track aliases produced by `.bind()` calls.
     bound_function_aliases: HashMap<String, BoundCallableAlias>,
     /// Internal flag for summary collection of tainted return values
@@ -642,6 +658,8 @@ impl<'a> DomXssVisitor<'a> {
             sanitizers: &*STATIC_SANITIZERS,
             function_summaries: HashMap::new(),
             instance_classes: HashMap::new(),
+            class_ctor_param_fields: HashMap::new(),
+            class_getter_fields: HashMap::new(),
             bound_function_aliases: HashMap::new(),
             collecting_tainted_returns: false,
             tainted_return_sources: Vec::new(),

--- a/src/scanning/ast_dom_analysis/mod.rs
+++ b/src/scanning/ast_dom_analysis/mod.rs
@@ -373,6 +373,15 @@ struct DomXssVisitor<'a> {
     url_search_params_objects: HashSet<String>,
     /// Track `paramsVar.key -> upstream source` for URLSearchParams set/get reparses.
     url_search_params_field_sources: HashMap<String, String>,
+    /// Variables bound to an IndexedDB *value* request — the object an
+    /// `objectStore(...).get(...)` / `.getAll()` / `.openCursor()` call
+    /// returns. Its `onsuccess` handler receives the stored record, which is
+    /// same-origin persisted data in exactly the trust class `localStorage` /
+    /// `sessionStorage` already sit in: whatever wrote it (an earlier visit, a
+    /// seeded parameter, another page on the origin) is not this page's
+    /// literal text. The database handle from `indexedDB.open(...)` is
+    /// deliberately *not* in here — its `result` is a connection, not data.
+    idb_request_vars: HashSet<String>,
     /// Variables that hold a `<script>` element created via
     /// `document.createElement('script')`. Assigning a tainted value to
     /// `.text` / `.textContent` / `.innerText` / `.innerHTML` on these
@@ -671,6 +680,7 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_sources: HashMap::new(),
             url_search_params_objects: HashSet::new(),
             url_search_params_field_sources: HashMap::new(),
+            idb_request_vars: HashSet::new(),
             script_element_vars: HashSet::new(),
             script_element_ids: HashSet::new(),
             response_object_vars: HashSet::new(),

--- a/src/scanning/ast_dom_analysis/mod.rs
+++ b/src/scanning/ast_dom_analysis/mod.rs
@@ -373,6 +373,17 @@ struct DomXssVisitor<'a> {
     url_search_params_objects: HashSet<String>,
     /// Track `paramsVar.key -> upstream source` for URLSearchParams set/get reparses.
     url_search_params_field_sources: HashMap<String, String>,
+    /// `--custom-property -> source` for CSS custom properties the page wrote a
+    /// tainted value into (`el.style.setProperty('--label', tainted)`). A
+    /// custom property round-trips through the CSSOM verbatim, so reading it
+    /// back with `getPropertyValue('--label')` returns the attacker's string —
+    /// a laundering step that hides the flow from a source/sink pairing.
+    ///
+    /// Keyed by the property name, and only ever populated from a tainted
+    /// write, so reading a custom property the page never fed untrusted data
+    /// into stays clean. Standard CSS properties are deliberately excluded:
+    /// the CSSOM normalizes those, so what comes back is not the input.
+    css_custom_property_sources: HashMap<String, String>,
     /// Variables bound to an IndexedDB *value* request — the object an
     /// `objectStore(...).get(...)` / `.getAll()` / `.openCursor()` call
     /// returns. Its `onsuccess` handler receives the stored record, which is
@@ -680,6 +691,7 @@ impl<'a> DomXssVisitor<'a> {
             url_search_params_sources: HashMap::new(),
             url_search_params_objects: HashSet::new(),
             url_search_params_field_sources: HashMap::new(),
+            css_custom_property_sources: HashMap::new(),
             idb_request_vars: HashSet::new(),
             script_element_vars: HashSet::new(),
             script_element_ids: HashSet::new(),

--- a/src/scanning/ast_dom_analysis/sinks.rs
+++ b/src/scanning/ast_dom_analysis/sinks.rs
@@ -940,6 +940,156 @@ impl<'a> DomXssVisitor<'a> {
             self.walk_expression(arg_expr);
         }
     }
+    /// `Object.assign(target, {...})` writing a sink property.
+    ///
+    /// The property setter still runs, so `Object.assign(location, {href: q})`
+    /// navigates exactly like `location.href = q` — but the sink never appears
+    /// in assignment position, so the assignment walk never sees it. Same for a
+    /// merge onto an element (`Object.assign(el, {innerHTML: q})`).
+    ///
+    /// Gated on the *target*, not the key: `href` / `src` / `innerHTML` are
+    /// perfectly ordinary keys on a plain configuration object, so a merge is
+    /// only a sink when the receiver is provably the `Location` object or a DOM
+    /// element the page just looked up. Only object *literal* sources are
+    /// inspected — a spread or a variable would need the key set proven, and
+    /// guessing there is how this check would start firing on config merges.
+    pub(super) fn handle_object_assign_sink(&mut self, call: &CallExpression<'a>) -> bool {
+        if self.get_expr_string(&call.callee).as_deref() != Some("Object.assign") {
+            return false;
+        }
+        let Some(target) = call.arguments.first().and_then(|arg| arg.as_expression()) else {
+            return false;
+        };
+        let is_location = self.expr_is_location_object(target);
+        if !is_location && !self.expr_is_dom_element_receiver(target) {
+            return false;
+        }
+
+        for arg in call.arguments.iter().skip(1) {
+            let Some(Expression::ObjectExpression(obj)) = arg.as_expression() else {
+                continue;
+            };
+            for prop in &obj.properties {
+                let ObjectPropertyKind::ObjectProperty(p) = prop else {
+                    continue;
+                };
+                let Some(key) = self.get_property_key_name(&p.key) else {
+                    continue;
+                };
+                // On `Location` only `href` navigates to an arbitrary scheme;
+                // `search` / `hash` / `pathname` cannot carry `javascript:`.
+                let is_sink_key = if is_location {
+                    key == "href"
+                } else {
+                    self.is_assignment_sink_property(&key)
+                };
+                if !is_sink_key || !self.is_tainted(&p.value) {
+                    continue;
+                }
+                let source = self.find_source_in_expr(&p.value);
+                let sink_name = if is_location {
+                    "location.href".to_string()
+                } else {
+                    key
+                };
+                self.report_vulnerability_with_source(
+                    call.span(),
+                    &sink_name,
+                    "Tainted value merged onto a sink property by Object.assign",
+                    source,
+                );
+                return true;
+            }
+        }
+        false
+    }
+    /// True when `expr` denotes the `Location` object, in any of its global
+    /// spellings.
+    pub(super) fn expr_is_location_object(&self, expr: &Expression<'a>) -> bool {
+        matches!(
+            self.get_expr_string(expr).as_deref(),
+            Some(
+                "location"
+                    | "window.location"
+                    | "document.location"
+                    | "self.location"
+                    | "top.location"
+                    | "parent.location"
+                    | "globalThis.location"
+            )
+        )
+    }
+    /// True when `expr` is an element the page just looked up or created.
+    /// Deliberately narrow — the point is to separate a DOM node from a plain
+    /// options object, not to resolve arbitrary element-valued expressions.
+    pub(super) fn expr_is_dom_element_receiver(&self, expr: &Expression<'a>) -> bool {
+        match expr {
+            Expression::ParenthesizedExpression(paren) => {
+                self.expr_is_dom_element_receiver(&paren.expression)
+            }
+            Expression::CallExpression(call) => matches!(
+                self.get_callee_property_name(&call.callee).as_deref(),
+                Some(
+                    "getElementById"
+                        | "querySelector"
+                        | "createElement"
+                        | "createElementNS"
+                        | "closest"
+                )
+            ),
+            Expression::StaticMemberExpression(member) => matches!(
+                self.get_member_string(member).as_deref(),
+                Some("document.body" | "document.head" | "document.documentElement")
+            ),
+            _ => false,
+        }
+    }
+    /// An iteration method handed a code-execution sink as its callback —
+    /// `q.split('\n').map(eval)`.
+    ///
+    /// `eval` never appears in call position here, so neither the sink-name
+    /// lookup nor the argument scan sees it; what makes the flow real is that
+    /// the *receiver* is tainted, since the iteratee is applied to each of its
+    /// elements. Restricted to callbacks that genuinely execute their argument:
+    /// `arr.map(Function)` builds functions without running them, and
+    /// `arr.map(Number)` is not a sink at all.
+    pub(super) fn handle_exec_callback_iteration(&mut self, call: &CallExpression<'a>) -> bool {
+        let Some(method) = self.get_callee_property_name(&call.callee) else {
+            return false;
+        };
+        if !matches!(
+            method.as_str(),
+            "map" | "forEach" | "flatMap" | "filter" | "find" | "findLast" | "some" | "every"
+        ) {
+            return false;
+        }
+        let Some(receiver) = self.get_callee_object_expr(&call.callee) else {
+            return false;
+        };
+        if !self.is_tainted(receiver) {
+            return false;
+        }
+        let Some(callback) = call.arguments.first().and_then(|arg| arg.as_expression()) else {
+            return false;
+        };
+        let Some(name) = self.get_expr_string(callback) else {
+            return false;
+        };
+        if !matches!(
+            name.as_str(),
+            "eval" | "window.eval" | "self.eval" | "globalThis.eval" | "execScript"
+        ) {
+            return false;
+        }
+        let source = self.find_source_in_expr(receiver);
+        self.report_vulnerability_with_source(
+            call.span(),
+            &name,
+            "Code-execution sink passed as an iteration callback over tainted elements",
+            source,
+        );
+        true
+    }
     /// Walk through a call expression
     pub(super) fn walk_call_expression(&mut self, call: &CallExpression<'a>) {
         // Standalone `trustedTypes.createPolicy('default', {...})` (not bound to
@@ -978,6 +1128,14 @@ impl<'a> DomXssVisitor<'a> {
         }
 
         if self.handle_add_event_listener(call) {
+            return;
+        }
+
+        if self.handle_object_assign_sink(call) {
+            return;
+        }
+
+        if self.handle_exec_callback_iteration(call) {
             return;
         }
 

--- a/src/scanning/ast_dom_analysis/sinks.rs
+++ b/src/scanning/ast_dom_analysis/sinks.rs
@@ -24,6 +24,7 @@ impl<'a> DomXssVisitor<'a> {
                     prop_name,
                     &assign.right,
                 );
+                self.analyze_idb_success_assignment(&member.object, prop_name, &assign.right);
                 // Script-element body assignments (e.g. `s.text = tainted`
                 // where `s` came from `document.createElement('script')`).
                 // The browser parses the value as JS source once the

--- a/src/scanning/ast_dom_analysis/sinks.rs
+++ b/src/scanning/ast_dom_analysis/sinks.rs
@@ -1113,6 +1113,8 @@ impl<'a> DomXssVisitor<'a> {
             return;
         }
 
+        self.record_css_custom_property_write(call);
+
         self.handle_jquery_html_constructor(call);
 
         if let Expression::StaticMemberExpression(member) = &call.callee

--- a/src/scanning/ast_dom_analysis/sinks.rs
+++ b/src/scanning/ast_dom_analysis/sinks.rs
@@ -139,11 +139,20 @@ impl<'a> DomXssVisitor<'a> {
             AssignmentTarget::AssignmentTargetIdentifier(id) => {
                 let target_name = id.name.as_str();
                 let mut assigned_instance_class = false;
+                self.clear_instance_field_taints(target_name);
                 if let Expression::NewExpression(new_expr) = &assign.right
                     && let Expression::Identifier(class_id) = &new_expr.callee
                 {
                     self.instance_classes
                         .insert(target_name.to_string(), class_id.name.to_string());
+                    // Same accessor bookkeeping the declarator form does, so
+                    // `m = new Message(tainted); el.innerHTML = m.body` is not
+                    // a blind spot the `const` spelling avoids.
+                    self.seed_instance_field_taints(
+                        target_name,
+                        class_id.name.as_str(),
+                        &new_expr.arguments,
+                    );
                     assigned_instance_class = true;
                 }
                 if !assigned_instance_class {
@@ -1089,6 +1098,10 @@ impl<'a> DomXssVisitor<'a> {
             "Code-execution sink passed as an iteration callback over tainted elements",
             source,
         );
+        // Consuming the call skips the trailing callee walk, so descend the
+        // receiver here — a sink nested inside it (`eval(t).split(',').map(eval)`)
+        // would otherwise go unreported.
+        self.walk_expression(receiver);
         true
     }
     /// Walk through a call expression

--- a/src/scanning/ast_dom_analysis/sources.rs
+++ b/src/scanning/ast_dom_analysis/sources.rs
@@ -243,4 +243,43 @@ impl<'a> DomXssVisitor<'a> {
             Some("objectStore" | "index")
         )
     }
+
+    /// Record `el.style.setProperty('--name', tainted)` so a later
+    /// `getPropertyValue('--name')` reads back tainted.
+    ///
+    /// Only custom properties (`--*`) are tracked: the CSSOM stores their value
+    /// as the author wrote it, while a standard property is parsed and
+    /// serialized back, so what a read returns is not the input string.
+    pub(super) fn record_css_custom_property_write(&mut self, call: &CallExpression<'a>) {
+        if self.get_callee_property_name(&call.callee).as_deref() != Some("setProperty") {
+            return;
+        }
+        let Some(name) = Self::extract_static_string_argument(call, 0) else {
+            return;
+        };
+        if !name.starts_with("--") {
+            return;
+        }
+        let Some(value) = call.arguments.get(1) else {
+            return;
+        };
+        let (tainted, source) = self.argument_taint_and_source(value);
+        if !tainted {
+            return;
+        }
+        self.css_custom_property_sources
+            .insert(name, source.unwrap_or_else(|| "unknown source".to_string()));
+    }
+    /// Source label when `call` reads back a CSS custom property this script
+    /// previously wrote a tainted value into.
+    pub(super) fn css_custom_property_read_source(
+        &self,
+        call: &CallExpression<'a>,
+    ) -> Option<String> {
+        if self.get_callee_property_name(&call.callee).as_deref() != Some("getPropertyValue") {
+            return None;
+        }
+        let name = Self::extract_static_string_argument(call, 0)?;
+        self.css_custom_property_sources.get(&name).cloned()
+    }
 }

--- a/src/scanning/ast_dom_analysis/sources.rs
+++ b/src/scanning/ast_dom_analysis/sources.rs
@@ -210,4 +210,37 @@ impl<'a> DomXssVisitor<'a> {
             self.clone_url_search_params_field_sources(id.name.as_str(), target);
         }
     }
+
+    /// True when `expr` is an IndexedDB request whose `result` is a *stored
+    /// value* — `store.get(k)`, `.getAll()`, `.openCursor()` and friends.
+    ///
+    /// The receiver has to be an `objectStore(...)` / `index(...)` call, which
+    /// is what separates a record read from the two IndexedDB calls whose
+    /// `result` is not data: `indexedDB.open(...)` resolves to a database
+    /// connection, and `store.put(...)` / `.add(...)` resolve to the key that
+    /// was written.
+    pub(super) fn expr_is_idb_value_request(&self, expr: &Expression<'a>) -> bool {
+        let Expression::CallExpression(call) = expr else {
+            return false;
+        };
+        let Some(method) = self.get_callee_property_name(&call.callee) else {
+            return false;
+        };
+        if !matches!(
+            method.as_str(),
+            "get" | "getAll" | "getAllKeys" | "openCursor" | "openKeyCursor"
+        ) {
+            return false;
+        }
+        let Some(receiver) = self.get_callee_object_expr(&call.callee) else {
+            return false;
+        };
+        let Expression::CallExpression(store_call) = receiver else {
+            return false;
+        };
+        matches!(
+            self.get_callee_property_name(&store_call.callee).as_deref(),
+            Some("objectStore" | "index")
+        )
+    }
 }

--- a/src/scanning/ast_dom_analysis/sources.rs
+++ b/src/scanning/ast_dom_analysis/sources.rs
@@ -235,13 +235,23 @@ impl<'a> DomXssVisitor<'a> {
         let Some(receiver) = self.get_callee_object_expr(&call.callee) else {
             return false;
         };
-        let Expression::CallExpression(store_call) = receiver else {
-            return false;
-        };
-        matches!(
-            self.get_callee_property_name(&store_call.callee).as_deref(),
-            Some("objectStore" | "index")
-        )
+        self.expr_is_idb_object_store(receiver)
+    }
+    /// True when `expr` denotes an IndexedDB object store or index — either the
+    /// `objectStore(...)` / `index(...)` call itself, or a variable bound to
+    /// one.
+    pub(super) fn expr_is_idb_object_store(&self, expr: &Expression<'a>) -> bool {
+        match expr {
+            Expression::ParenthesizedExpression(paren) => {
+                self.expr_is_idb_object_store(&paren.expression)
+            }
+            Expression::Identifier(id) => self.idb_object_store_vars.contains(id.name.as_str()),
+            Expression::CallExpression(store_call) => matches!(
+                self.get_callee_property_name(&store_call.callee).as_deref(),
+                Some("objectStore" | "index")
+            ),
+            _ => false,
+        }
     }
 
     /// Record `el.style.setProperty('--name', tainted)` so a later

--- a/src/scanning/ast_dom_analysis/summaries.rs
+++ b/src/scanning/ast_dom_analysis/summaries.rs
@@ -57,6 +57,14 @@ impl<'a> DomXssVisitor<'a> {
         let saved_instance_classes = self.instance_classes.clone();
         let saved_bound_aliases = self.bound_function_aliases.clone();
         let saved_response_vars = self.response_object_vars.clone();
+        // The summary walk is *hypothetical* — it assumes each parameter in
+        // turn is tainted — so any state it records must not leak into the real
+        // walk. The CSS custom-property map is keyed by a global property name
+        // rather than by a variable, so a helper that writes a parameter into
+        // `--label` would otherwise leave every later `getPropertyValue('--label')`
+        // reading tainted no matter what the helper was actually called with.
+        let saved_css_custom_properties = self.css_custom_property_sources.clone();
+        let saved_idb_requests = self.idb_request_vars.clone();
         let saved_vuln_len = self.vulnerabilities.len();
         let saved_collecting_tainted_returns = self.collecting_tainted_returns;
         let saved_tainted_return_sources = std::mem::take(&mut self.tainted_return_sources);
@@ -111,6 +119,8 @@ impl<'a> DomXssVisitor<'a> {
         self.instance_classes = saved_instance_classes;
         self.bound_function_aliases = saved_bound_aliases;
         self.response_object_vars = saved_response_vars;
+        self.css_custom_property_sources = saved_css_custom_properties;
+        self.idb_request_vars = saved_idb_requests;
         self.vulnerabilities.truncate(saved_vuln_len);
         self.collecting_tainted_returns = saved_collecting_tainted_returns;
         self.tainted_return_sources = saved_tainted_return_sources;

--- a/src/scanning/ast_dom_analysis/summaries.rs
+++ b/src/scanning/ast_dom_analysis/summaries.rs
@@ -170,6 +170,7 @@ impl<'a> DomXssVisitor<'a> {
         class_name: &str,
         class_decl: &Class<'a>,
     ) {
+        self.register_class_accessor_fields(class_name, class_decl);
         for elem in &class_decl.body.body {
             let ClassElement::MethodDefinition(method_def) = elem else {
                 continue;
@@ -188,6 +189,89 @@ impl<'a> DomXssVisitor<'a> {
                 self.extract_param_names(&method_def.value.params),
                 &body.statements,
             );
+        }
+    }
+
+    /// Record the two halves of the accessor indirection for `class_name`:
+    /// which fields the constructor stores straight from a parameter, and which
+    /// getters just hand a field back.
+    ///
+    /// Together they let `new C(tainted).accessor` resolve — a read the member
+    /// walk cannot follow on its own, because the accessor is a function call
+    /// whose body never mentions the constructor argument.
+    ///
+    /// Both halves are deliberately literal-minded. Only a bare
+    /// `this.field = param` is a stored parameter, so a constructor that
+    /// sanitizes (`this.field = escapeHtml(param)`) records nothing and the
+    /// accessor reads clean; and only a getter whose body is `return this.field`
+    /// is an alias, so a getter that formats or escapes its field records
+    /// nothing either.
+    pub(super) fn register_class_accessor_fields(
+        &mut self,
+        class_name: &str,
+        class_decl: &Class<'a>,
+    ) {
+        for elem in &class_decl.body.body {
+            let ClassElement::MethodDefinition(method_def) = elem else {
+                continue;
+            };
+            let Some(body) = &method_def.value.body else {
+                continue;
+            };
+            match method_def.kind {
+                MethodDefinitionKind::Constructor => {
+                    let params = self.extract_param_names(&method_def.value.params);
+                    for stmt in &body.statements {
+                        let Statement::ExpressionStatement(expr_stmt) = stmt else {
+                            continue;
+                        };
+                        let Expression::AssignmentExpression(assign) = &expr_stmt.expression else {
+                            continue;
+                        };
+                        if assign.operator != AssignmentOperator::Assign {
+                            continue;
+                        }
+                        let AssignmentTarget::StaticMemberExpression(target) = &assign.left else {
+                            continue;
+                        };
+                        if !matches!(target.object, Expression::ThisExpression(_)) {
+                            continue;
+                        }
+                        let Expression::Identifier(rhs) = &assign.right else {
+                            continue;
+                        };
+                        let Some(idx) = params.iter().position(|p| p == rhs.name.as_str()) else {
+                            continue;
+                        };
+                        self.class_ctor_param_fields.insert(
+                            format!("{class_name}.{}", target.property.name.as_str()),
+                            idx,
+                        );
+                    }
+                }
+                MethodDefinitionKind::Get => {
+                    let Some(getter_name) = self.get_property_key_name(&method_def.key) else {
+                        continue;
+                    };
+                    for stmt in &body.statements {
+                        let Statement::ReturnStatement(ret) = stmt else {
+                            continue;
+                        };
+                        let Some(Expression::StaticMemberExpression(member)) = &ret.argument else {
+                            continue;
+                        };
+                        if !matches!(member.object, Expression::ThisExpression(_)) {
+                            continue;
+                        }
+                        self.class_getter_fields.insert(
+                            format!("{class_name}.{getter_name}"),
+                            member.property.name.to_string(),
+                        );
+                        break;
+                    }
+                }
+                _ => {}
+            }
         }
     }
 }

--- a/src/scanning/ast_dom_analysis/summaries.rs
+++ b/src/scanning/ast_dom_analysis/summaries.rs
@@ -65,6 +65,7 @@ impl<'a> DomXssVisitor<'a> {
         // reading tainted no matter what the helper was actually called with.
         let saved_css_custom_properties = self.css_custom_property_sources.clone();
         let saved_idb_requests = self.idb_request_vars.clone();
+        let saved_idb_stores = self.idb_object_store_vars.clone();
         let saved_vuln_len = self.vulnerabilities.len();
         let saved_collecting_tainted_returns = self.collecting_tainted_returns;
         let saved_tainted_return_sources = std::mem::take(&mut self.tainted_return_sources);
@@ -121,6 +122,7 @@ impl<'a> DomXssVisitor<'a> {
         self.response_object_vars = saved_response_vars;
         self.css_custom_property_sources = saved_css_custom_properties;
         self.idb_request_vars = saved_idb_requests;
+        self.idb_object_store_vars = saved_idb_stores;
         self.vulnerabilities.truncate(saved_vuln_len);
         self.collecting_tainted_returns = saved_collecting_tainted_returns;
         self.tainted_return_sources = saved_tainted_return_sources;

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -495,6 +495,41 @@ impl<'a> DomXssVisitor<'a> {
         }
         None
     }
+    /// The argument a taint-forwarding constructor hands straight back out
+    /// through the object it builds.
+    ///
+    /// `new Proxy(target, handler)` is the motivating one: every property read
+    /// off the proxy is served by the handler from `target`, so a proxy wrapped
+    /// around tainted data reads back tainted — but the read is a trap call, not
+    /// a property access on the object the taint was stored in, so nothing in
+    /// the member/alias tracking connects the two. The collection constructors
+    /// are here for the same reason: `new Map(tainted)` stores exactly the
+    /// argument's values, and a later `.get(k)` hands one back.
+    ///
+    /// Deliberately a short allowlist rather than "any `new` with a tainted
+    /// argument": most constructors transform their input into something whose
+    /// taint has to be argued separately (`new Date(x)` yields a timestamp,
+    /// `new Function(x)` is a *sink*, `new URL(x)` / `new URLSearchParams(x)`
+    /// already have their own richer source tracking that this must not
+    /// shadow).
+    pub(super) fn taint_forwarding_new_argument<'b>(
+        &self,
+        new_expr: &'b NewExpression<'a>,
+    ) -> Option<&'b Expression<'a>> {
+        const TAINT_FORWARDING_CONSTRUCTORS: &[&str] = &[
+            "Proxy", "Map", "Set", "WeakMap", "WeakSet", "String", "Object",
+        ];
+        let Expression::Identifier(id) = &new_expr.callee else {
+            return None;
+        };
+        if !TAINT_FORWARDING_CONSTRUCTORS.contains(&id.name.as_str()) {
+            return None;
+        }
+        new_expr.arguments.first().and_then(|arg| match arg {
+            Argument::SpreadElement(spread) => Some(&spread.argument),
+            _ => arg.as_expression(),
+        })
+    }
     /// Check if expression is tainted.
     ///
     /// Hostile JavaScript can nest expressions arbitrarily deep (`a.b.c.d…`,
@@ -611,6 +646,11 @@ impl<'a> DomXssVisitor<'a> {
             Expression::TaggedTemplateExpression(tagged) => {
                 self.tagged_template_source(tagged).is_some()
             }
+            // `new Proxy(taintedTarget, handler)` and the collection
+            // constructors hand their argument's values back out on read.
+            Expression::NewExpression(new_expr) => self
+                .taint_forwarding_new_argument(new_expr)
+                .is_some_and(|arg| self.is_tainted(arg)),
             _ => false,
         }
     }

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -241,6 +241,12 @@ impl<'a> DomXssVisitor<'a> {
             }
         }
 
+        // `getComputedStyle(el).getPropertyValue('--x')` reads back a custom
+        // property this script wrote a tainted value into.
+        if let Some(source) = self.css_custom_property_read_source(call) {
+            return (true, Some(source));
+        }
+
         // The tainted value can also arrive as the *return value* of a callback
         // the call runs over its receiver — `tpl.replace('SLOT', () => tainted)`
         // never receives the tainted value as an argument at all.

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -436,6 +436,65 @@ impl<'a> DomXssVisitor<'a> {
         }
         None
     }
+    /// Source label when a tagged template `tag`…${x}…`` produces tainted data.
+    ///
+    /// The interpolated value never appears in the template literal's cooked
+    /// strings — the tag function receives it as a positional argument
+    /// (`tag(strings, v0, v1, …)`) and decides what to do with it. So the
+    /// verdict is the *tag's* verdict, read off its function summary: only a
+    /// tag we can see the body of, and whose body returns one of the
+    /// interpolated values, taints its result.
+    ///
+    /// That restriction is what keeps the modern component-library idiom
+    /// (`html`<div>${x}</div>`` from lit-html and friends) quiet: those tags
+    /// are imported, have no summary here, and insert their values as text
+    /// rather than markup. A tag whose body we cannot read is treated as
+    /// opaque, exactly like any other unknown call.
+    ///
+    /// Parameter 0 is the cooked-strings array — page-authored literal text,
+    /// never attacker-controlled — so a tag that merely returns
+    /// `strings.join('')` does not taint; only parameters 1.. (the `${}`
+    /// slots) are consulted.
+    pub(super) fn tagged_template_source(
+        &self,
+        tagged: &TaggedTemplateExpression<'a>,
+    ) -> Option<String> {
+        let _guard = self.enter_recursion()?;
+
+        // A tag with a sanitizer's name neutralizes its inputs, like any other
+        // sanitizing call.
+        if let Some(tag_name) = self.get_expr_string(&tagged.tag)
+            && (self.sanitizers.contains(tag_name.as_str())
+                || Self::is_likely_sanitizer_name(&tag_name))
+        {
+            return None;
+        }
+
+        let summary_key = self.get_summary_key_for_callee_expr(&tagged.tag)?;
+        let summary = self.function_summaries.get(&summary_key)?;
+
+        // The tag returns a tainted value regardless of its arguments
+        // (e.g. it reads `location.hash` itself).
+        if let Some(source) = &summary.return_without_tainted_params {
+            return Some(source.clone());
+        }
+
+        for (idx, fallback_source) in &summary.tainted_param_returns {
+            // Slot i is argument i + 1; argument 0 is the strings array.
+            let Some(slot) = idx.checked_sub(1) else {
+                continue;
+            };
+            let Some(expr) = tagged.quasi.expressions.get(slot) else {
+                continue;
+            };
+            if self.is_tainted(expr) {
+                return self
+                    .find_source_in_expr(expr)
+                    .or_else(|| Some(fallback_source.clone()));
+            }
+        }
+        None
+    }
     /// Check if expression is tainted.
     ///
     /// Hostile JavaScript can nest expressions arbitrarily deep (`a.b.c.d…`,
@@ -548,6 +607,10 @@ impl<'a> DomXssVisitor<'a> {
             // `await taintedPromise` yields the resolved tainted value — e.g.
             // `await r.text()` on a fetch Response (issue #1024).
             Expression::AwaitExpression(await_expr) => self.is_tainted(&await_expr.argument),
+            // ``tag`…${x}…` `` — the verdict belongs to the tag function.
+            Expression::TaggedTemplateExpression(tagged) => {
+                self.tagged_template_source(tagged).is_some()
+            }
             _ => false,
         }
     }

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -241,6 +241,13 @@ impl<'a> DomXssVisitor<'a> {
             }
         }
 
+        // The tainted value can also arrive as the *return value* of a callback
+        // the call runs over its receiver — `tpl.replace('SLOT', () => tainted)`
+        // never receives the tainted value as an argument at all.
+        if let Some(source) = self.callback_result_source(call) {
+            return (true, Some(source));
+        }
+
         // Conservative fallback: tainted argument taints call result.
         for arg in &call.arguments {
             let (tainted, source_hint) = self.argument_taint_and_source(arg);
@@ -302,6 +309,132 @@ impl<'a> DomXssVisitor<'a> {
             return None;
         }
         (member.property.name.as_str() == "result").then(|| "FileReader.result".to_string())
+    }
+    /// Source label when a *callback* handed to a value-producing method
+    /// returns tainted data, so the call's own result is tainted even though
+    /// nothing tainted was ever passed as an argument.
+    ///
+    /// The motivating shape is the templating idiom
+    /// `template.replace('SLOT', function () { return userInput; })` — the
+    /// replacer's return value is spliced into the result string, and
+    /// `replace()` itself only ever sees a constant pattern and a function.
+    /// The array transforms (`map` / `flatMap` / `reduce`) build their result
+    /// out of callback return values the same way.
+    ///
+    /// Two deliberate restrictions keep this precise:
+    ///
+    /// * only the callback position of the listed methods is inspected, so an
+    ///   arbitrary function argument (an `addEventListener` handler, a
+    ///   comparator, …) whose return value is discarded never taints anything;
+    /// * a callback whose parameter list is anything but plain identifiers, or
+    ///   whose parameter *shadows* a name we currently consider tainted, is
+    ///   skipped entirely — otherwise `tpl.replace(re, function (q) { return q; })`
+    ///   would read the shadowed parameter as the outer tainted `q`.
+    pub(super) fn callback_result_source(&self, call: &CallExpression<'a>) -> Option<String> {
+        let method = self.get_callee_property_name(&call.callee)?;
+        let cb_index = match method.as_str() {
+            // `str.replace(pattern, replacerFn)` / `replaceAll`.
+            "replace" | "replaceAll" => 1,
+            // Array transforms whose result is built from the callback's
+            // return values.
+            "map" | "flatMap" | "reduce" | "reduceRight" => 0,
+            _ => return None,
+        };
+        let cb = call.arguments.get(cb_index)?.as_expression()?;
+        self.callback_return_source(cb)
+    }
+    /// Source of the first tainted `return` in a function/arrow expression,
+    /// or `None` when the callback is unanalysable (see
+    /// [`callback_result_source`](Self::callback_result_source) for why
+    /// shadowing parameters bail out).
+    pub(super) fn callback_return_source(&self, cb: &Expression<'a>) -> Option<String> {
+        let _guard = self.enter_recursion()?;
+        let (params, statements, concise) = match cb {
+            Expression::FunctionExpression(func) => {
+                (&func.params, &func.body.as_ref()?.statements, false)
+            }
+            Expression::ArrowFunctionExpression(arrow) => {
+                (&arrow.params, &arrow.body.statements, arrow.expression)
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                return self.callback_return_source(&paren.expression);
+            }
+            _ => return None,
+        };
+
+        // Only plain-identifier parameters are analysable from outside the
+        // callback; a destructured / defaulted / rest parameter can bind names
+        // we cannot enumerate, so it might shadow a tainted one.
+        for param in &params.items {
+            let BindingPattern::BindingIdentifier(id) = &param.pattern else {
+                return None;
+            };
+            let name = id.name.as_str();
+            if self.tainted_vars.contains(name) || self.global_taints.contains(name) {
+                return None;
+            }
+        }
+        if params.rest.is_some() {
+            return None;
+        }
+
+        // `x => tainted` has no `return` statement: the concise body *is* the
+        // returned expression.
+        if concise {
+            let Some(Statement::ExpressionStatement(stmt)) = statements.first() else {
+                return None;
+            };
+            return self
+                .is_tainted(&stmt.expression)
+                .then(|| self.find_source_in_expr(&stmt.expression))
+                .flatten();
+        }
+        self.first_tainted_return_source(statements)
+    }
+    /// First tainted `return <expr>` reachable in `stmts`, descending through
+    /// the block-shaped statements a callback body commonly wraps its returns
+    /// in. Nested function bodies are *not* descended: their returns belong to
+    /// that inner function, not to this callback.
+    pub(super) fn first_tainted_return_source(
+        &self,
+        stmts: &[Statement<'a>],
+    ) -> Option<String> {
+        let _guard = self.enter_recursion()?;
+        for stmt in stmts {
+            let found = match stmt {
+                Statement::ReturnStatement(ret) => ret
+                    .argument
+                    .as_ref()
+                    .filter(|arg| self.is_tainted(arg))
+                    .and_then(|arg| self.find_source_in_expr(arg)),
+                Statement::BlockStatement(block) => self.first_tainted_return_source(&block.body),
+                Statement::IfStatement(if_stmt) => {
+                    self.first_tainted_return_source(std::slice::from_ref(&if_stmt.consequent))
+                        .or_else(|| {
+                            if_stmt.alternate.as_ref().and_then(|alt| {
+                                self.first_tainted_return_source(std::slice::from_ref(alt))
+                            })
+                        })
+                }
+                Statement::TryStatement(try_stmt) => self
+                    .first_tainted_return_source(&try_stmt.block.body)
+                    .or_else(|| {
+                        try_stmt
+                            .handler
+                            .as_ref()
+                            .and_then(|h| self.first_tainted_return_source(&h.body.body))
+                    }),
+                Statement::SwitchStatement(switch_stmt) => switch_stmt
+                    .cases
+                    .iter()
+                    .find_map(|case| self.first_tainted_return_source(&case.consequent)),
+                _ => None,
+            };
+            if found.is_some() {
+                return found;
+            }
+        }
+        None
     }
     /// Check if expression is tainted.
     ///

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -530,6 +530,53 @@ impl<'a> DomXssVisitor<'a> {
             _ => arg.as_expression(),
         })
     }
+    /// Source label for a read off a freshly constructed instance —
+    /// `new Message(tainted).body` — resolved through the class's accessor
+    /// bookkeeping.
+    ///
+    /// The accessor is a function call, so no member/alias tracking connects
+    /// the property the sink reads to the constructor argument the value came
+    /// from; the two halves recorded by
+    /// [`register_class_accessor_fields`](Self::register_class_accessor_fields)
+    /// are what bridge it.
+    pub(super) fn class_accessor_taint_source(
+        &self,
+        member: &StaticMemberExpression<'a>,
+    ) -> Option<String> {
+        let Expression::NewExpression(new_expr) = &member.object else {
+            return None;
+        };
+        let Expression::Identifier(class_id) = &new_expr.callee else {
+            return None;
+        };
+        self.class_property_ctor_arg_source(
+            class_id.name.as_str(),
+            member.property.name.as_str(),
+            &new_expr.arguments,
+        )
+    }
+    /// Source label when reading `property` off an instance of `class_name`
+    /// constructed with `args` yields the value of a tainted constructor
+    /// argument — either because the property *is* a stored field, or because
+    /// it is a getter that returns one.
+    pub(super) fn class_property_ctor_arg_source(
+        &self,
+        class_name: &str,
+        property: &str,
+        args: &[Argument<'a>],
+    ) -> Option<String> {
+        let field = self
+            .class_getter_fields
+            .get(&format!("{class_name}.{property}"))
+            .cloned()
+            .unwrap_or_else(|| property.to_string());
+        let idx = *self
+            .class_ctor_param_fields
+            .get(&format!("{class_name}.{field}"))?;
+        let arg = args.get(idx)?;
+        let (tainted, source) = self.argument_taint_and_source(arg);
+        tainted.then(|| source.unwrap_or_else(|| "unknown source".to_string()))
+    }
     /// Check if expression is tainted.
     ///
     /// Hostile JavaScript can nest expressions arbitrarily deep (`a.b.c.d…`,
@@ -552,6 +599,9 @@ impl<'a> DomXssVisitor<'a> {
             }
             Expression::StaticMemberExpression(member) => {
                 if self.url_search_params_source_for_member(member).is_some() {
+                    return true;
+                }
+                if self.class_accessor_taint_source(member).is_some() {
                     return true;
                 }
                 if self.xhr_response_source_for_member(member).is_some() {

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5232,3 +5232,59 @@ document.getElementById('out').textContent = steps.length + nums.length + fns.le
         "clean receivers and non-executing callbacks must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// IndexedDB stored records as a source
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_indexeddb_get_result_reaches_sink() {
+    // xssmaze domsource-level1: the value is persisted to IndexedDB and read
+    // back through two async callbacks.
+    let code = r#"
+var open = indexedDB.open('notes-db', 1);
+open.onsuccess = function (e) {
+  var db = e.target.result;
+  var get = db.transaction('notes', 'readonly').objectStore('notes').get('latest');
+  get.onsuccess = function (ev) {
+    if (ev.target.result != null) {
+      document.getElementById('out').innerHTML = ev.target.result;
+    }
+  };
+};
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns
+            .iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("indexedDB")),
+        "IndexedDB record read should reach the sink: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_indexeddb_fp_control_connection_and_write_requests() {
+    // FP control: neither of the two IndexedDB requests whose `result` is not
+    // data may be treated as a source — `indexedDB.open()` resolves to a
+    // database connection, and `put()` resolves to the written key. Nor may a
+    // same-named `.get()` on a plain Map.
+    let code = r#"
+var open = indexedDB.open('notes-db', 1);
+open.onsuccess = function (e) {
+  document.getElementById('a').innerHTML = e.target.result.name;
+  var db = e.target.result;
+  var put = db.transaction('notes', 'readwrite').objectStore('notes').put('hi', 'k');
+  put.onsuccess = function (ev) {
+    document.getElementById('b').innerHTML = ev.target.result;
+  };
+};
+var settings = new Map();
+var got = settings.get('theme');
+document.getElementById('c').innerHTML = got;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "connection / write requests and plain Map reads must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5351,3 +5351,70 @@ document.getElementById('out').insertAdjacentHTML('beforeend', label);
         "a hypothetical summary walk must not taint a global custom property: {vulns:?}"
     );
 }
+
+#[test]
+fn test_class_accessor_taint_cleared_on_rebinding() {
+    // Rebinding the name replaces the instance, so the accessor read must not
+    // keep the previous instance's taint — in either spelling.
+    let code = r#"
+class Message {
+  constructor(value) { this._value = value; }
+  get body() { return this._value; }
+}
+var m = new Message(location.hash.slice(1));
+var m2 = new Message('static');
+document.getElementById('a').innerHTML = m2.body;
+m = new Message('static');
+document.getElementById('b').innerHTML = m.body;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "a rebound instance must not keep the earlier accessor taint: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_class_accessor_through_assignment_form() {
+    // Parity with the declarator form: `m = new Message(tainted)` must not be a
+    // blind spot the `const` spelling avoids.
+    let code = r#"
+class Message {
+  constructor(value) { this._value = value; }
+  get body() { return this._value; }
+}
+var m;
+m = new Message(location.hash.slice(1));
+document.getElementById('out').innerHTML = m.body;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "assignment-form construction should report like the declarator: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_indexeddb_named_object_store_variable() {
+    // The idiomatic spelling names the store before reading from it, rather
+    // than chaining `objectStore(...).get(...)` in one expression.
+    let code = r#"
+var open = indexedDB.open('notes-db', 1);
+open.onsuccess = function (e) {
+  var db = e.target.result;
+  var tx = db.transaction('notes', 'readonly');
+  var store = tx.objectStore('notes');
+  var req = store.get('latest');
+  req.onsuccess = function (ev) {
+    document.getElementById('out').innerHTML = ev.target.result;
+  };
+};
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns
+            .iter()
+            .any(|v| v.sink == "innerHTML" && v.source.contains("indexedDB")),
+        "a named object-store variable should still resolve: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5288,3 +5288,66 @@ document.getElementById('c').innerHTML = got;
         "connection / write requests and plain Map reads must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// CSS custom property round-trip
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_css_custom_property_round_trip() {
+    // xssmaze domsource-level6: the value is stashed on a --custom-property and
+    // read back through the CSSOM before it reaches an HTML sink.
+    let code = r#"
+var raw = decodeURIComponent(location.hash.slice(1));
+if (raw) { document.documentElement.style.setProperty('--maze-label', raw); }
+var label = getComputedStyle(document.documentElement)
+  .getPropertyValue('--maze-label').trim();
+if (label) { document.getElementById('out').insertAdjacentHTML('beforeend', label); }
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "insertAdjacentHTML"),
+        "a custom property written tainted should read back tainted: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_css_custom_property_fp_control() {
+    // FP control: a custom property the page only ever wrote literal text into,
+    // and a *standard* property — whose value the CSSOM reparses, so what comes
+    // back is not the input string.
+    let code = r#"
+var raw = decodeURIComponent(location.hash.slice(1));
+document.documentElement.style.setProperty('--theme', 'dark');
+var theme = getComputedStyle(document.documentElement).getPropertyValue('--theme');
+document.getElementById('a').insertAdjacentHTML('beforeend', theme);
+document.documentElement.style.setProperty('color', raw);
+var color = getComputedStyle(document.documentElement).getPropertyValue('color');
+document.getElementById('b').insertAdjacentHTML('beforeend', color);
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "clean custom properties and standard properties must not report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_css_custom_property_helper_summary_does_not_leak() {
+    // The summary walk assumes each parameter is tainted in turn, so a helper
+    // that writes its parameter into a custom property must not leave that
+    // property tainted for a read that follows a *clean* call.
+    let code = r#"
+function setLabel(value) {
+  document.documentElement.style.setProperty('--label', value);
+}
+setLabel('Drafts');
+var label = getComputedStyle(document.documentElement).getPropertyValue('--label');
+document.getElementById('out').insertAdjacentHTML('beforeend', label);
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "a hypothetical summary walk must not taint a global custom property: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4858,3 +4858,64 @@ xhr.open('GET', location.hash);
         "xhr.open must not be treated as a navigation sink, got {r:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Promise combinator roots (`Promise.all` / `Promise.resolve`)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_promise_all_indexed_element_reaches_sink() {
+    // xssmaze taintflow-level5: the tainted element is identified only by its
+    // index inside the `Promise.all` array, and arrives in the callback as one
+    // slot of the settled array.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+Promise.all([
+  Promise.resolve('<section>'),
+  Promise.resolve(q),
+  Promise.resolve('</section>')
+]).then(function (parts) {
+  document.getElementById('out').innerHTML = parts.join('');
+});
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "Promise.all element taint should reach the .then callback: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_promise_resolve_tainted_reaches_sink() {
+    let code = r#"
+var q = location.hash.slice(1);
+Promise.resolve(q).then(function (v) {
+  document.getElementById('out').innerHTML = v;
+});
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "Promise.resolve(tainted) should carry taint into .then: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_promise_combinator_fp_control_untainted_values() {
+    // FP control: nothing attacker-controlled enters the chain, so no finding —
+    // the combinator must be a *link*, never a source of its own.
+    let code = r#"
+var greeting = '<b>hello</b>';
+Promise.all([Promise.resolve('<section>'), Promise.resolve(greeting)]).then(function (parts) {
+  document.getElementById('out').innerHTML = parts.join('');
+});
+Promise.resolve('static').then(function (v) {
+  document.getElementById('out2').innerHTML = v;
+});
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "untainted Promise chains must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5146,3 +5146,89 @@ document.getElementById('c').innerHTML = t.title;
         "escaping constructors and unrelated accessors must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Object.assign and iteration-callback exec sinks
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_object_assign_onto_location_href() {
+    // xssmaze domsink-level6: the href setter still fires, so a javascript:
+    // URL navigates and runs.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+if (q) { Object.assign(location, { href: q }); }
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "location.href"),
+        "Object.assign onto location should report a navigation sink: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_object_assign_onto_element_inner_html() {
+    let code = r#"
+var q = location.hash.slice(1);
+Object.assign(document.getElementById('out'), { innerHTML: q });
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "Object.assign onto a looked-up element should report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_object_assign_fp_control_plain_config_object() {
+    // FP control: `href` / `src` are ordinary keys on a plain options object,
+    // and a merge onto `location` of anything but `href` cannot navigate to a
+    // javascript: URL.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+var opts = { retries: 1 };
+Object.assign(opts, { href: q, src: q, innerHTML: q });
+Object.assign(location, { hash: q, search: q, pathname: q });
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "config-object merges and non-navigating location keys must not report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_array_map_eval_over_tainted_receiver() {
+    // xssmaze domsink-level5: eval is handed to .map() as a callback and never
+    // appears in call position.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+if (q) {
+  var results = q.split('\n').map(eval);
+  document.getElementById('out').textContent = 'ran ' + results.length;
+}
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "eval"),
+        "map(eval) over a tainted receiver should report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_exec_callback_iteration_fp_control() {
+    // FP control: a clean receiver, a non-executing builtin callback, and a
+    // sink name that only builds functions rather than running them.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+var steps = ['1+1', '2+2'].map(eval);
+var nums = q.split(',').map(Number);
+var fns = q.split(',').map(Function);
+document.getElementById('out').textContent = steps.length + nums.length + fns.length;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "clean receivers and non-executing callbacks must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5078,3 +5078,71 @@ document.getElementById('b').innerHTML = when;
         "clean Proxy and non-forwarding constructors must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Class accessors
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_class_getter_returns_constructor_argument() {
+    // xssmaze taintflow-level3: the sink reads an accessor property, not the
+    // field the value was written to.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+class Message {
+  constructor(value) { this._value = value; }
+  get body() { return this._value; }
+}
+document.getElementById('out').innerHTML = new Message(q).body;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "class getter over a tainted constructor argument should report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_class_getter_through_instance_variable() {
+    let code = r#"
+class Message {
+  constructor(value) { this._value = value; }
+  get body() { return this._value; }
+}
+var m = new Message(location.hash.slice(1));
+document.getElementById('out').innerHTML = m.body;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "accessor read off an instance variable should report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_class_accessor_fp_control() {
+    // FP control:
+    //  1. the constructor escapes before storing, so the accessor reads clean;
+    //  2. the accessor returns a different, page-authored field;
+    //  3. the tainted argument is stored in a field nothing reads.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+class Escaped {
+  constructor(value) { this._value = encodeURIComponent(value); }
+  get body() { return this._value; }
+}
+document.getElementById('a').innerHTML = new Escaped(q).body;
+class Titled {
+  constructor(value) { this._value = value; this._title = 'Draft'; }
+  get title() { return this._title; }
+}
+document.getElementById('b').innerHTML = new Titled(q).title;
+var t = new Titled(q);
+document.getElementById('c').innerHTML = t.title;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "escaping constructors and unrelated accessors must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5024,3 +5024,57 @@ document.getElementById('c').innerHTML = justStrings`<article>${raw}</article>`;
         "unknown / escaping / strings-only tags must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Taint-forwarding constructors (`new Proxy(...)`, collections)
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_proxy_get_trap_forwards_taint() {
+    // xssmaze taintflow-level2: the sink reads a property whose value is
+    // produced by a Proxy get trap, not by an access on the wrapped object.
+    let code = r#"
+var raw = decodeURIComponent(location.hash.slice(1));
+var store = new Proxy({ body: raw }, {
+  get: function (target, prop) { return target[prop]; }
+});
+if (store.body) { document.getElementById('out').innerHTML = store.body; }
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "Proxy over a tainted target should read back tainted: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_map_constructor_forwards_taint() {
+    let code = r#"
+var raw = location.hash.slice(1);
+var m = new Map([['body', raw]]);
+document.getElementById('out').innerHTML = m.get('body');
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "new Map(taintedEntries) should read back tainted: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_taint_forwarding_constructor_fp_control() {
+    // FP control: a Proxy/Map built from page-authored data stays clean, and a
+    // constructor outside the allowlist does not forward taint on its own.
+    let code = r#"
+var raw = location.hash.slice(1);
+var defaults = new Proxy({ body: '<b>hi</b>' }, { get: function (t, p) { return t[p]; } });
+document.getElementById('a').innerHTML = defaults.body;
+var when = new Date(raw);
+document.getElementById('b').innerHTML = when;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "clean Proxy and non-forwarding constructors must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4977,3 +4977,50 @@ document.getElementById('c').innerHTML = t3;
         "sanitized / shadowed / discarded callback returns must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Tagged templates
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_tagged_template_tag_returns_interpolated_value() {
+    // xssmaze taintflow-level7: the value is never in the cooked strings — the
+    // tag receives it as a positional argument and splices it into its result.
+    let code = r#"
+var raw = decodeURIComponent(location.hash.slice(1));
+function html(strings, value) {
+  return strings[0] + value + strings[1];
+}
+document.getElementById('out').innerHTML = html`<article>${raw}</article>`;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "tagged template with a value-splicing tag should report: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_tagged_template_fp_control_unknown_and_escaping_tags() {
+    // FP control, both halves of the realistic benign space:
+    //  1. `html` is imported (lit-html and friends) — no summary, and those
+    //     tags insert values as text, so an unknown tag must stay opaque;
+    //  2. a local tag that escapes every interpolated slot.
+    let code = r#"
+var raw = decodeURIComponent(location.hash.slice(1));
+document.getElementById('a').innerHTML = html`<article>${raw}</article>`;
+function safe(strings, value) {
+  return strings[0] + encodeURIComponent(value) + strings[1];
+}
+document.getElementById('b').innerHTML = safe`<article>${raw}</article>`;
+function justStrings(strings) {
+  return strings.join('');
+}
+document.getElementById('c').innerHTML = justStrings`<article>${raw}</article>`;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "unknown / escaping / strings-only tags must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -4919,3 +4919,61 @@ Promise.resolve('static').then(function (v) {
         "untainted Promise chains must not report: {vulns:?}"
     );
 }
+
+// ---------------------------------------------------------------------------
+// Taint arriving as a callback's *return* value
+// ---------------------------------------------------------------------------
+
+#[test]
+fn test_string_replace_replacer_function_return() {
+    // xssmaze taintflow-level8: the tainted value is the replacer's return
+    // value; `replace()` itself only ever sees a constant pattern.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+var template = '<p>Hello NAME_SLOT!</p>';
+var rendered = template.replace('NAME_SLOT', function () { return q; });
+document.getElementById('out').innerHTML = rendered;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "replacer-function return should taint the replace() result: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_array_map_arrow_return_taints_result() {
+    let code = r#"
+var q = location.hash.slice(1);
+var rows = ['a', 'b'].map(row => '<li>' + q + '</li>');
+document.getElementById('out').innerHTML = rows.join('');
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.iter().any(|v| v.sink == "innerHTML"),
+        "map callback return should taint the mapped array: {vulns:?}"
+    );
+}
+
+#[test]
+fn test_callback_return_fp_control_sanitized_and_shadowed() {
+    // Three benign forms that must stay silent:
+    //  1. the replacer returns a *sanitized* value;
+    //  2. the replacer's parameter shadows the tainted outer name, so the
+    //     returned identifier is the match, not the URL parameter;
+    //  3. the callback is in a position whose return value is discarded.
+    let code = r#"
+var q = new URLSearchParams(location.search).get('query') || '';
+var t1 = '<p>SLOT</p>'.replace('SLOT', function () { return encodeURIComponent(q); });
+document.getElementById('a').innerHTML = t1;
+var t2 = '<p>xx</p>'.replace(/x/g, function (q) { return q.toUpperCase(); });
+document.getElementById('b').innerHTML = t2;
+var t3 = ['a'].filter(function () { return q; });
+document.getElementById('c').innerHTML = t3;
+"#;
+    let vulns = AstDomAnalyzer::new().analyze(code).unwrap();
+    assert!(
+        vulns.is_empty(),
+        "sanitized / shadowed / discarded callback returns must not report: {vulns:?}"
+    );
+}

--- a/src/scanning/ast_dom_analysis/walk.rs
+++ b/src/scanning/ast_dom_analysis/walk.rs
@@ -262,6 +262,13 @@ impl<'a> DomXssVisitor<'a> {
                     self.walk_expression(e);
                 }
             }
+            // ``tag`…${x}…` `` — walk the interpolated slots so a sink nested
+            // inside one (`` html`${eval(location.hash)}` ``) is still seen.
+            Expression::TaggedTemplateExpression(tagged) => {
+                for e in &tagged.quasi.expressions {
+                    self.walk_expression(e);
+                }
+            }
             Expression::BinaryExpression(binary) => {
                 self.walk_expression(&binary.left);
                 self.walk_expression(&binary.right);

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -522,6 +522,10 @@ fn source_uses_bootstrap_query_param(source: &str) -> bool {
         || source.contains("document.referrer")
         || source.contains("localStorage")
         || source.contains("sessionStorage")
+        // IndexedDB records sit in the same trust class as web storage: the
+        // page seeds them on one visit and renders them on the next, so a
+        // link that carries the seed is still the delivery vehicle.
+        || source.contains("indexedDB")
         || source.contains("history.state")
         || source.contains("event.data")
         || source.contains(".message")
@@ -679,6 +683,13 @@ pub(crate) fn build_dom_xss_manual_poc_hint(
         return Some(format!(
             "set a same-origin cookie whose value carries {} (cookie-safe variant may be needed), then open {};",
             quoted_payload, quoted_url
+        ));
+    }
+
+    if source.contains("indexedDB") {
+        return Some(format!(
+            "open {} once with a query parameter carrying {} so the page persists it to IndexedDB, then reopen the page (the record renders on every later visit);",
+            quoted_url, quoted_payload
         ));
     }
 

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -296,7 +296,16 @@ fn prune_blocked_raw_angles(payloads: Vec<String>, invalid_specials: &[char]) ->
     }
     payloads
         .into_iter()
-        .filter(|p| !((block_lt && p.contains('<')) || (block_gt && p.contains('>'))))
+        .filter(|p| {
+            // Leading-window ("positional") filter bypass payloads carry raw
+            // `<`/`>` on purpose: their premise is that the block is positional,
+            // so the raw angle passes once the leading pad pushes it past the
+            // filtered window. Keep them despite the blocked-angle classification
+            // (they are FP-safe — a non-positional filter still encodes the `<`
+            // and nothing verifies). See `synthesis::positional_pad_payloads`.
+            crate::payload::synthesis::is_positional_pad_bypass(p)
+                || !((block_lt && p.contains('<')) || (block_gt && p.contains('>')))
+        })
         .collect()
 }
 
@@ -358,17 +367,30 @@ fn hoist_angle_free_payloads(payloads: Vec<String>, invalid_specials: &[char]) -
     if !block_lt && !block_gt {
         return payloads;
     }
+    // Three tiers, front to back:
+    //   pad   — leading-window ("positional") bypass payloads (raw `<` on
+    //           purpose). When angles are reported blocked the block may be
+    //           positional, and these are then the *only* shapes that can reach
+    //           a tag injection, so they must lead — otherwise the DOM phase's
+    //           inert-echo early exit can retire before they are ever tried.
+    //   clean — angle-free survivors (event-handler / quote-breakout shapes).
+    //   rest  — encoded-angle variants (need a naive single-pass-decode filter).
+    let mut pad: Vec<String> = Vec::new();
     let mut clean: Vec<String> = Vec::with_capacity(payloads.len());
     let mut rest: Vec<String> = Vec::with_capacity(payloads.len());
     for p in payloads {
-        if payload_is_angle_free(&p) {
+        if crate::payload::synthesis::is_positional_pad_bypass(&p) {
+            pad.push(p);
+        } else if payload_is_angle_free(&p) {
             clean.push(p);
         } else {
             rest.push(p);
         }
     }
-    clean.extend(rest);
-    clean
+    pad.reserve(clean.len() + rest.len());
+    pad.extend(clean);
+    pad.extend(rest);
+    pad
 }
 
 fn get_fallback_reflection_payloads(

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -971,7 +971,11 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
             }
             url
         }
-        Location::Body | Location::JsonBody | Location::MultipartBody => {
+        Location::Body
+        | Location::JsonBody
+        | Location::MultipartBody
+        | Location::GraphqlBody
+        | Location::XmlBody => {
             // Body params use the form action URL when discovered from a form,
             // so the displayed request matches the POST actually sent.
             crate::scanning::url_inject::effective_query_base(&target.url, param)
@@ -982,14 +986,14 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
     let method = crate::scanning::url_inject::effective_method(&target.method, param);
     // Body-bearing locations always send a body; synthesize one when the
     // target has no original `data`, so the displayed PoC isn't an empty POST.
-    let (body, content_type): (Option<String>, Option<&'static str>) = match param.location {
+    let (body, content_type): (Option<String>, Option<String>) = match param.location {
         Location::Body => {
             let body = crate::scanning::url_inject::urlencoded_body(
                 target.data.as_deref(),
                 &param.name,
                 payload,
             );
-            (Some(body), Some("application/x-www-form-urlencoded"))
+            (Some(body), Some("application/x-www-form-urlencoded".to_string()))
         }
         Location::JsonBody => {
             let body = crate::scanning::url_inject::json_body(
@@ -998,9 +1002,25 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
                 &param.value,
                 payload,
             );
-            (Some(body), Some("application/json"))
+            (Some(body), Some("application/json".to_string()))
         }
-        Location::MultipartBody => (target.data.clone(), Some("multipart/form-data")),
+        Location::MultipartBody => (target.data.clone(), Some("multipart/form-data".to_string())),
+        // GraphQL / XML rebuild the whole body from the param's pipeline
+        // (`JsonField` into the GraphQL request / `Splice` around the XML
+        // injection point). `apply_param_encoding` runs that pipeline on the
+        // raw `payload`, so the displayed PoC body is exactly what goes on the
+        // wire.
+        Location::GraphqlBody => {
+            let body = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
+            (Some(body), Some("application/json".to_string()))
+        }
+        Location::XmlBody => {
+            let body = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
+            (
+                Some(body),
+                Some(crate::scanning::url_inject::xml_request_content_type(target)),
+            )
+        }
         _ => (target.data.clone(), None),
     };
 
@@ -1063,7 +1083,7 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
     // Body injectors always set their own `Content-Type` on the wire; a
     // Query/Path injector re-sends the original body verbatim and passes
     // `None` here, keeping whatever the target captured.
-    if let Some(ct) = content_type {
+    if let Some(ct) = &content_type {
         buf.push_str("\r\nContent-Type: ");
         buf.push_str(ct);
     }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -661,6 +661,42 @@ fn test_hoist_angle_free_payloads_no_op_without_block() {
     assert_eq!(hoisted, original, "non-angle invalids must not reorder");
 }
 
+#[test]
+fn test_prune_keeps_positional_pad_bypass_despite_blocked_angles() {
+    // A leading-window ("positional") pad payload carries a raw `<` on purpose —
+    // the block may only touch a leading window, so the tag passes once padded
+    // past it. The raw-angle prune must exempt it while still dropping ordinary
+    // raw-angle payloads.
+    let pad = format!("{}<svg onload=alert(1) class=x>", "0".repeat(24));
+    let payloads = vec![
+        pad.clone(),
+        "<svg onload=alert(1)>".to_string(), // ordinary raw-angle: dropped
+        "\" onfocus=alert(1) \"".to_string(), // angle-free: kept
+    ];
+    let pruned = prune_blocked_raw_angles(payloads, &['<', '>']);
+    assert!(pruned.contains(&pad), "positional-pad payload must survive the prune");
+    assert!(
+        !pruned.iter().any(|p| p == "<svg onload=alert(1)>"),
+        "ordinary raw-angle payloads must still be dropped"
+    );
+}
+
+#[test]
+fn test_hoist_puts_positional_pad_bypass_first() {
+    // When angles are reported blocked, positional-pad payloads must lead so the
+    // DOM phase's inert-echo early exit cannot retire before they are tried.
+    let pad = format!("{}<svg onload=alert(1) class=x>", "0".repeat(24));
+    let payloads = vec![
+        "\" onfocus=alert(1) \"".to_string(), // angle-free
+        pad.clone(),                          // positional pad (raw <)
+        "%3Csvg%3E".to_string(),              // encoded angle
+    ];
+    let hoisted = hoist_angle_free_payloads(payloads, &['<']);
+    assert_eq!(hoisted[0], pad, "positional-pad payload must be hoisted to the very front");
+    assert_eq!(hoisted[1], "\" onfocus=alert(1) \"");
+    assert!(hoisted[2].contains("%3C"));
+}
+
 // ── expand_waf_payloads: orthogonal mutation/encoder expansion ───────
 
 #[test]

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -141,11 +141,13 @@ pub(crate) fn body_location_method_for_param(
 /// method. Finding metadata must match the verb that is actually sent.
 pub(crate) fn effective_method(target_method: &str, param: &Param) -> String {
     match param.location {
-        Location::Body | Location::JsonBody | Location::MultipartBody => {
-            body_location_method_for_param(target_method, param)
-                .as_str()
-                .to_string()
-        }
+        Location::Body
+        | Location::JsonBody
+        | Location::MultipartBody
+        | Location::GraphqlBody
+        | Location::XmlBody => body_location_method_for_param(target_method, param)
+            .as_str()
+            .to_string(),
         _ => target_method.to_string(),
     }
 }
@@ -265,7 +267,11 @@ pub(crate) fn build_injected_url(base: &url::Url, param: &Param, injected: &str)
             }
             url.to_string()
         }
-        Location::Body | Location::JsonBody | Location::MultipartBody => {
+        Location::Body
+        | Location::JsonBody
+        | Location::MultipartBody
+        | Location::GraphqlBody
+        | Location::XmlBody => {
             // For body params, the URL itself does not change.
             // Return the base URL as-is; actual payload injection happens in the
             // request body (handled by the caller when building the request).
@@ -701,6 +707,70 @@ pub(crate) fn resolve_form_action_url(param: &Param, target: &Target) -> url::Ur
         .unwrap_or_else(|| target.url.clone())
 }
 
+/// The XML content-type to frame an [`Location::XmlBody`] injection with:
+/// the request's own declared `Content-Type` when it is an XML family type,
+/// else `application/xml`. Preserving `application/soap+xml` matters — a SOAP
+/// endpoint routes on it — while a stray non-XML captured type (or none) must
+/// not override the XML body we are actually sending.
+pub(crate) fn xml_request_content_type(target: &Target) -> String {
+    target
+        .headers
+        .iter()
+        .find(|(k, _)| k.eq_ignore_ascii_case("content-type"))
+        .map(|(_, v)| v.trim())
+        .filter(|v| {
+            let primary = crate::utils::content_type_primary(v);
+            matches!(
+                primary.as_deref(),
+                Some("text/xml")
+                    | Some("application/xml")
+                    | Some("application/soap+xml")
+                    | Some("application/xhtml+xml")
+            )
+        })
+        .map(str::to_string)
+        .unwrap_or_else(|| "application/xml".to_string())
+}
+
+/// GraphQL body injection. The param's `pre_encoding_pipeline` has already
+/// rebuilt the full request body (query + all variables, the target variable
+/// carrying `value`), so it ships verbatim as `application/json`.
+pub(crate) fn build_graphql_body_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let parsed_url = resolve_form_action_url(param, target);
+    let method = body_location_method_for_param(&target.method, param);
+    let base =
+        crate::utils::build_body_request_base(client, target, method, parsed_url, Some(value.to_string()));
+    crate::utils::apply_header_overrides(
+        base,
+        &[("Content-Type".to_string(), "application/json".to_string())],
+    )
+}
+
+/// XML / SOAP body injection. The param's `pre_encoding_pipeline` (a `Splice`)
+/// has already re-glued the original document around the injection point, so
+/// `value` is the complete XML body; it ships with the request's declared XML
+/// content-type (see [`xml_request_content_type`]).
+pub(crate) fn build_xml_body_request(
+    client: &Client,
+    target: &Target,
+    param: &Param,
+    value: &str,
+) -> reqwest::RequestBuilder {
+    let parsed_url = resolve_form_action_url(param, target);
+    let method = body_location_method_for_param(&target.method, param);
+    let base =
+        crate::utils::build_body_request_base(client, target, method, parsed_url, Some(value.to_string()));
+    crate::utils::apply_header_overrides(
+        base,
+        &[("Content-Type".to_string(), xml_request_content_type(target))],
+    )
+}
+
 /// `application/x-www-form-urlencoded` body injection.
 pub(crate) fn build_body_request(
     client: &Client,
@@ -801,6 +871,8 @@ pub(crate) fn build_inject_request(
         Location::Body => build_body_request(client, target, param, value),
         Location::JsonBody => build_json_body_request(client, target, param, value),
         Location::MultipartBody => build_multipart_request(client, target, param, value),
+        Location::GraphqlBody => build_graphql_body_request(client, target, param, value),
+        Location::XmlBody => build_xml_body_request(client, target, param, value),
         _ => build_url_inject_request(client, target, param, value, default_method),
     }
 }

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -928,3 +928,31 @@ fn build_injected_url_output_is_always_parseable() {
         }
     }
 }
+
+#[test]
+fn xml_content_type_prefers_declared_xml_family() {
+    for (declared, expected) in [
+        ("text/xml", "text/xml"),
+        ("application/xml; charset=utf-8", "application/xml; charset=utf-8"),
+        ("application/soap+xml; action=\"x\"", "application/soap+xml; action=\"x\""),
+    ] {
+        let target = Target {
+            headers: vec![("Content-Type".to_string(), declared.to_string())],
+            ..Target::for_url(Url::parse("http://x/").unwrap())
+        };
+        assert_eq!(xml_request_content_type(&target), expected);
+    }
+}
+
+#[test]
+fn xml_content_type_defaults_when_non_xml_or_absent() {
+    // A non-XML captured type must not override the XML body we send.
+    let json_target = Target {
+        headers: vec![("content-type".to_string(), "application/json".to_string())],
+        ..Target::for_url(Url::parse("http://x/").unwrap())
+    };
+    assert_eq!(xml_request_content_type(&json_target), "application/xml");
+    // No content-type at all → default.
+    let bare = Target::for_url(Url::parse("http://x/").unwrap());
+    assert_eq!(xml_request_content_type(&bare), "application/xml");
+}

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -406,12 +406,30 @@ pub(crate) fn generate_adaptive_payloads(
         None,
     );
 
+    // Leading-window ("positional") filter bypass: some filters entity-encode /
+    // strip only a fixed leading window of the value, which the per-character
+    // probe cannot see (it reflects its `<` past the window and records it
+    // valid). These padded tag payloads push the real vector past that window;
+    // they carry raw `<`/`>` deliberately, so the caller's raw-angle prune
+    // exempts them via `synthesis::is_positional_pad_bypass`. FP-safe by marker
+    // verification. Placed AFTER `synthesized` (which leads with the clean tag
+    // shapes) so an easily-exploitable param still verifies on — and reports —
+    // the tidy PoC first; on an easy param the DOM phase stops at that `[V]` and
+    // these are never sent. Still well inside the DOM phase's 256-echo early-exit
+    // window, so they are reached when the clean tags are positionally filtered.
+    let positional = crate::payload::synthesis::positional_pad_payloads(context);
+
     // Apply adaptive encoders with pre-allocated capacity
-    let estimated_cap =
-        (synthesized.len() + filtered_payloads.len()) * (2 + adaptive_encoders.len());
+    let estimated_cap = (positional.len() + synthesized.len() + filtered_payloads.len())
+        * (2 + adaptive_encoders.len());
     let mut out = Vec::with_capacity(estimated_cap);
     let mut seen = std::collections::HashSet::with_capacity(estimated_cap);
     for p in synthesized {
+        if seen.insert(p.clone()) {
+            out.push(p);
+        }
+    }
+    for p in positional {
         if seen.insert(p.clone()) {
             out.push(p);
         }


### PR DESCRIPTION
Expands XSS coverage across three independent tracks (injection surface, DOM dataflow, filter/encoding bypass), integrated on one branch. Every new detection ships with adversarial FP-control tests; validated against xssmaze with zero regressions.

`cargo test`: **2774 passed / 0 failed** · `cargo clippy --all-targets -- -D warnings`: clean.

## Tracks

### 1. New injection surfaces
- **GraphQL variables** (`Location::GraphqlBody`): injects each string leaf inside a GraphQL-over-JSON `variables` object, rebuilding the whole request per variable. Detection fires only when an operation-keyword `query` and a `variables` object co-exist (a plain REST search box named `query` is not GraphQL).
- **XML / SOAP bodies** (`Location::XmlBody` + `EncodingStep::Splice`): a self-written byte-range tokenizer finds text-node / attribute leaves and splices the payload in, preserving every non-target byte verbatim (no parse-reserialize garble). Preserves the request's XML content-type.
- File-upload XSS deferred as design-only (stored-XSS, outside the reflection model).

### 2. DOM dataflow (AST taint) gaps
- Propagation: callback-return taint (`replace`/`map`/`reduce`), `Promise.all`/`resolve` chain roots, tagged templates, `Proxy`/collection taint-forwarding constructors, class accessor → constructor argument.
- Sinks: `Object.assign` merges onto navigation/HTML sinks, iteration-callback `eval` (`.map(eval)`).
- Sources: IndexedDB stored records, CSS custom-property round-trip.
- xssmaze DOM family **12/38 → 21/38** by `detection_method=ast` (taintflow 8/8, domsink 7/8, domsource 6/7); ast-findings 128→137 with **zero lost**, reflection control flat (222→222), FP-control levels unchanged.

### 3. Filter / encoding bypass (payload synthesis)
- **Leading-window ("positional") pad**: inert digit pad pushes the real vector past a filter that only encodes/strips a fixed leading window. Bounded (≤4 payloads, HTML-text only), prune-exempt + hoisted so the DOM early-exit can't skip them; sent only when the plain tags fail.
- **Paren-free / backtick-free handler**: `throw onerror=alert,1` / `onerror=alert;throw 1` for filters that strip `()`/backticks.
- xssmaze filter/encoding verify **20 → 23/25** (edgefilter-6, encodingedge-4, filterchain-5; filterchain-5 requests 2750→173).

## FP safety
Every new source / sink / propagation / payload has a paired FP-control test that asserts non-detection on the discriminating benign shape (parsed with `scraper` for the synthesis paths). No headless / browser dependency added; DOM findings remain statically verified by design.

## Deferred (documented, not lost)
- **CSTI as a detection class** — measured redundant (every xssmaze CSTI level already `[V]` via plain HTML injection) plus EOL/FP risk.
- **Prototype pollution** — recon only; needs its own informational detection kind (a literal `__proto__` matcher is the wrong signal).
- `replaceSync` (CSS ≠ script execution), `dataset`/`getAttribute`/`form.action` sources (need HTML pre-scan correlation), `encodingedge-3` sacrificial-quote (suppressed by the shared `check_reflection` FP gate — reverted, with a targeted fix recommendation).

## Notes
Docs (EN/KO), skills, and MCP tool descriptions are not updated in this PR — a follow-up if these surfaces should reflect the new injection types.
