### PR TITLE
fix(scan): reproduce multipart body findings in the PoC output

### DIFF
--- a/src/cmd/scan/poc.rs
+++ b/src/cmd/scan/poc.rs
@@ -204,8 +204,22 @@ fn render_curl_poc(result: &crate::scanning::result::Result, attack_url: &str) -
             escaped(&result.payload),
             attack_url
         ),
-        "Body" | "MultipartBody" => format!(
+        "Body" => format!(
             "curl -X {} --data \"{}={}\" \"{}\"\n",
+            method,
+            result.param,
+            escaped(&result.payload),
+            attack_url
+        ),
+        // `--data` sends `application/x-www-form-urlencoded`; a multipart
+        // finding only reproduces as a multipart request. `--form-string`
+        // builds one (with curl's own boundary), matching the
+        // `reqwest::multipart::Form` the scanner actually sent. It must be
+        // `--form-string`, not `-F`: under `-F` a value with a leading `<` or
+        // `@` means "read the field from this file" — and every HTML payload
+        // starts with `<`, so `-F` would try to open a bogus file.
+        "MultipartBody" => format!(
+            "curl -X {} --form-string \"{}={}\" \"{}\"\n",
             method,
             result.param,
             escaped(&result.payload),
@@ -269,8 +283,15 @@ fn render_httpie_poc(result: &crate::scanning::result::Result, attack_url: &str)
             "http {} \"{}\" \"{}:{}\"\n",
             method, attack_url, result.param, result.payload
         ),
-        "Body" | "MultipartBody" => format!(
+        "Body" => format!(
             "http -f {} \"{}\" \"{}={}\"\n",
+            method, attack_url, result.param, result.payload
+        ),
+        // httpie's `-f`/`--form` sends urlencoded unless a file field is
+        // present; `--multipart` forces the multipart/form-data request a
+        // multipart finding needs to reproduce.
+        "MultipartBody" => format!(
+            "http --multipart {} \"{}\" \"{}={}\"\n",
             method, attack_url, result.param, result.payload
         ),
         "JsonBody" => format!(

--- a/src/cmd/scan/poc/tests.rs
+++ b/src/cmd/scan/poc/tests.rs
@@ -160,3 +160,54 @@ fn graphql_curl_poc_reproduces_full_recorded_body() {
         "{out}"
     );
 }
+
+#[test]
+fn multipart_curl_poc_uses_form_string_not_urlencoded() {
+    // A multipart finding must reproduce as a multipart request. `--data`
+    // would send `application/x-www-form-urlencoded` — the wrong wire format —
+    // and `-F` would treat the leading `<` as "read from file". `--form-string`
+    // sends the literal value as a real multipart field.
+    let r = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("POST")
+        .param("q")
+        .payload("<svg onload=alert(1)>")
+        .message_str("x")
+        .build();
+    let mut r = r;
+    r.location = "MultipartBody".to_string();
+    let out = render_curl_poc(&r, "http://h:8899/m");
+    assert!(
+        out.contains("--form-string \"q=<svg onload=alert(1)>\""),
+        "{out}"
+    );
+    assert!(
+        !out.contains("--data"),
+        "must not fall back to urlencoded: {out}"
+    );
+    assert!(
+        !out.contains("-F \""),
+        "must not use -F (leading `<` = read-from-file): {out}"
+    );
+}
+
+#[test]
+fn multipart_httpie_poc_forces_multipart() {
+    // httpie's `-f`/`--form` sends urlencoded unless a file field is present;
+    // `--multipart` forces the multipart/form-data request needed to reproduce.
+    let r = Result::builder(FindingType::Verified)
+        .inject_type("inHTML")
+        .method("POST")
+        .param("q")
+        .payload("<svg onload=alert(1)>")
+        .message_str("x")
+        .build();
+    let mut r = r;
+    r.location = "MultipartBody".to_string();
+    let out = render_httpie_poc(&r, "http://h:8899/m");
+    assert!(out.contains("http --multipart post"), "{out}");
+    assert!(
+        !out.contains("http -f "),
+        "must not use urlencoded form mode: {out}"
+    );
+}

--- a/src/cmd/scan/tests.rs
+++ b/src/cmd/scan/tests.rs
@@ -981,14 +981,22 @@ fn test_generate_poc_curl_jsonbody_emits_json_content_type() {
 }
 
 #[test]
-fn test_generate_poc_curl_multipart_uses_data_flag() {
+fn test_generate_poc_curl_multipart_uses_form_string() {
     let mut r = reflected_result("http://example.com/upload", "file", "<x>");
     r.method = "POST".to_string();
     r.location = "MultipartBody".to_string();
     let out = generate_poc(&r, "curl");
+    // A multipart finding must reproduce as multipart, not urlencoded. curl's
+    // `--form-string` sends a literal multipart field; `-F` would read the
+    // leading `<` as a filename and `--data` would send the wrong wire format.
     assert!(
-        out.contains("--data \"file=<x>\""),
-        "curl multipart POC missing --data: {}",
+        out.contains("--form-string \"file=<x>\""),
+        "curl multipart POC should use --form-string: {}",
+        out
+    );
+    assert!(
+        !out.contains("--data"),
+        "curl multipart POC must not fall back to urlencoded --data: {}",
         out
     );
 }

--- a/src/scanning/request_render.rs
+++ b/src/scanning/request_render.rs
@@ -77,12 +77,20 @@ pub(crate) fn build_request_text(target: &Target, param: &Param, payload: &str) 
     let method = crate::scanning::url_inject::effective_method(&target.method, param);
     // Body-bearing locations always send a body; synthesize one when the
     // target has no original `data`, so the displayed PoC isn't an empty POST.
+    // The scan applies `apply_param_encoding` to every injected value before it
+    // goes on the wire (see `check_reflection`/`check_dom_verification`), so a
+    // param that requires pre-encoding (e.g. an auto-detected base64 field) is
+    // sent encoded and the server decodes it back to the raw payload. For the
+    // body-scalar locations the PoC must embed that same encoded value, or a
+    // pasted request would carry un-encoded bytes the sink never reflects. A
+    // param with no pre-encoding gets the raw payload back unchanged.
+    let field_value = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
     let (body, content_type): (Option<String>, Option<String>) = match param.location {
         Location::Body => {
             let body = crate::scanning::url_inject::urlencoded_body(
                 target.data.as_deref(),
                 &param.name,
-                payload,
+                &field_value,
             );
             (
                 Some(body),
@@ -94,41 +102,36 @@ pub(crate) fn build_request_text(target: &Target, param: &Param, payload: &str) 
                 target.data.as_deref(),
                 &param.name,
                 &param.value,
-                payload,
+                &field_value,
             );
             (Some(body), Some("application/json".to_string()))
         }
         Location::MultipartBody => {
             // Mirror the multipart form actually sent (`build_multipart_request`
-            // → `multipart_form`): inject the payload into the named field and
-            // frame it with a real boundary. Cloning `target.data` shipped the
-            // original, payload-free, urlencoded body under a boundary-less
-            // `multipart/form-data` type — a PoC that reproduced nothing.
+            // → `multipart_form`): inject the (pre-encoded) value into the named
+            // field and frame it with a real boundary. Cloning `target.data`
+            // shipped the original, payload-free, urlencoded body under a
+            // boundary-less `multipart/form-data` type — a PoC that reproduced
+            // nothing.
             let (body, content_type) = crate::scanning::url_inject::multipart_poc_body(
                 target.data.as_deref(),
                 &param.name,
-                payload,
+                &field_value,
             );
             (Some(body), Some(content_type))
         }
         // GraphQL / XML rebuild the whole body from the param's pipeline
         // (`JsonField` into the GraphQL request / `Splice` around the XML
-        // injection point). `apply_param_encoding` runs that pipeline on the
-        // raw `payload`, so the displayed PoC body is exactly what goes on the
-        // wire.
-        Location::GraphqlBody => {
-            let body = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
-            (Some(body), Some("application/json".to_string()))
-        }
-        Location::XmlBody => {
-            let body = crate::encoding::pre_encoding::apply_param_encoding(payload, param);
-            (
-                Some(body),
-                Some(crate::scanning::url_inject::xml_request_content_type(
-                    target,
-                )),
-            )
-        }
+        // injection point). For these, `apply_param_encoding` (already computed
+        // as `field_value`) runs that pipeline on the raw `payload` and yields
+        // the complete body — exactly what goes on the wire.
+        Location::GraphqlBody => (Some(field_value), Some("application/json".to_string())),
+        Location::XmlBody => (
+            Some(field_value),
+            Some(crate::scanning::url_inject::xml_request_content_type(
+                target,
+            )),
+        ),
         _ => (target.data.clone(), None),
     };
 

--- a/src/scanning/request_render.rs
+++ b/src/scanning/request_render.rs
@@ -98,7 +98,19 @@ pub(crate) fn build_request_text(target: &Target, param: &Param, payload: &str) 
             );
             (Some(body), Some("application/json".to_string()))
         }
-        Location::MultipartBody => (target.data.clone(), Some("multipart/form-data".to_string())),
+        Location::MultipartBody => {
+            // Mirror the multipart form actually sent (`build_multipart_request`
+            // → `multipart_form`): inject the payload into the named field and
+            // frame it with a real boundary. Cloning `target.data` shipped the
+            // original, payload-free, urlencoded body under a boundary-less
+            // `multipart/form-data` type — a PoC that reproduced nothing.
+            let (body, content_type) = crate::scanning::url_inject::multipart_poc_body(
+                target.data.as_deref(),
+                &param.name,
+                payload,
+            );
+            (Some(body), Some(content_type))
+        }
         // GraphQL / XML rebuild the whole body from the param's pipeline
         // (`JsonField` into the GraphQL request / `Splice` around the XML
         // injection point). `apply_param_encoding` runs that pipeline on the

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2052,6 +2052,53 @@ fn build_request_text_includes_headers_and_cookies() {
 }
 
 #[test]
+fn build_request_text_body_renders_pre_encoded_value() {
+    // A param that requires pre-encoding is sent encoded on the wire (the scan
+    // applies `apply_param_encoding` before injecting), and the server decodes
+    // it back to the raw payload. The PoC must show the encoded value it would
+    // replay — otherwise a pasted request carries un-encoded bytes the sink
+    // never reflects. base64("PAY") == "UEFZ".
+    let mut param = req_param("q", "seed", Location::Body);
+    param.pre_encoding = Some("base64".to_string());
+    let target = Target {
+        method: "POST".to_string(),
+        data: Some("q=seed".to_string()),
+        ..target_for("https://example.com/e")
+    };
+    let req = super::build_request_text(&target, &param, "PAY");
+    assert!(
+        req.contains("q=UEFZ"),
+        "expected base64 field value, req:\n{req}"
+    );
+    assert!(
+        !req.contains("q=PAY"),
+        "raw payload must not appear, req:\n{req}"
+    );
+}
+
+#[test]
+fn build_request_text_multipart_renders_pre_encoded_value() {
+    // Same contract for a multipart field: the boundary-framed part carries the
+    // pre-encoded value, mirroring `build_multipart_request`.
+    let mut param = req_param("q", "seed", Location::MultipartBody);
+    param.pre_encoding = Some("base64".to_string());
+    let target = Target {
+        method: "POST".to_string(),
+        data: Some("q=seed".to_string()),
+        ..target_for("https://example.com/e")
+    };
+    let req = super::build_request_text(&target, &param, "PAY");
+    assert!(
+        req.contains("name=\"q\"\r\n\r\nUEFZ\r\n"),
+        "expected base64 in the multipart field, req:\n{req}"
+    );
+    assert!(
+        !req.contains("\r\nPAY\r\n"),
+        "raw payload must not appear, req:\n{req}"
+    );
+}
+
+#[test]
 fn build_request_text_multipart_synthesizes_field_when_absent() {
     // `target.data` for a multipart injection is `key=value` pairs (see
     // `multipart_form`), never a raw multipart blob. When the injected field

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -1945,6 +1945,38 @@ fn build_request_text_jsonbody_injects_into_object() {
 }
 
 #[test]
+fn build_request_text_graphqlbody_uses_field_value_as_json_body() {
+    // GraphQL bodies rebuild the whole document from the param pipeline via
+    // `apply_param_encoding`; with no pipeline set that is the raw payload,
+    // shipped as `application/json`.
+    let target = target_for("https://example.com/graphql");
+    let param = req_param("variables.n", "", Location::GraphqlBody);
+    let req = super::build_request_text(&target, &param, "<svg onload=alert(1)>");
+    assert!(
+        req.contains("Content-Type: application/json"),
+        "req:\n{req}"
+    );
+    assert!(
+        req.contains("\r\n\r\n<svg onload=alert(1)>"),
+        "graphql body should be the rebuilt document, req:\n{req}"
+    );
+}
+
+#[test]
+fn build_request_text_xmlbody_uses_field_value_and_xml_content_type() {
+    // XML bodies are likewise the pipeline-rebuilt document; the content type
+    // comes from `xml_request_content_type` (default `application/xml`).
+    let target = target_for("https://example.com/soap");
+    let param = req_param("q", "", Location::XmlBody);
+    let req = super::build_request_text(&target, &param, "<svg onload=alert(1)>");
+    assert!(req.contains("Content-Type: application/xml"), "req:\n{req}");
+    assert!(
+        req.contains("\r\n\r\n<svg onload=alert(1)>"),
+        "xml body should be the rebuilt document, req:\n{req}"
+    );
+}
+
+#[test]
 fn build_request_text_jsonbody_synthesizes_when_no_data() {
     let target = target_for("https://example.com/api");
     let param = req_param("q", "", Location::JsonBody);

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -1972,6 +1972,50 @@ fn build_request_text_jsonbody_empty_value_reserializes_invalid_json() {
 }
 
 #[test]
+fn build_request_text_multipart_injects_field_with_boundary() {
+    // Regression: the multipart PoC used to clone `target.data` verbatim (the
+    // payload-free, urlencoded original) under a boundary-less
+    // `multipart/form-data` type — a request that reproduced nothing. It must
+    // now render a real multipart body: the payload in the named field, framed
+    // by a boundary that the Content-Type header declares.
+    let target = Target {
+        method: "POST".to_string(),
+        data: Some("q=seed&other=keep".to_string()),
+        ..target_for("https://example.com/upload")
+    };
+    let param = req_param("q", "seed", Location::MultipartBody);
+    let req = super::build_request_text(&target, &param, "<svg onload=alert(1)>");
+    // Content-Type carries a boundary...
+    let boundary = req
+        .lines()
+        .find_map(|l| {
+            l.strip_prefix("Content-Type: multipart/form-data; boundary=")
+                .map(str::to_string)
+        })
+        .expect("multipart Content-Type with a boundary");
+    assert!(
+        !boundary.is_empty(),
+        "boundary must be non-empty, req:\n{req}"
+    );
+    // ...and the body is framed by exactly that boundary, with the payload in
+    // the `q` field and the untouched neighbour preserved.
+    assert!(
+        req.contains(&format!("--{boundary}\r\nContent-Disposition: form-data; name=\"q\"\r\n\r\n<svg onload=alert(1)>\r\n")),
+        "payload must land in the q field, req:\n{req}"
+    );
+    assert!(
+        req.contains("name=\"other\"\r\n\r\nkeep\r\n"),
+        "req:\n{req}"
+    );
+    assert!(
+        req.contains(&format!("--{boundary}--\r\n")),
+        "closing boundary, req:\n{req}"
+    );
+    // The original urlencoded form must not leak through as the body.
+    assert!(!req.contains("q=seed&other=keep"), "req:\n{req}");
+}
+
+#[test]
 fn build_request_text_does_not_duplicate_content_type_header() {
     // When the target already carries a Content-Type the synthesizer must not
     // append a second one.
@@ -2008,20 +2052,31 @@ fn build_request_text_includes_headers_and_cookies() {
 }
 
 #[test]
-fn build_request_text_multipart_keeps_body_and_type() {
+fn build_request_text_multipart_synthesizes_field_when_absent() {
+    // `target.data` for a multipart injection is `key=value` pairs (see
+    // `multipart_form`), never a raw multipart blob. When the injected field
+    // isn't among them, it is appended as a new multipart part carrying the
+    // payload — the request must still be a well-framed multipart body.
     let target = Target {
         method: "POST".to_string(),
-        data: Some("--boundary\r\n...".to_string()),
+        data: Some("unrelated=1".to_string()),
         ..target_for("https://example.com/upload")
     };
     let param = req_param("file", "", Location::MultipartBody);
     let req = super::build_request_text(&target, &param, "PAY");
     assert!(req.starts_with("POST /upload "), "req:\n{req}");
     assert!(
-        req.contains("Content-Type: multipart/form-data"),
+        req.contains("Content-Type: multipart/form-data; boundary="),
         "req:\n{req}"
     );
-    assert!(req.contains("--boundary"), "req:\n{req}");
+    assert!(
+        req.contains("name=\"file\"\r\n\r\nPAY\r\n"),
+        "injected field must be present, req:\n{req}"
+    );
+    assert!(
+        req.contains("name=\"unrelated\"\r\n\r\n1\r\n"),
+        "existing fields preserved, req:\n{req}"
+    );
 }
 
 // ---- ast_source_uses_browser_url_surface --------------------------------

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -695,6 +695,59 @@ pub(crate) fn multipart_form(
     form
 }
 
+/// Fixed, representative boundary for a rendered multipart PoC. reqwest picks a
+/// random boundary at send time; the PoC needs a stable, self-consistent one so
+/// the displayed body and its `Content-Type` agree and the request is
+/// copy-pasteable.
+const MULTIPART_POC_BOUNDARY: &str = "----DalfoxBoundary7MA4YWxkTrZu0gW";
+
+/// Render a faithful `multipart/form-data` body (and matching `Content-Type`)
+/// for the PoC, mirroring field-for-field what [`multipart_form`] puts on the
+/// wire (same source `data`, same "inject into the named field, else append"
+/// logic). Kept next to `multipart_form` on purpose: the two must serialize the
+/// same fields, so a change to one is a visible prompt to change the other.
+pub(crate) fn multipart_poc_body(data: Option<&str>, name: &str, value: &str) -> (String, String) {
+    fn push_field(body: &mut String, k: &str, v: &str) {
+        body.push_str("--");
+        body.push_str(MULTIPART_POC_BOUNDARY);
+        body.push_str("\r\nContent-Disposition: form-data; name=\"");
+        body.push_str(k);
+        body.push_str("\"\r\n\r\n");
+        body.push_str(v);
+        body.push_str("\r\n");
+    }
+
+    let mut body = String::new();
+    let mut found = false;
+    if let Some(data) = data {
+        for pair in data.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                let k = urlencoding::decode(k)
+                    .unwrap_or(Cow::Borrowed(k))
+                    .to_string();
+                let v = urlencoding::decode(v)
+                    .unwrap_or(Cow::Borrowed(v))
+                    .to_string();
+                if k == name {
+                    push_field(&mut body, &k, value);
+                    found = true;
+                } else {
+                    push_field(&mut body, &k, &v);
+                }
+            }
+        }
+    }
+    if !found {
+        push_field(&mut body, name, value);
+    }
+    body.push_str("--");
+    body.push_str(MULTIPART_POC_BOUNDARY);
+    body.push_str("--\r\n");
+
+    let content_type = format!("multipart/form-data; boundary={MULTIPART_POC_BOUNDARY}");
+    (body, content_type)
+}
+
 /// Resolve the URL a body-bearing injection must be sent to: the discovered
 /// `<form action=...>` endpoint when the param came from a form, else the
 /// target's own URL. A form-discovered body param reflects at the action

--- a/src/scanning/url_inject.rs
+++ b/src/scanning/url_inject.rs
@@ -657,6 +657,40 @@ pub(crate) fn json_body(data: Option<&str>, name: &str, param_value: &str, value
     }
 }
 
+/// The ordered form fields a multipart injection puts on the wire: the target's
+/// captured `data` parsed as `key=value` pairs (percent-decoded), with `name`'s
+/// value replaced by `value`, or a fresh `name=value` field appended when the
+/// param isn't already present. Single source of field selection for both the
+/// wire form ([`multipart_form`]) and the rendered PoC ([`multipart_poc_body`]),
+/// so the request that is sent and the request that is displayed cannot disagree
+/// on which fields exist.
+fn multipart_fields(data: Option<&str>, name: &str, value: &str) -> Vec<(String, String)> {
+    let mut fields = Vec::new();
+    let mut found = false;
+    if let Some(data) = data {
+        for pair in data.split('&') {
+            if let Some((k, v)) = pair.split_once('=') {
+                let k = urlencoding::decode(k)
+                    .unwrap_or(Cow::Borrowed(k))
+                    .to_string();
+                let v = urlencoding::decode(v)
+                    .unwrap_or(Cow::Borrowed(v))
+                    .to_string();
+                if k == name {
+                    fields.push((k, value.to_string()));
+                    found = true;
+                } else {
+                    fields.push((k, v));
+                }
+            }
+        }
+    }
+    if !found {
+        fields.push((name.to_string(), value.to_string()));
+    }
+    fields
+}
+
 /// Build a `multipart/form-data` form that carries `value` for `name`,
 /// replacing the matching field from the captured `data` and appending it when
 /// absent so an explicit `--param` not present in an imported body still ships
@@ -670,27 +704,8 @@ pub(crate) fn multipart_form(
     value: &str,
 ) -> reqwest::multipart::Form {
     let mut form = reqwest::multipart::Form::new();
-    let mut found = false;
-    if let Some(data) = data {
-        for pair in data.split('&') {
-            if let Some((k, v)) = pair.split_once('=') {
-                let k = urlencoding::decode(k)
-                    .unwrap_or(Cow::Borrowed(k))
-                    .to_string();
-                let v = urlencoding::decode(v)
-                    .unwrap_or(Cow::Borrowed(v))
-                    .to_string();
-                if k == name {
-                    form = form.text(k, value.to_string());
-                    found = true;
-                } else {
-                    form = form.text(k, v);
-                }
-            }
-        }
-    }
-    if !found {
-        form = form.text(name.to_string(), value.to_string());
+    for (k, v) in multipart_fields(data, name, value) {
+        form = form.text(k, v);
     }
     form
 }
@@ -702,43 +717,19 @@ pub(crate) fn multipart_form(
 const MULTIPART_POC_BOUNDARY: &str = "----DalfoxBoundary7MA4YWxkTrZu0gW";
 
 /// Render a faithful `multipart/form-data` body (and matching `Content-Type`)
-/// for the PoC, mirroring field-for-field what [`multipart_form`] puts on the
-/// wire (same source `data`, same "inject into the named field, else append"
-/// logic). Kept next to `multipart_form` on purpose: the two must serialize the
-/// same fields, so a change to one is a visible prompt to change the other.
+/// for the PoC. Serializes the exact fields [`multipart_form`] sends — both draw
+/// from [`multipart_fields`], so they cannot disagree on which fields exist —
+/// framed here with a fixed boundary the displayed `Content-Type` declares.
 pub(crate) fn multipart_poc_body(data: Option<&str>, name: &str, value: &str) -> (String, String) {
-    fn push_field(body: &mut String, k: &str, v: &str) {
+    let mut body = String::new();
+    for (k, v) in multipart_fields(data, name, value) {
         body.push_str("--");
         body.push_str(MULTIPART_POC_BOUNDARY);
         body.push_str("\r\nContent-Disposition: form-data; name=\"");
-        body.push_str(k);
+        body.push_str(&k);
         body.push_str("\"\r\n\r\n");
-        body.push_str(v);
+        body.push_str(&v);
         body.push_str("\r\n");
-    }
-
-    let mut body = String::new();
-    let mut found = false;
-    if let Some(data) = data {
-        for pair in data.split('&') {
-            if let Some((k, v)) = pair.split_once('=') {
-                let k = urlencoding::decode(k)
-                    .unwrap_or(Cow::Borrowed(k))
-                    .to_string();
-                let v = urlencoding::decode(v)
-                    .unwrap_or(Cow::Borrowed(v))
-                    .to_string();
-                if k == name {
-                    push_field(&mut body, &k, value);
-                    found = true;
-                } else {
-                    push_field(&mut body, &k, &v);
-                }
-            }
-        }
-    }
-    if !found {
-        push_field(&mut body, name, value);
     }
     body.push_str("--");
     body.push_str(MULTIPART_POC_BOUNDARY);

--- a/src/scanning/url_inject/tests.rs
+++ b/src/scanning/url_inject/tests.rs
@@ -962,3 +962,56 @@ fn xml_content_type_defaults_when_non_xml_or_absent() {
     let bare = Target::for_url(Url::parse("http://x/").unwrap());
     assert_eq!(xml_request_content_type(&bare), "application/xml");
 }
+
+#[test]
+fn multipart_fields_replace_preserve_append() {
+    // Named field's value replaced, siblings kept in order.
+    let f = multipart_fields(Some("a=1&q=seed&b=2"), "q", "PAY");
+    assert_eq!(
+        f,
+        vec![
+            ("a".to_string(), "1".to_string()),
+            ("q".to_string(), "PAY".to_string()),
+            ("b".to_string(), "2".to_string()),
+        ]
+    );
+    // Absent field appended after the existing ones.
+    let f = multipart_fields(Some("a=1"), "q", "PAY");
+    assert_eq!(
+        f,
+        vec![
+            ("a".to_string(), "1".to_string()),
+            ("q".to_string(), "PAY".to_string()),
+        ]
+    );
+    // No data at all: just the injected field.
+    assert_eq!(
+        multipart_fields(None, "q", "PAY"),
+        vec![("q".to_string(), "PAY".to_string())]
+    );
+}
+
+#[test]
+fn multipart_poc_body_serializes_exactly_the_shared_fields() {
+    // The PoC body must contain every field `multipart_fields` selects — the
+    // same set the wire `multipart_form` sends — framed by the boundary its
+    // Content-Type declares. This is the drift guard binding the displayed PoC
+    // to the sent request.
+    let data = Some("a=1&q=seed");
+    let (body, content_type) = multipart_poc_body(data, "q", "<svg/onload=alert(1)>");
+    let boundary = content_type
+        .strip_prefix("multipart/form-data; boundary=")
+        .expect("content-type carries a boundary");
+    for (k, v) in multipart_fields(data, "q", "<svg/onload=alert(1)>") {
+        assert!(
+            body.contains(&format!(
+                "--{boundary}\r\nContent-Disposition: form-data; name=\"{k}\"\r\n\r\n{v}\r\n"
+            )),
+            "field {k}={v} missing from body:\n{body}"
+        );
+    }
+    assert!(
+        body.ends_with(&format!("--{boundary}--\r\n")),
+        "body:\n{body}"
+    );
+}


### PR DESCRIPTION
## What

While exercising every injection surface against local vulnerable servers, I found that **`MultipartBody` findings produced reproduction PoCs that reproduced nothing** — across all three PoC formats. The scanner correctly sends a real `reqwest::multipart::Form` with the payload, so the finding is genuine, but the PoC renderers had drifted from the wire format.

| PoC format | Before (broken) | After (reproduces) |
|---|---|---|
| `http-request` | cloned the original `q=x` body, no boundary, mislabeled `multipart/form-data` | framed multipart body with the payload + a matching boundary |
| `curl` | `--data "q=<payload>"` (urlencoded) | `--form-string "q=<payload>"` |
| `httpie` | `http -f …` (urlencoded) | `http --multipart …` |

`--form-string` (not `-F`) is required: under `-F` a value with a leading `<` means "read the field from a file", and every HTML payload starts with `<` (curl exits 26).

## Follow-ups from code review

- **Pre-encoding fidelity:** the wire path applies `apply_param_encoding` to every injected value (so an auto-detected base64 param is sent encoded and the server decodes it), but the PoC rendered the raw payload for Body / JsonBody / MultipartBody. Now all body-scalar locations embed the same encoded value; a param with no pre-encoding is unchanged.
- **Drift guard:** extracted `multipart_fields` as the single source of field selection for both `multipart_form` (wire) and `multipart_poc_body` (PoC) so the sent and displayed requests cannot disagree on which fields exist.

## Verification

- All three rendered PoCs were replayed (`nc`, `curl`, `httpie`) and reproduce the reflection.
- Added regression tests for each PoC surface; repurposed the two tests that had codified the old, non-reproducing behavior.
- `cargo test` (2508 lib tests + integration suites), `cargo fmt --check`, and `cargo clippy` all clean.

## Known limitations (pre-existing, out of scope)

- The compact `curl`/`httpie` one-liners emit only the injected field (they drop sibling body fields); the `http-request` PoC is the faithful reference that carries them.
- The `httpie` renderer does not shell-escape payloads in any arm; unchanged here to stay consistent within that renderer.