### PR TITLE
docs: document GraphQL and XML/SOAP body injection surfaces

### DIFF
--- a/docs/content/guide/parameters.ko.md
+++ b/docs/content/guide/parameters.ko.md
@@ -29,7 +29,7 @@ dalfox https://target.app/api \
   -p token:cookie
 ```
 
-위치(Location): `query`, `body`, `json`, `multipart`, `cookie`, `header`. 주입 지점이 쿼리 문자열이 아니라면 `name:location` 형식을 쓰세요.
+위치(Location): `query`, `body`, `json`, `multipart`, `cookie`, `header`, `graphql`, `xml`. 주입 지점이 쿼리 문자열이 아니라면 `name:location` 형식을 쓰세요. `graphql`과 `xml`은 요청 본문에서 자동으로 탐지됩니다([GraphQL 및 XML 본문 주입](#graphql-및-xml-본문-주입) 참조). 힌트는 이미 발견된 파라미터를 필터링할 수는 있지만, 이름만으로 새 본문을 합성하지는 못합니다.
 
 위치 힌트가 없는 경우(`-p q`만 지정):
 
@@ -163,6 +163,34 @@ dalfox scan https://example.com -H 'X-Search: FUZZ' --inject-marker FUZZ
 JWT의 경우 원래 헤더와 서명 세그먼트는 그대로(verbatim) 보존됩니다. 서명은 수정된 페이로드와 일치하지 않으므로, 이는 토큰을 검증하지 않는 엔드포인트에서만 발동합니다. 올바르게 서명된 JWT는 탐지 결과를 반환하지 않습니다. 이는 놓친 것이 아니라 의도된 동작입니다.
 
 대상이 Dalfox가 자동 탐지하지 못하는 래핑을 쓴다면, `--inject-marker`로 주입 지점을 강제로 지정할 수 있습니다(위 참조).
+
+## GraphQL 및 XML 본문 주입
+
+요청 본문(`-d`, 또는 캡처된 `raw-http` / `har` 요청)이 GraphQL이나 XML 문서라면, Dalfox는 본문 전체를 하나의 불투명한 덩어리로 테스트하는 대신 그 안의 값들을 주입 지점으로 다룹니다.
+
+**GraphQL**(`application/json` 또는 `application/graphql`): GraphQL 오퍼레이션(값이 `query`/`mutation`/`subscription` 또는 익명 `{ … }` 축약형으로 시작하는 `query`/`mutation` 필드)과 `variables` 오브젝트를 **둘 다** 가진 본문은, `variables` 안의 모든 문자열 leaf가 각각 `graphql` 파라미터로 등록됩니다. 각 페이로드는 요청 전체를 재구성하며(오퍼레이션과 다른 변수들은 그대로 함께 전송) 서버는 항상 유효하고 파싱 가능한 GraphQL 요청을 받습니다.
+
+```bash
+dalfox https://target.app/graphql \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"query($q:String!){ search(term:$q){ id } }","variables":{"q":"seed"}}'
+# → variables.q 가 `graphql` 파라미터로 주입됩니다
+```
+
+단지 `query`라는 이름의 필드만 있는 평범한 REST 엔드포인트(검색창, `{"query":"laptop"}`)는 GraphQL로 **취급되지 않습니다** — `variables` 오브젝트와 오퍼레이션 형태의 값이 모두 필요하므로, 일반 JSON 본문은 그대로 `json` 경로에 남습니다.
+
+**XML / SOAP**(`text/xml`, `application/xml`, `application/soap+xml`, 또는 `<?xml …?>` 프롤로그가 있는 본문): 각 엘리먼트 텍스트 노드와 속성 값이 `xml` 파라미터가 됩니다. byte-range splice가 페이로드를 제자리에 주입하며, 문서의 다른 모든 바이트 — 네임스페이스, 형제 엘리먼트, SOAP 엔벨로프 — 는 그대로 유지되고 요청의 XML content-type도 보존됩니다.
+
+```bash
+dalfox https://target.app/soap \
+  -X POST \
+  -H 'Content-Type: application/soap+xml' \
+  -d '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><search><term>seed</term></search></soap:Body></soap:Envelope>'
+# → <term> 텍스트 노드가 `xml` 파라미터로 주입됩니다
+```
+
+모든 반사 결과와 마찬가지로, 값은 응답이 이를 HTML로 파싱할 때만 `[V]`로 등급이 매겨집니다 — `application/json`으로 응답하는 GraphQL API나 이스케이프된 값을 되돌려주는 XML 서비스는 올바르게 무해(inert)로 보고됩니다. 실제 도달점은 반사된 값을 마크업으로 렌더링하는 관리자 화면, 리포트, 에러 페이지입니다.
 
 ## 반사 프로브 형태
 

--- a/docs/content/guide/parameters.md
+++ b/docs/content/guide/parameters.md
@@ -29,7 +29,7 @@ dalfox https://target.app/api \
   -p token:cookie
 ```
 
-Locations: `query`, `body`, `json`, `multipart`, `cookie`, `header`. Prefer `name:location` when the injection point is not the query string.
+Locations: `query`, `body`, `json`, `multipart`, `cookie`, `header`, `graphql`, `xml`. Prefer `name:location` when the injection point is not the query string. `graphql` and `xml` are discovered automatically from the request body (see [GraphQL and XML body injection](#graphql-and-xml-body-injection)); a hint filters an already-discovered one but cannot synthesize a fresh body from a bare name.
 
 Without a location hint (`-p q` only):
 
@@ -163,6 +163,34 @@ Each leaf is registered as a separate Param using bracket-style display naming. 
 For JWTs the original header and signature segments are preserved verbatim. The signature won't match the modified payload, so this only fires on endpoints that don't verify the token. Properly-signed JWTs return no findings. That's expected behaviour, not a miss.
 
 If your target uses a wrapping that Dalfox doesn't auto-detect, you can still force the injection point with `--inject-marker` (see above).
+
+## GraphQL and XML body injection
+
+When the request body (`-d`, or a captured `raw-http` / `har` request) is a GraphQL or XML document, Dalfox treats its inner values as injection points instead of testing the raw body as one opaque blob.
+
+**GraphQL** (`application/json` or `application/graphql`): a body that carries both a GraphQL operation (a `query`/`mutation` field whose value starts with `query`/`mutation`/`subscription` or the anonymous `{ … }` shorthand) **and** a `variables` object has every string leaf inside `variables` registered as its own `graphql` parameter. Each payload rebuilds the whole request — the operation and the other variables ride along unchanged — so the server always receives a valid, parseable GraphQL request.
+
+```bash
+dalfox https://target.app/graphql \
+  -X POST \
+  -H 'Content-Type: application/json' \
+  -d '{"query":"query($q:String!){ search(term:$q){ id } }","variables":{"q":"seed"}}'
+# → variables.q is injected as a `graphql` parameter
+```
+
+A plain REST endpoint that merely has a field named `query` (a search box, `{"query":"laptop"}`) is **not** treated as GraphQL — the `variables` object and an operation-shaped value are both required, so ordinary JSON bodies stay on the normal `json` path.
+
+**XML / SOAP** (`text/xml`, `application/xml`, `application/soap+xml`, or a body with an `<?xml …?>` prolog): each element text node and attribute value becomes an `xml` parameter. A byte-range splice injects the payload in place, leaving every other byte of the document — namespaces, sibling elements, the SOAP envelope — untouched, and the request's XML content-type is preserved.
+
+```bash
+dalfox https://target.app/soap \
+  -X POST \
+  -H 'Content-Type: application/soap+xml' \
+  -d '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"><soap:Body><search><term>seed</term></search></soap:Body></soap:Envelope>'
+# → the <term> text node is injected as an `xml` parameter
+```
+
+As with every reflected finding, a value only grades `[V]` when the response parses it as HTML — a GraphQL API that answers `application/json`, or an XML service that echoes an escaped value, is correctly reported as inert. The real reach is an admin view, report, or error page that renders the reflected value as markup.
 
 ## Reflection probe shape
 

--- a/docs/static/.well-known/agent-skills/dalfox/SKILL.md
+++ b/docs/static/.well-known/agent-skills/dalfox/SKILL.md
@@ -66,7 +66,7 @@ If the number is huge or `reachable == false`, report back to the user before se
      ```
    - **MCP long scan**: `scan_with_dalfox` with `wait=false` → store `scan_id` → poll `get_results_dalfox`. Prefer explicit `param` (`["q:query"]` when location is known).
    - **CLI**: `dalfox scan https://target/?q=test -p q --skip-mining ...`  
-     Bare `-p name` is fine for query params (synthesized if discovery was skipped). Use `name:location` for body/header/cookie/json (`-p user:body`). Cap volume with `--max-payloads-per-param`.
+     Bare `-p name` is fine for query params (synthesized if discovery was skipped). Use `name:location` for body/header/cookie/json (`-p user:body`). GraphQL `variables` and XML/SOAP bodies are auto-detected as `graphql`/`xml` injection points from a matching `-d` body (or raw-http/har). Cap volume with `--max-payloads-per-param`.
 3. Poll only when not using `wait=true`.
 4. Present findings using the rules in `references/results.md` (lead with V, surface `type_description` and `inject_type`).
 5. Clean up: `delete_scan_dalfox` (MCP) or just let the process end (CLI). Terminal jobs auto-expire after 1 h.

--- a/docs/static/.well-known/agent-skills/index.json
+++ b/docs/static/.well-known/agent-skills/index.json
@@ -6,7 +6,7 @@
       "type": "skill-md",
       "description": "Use when scanning a URL or parameter for XSS (reflected, DOM, stored, blind), enumerating reflected parameters, or when the user explicitly mentions \"dalfox\" or \"XSS scan\". Runs as CLI (`dalfox scan`) or MCP server (6 tools). Authoritative workflows for dalfox v3 (Rust). Not for non-XSS vulnerabilities.",
       "url": "/.well-known/agent-skills/dalfox/SKILL.md",
-      "digest": "sha256:45175bea7c3f142a95ea31c6074a541b183df9e7f3ef813cb4bee7c032969313"
+      "digest": "sha256:8d623948a66d0206a4e36ecfbe6c3a614bc9d00ccb2467a3f105a0a121dffc1e"
     }
   ]
 }

--- a/skills/dalfox/SKILL.md
+++ b/skills/dalfox/SKILL.md
@@ -66,7 +66,7 @@ If the number is huge or `reachable == false`, report back to the user before se
      ```
    - **MCP long scan**: `scan_with_dalfox` with `wait=false` → store `scan_id` → poll `get_results_dalfox`. Prefer explicit `param` (`["q:query"]` when location is known).
    - **CLI**: `dalfox scan https://target/?q=test -p q --skip-mining ...`  
-     Bare `-p name` is fine for query params (synthesized if discovery was skipped). Use `name:location` for body/header/cookie/json (`-p user:body`). Cap volume with `--max-payloads-per-param`.
+     Bare `-p name` is fine for query params (synthesized if discovery was skipped). Use `name:location` for body/header/cookie/json (`-p user:body`). GraphQL `variables` and XML/SOAP bodies are auto-detected as `graphql`/`xml` injection points from a matching `-d` body (or raw-http/har). Cap volume with `--max-payloads-per-param`.
 3. Poll only when not using `wait=true`.
 4. Present findings using the rules in `references/results.md` (lead with V, surface `type_description` and `inject_type`).
 5. Clean up: `delete_scan_dalfox` (MCP) or just let the process end (CLI). Terminal jobs auto-expire after 1 h.

--- a/src/cmd/scan/args.rs
+++ b/src/cmd/scan/args.rs
@@ -410,7 +410,7 @@ pub struct ScanArgs {
     pub baseline_mode_arg: Option<String>,
 
     #[clap(help_heading = "TARGETS")]
-    /// Specify parameter names to analyze (e.g., -p sort -p id:query). Types: query, body, json, cookie, header.
+    /// Specify parameter names to analyze (e.g., -p sort -p id:query). Types: query, body, json, multipart, cookie, header, graphql, xml.
     #[arg(short = 'p', long)]
     pub param: Vec<String>,
 


### PR DESCRIPTION
Documents the GraphQL and XML/SOAP body injection surfaces added in #1426 across the user-facing surfaces that were still listing only the pre-existing injection types.

## Changes
- **`guide/parameters.md` (+ `.ko.md`)** — add `graphql`/`xml` to the location list, and a new **"GraphQL and XML body injection"** section: auto-detection from a `-d` / raw-http / har body, the GraphQL `query`+`variables` gate (a plain REST `query` field is *not* GraphQL), the XML/SOAP byte-range splice that preserves the rest of the document, and the HTML-parse content-type caveat that keeps both FP-safe.
- **scan `-p` help** — fix the Types enumeration: it was missing `multipart` even before this, now also lists `graphql`/`xml`.
- **`skills/dalfox/SKILL.md` + published `.well-known` copy** — note the auto-detected graphql/xml injection points; refresh the `index.json` sha256 digest.

## Deliberately out of scope
The DOM-dataflow and filter/encoding-bypass parts of #1426 are internal engine improvements with no new flags or user knobs; the docs' source/sink and payload lists are illustrative (`…`), so they aren't enumerated here to avoid staleness.

## Verified locally
- `crystal run scripts/docs_lint.cr` — EN/KO pairing, `#anchor` resolution (incl. the new EN `#graphql-and-xml-body-injection` and KO `#graphql-및-xml-본문-주입`), skill-digest — all pass.
- `crystal run scripts/surface_parity.cr` (with a release binary) — **46 passed / 0 failed**.
- `cargo test --test agent_skills_sync_test` — SKILL.md copies byte-identical + digest matches.
