### PR TITLE
docs: restyle the site footer as one centered tier

### DIFF
--- a/docs/static/css/style.css
+++ b/docs/static/css/style.css
@@ -1183,11 +1183,14 @@ nav.pagination a:hover {
 /* ==========================================================================
    Site footer
    ========================================================================== */
+/* One centered tier on the body ground: the old two-column branding/links
+   split was more scaffolding than four links and a copyright ever needed.
+   No panel fill — the hairline and its seal carry the close. */
 .site-footer {
     position: relative;
     border-top: 1px solid var(--ink-line);
-    padding: 2.5rem 2rem;
-    background: var(--bg-sidebar);
+    padding: 3rem 2rem 3.25rem;
+    text-align: center;
 }
 /* Lozenge seal centred on the footer's top divider — mirrors `.section::after`
    so the footer reads as the final panel in the same sequence of dividers. */
@@ -1246,38 +1249,73 @@ body:has(.docs-layout) .site-footer {
     max-width: 1100px;
     margin: 0 auto;
     display: flex;
-    justify-content: space-between;
+    flex-direction: column;
     align-items: center;
-    gap: 1rem;
-    flex-wrap: wrap;
+    gap: 1.1rem;
 }
-.footer-branding {
-    display: flex;
-    align-items: center;
-    gap: 0.75rem;
-    color: var(--text-muted);
-    font-size: 0.82rem;
-}
-.footer-branding a {
-    color: var(--text-secondary);
-    text-decoration: none;
-}
-.footer-branding a:hover {
-    color: var(--text-primary);
-}
+/* Borrows the header nav's quiet pill so the row reads as the header's echo
+   rather than a second link idiom. Wrapping keeps it upright without a
+   breakpoint. */
 .footer-links {
     display: flex;
-    gap: 1.25rem;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 0.25rem 0.4rem;
 }
 .footer-links a {
+    padding: 0.3rem 0.7rem;
+    border-radius: 999px;
     color: var(--text-muted);
     text-decoration: none;
     font-size: 0.8rem;
     font-weight: 500;
-    transition: color 0.15s;
+    transition:
+        color 0.15s,
+        background 0.15s;
 }
 .footer-links a:hover {
+    background: var(--accent-dim);
     color: var(--text-primary);
+}
+.footer-meta {
+    display: flex;
+    flex-wrap: wrap;
+    align-items: center;
+    justify-content: center;
+    gap: 0.3rem 0.55rem;
+    margin: 0;
+    color: var(--text-muted);
+    font-size: 0.82rem;
+}
+.footer-meta a {
+    color: var(--text-secondary);
+    text-decoration: none;
+}
+.footer-meta a:hover {
+    color: var(--text-primary);
+}
+/* Dim the separators one step below the meta text so they read as spacing
+   rather than punctuation. */
+.footer-sep {
+    opacity: 0.55;
+}
+/* The hahwul mark, folded into the meta line: the signature costs a glyph
+   here instead of the landing footer's own block. */
+.footer-sig {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4rem;
+}
+.footer-sig .hahwul-img {
+    width: 22px;
+    height: 22px;
+}
+.footer-sig:hover .hahwul-img {
+    background-color: var(--text-primary);
+}
+.footer-sig .footer-love {
+    margin-top: 0;
+    font-size: 0.9rem;
 }
 /* ==========================================================================
    Landing page
@@ -2481,10 +2519,6 @@ body:has(.docs-layout) .site-footer {
     }
     .cta-illustration {
         opacity: 0.1;
-    }
-    .footer-inner {
-        flex-direction: column;
-        text-align: center;
     }
 }
 

--- a/docs/templates/footer.html
+++ b/docs/templates/footer.html
@@ -27,21 +27,29 @@
       <div class="search-results" id="searchResults"></div>
     </div>
   </div>
+  {# One centered tier, mirroring the gori docs footer: a quiet pill row of
+     outbound links over a single meta line that carries the hahwul signature,
+     the licence and the generator credit. "Built with Love" stays untranslated
+     on purpose — it is a signature, and the handwriting stack carries no
+     Hangul anyway. #}
   <footer class="site-footer">
     <div class="footer-inner">
-      <div class="footer-branding">
-        <span>&copy; 2026 <a href="https://github.com/hahwul">HAHWUL</a></span>
-        <span class="divider" style="color:var(--border-light)">·</span>
-        <span>{% if page_language == "ko" %}MIT 라이선스로 배포{% else %}Released under the MIT License{% endif %}</span>
-        <span class="divider" style="color:var(--border-light)">·</span>
-        <span>{% if page_language == "ko" %}<a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">hwaro</a>로 제작{% else %}Built with <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">hwaro</a>{% endif %}</span>
-      </div>
-      <div class="footer-links">
+      <nav class="footer-links" aria-label="{% if page_language == "ko" %}푸터 링크{% else %}Footer links{% endif %}">
         <a href="https://github.com/hahwul/dalfox" target="_blank" rel="noopener">GitHub</a>
         <a href="https://github.com/hahwul/dalfox/releases" target="_blank" rel="noopener">{% if page_language == "ko" %}릴리스{% else %}Releases{% endif %}</a>
         <a href="https://github.com/hahwul/dalfox/issues" target="_blank" rel="noopener">{% if page_language == "ko" %}이슈{% else %}Issues{% endif %}</a>
         <a href="https://github.com/hahwul/dalfox/blob/main/.github/CONTRIBUTING.md" target="_blank" rel="noopener">{% if page_language == "ko" %}기여하기{% else %}Contribute{% endif %}</a>
-      </div>
+      </nav>
+      <p class="footer-meta">
+        <a class="footer-sig" href="https://www.hahwul.com" target="_blank" rel="noopener" aria-label="hahwul, Built with Love">
+          <span class="hahwul-img" aria-hidden="true"></span>
+          <span class="footer-love">Built with Love</span>
+        </a>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <span>MIT &middot; &copy; 2026 <a href="https://github.com/hahwul" target="_blank" rel="noopener">HAHWUL</a></span>
+        <span class="footer-sep" aria-hidden="true">·</span>
+        <span>{% if page_language == "ko" %}<a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">hwaro</a>로 제작{% else %}Built with <a href="https://hwaro.hahwul.com" target="_blank" rel="noopener">hwaro</a>{% endif %}</span>
+      </p>
     </div>
   </footer>
   <script src="{{ base_url }}/assets/js/highlight.min.js"></script>


### PR DESCRIPTION
Reworks the docs site footer to match the [gori docs](https://github.com/hahwul/gori) footer idiom.

**Before** — two-column row on a `--bg-sidebar` panel: branding left, links right.

**After** — one centered tier:

```
             GitHub  Releases  Issues  Contribute
   [hahwul mark] Built with Love  ·  MIT · © 2026 HAHWUL  ·  Built with hwaro
```

### What changed

- **hahwul signature folded into the meta line** (`.footer-sig`: 22px mark + the handwriting "Built with Love"), the same way gori carries it. Scoped via `.footer-sig .hahwul-img`, so the landing footer keeps its 80px block untouched.
- **Panel fill dropped.** `background: var(--bg-sidebar)` is gone; the hairline and its lozenge seal (`::before`) carry the close on their own. Padding `2.5rem` → `3rem / 3.25rem`.
- **Links become a quiet pill row** — centered, `border-radius: 999px`, `--accent-dim` on hover, echoing the header nav. gori dropped its links entirely; Dalfox keeps GitHub / Releases / Issues / Contribute because they are a real path out of the docs.
- The `·` separators move off an inline `style` attribute onto a `.footer-sep` class dimmed to `opacity: .55`, so they read as spacing rather than punctuation. One less inline style under the site's `script-src 'self'` CSP posture.
- `flex-wrap` now handles narrow widths, so the 768px `.footer-inner { flex-direction: column }` override is redundant and removed.
- "Built with Love" stays untranslated on purpose — it is a signature, and the handwriting stack carries no Hangul. Everything else keeps its EN/KO pair (`릴리스 / 이슈 / 기여하기 / hwaro로 제작`).

### Verification

- `hwaro build -i docs` clean in both dev and production (CSP-on) modes.
- `just docs-lint` — 25/25 passed.
- Headless-Chrome captures of the EN footer, the KO footer, a 480px-wide viewport, and the landing footer (unchanged) all render correctly.