### PR TITLE
chore: fix cargo fmt formatting across codebase

### DIFF
--- a/src/cmd/scan/poc/tests.rs
+++ b/src/cmd/scan/poc/tests.rs
@@ -103,7 +103,10 @@ fn poc_location_in_url_false_for_side_channel_locations() {
 
 #[test]
 fn poc_location_tag_graphql_and_xml() {
-    assert_eq!(poc_location_tag("GraphqlBody", "variables.n"), Some("graphql"));
+    assert_eq!(
+        poc_location_tag("GraphqlBody", "variables.n"),
+        Some("graphql")
+    );
     assert_eq!(poc_location_tag("XmlBody", "msg"), Some("xml"));
 }
 
@@ -145,9 +148,15 @@ fn graphql_curl_poc_reproduces_full_recorded_body() {
     r.location = "GraphqlBody".to_string();
     r.request = Some(req.to_string());
     let out = render_curl_poc(&r, "http://h:8899/graphql");
-    assert!(out.contains("-H \"Content-Type: application/json\""), "{out}");
+    assert!(
+        out.contains("-H \"Content-Type: application/json\""),
+        "{out}"
+    );
     // The full structured body (query + the injected variable) is present,
     // not a lossy `{"variables.n":"payload"}` fragment.
     assert!(out.contains("mutation($n:String)"), "{out}");
-    assert!(out.contains("\\\"variables\\\":{\\\"n\\\":\\\"<svg onload=alert(1)>\\\"}"), "{out}");
+    assert!(
+        out.contains("\\\"variables\\\":{\\\"n\\\":\\\"<svg onload=alert(1)>\\\"}"),
+        "{out}"
+    );
 }

--- a/src/encoding/pipeline/tests.rs
+++ b/src/encoding/pipeline/tests.rs
@@ -516,7 +516,10 @@ fn graphql_variables_string_leaf_is_detected() {
     assert_eq!(fields[0].pointer, "/variables/n");
     assert_eq!(fields[0].path, vec!["variables", "n"]);
     // The pipeline rebuilds the whole request with the payload in that slot.
-    let body = fields[0].pipeline.apply("<svg/onload=alert(1)>").expect("apply");
+    let body = fields[0]
+        .pipeline
+        .apply("<svg/onload=alert(1)>")
+        .expect("apply");
     let parsed: serde_json::Value = serde_json::from_str(&body).expect("valid json");
     assert_eq!(parsed["variables"]["n"], "<svg/onload=alert(1)>");
     // Query source is preserved intact.

--- a/src/parameter_analysis/mining.rs
+++ b/src/parameter_analysis/mining.rs
@@ -1769,13 +1769,12 @@ pub async fn probe_xml_body_params(
 
         // Exact-byte-range splice: prefix + payload + suffix rebuilds the whole
         // document with only this leaf replaced.
-        let pipeline =
-            crate::encoding::pipeline::EncodingPipeline::new(vec![
-                crate::encoding::pipeline::EncodingStep::Splice {
-                    prefix: data[..point.start].to_string(),
-                    suffix: data[point.end..].to_string(),
-                },
-            ]);
+        let pipeline = crate::encoding::pipeline::EncodingPipeline::new(vec![
+            crate::encoding::pipeline::EncodingStep::Splice {
+                prefix: data[..point.start].to_string(),
+                suffix: data[point.end..].to_string(),
+            },
+        ]);
 
         let client_clone = client.clone();
         let url = target.url.clone();

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -1484,8 +1484,10 @@ async fn probe_graphql_params_seeds_reflected_variable() {
     let target = parse_target(&format!("http://{}:{}/graphql", addr.ip(), addr.port()))
         .expect("parse target");
     let mut args = default_scan_args();
-    args.data =
-        Some(r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#.to_string());
+    args.data = Some(
+        r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#
+            .to_string(),
+    );
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
@@ -1496,7 +1498,11 @@ async fn probe_graphql_params_seeds_reflected_variable() {
         .iter()
         .filter(|p| p.location == Location::GraphqlBody)
         .collect();
-    assert_eq!(gql.len(), 1, "expected one GraphQL variable param, got {params:?}");
+    assert_eq!(
+        gql.len(),
+        1,
+        "expected one GraphQL variable param, got {params:?}"
+    );
     assert_eq!(gql[0].name, "variables.n");
     assert!(
         gql[0].pre_encoding_pipeline.is_some(),
@@ -1533,8 +1539,10 @@ async fn probe_json_body_params_defers_graphql_body() {
     let target = parse_target(&format!("http://{}:{}/graphql", addr.ip(), addr.port()))
         .expect("parse target");
     let mut args = default_scan_args();
-    args.data =
-        Some(r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#.to_string());
+    args.data = Some(
+        r#"{"query":"mutation($n:String!){add(name:$n){id}}","variables":{"n":"seed"}}"#
+            .to_string(),
+    );
 
     let reflection_params = Arc::new(Mutex::new(Vec::<Param>::new()));
     let semaphore = Arc::new(tokio::sync::Semaphore::new(2));
@@ -1573,8 +1581,8 @@ async fn start_xml_server() -> SocketAddr {
 }
 
 fn xml_target(addr: &SocketAddr) -> Target {
-    let mut t = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
-        .expect("parse target");
+    let mut t =
+        parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port())).expect("parse target");
     t.headers
         .push(("Content-Type".to_string(), "application/xml".to_string()));
     t
@@ -1607,7 +1615,10 @@ async fn probe_xml_body_params_seeds_reflected_text_node() {
         .unwrap()
         .apply("<svg/onload=alert(1)>")
         .expect("apply");
-    assert_eq!(body, "<req><item id=\"1\">x</item><msg><svg/onload=alert(1)></msg></req>");
+    assert_eq!(
+        body,
+        "<req><item id=\"1\">x</item><msg><svg/onload=alert(1)></msg></req>"
+    );
 }
 
 #[tokio::test]
@@ -1615,8 +1626,8 @@ async fn probe_xml_body_params_noop_without_xml_content_type() {
     // FP control: an XML-looking body but no XML content-type and no `<?xml`
     // prolog must not be treated as XML.
     let addr = start_xml_server().await;
-    let target = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
-        .expect("parse target"); // no Content-Type header
+    let target =
+        parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port())).expect("parse target"); // no Content-Type header
     let mut args = default_scan_args();
     args.data = Some("<req><msg>seed</msg></req>".to_string());
 
@@ -1646,8 +1657,8 @@ async fn probe_xml_body_params_fires_on_xml_prolog_without_content_type() {
     // An `<?xml` prolog is a strong enough signal to probe even when the user
     // forgot the Content-Type header.
     let addr = start_xml_server().await;
-    let target = parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port()))
-        .expect("parse target");
+    let target =
+        parse_target(&format!("http://{}:{}/xml", addr.ip(), addr.port())).expect("parse target");
     let mut args = default_scan_args();
     args.data = Some("<?xml version=\"1.0\"?><req><msg>seed</msg></req>".to_string());
 

--- a/src/parameter_analysis/xml_inject/tests.rs
+++ b/src/parameter_analysis/xml_inject/tests.rs
@@ -51,7 +51,10 @@ fn single_quoted_attribute() {
     let xml = "<a href='http://x'>t</a>";
     let pts = xml_injection_points(xml);
     assert_ranges_match_values(xml, &pts);
-    assert!(pts.iter().any(|p| p.name == "a@href" && p.value == "http://x"));
+    assert!(
+        pts.iter()
+            .any(|p| p.name == "a@href" && p.value == "http://x")
+    );
 }
 
 #[test]
@@ -190,7 +193,10 @@ fn multibyte_utf8_text_and_attribute_ranges_are_char_aligned() {
     let xml = "<r><t title=\"héllo\">wörld😀世</t></r>";
     let pts = xml_injection_points(xml);
     assert_ranges_match_values(xml, &pts); // slices here; panics if misaligned
-    assert!(pts.iter().any(|p| p.name == "t@title" && p.value == "héllo"));
+    assert!(
+        pts.iter()
+            .any(|p| p.name == "t@title" && p.value == "héllo")
+    );
     assert!(pts.iter().any(|p| p.name == "t" && p.value == "wörld😀世"));
     let t = pts.iter().find(|p| p.name == "t").unwrap();
     assert_eq!(splice(xml, t, "X"), "<r><t title=\"héllo\">X</t></r>");

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -806,11 +806,23 @@ fn positional_pad_payloads_are_padded_verifiable_tags() {
             is_positional_pad_bypass(p),
             "pad payload must be recognised by the prune exemption: {p:?}"
         );
-        assert!(p.contains(class), "pad payload must carry the class marker: {p:?}");
-        assert!(p.contains("alert(1)"), "pad payload must carry an executor: {p:?}");
+        assert!(
+            p.contains(class),
+            "pad payload must carry the class marker: {p:?}"
+        );
+        assert!(
+            p.contains("alert(1)"),
+            "pad payload must carry an executor: {p:?}"
+        );
         let digits = p.bytes().take_while(u8::is_ascii_digit).count();
-        assert!(digits >= 20, "pad prefix must exceed common leading windows: {p:?}");
-        assert!(p.as_bytes()[digits] == b'<', "digits must run right up to the tag: {p:?}");
+        assert!(
+            digits >= 20,
+            "pad prefix must exceed common leading windows: {p:?}"
+        );
+        assert!(
+            p.as_bytes()[digits] == b'<',
+            "digits must run right up to the tag: {p:?}"
+        );
     }
 }
 
@@ -821,11 +833,11 @@ fn positional_pad_bypass_predicate_rejects_ordinary_payloads() {
     // wrongly survive the raw-angle prune and waste requests.
     for p in [
         "<svg onload=alert(1) class=x>",
-        "1<svg onload=alert(1)>",             // short digit run, not a pad
-        "0000000000<svg>",                     // 10 digits < MIN_RUN(12)
+        "1<svg onload=alert(1)>", // short digit run, not a pad
+        "0000000000<svg>",        // 10 digits < MIN_RUN(12)
         "'><svg onload=alert(1)>",
         "\" onmouseover=alert(1) x=\"",
-        "000000000000000000000000alert(1)",    // digits but no tag
+        "000000000000000000000000alert(1)", // digits but no tag
     ] {
         assert!(
             !is_positional_pad_bypass(p),
@@ -833,7 +845,9 @@ fn positional_pad_bypass_predicate_rejects_ordinary_payloads() {
         );
     }
     // ...and accept a real pad payload.
-    assert!(is_positional_pad_bypass("000000000000<svg onload=alert(1) class=x>"));
+    assert!(is_positional_pad_bypass(
+        "000000000000<svg onload=alert(1) class=x>"
+    ));
 }
 
 #[test]

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -60,11 +60,7 @@ impl<'a> DomXssVisitor<'a> {
             // `const m = new Message(tainted)` — record the accessor reads that
             // now hand the tainted constructor argument back out, so a later
             // `m.body` resolves without re-deriving the construction.
-            self.seed_instance_field_taints(
-                var_name,
-                class_id.name.as_str(),
-                &new_expr.arguments,
-            );
+            self.seed_instance_field_taints(var_name, class_id.name.as_str(), &new_expr.arguments);
             assigned_instance_class = true;
         }
         if !assigned_instance_class {

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -401,10 +401,7 @@ impl<'a> DomXssVisitor<'a> {
     /// the block-shaped statements a callback body commonly wraps its returns
     /// in. Nested function bodies are *not* descended: their returns belong to
     /// that inner function, not to this callback.
-    pub(super) fn first_tainted_return_source(
-        &self,
-        stmts: &[Statement<'a>],
-    ) -> Option<String> {
+    pub(super) fn first_tainted_return_source(&self, stmts: &[Statement<'a>]) -> Option<String> {
         let _guard = self.enter_recursion()?;
         for stmt in stmts {
             let found = match stmt {
@@ -414,14 +411,13 @@ impl<'a> DomXssVisitor<'a> {
                     .filter(|arg| self.is_tainted(arg))
                     .and_then(|arg| self.find_source_in_expr(arg)),
                 Statement::BlockStatement(block) => self.first_tainted_return_source(&block.body),
-                Statement::IfStatement(if_stmt) => {
-                    self.first_tainted_return_source(std::slice::from_ref(&if_stmt.consequent))
-                        .or_else(|| {
-                            if_stmt.alternate.as_ref().and_then(|alt| {
-                                self.first_tainted_return_source(std::slice::from_ref(alt))
-                            })
+                Statement::IfStatement(if_stmt) => self
+                    .first_tainted_return_source(std::slice::from_ref(&if_stmt.consequent))
+                    .or_else(|| {
+                        if_stmt.alternate.as_ref().and_then(|alt| {
+                            self.first_tainted_return_source(std::slice::from_ref(alt))
                         })
-                }
+                    }),
                 Statement::TryStatement(try_stmt) => self
                     .first_tainted_return_source(&try_stmt.block.body)
                     .or_else(|| {

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -1015,7 +1015,10 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
                 &param.name,
                 payload,
             );
-            (Some(body), Some("application/x-www-form-urlencoded".to_string()))
+            (
+                Some(body),
+                Some("application/x-www-form-urlencoded".to_string()),
+            )
         }
         Location::JsonBody => {
             let body = crate::scanning::url_inject::json_body(
@@ -1040,7 +1043,9 @@ fn build_request_text(target: &Target, param: &Param, payload: &str) -> String {
             let body = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
             (
                 Some(body),
-                Some(crate::scanning::url_inject::xml_request_content_type(target)),
+                Some(crate::scanning::url_inject::xml_request_content_type(
+                    target,
+                )),
             )
         }
         _ => (target.data.clone(), None),

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -674,7 +674,10 @@ fn test_prune_keeps_positional_pad_bypass_despite_blocked_angles() {
         "\" onfocus=alert(1) \"".to_string(), // angle-free: kept
     ];
     let pruned = prune_blocked_raw_angles(payloads, &['<', '>']);
-    assert!(pruned.contains(&pad), "positional-pad payload must survive the prune");
+    assert!(
+        pruned.contains(&pad),
+        "positional-pad payload must survive the prune"
+    );
     assert!(
         !pruned.iter().any(|p| p == "<svg onload=alert(1)>"),
         "ordinary raw-angle payloads must still be dropped"
@@ -692,7 +695,10 @@ fn test_hoist_puts_positional_pad_bypass_first() {
         "%3Csvg%3E".to_string(),              // encoded angle
     ];
     let hoisted = hoist_angle_free_payloads(payloads, &['<']);
-    assert_eq!(hoisted[0], pad, "positional-pad payload must be hoisted to the very front");
+    assert_eq!(
+        hoisted[0], pad,
+        "positional-pad payload must be hoisted to the very front"
+    );
     assert_eq!(hoisted[1], "\" onfocus=alert(1) \"");
     assert!(hoisted[2].contains("%3C"));
 }

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -743,8 +743,13 @@ pub(crate) fn build_graphql_body_request(
 ) -> reqwest::RequestBuilder {
     let parsed_url = resolve_form_action_url(param, target);
     let method = body_location_method_for_param(&target.method, param);
-    let base =
-        crate::utils::build_body_request_base(client, target, method, parsed_url, Some(value.to_string()));
+    let base = crate::utils::build_body_request_base(
+        client,
+        target,
+        method,
+        parsed_url,
+        Some(value.to_string()),
+    );
     crate::utils::apply_header_overrides(
         base,
         &[("Content-Type".to_string(), "application/json".to_string())],
@@ -763,8 +768,13 @@ pub(crate) fn build_xml_body_request(
 ) -> reqwest::RequestBuilder {
     let parsed_url = resolve_form_action_url(param, target);
     let method = body_location_method_for_param(&target.method, param);
-    let base =
-        crate::utils::build_body_request_base(client, target, method, parsed_url, Some(value.to_string()));
+    let base = crate::utils::build_body_request_base(
+        client,
+        target,
+        method,
+        parsed_url,
+        Some(value.to_string()),
+    );
     crate::utils::apply_header_overrides(
         base,
         &[("Content-Type".to_string(), xml_request_content_type(target))],

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -933,8 +933,14 @@ fn build_injected_url_output_is_always_parseable() {
 fn xml_content_type_prefers_declared_xml_family() {
     for (declared, expected) in [
         ("text/xml", "text/xml"),
-        ("application/xml; charset=utf-8", "application/xml; charset=utf-8"),
-        ("application/soap+xml; action=\"x\"", "application/soap+xml; action=\"x\""),
+        (
+            "application/xml; charset=utf-8",
+            "application/xml; charset=utf-8",
+        ),
+        (
+            "application/soap+xml; action=\"x\"",
+            "application/soap+xml; action=\"x\"",
+        ),
     ] {
         let target = Target {
             headers: vec![("Content-Type".to_string(), declared.to_string())],


### PR DESCRIPTION
Fixes formatting discrepancies flagged by `cargo fmt --all -- --check` on CI.