### PR TITLE
fix(scan): don't send requests through the environment's HTTP_PROXY

### DIFF
--- a/src/oob/interactsh/mod.rs
+++ b/src/oob/interactsh/mod.rs
@@ -92,6 +92,7 @@ impl InteractshClient {
 
         let mut builder = Client::builder()
             .timeout(Duration::from_secs(config.timeout.max(1)))
+            .no_proxy()
             .danger_accept_invalid_certs(config.insecure);
         if let Some(pxy) = config.proxy.as_ref()
             && let Ok(proxy) = reqwest::Proxy::all(pxy)

--- a/src/target_parser/mod.rs
+++ b/src/target_parser/mod.rs
@@ -185,6 +185,9 @@ impl Target {
         // is harmless (the loser's value is dropped on insert).
         let mut client_builder = Client::builder()
             .timeout(Duration::from_secs(self.timeout))
+            // reqwest reads HTTP_PROXY/HTTPS_PROXY/ALL_PROXY by default;
+            // `--proxy` is applied below and still takes effect.
+            .no_proxy()
             // Insecure mode for scanner (default on; `--insecure=false` to
             // enforce TLS certificate validation).
             .danger_accept_invalid_certs(self.insecure);


### PR DESCRIPTION
`HTTP_PROXY` exported in your shell or your CI image, no `--proxy` on the command line, and dalfox routes the whole scan through it - the target URLs, and whatever you passed with `-H` or `--cookies`.

Nothing warns you, because `docs/content/reference/environment.md` files proxy under "Not environment variables" and says dalfox "doesn't read `HTTP_PROXY`/`HTTPS_PROXY` to avoid accidental traffic interception".

Against the v3.2.2 release binary, with a listener sat on 127.0.0.1:8899:

    HTTP_PROXY=http://127.0.0.1:8899 dalfox scan 'http://example.invalid/?q=1' --dry-run

124 requests arrive, absolute-form, starting `HEAD http://example.invalid/?q=1 HTTP/1.1` and carrying on through the discovery and mining sweep. That host doesnt exist, which is the giveaway - it only got anywhere because the proxy resolved it.

reqwest has system proxy detection on by default and `build_client` never calls `no_proxy()`. `ClientBuilder::proxy()` clears the flag by itself, so this only ever bites a run with no `--proxy` on it. In v2 `CreateDefaultTransport` left `http.Transport.Proxy` nil, so the sentance in the docs was true right up until the rewrite.

The interactsh client gets the same line, as it already takes the scan's `--proxy`.

I havent checked whether anyone is leaning on the current behaviour to reach targets through a corporate proxy without passing `--proxy`.

---

Left alone on purpose: the remote payload and wordlist fetchers in `src/payload/remote.rs` read the environment too, but two of their three entry points take no proxy argument at all, so switching it off there would strand anyone who needs a proxy to reach GitHub. Same for the `Client::new()` fallback in `build_client_or_default`, which picks them up despite the comment above it saying the default client carries no proxy.
