### PR TITLE
perf(scan,mining): ramp payload batches, stop paying for skipped mining probes

### DIFF
--- a/skills/dalfox/references/cli.md
+++ b/skills/dalfox/references/cli.md
@@ -65,6 +65,15 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 | `-W, --mining-dict-word` | Path to custom wordlist for dictionary mining |
 | `--remote-wordlists` | `burp,assetnote` (comma-separated) |
 
+Dictionary and DOM mining drop duplicate names and already-discovered query
+slots before probing, so a repeated entry costs no request and cannot inflate
+the reflection ratio. Eligibility for the arbitrary-name sentinel check is still
+measured on the wordlist as loaded, so a heavily filtered list keeps that check.
+When reflection sampling stops a stage early, queued probes stop before sending
+and in-flight ones are drained; the parameters already confirmed are kept unless
+the sentinels show the target echoes names it does not have. Same-named
+body/header parameters remain separate injection points.
+
 **Common fast-mode combo**: `--skip-mining` (or `--skip-mining-dom`) + explicit `-p` for the params you care about. With `--skip-discovery`, always pass `-p` (bare name is OK for query; use `name:location` for body/header/cookie/json).
 
 ## Network & Concurrency
@@ -84,6 +93,15 @@ All flags are defined in `src/cmd/scan/args.rs:ScanArgs`. Defaults are centraliz
 | `--workers` | 50 | Concurrent workers |
 | `--max-concurrent-targets` | 50 | For file/pipe input |
 | `--max-targets-per-host` | 100 | Safety cap per host |
+
+Reflection and DOM payload batches start small and grow toward the worker limit.
+An early hit therefore avoids a full batch of speculative requests. Already-fetched
+responses are still checked for verified evidence after a reflection or DOM
+early-exit signal. Payload order and catalogs are unchanged; `--sxss`,
+`--waf-evasion`, and positive `--delay` retain serial payload requests. Targets
+that need the full catalog reach it in the same number of requests but a few
+more round trips, so a tight `--scan-timeout` can now cut a deep payload the
+full-window batching would have reached.
 
 ## XSS Engine
 

--- a/src/parameter_analysis/mining/collapse.rs
+++ b/src/parameter_analysis/mining/collapse.rs
@@ -112,6 +112,30 @@ pub(super) async fn snapshot_param_slots(
         .collect()
 }
 
+/// Filter before EWMA sampling and task creation: repeated dictionary entries
+/// must not inflate reflection statistics, and already-discovered query slots
+/// need no new probes. Same-named body/header slots stay eligible.
+///
+/// Callers must measure sentinel-pre-probe eligibility *before* calling this —
+/// a list that shrinks past that threshold here still needs the arbitrary-name
+/// check, which is the only source of the synthetic `any` injection point.
+pub(super) async fn unique_query_candidates(
+    names: Vec<String>,
+    reflection_params: &Arc<Mutex<Vec<Param>>>,
+) -> Vec<String> {
+    let mut seen: std::collections::HashSet<String> = reflection_params
+        .lock()
+        .await
+        .iter()
+        .filter(|p| p.location == Location::Query)
+        .map(|p| p.name.clone())
+        .collect();
+    names
+        .into_iter()
+        .filter(|name| seen.insert(name.clone()))
+        .collect()
+}
+
 /// Build the synthetic `any` param standing in for "this target echoes
 /// arbitrary parameter names at `location`".
 ///

--- a/src/parameter_analysis/mining/mod.rs
+++ b/src/parameter_analysis/mining/mod.rs
@@ -13,6 +13,12 @@
 //! collapse detection to short-circuit when a target reflects everything
 //! (sustained ≥85% reflection rate after ≥15 attempts). Filters out 5xx
 //! responses to avoid false positives from debug/error pages.
+//! Query candidates are deduplicated and already-discovered Query slots dropped
+//! before probing; the sentinel pre-probe's eligibility is still measured on the
+//! candidate list as loaded. On collapse, queued dictionary/DOM probes stop
+//! before sending and started workers are drained; folding the mined params into
+//! the synthetic `any` additionally requires the sentinels to confirm that this
+//! target really does echo parameter names it does not have.
 //!
 //! **Skippable via:** `--skip-mining`, `--skip-mining-dict`, `--skip-mining-dom`.
 

--- a/src/parameter_analysis/mining/probe_dictionary.rs
+++ b/src/parameter_analysis/mining/probe_dictionary.rs
@@ -69,32 +69,45 @@ pub async fn probe_dictionary_params(
         params = GF_PATTERNS_PARAMS.iter().map(ToString::to_string).collect();
     }
 
+    // Pre-probe eligibility is measured on the *loaded* wordlist, before the
+    // filtering below. The arbitrary-name check is the only thing that finds
+    // the synthetic `any` injection point, and a list that shrinks past the
+    // threshold because its entries are duplicates or already-discovered slots
+    // says nothing about whether this target echoes names it does not have.
+    let sentinel_eligible = params.len() > SENTINEL_PROBE_COUNT * 5;
+
+    // Stable dedup also keeps repeats from manufacturing a high EWMA and
+    // collapsing real, distinct candidates later in the wordlist to `any`.
+    params = unique_query_candidates(params, &reflection_params).await;
+
     // Sentinel pre-probe: 3 unique random param names. If every one reflects,
     // the page echoes arbitrary input and the wordlist would just balloon
     // into Stage 3-6 cost. Skip the wordlist and add a single "any" param
     // instead — the params discovered before this stage are kept and still
     // scanned. Skip when the wordlist is small enough that the pre-probe is
     // more expensive than just running it.
-    if params.len() > SENTINEL_PROBE_COUNT * 5
-        && let Some(text) = pre_collapse_query_probe(&client, target).await
-    {
-        if !silence {
-            eprintln!(
-                "[mining-collapse] sentinel pre-probe collapsed Query mining: \
-                 every random param name reflected; adding single 'any' param"
-            );
+    let mut arbitrary_names_disproved = false;
+    if sentinel_eligible {
+        if let Some(text) = pre_collapse_query_probe(&client, target).await {
+            if !silence {
+                eprintln!(
+                    "[mining-collapse] sentinel pre-probe collapsed Query mining: \
+                     every random param name reflected; adding single 'any' param"
+                );
+            }
+            collapse_mined_params(
+                &reflection_params,
+                &preexisting,
+                Location::Query,
+                Some(&text),
+            )
+            .await;
+            if let Some(ref pb) = pb {
+                pb.finish_and_clear();
+            }
+            return;
         }
-        collapse_mined_params(
-            &reflection_params,
-            &preexisting,
-            Location::Query,
-            Some(&text),
-        )
-        .await;
-        if let Some(ref pb) = pb {
-            pb.finish_and_clear();
-        }
-        return;
+        arbitrary_names_disproved = true;
     }
 
     if let Some(ref pb) = pb {
@@ -123,26 +136,13 @@ pub async fn probe_dictionary_params(
         // Per-chunk handles, drained at the end of this chunk (see below).
         let mut handles: Vec<tokio::task::JoinHandle<Option<Param>>> = Vec::new();
         for param in param_chunk {
-            // Early collapse stop. (A second identical `collapsed` check used to
-            // follow immediately with no await in between — dead code, since
-            // this `break 'outer` already fires first when collapsed is set.)
+            // Stop spawning, then drain this chunk below. Breaking the outer
+            // loop here would detach its tasks and discard their metadata.
             {
                 let st = stats.lock().await;
                 if st.collapsed {
-                    break 'outer;
+                    break;
                 }
-            }
-            // Skip only when this *slot* was already discovered. Matching on
-            // the name alone let a param found at another wire location (a
-            // query `q`, a header `q`) suppress mining of the same name here,
-            // so the slot was never probed at all. See `param_slot_key`.
-            let exists = reflection_params
-                .lock()
-                .await
-                .iter()
-                .any(|p| p.name == *param && p.location == Location::Query);
-            if exists {
-                continue;
             }
 
             let mut url = target.url.clone();
@@ -163,10 +163,17 @@ pub async fn probe_dictionary_params(
             let handle = tokio::spawn(crate::with_job_scopes(
                 crate::JobScopes::capture(),
                 async move {
-                    let permit = semaphore_clone
-                        .acquire()
-                        .await
-                        .expect("acquire semaphore permit");
+                    let Ok(permit) = semaphore_clone.acquire().await else {
+                        return None;
+                    };
+                    // Collapse may have fired while this task waited for its
+                    // permit. Only requests already in flight may finish.
+                    if stats_clone.lock().await.collapsed {
+                        if let Some(ref pb) = pb_clone {
+                            pb.inc(1);
+                        }
+                        return None;
+                    }
                     let request = crate::utils::build_request(
                         &client_clone,
                         &target_clone,
@@ -215,22 +222,53 @@ pub async fn probe_dictionary_params(
                             let mut st = stats_clone.lock().await;
                             st.record_attempt();
                             st.record_reflection();
-                            if !st.collapsed {
-                                discovered = Some(Param {
-                                    injection_context: Some(
-                                        crate::parameter_analysis::InjectionContext::AttributeUrl(
-                                            None,
-                                        ),
-                                    ),
-                                    ..Param::new(
+                            // Recorded even if a sibling set `collapsed` while
+                            // this request was in flight: the response is paid
+                            // for, and a confirmed collapse folds it anyway.
+                            discovered = Some(Param {
+                                injection_context: Some(
+                                    crate::parameter_analysis::InjectionContext::AttributeUrl(None),
+                                ),
+                                ..Param::new(
+                                    param_name.clone(),
+                                    crate::scanning::markers::bracketed_marker().to_string(),
+                                    crate::parameter_analysis::Location::Query,
+                                )
+                            });
+                            if !silence {
+                                eprintln!(
+                                    "Discovered parameter (redirect): {} (EWMA {:.2}, {}/{})",
+                                    param_name, st.ewma_ratio, st.reflections, st.attempts
+                                );
+                            }
+                            if st.should_collapse() {
+                                st.collapsed = true;
+                                if !silence {
+                                    eprintln!(
+                                        "[mining-collapse] High reflection EWMA {:.2} after {} attempts ({} reflections)",
+                                        st.ewma_ratio, st.attempts, st.reflections
+                                    );
+                                }
+                            }
+                        } else if let Ok(text) = crate::utils::http::read_body(r).await {
+                            let mut st = stats_clone.lock().await;
+                            st.record_attempt();
+                            if crate::scanning::markers::classify_probe_reflection(&text).detected()
+                            {
+                                st.record_reflection();
+                                // See the redirect arm: an in-flight response is
+                                // kept regardless of the collapse flag.
+                                discovered = Some(
+                                    Param::new(
                                         param_name.clone(),
                                         crate::scanning::markers::bracketed_marker().to_string(),
                                         crate::parameter_analysis::Location::Query,
                                     )
-                                });
+                                    .with_reflection_analysis(&text),
+                                );
                                 if !silence {
                                     eprintln!(
-                                        "Discovered parameter (redirect): {} (EWMA {:.2}, {}/{})",
+                                        "Discovered parameter: {} (EWMA {:.2}, {}/{})",
                                         param_name, st.ewma_ratio, st.reflections, st.attempts
                                     );
                                 }
@@ -241,39 +279,6 @@ pub async fn probe_dictionary_params(
                                             "[mining-collapse] High reflection EWMA {:.2} after {} attempts ({} reflections)",
                                             st.ewma_ratio, st.attempts, st.reflections
                                         );
-                                    }
-                                }
-                            }
-                        } else if let Ok(text) = crate::utils::http::read_body(r).await {
-                            let mut st = stats_clone.lock().await;
-                            st.record_attempt();
-                            if crate::scanning::markers::classify_probe_reflection(&text).detected()
-                            {
-                                st.record_reflection();
-                                if !st.collapsed {
-                                    discovered = Some(
-                                        Param::new(
-                                            param_name.clone(),
-                                            crate::scanning::markers::bracketed_marker()
-                                                .to_string(),
-                                            crate::parameter_analysis::Location::Query,
-                                        )
-                                        .with_reflection_analysis(&text),
-                                    );
-                                    if !silence {
-                                        eprintln!(
-                                            "Discovered parameter: {} (EWMA {:.2}, {}/{})",
-                                            param_name, st.ewma_ratio, st.reflections, st.attempts
-                                        );
-                                    }
-                                    if st.should_collapse() {
-                                        st.collapsed = true;
-                                        if !silence {
-                                            eprintln!(
-                                                "[mining-collapse] High reflection EWMA {:.2} after {} attempts ({} reflections)",
-                                                st.ewma_ratio, st.attempts, st.reflections
-                                            );
-                                        }
                                     }
                                 }
                             } else {
@@ -316,8 +321,34 @@ pub async fn probe_dictionary_params(
     // Only the Query params *this stage mined* collapse — params discovered via
     // other channels (Body, Header, Path, JsonBody, …) and the Query params
     // Stage 1 discovery already confirmed are left alone.
-    let st_final = stats.lock().await;
-    if st_final.collapsed {
-        collapse_mined_params(&reflection_params, &preexisting, Location::Query, None).await;
+    let collapsed = stats.lock().await.collapsed;
+    if collapsed {
+        // The EWMA stop is a cost control and always applies — an endpoint that
+        // reflects most of a wordlist would otherwise hand Stage 3-6 hundreds of
+        // near-identical injection points. Replacing what it *did* mine with the
+        // synthetic `any` is a different claim, and only the sentinels can back
+        // it: fold when they reflect, keep the confirmed params when they do not.
+        // `arbitrary_names_disproved` already carries that answer (the pre-probe
+        // ran above); otherwise the wordlist was under the pre-probe threshold,
+        // so ask now — 3 requests to avoid deleting real findings.
+        let confirmed = if arbitrary_names_disproved {
+            None
+        } else {
+            pre_collapse_query_probe(&client, target).await
+        };
+        if let Some(text) = confirmed {
+            collapse_mined_params(
+                &reflection_params,
+                &preexisting,
+                Location::Query,
+                Some(&text),
+            )
+            .await;
+        } else if !silence {
+            eprintln!(
+                "[mining-collapse] high reflection EWMA, but the sentinels did not \
+                 reflect: keeping the mined params instead of folding them into 'any'"
+            );
+        }
     }
 }

--- a/src/parameter_analysis/mining/probe_response_id.rs
+++ b/src/parameter_analysis/mining/probe_response_id.rs
@@ -63,32 +63,40 @@ pub async fn probe_response_id_params(
                 MAX_DOM_MINING_PARAMS, original
             );
         }
+        // Measured before the filtering below, for the reason given in
+        // `probe_dictionary_params`: a candidate set that shrinks because its
+        // names are duplicates or already-discovered slots still needs the
+        // arbitrary-name check.
+        let sentinel_eligible = params_to_check.len() > SENTINEL_PROBE_COUNT * 5;
+        let params_to_check = unique_query_candidates(params_to_check, &reflection_params).await;
 
         // Sentinel pre-probe — same rationale as Query mining: a
         // reflect-everything page would mark every DOM-extracted name as
         // reflected and balloon downstream cost. Threshold matches Query
         // mining: only run when the candidate set exceeds the pre-probe
         // ceiling.
-        if params_to_check.len() > SENTINEL_PROBE_COUNT * 5
-            && let Some(text) = pre_collapse_query_probe(&client, target).await
-        {
-            if !silence {
-                eprintln!(
-                    "[mining-collapse] sentinel pre-probe collapsed DOM mining: \
-                     every random param name reflected; adding single 'any' param"
-                );
+        let mut arbitrary_names_disproved = false;
+        if sentinel_eligible {
+            if let Some(text) = pre_collapse_query_probe(&client, target).await {
+                if !silence {
+                    eprintln!(
+                        "[mining-collapse] sentinel pre-probe collapsed DOM mining: \
+                         every random param name reflected; adding single 'any' param"
+                    );
+                }
+                collapse_mined_params(
+                    &reflection_params,
+                    &preexisting,
+                    Location::Query,
+                    Some(&text),
+                )
+                .await;
+                if let Some(ref pb) = pb {
+                    pb.finish_and_clear();
+                }
+                return;
             }
-            collapse_mined_params(
-                &reflection_params,
-                &preexisting,
-                Location::Query,
-                Some(&text),
-            )
-            .await;
-            if let Some(ref pb) = pb {
-                pb.finish_and_clear();
-            }
-            return;
+            arbitrary_names_disproved = true;
         }
 
         if let Some(ref pb) = pb {
@@ -108,15 +116,6 @@ pub async fn probe_response_id_params(
                     break;
                 }
             }
-            // Slot-scoped, not name-scoped: see `param_slot_key`.
-            let existing = reflection_params
-                .lock()
-                .await
-                .iter()
-                .any(|p| p.name == param && p.location == Location::Query);
-            if existing {
-                continue;
-            }
             let mut url = target.url.clone();
             url.query_pairs_mut()
                 .append_pair(&param, crate::scanning::markers::bracketed_marker());
@@ -134,10 +133,17 @@ pub async fn probe_response_id_params(
             let handle = tokio::spawn(crate::with_job_scopes(
                 crate::JobScopes::capture(),
                 async move {
-                    let permit = semaphore_clone
-                        .acquire()
-                        .await
-                        .expect("acquire semaphore permit");
+                    let Ok(permit) = semaphore_clone.acquire().await else {
+                        return None;
+                    };
+                    // Do not send probes queued before another worker
+                    // established that this mining stage should stop.
+                    if stats_clone.lock().await.collapsed {
+                        if let Some(ref pb) = pb_clone {
+                            pb.inc(1);
+                        }
+                        return None;
+                    }
                     let m = parsed_method;
                     let request = crate::utils::build_request(
                         &client_clone,
@@ -170,31 +176,31 @@ pub async fn probe_response_id_params(
                             if crate::scanning::markers::classify_probe_reflection(&text).detected()
                             {
                                 st.record_reflection();
-                                if !st.collapsed {
-                                    // Store discovered Param for return (batched later)
-                                    discovered = Some(
-                                        Param::new(
-                                            param.clone(),
-                                            crate::scanning::markers::bracketed_marker()
-                                                .to_string(),
-                                            crate::parameter_analysis::Location::Query,
-                                        )
-                                        .with_reflection_analysis(&text),
+                                // Store discovered Param for return (batched
+                                // later). Kept even when a sibling set
+                                // `collapsed` mid-flight: the response is paid
+                                // for, and a confirmed collapse folds it anyway.
+                                discovered = Some(
+                                    Param::new(
+                                        param.clone(),
+                                        crate::scanning::markers::bracketed_marker().to_string(),
+                                        crate::parameter_analysis::Location::Query,
+                                    )
+                                    .with_reflection_analysis(&text),
+                                );
+                                if !silence {
+                                    eprintln!(
+                                        "Discovered DOM param: {} (EWMA {:.2}, {}/{})",
+                                        param, st.ewma_ratio, st.reflections, st.attempts
                                     );
+                                }
+                                if st.should_collapse() {
+                                    st.collapsed = true;
                                     if !silence {
                                         eprintln!(
-                                            "Discovered DOM param: {} (EWMA {:.2}, {}/{})",
-                                            param, st.ewma_ratio, st.reflections, st.attempts
+                                            "[mining-collapse] DOM mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
+                                            st.ewma_ratio, st.attempts, st.reflections
                                         );
-                                    }
-                                    if st.should_collapse() {
-                                        st.collapsed = true;
-                                        if !silence {
-                                            eprintln!(
-                                                "[mining-collapse] DOM mining collapsed at EWMA {:.2} after {} attempts ({} reflections)",
-                                                st.ewma_ratio, st.attempts, st.reflections
-                                            );
-                                        }
                                     }
                                 }
                             } else {
@@ -233,9 +239,30 @@ pub async fn probe_response_id_params(
         // triggered it. Only the Query params this stage mined are folded in;
         // params discovered via other channels — and the ones discovery already
         // confirmed — survive.
-        let st_final = stats.lock().await;
-        if st_final.collapsed {
-            collapse_mined_params(&reflection_params, &preexisting, Location::Query, None).await;
+        let collapsed = stats.lock().await.collapsed;
+        if collapsed {
+            // Confirm the collapse premise before folding — the EWMA alone
+            // cannot tell "echoes any name" from "these fields all reflect".
+            // See `probe_dictionary_params` for the full rationale.
+            let confirmed = if arbitrary_names_disproved {
+                None
+            } else {
+                pre_collapse_query_probe(&client, target).await
+            };
+            if let Some(text) = confirmed {
+                collapse_mined_params(
+                    &reflection_params,
+                    &preexisting,
+                    Location::Query,
+                    Some(&text),
+                )
+                .await;
+            } else if !silence {
+                eprintln!(
+                    "[mining-collapse] high reflection EWMA, but the sentinels did not \
+                     reflect: keeping the mined DOM params instead of folding them into 'any'"
+                );
+            }
         }
     }
 }

--- a/src/parameter_analysis/mining/tests.rs
+++ b/src/parameter_analysis/mining/tests.rs
@@ -5,6 +5,9 @@ use std::collections::HashMap;
 use std::net::{Ipv4Addr, SocketAddr};
 use tokio::time::{Duration, sleep};
 
+mod collapse_recall;
+mod request_efficiency;
+
 #[test]
 fn cap_dom_params_boundary() {
     let mk = |n: usize| (0..n).map(|i| i.to_string()).collect::<Vec<_>>();

--- a/src/parameter_analysis/mining/tests/collapse_recall.rs
+++ b/src/parameter_analysis/mining/tests/collapse_recall.rs
@@ -1,0 +1,172 @@
+//! Collapse-vs-recall guards: the request-saving filters in Query/DOM mining
+//! must not cost an injection point the previous revision would have found.
+
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+/// Echo-everything page: any query param name is reflected raw, sentinels
+/// included.
+async fn echo_all_server() -> (Target, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let app = Router::new().route(
+        "/",
+        get(move |Query(params): Query<HashMap<String, String>>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                let mut body = String::from("<html><body>");
+                for (_name, value) in params {
+                    body.push_str(&value);
+                }
+                body.push_str("</body></html>");
+                Html(body)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut target = parse_target(&format!("http://{addr}/")).unwrap();
+    target.workers = 1;
+    (target, requests, server)
+}
+
+/// Only `cand_*` names reflect — the target has many real reflecting params but
+/// does *not* echo names it has never heard of.
+async fn selective_server() -> (Target, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let app = Router::new().route(
+        "/",
+        get(move |Query(params): Query<HashMap<String, String>>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                let mut body = String::from("<html><body>");
+                for (name, value) in params {
+                    if name.starts_with("cand_") {
+                        body.push_str(&value);
+                    }
+                }
+                body.push_str("</body></html>");
+                Html(body)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut target = parse_target(&format!("http://{addr}/")).unwrap();
+    target.workers = 1;
+    (target, requests, server)
+}
+
+/// A wordlist whose entries are all already-discovered Query slots still has to
+/// run the arbitrary-name pre-probe: `any` is the only injection point that
+/// covers "this target echoes names it does not have", and nothing else in the
+/// stage can find it. Pre-probe eligibility therefore comes from the loaded
+/// wordlist, not from what survives filtering.
+#[tokio::test]
+async fn known_slots_keep_arbitrary_name_coverage() {
+    let (target, _requests, server) = echo_all_server().await;
+    let words = (0..20).map(|i| format!("known_{i}\n")).collect::<String>();
+    let wordlist = TempWordlist::new("collapse-recall-known", &words);
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(
+        (0..20)
+            .map(|i| Param::new(format!("known_{i}"), "a", Location::Query))
+            .collect::<Vec<_>>(),
+    ));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+    assert!(params.iter().any(|p| p.name == "any"), "{names:?}");
+    assert_eq!(params.len(), 21, "the known slots survive too: {names:?}");
+}
+
+/// The reflection EWMA cannot tell "echoes any name" from "these fields all
+/// reflect". Its stop stays (an endpoint reflecting most of a wordlist would
+/// otherwise hand Stage 3-6 hundreds of near-identical injection points), but
+/// replacing the confirmed params with the synthetic `any` needs the sentinels
+/// to agree. They do not here, so the mined params must stay.
+#[tokio::test]
+async fn unconfirmed_ewma_stop_keeps_the_real_params() {
+    let (target, _requests, server) = selective_server().await;
+    let words = (0..20).map(|i| format!("cand_{i}\n")).collect::<String>();
+    let wordlist = TempWordlist::new("collapse-recall-ewma", &words);
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+    assert!(
+        !params.iter().any(|p| p.name == "any"),
+        "the sentinels never reflected, so `any` is a stand-in for nothing: {names:?}"
+    );
+    // Serial (`workers = 1`) probing, so the stop lands on the fifteenth
+    // attempt — the minimum the EWMA collapse requires.
+    assert_eq!(params.len(), 15, "{names:?}");
+    assert!(params.iter().all(|p| p.name.starts_with("cand_")));
+}
+
+/// A wordlist at or under the pre-probe threshold never ran the arbitrary-name
+/// check, so a collapse there has no evidence yet: confirm before folding. When
+/// the sentinels do reflect, the fold happens exactly as before — and the
+/// sentinel body, not a mined param, seeds `any`'s metadata.
+#[tokio::test]
+async fn unprobed_wordlist_confirms_before_folding() {
+    let (target, requests, server) = echo_all_server().await;
+    let words = (0..SENTINEL_PROBE_COUNT * 5)
+        .map(|i| format!("cand_{i}\n"))
+        .collect::<String>();
+    let wordlist = TempWordlist::new("collapse-recall-confirm", &words);
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, ["any"], "{names:?}");
+    assert!(
+        params[0].valid_specials.is_some(),
+        "sentinel body seeds `any`"
+    );
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        SENTINEL_PROBE_COUNT * 5 + SENTINEL_PROBE_COUNT,
+        "fifteen candidates, then the three confirming sentinels"
+    );
+}

--- a/src/parameter_analysis/mining/tests/collapse_recall.rs
+++ b/src/parameter_analysis/mining/tests/collapse_recall.rs
@@ -16,6 +16,11 @@ async fn echo_all_server() -> (Target, Arc<AtomicUsize>, tokio::task::JoinHandle
             async move {
                 count.fetch_add(1, Ordering::Relaxed);
                 let mut body = String::from("<html><body>");
+                if params.is_empty() {
+                    for i in 0..SENTINEL_PROBE_COUNT * 5 {
+                        body.push_str(&format!("<input name=field_{i}>"));
+                    }
+                }
                 for (_name, value) in params {
                     body.push_str(&value);
                 }
@@ -168,5 +173,31 @@ async fn unprobed_wordlist_confirms_before_folding() {
         requests.load(Ordering::Relaxed),
         SENTINEL_PROBE_COUNT * 5 + SENTINEL_PROBE_COUNT,
         "fifteen candidates, then the three confirming sentinels"
+    );
+}
+
+/// The DOM stage carries the same fold-time confirmation. Exactly
+/// `SENTINEL_PROBE_COUNT * 5` candidate fields keep it under the pre-probe
+/// threshold, so the collapse it reaches has to ask the sentinels itself.
+#[tokio::test]
+async fn unprobed_dom_candidates_confirm_before_folding() {
+    let (target, requests, server) = echo_all_server().await;
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_response_id_params(
+        &target,
+        &default_scan_args(),
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<&str> = params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, ["any"], "{names:?}");
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        1 + SENTINEL_PROBE_COUNT * 5 + SENTINEL_PROBE_COUNT,
+        "HTML fetch, fifteen fields, then the three confirming sentinels"
     );
 }

--- a/src/parameter_analysis/mining/tests/request_efficiency.rs
+++ b/src/parameter_analysis/mining/tests/request_efficiency.rs
@@ -1,0 +1,308 @@
+use super::*;
+use std::sync::atomic::{AtomicUsize, Ordering};
+
+async fn mining_server() -> (Target, Arc<AtomicUsize>, tokio::task::JoinHandle<()>) {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let app = Router::new().route(
+        "/",
+        get(move |Query(params): Query<HashMap<String, String>>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                // Let tasks queue behind the semaphore before reflection
+                // statistics decide to stop the mining stage.
+                sleep(Duration::from_millis(2)).await;
+                let mut body = String::from("<html><body>");
+                if params.is_empty() {
+                    for i in 0..500 {
+                        body.push_str(&format!("<input name=candidate_{i}>"));
+                    }
+                }
+                for (name, value) in params {
+                    // Real candidates reflect, sentinel names do not. This
+                    // exercises the adaptive stop rather than the pre-probe.
+                    if name.starts_with("candidate_") || name == "selected" || name == "hidden" {
+                        body.push_str(&value);
+                    }
+                }
+                body.push_str("</body></html>");
+                Html(body)
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut target = parse_target(&format!("http://{addr}/")).unwrap();
+    target.workers = 1;
+    (target, requests, server)
+}
+
+fn candidate_wordlist() -> TempWordlist {
+    let words = (0..500)
+        .map(|i| format!("candidate_{i}\n"))
+        .collect::<String>();
+    TempWordlist::new("mining-efficiency", &words)
+}
+
+#[tokio::test]
+async fn duplicate_words_do_not_hide_a_later_real_parameter() {
+    let (target, requests, server) = mining_server().await;
+    let wordlist = TempWordlist::new("duplicate-mining", &("selected\n".repeat(500) + "hidden\n"));
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<_> = params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(names, ["selected", "hidden"]);
+    // Two candidate probes, plus the first sentinel of the arbitrary-name
+    // pre-probe (it does not reflect here, so the probe stops after one).
+    // Eligibility is measured on the loaded wordlist, not on what survives
+    // dedup, so shrinking the list cannot silently drop that check.
+    assert_eq!(requests.load(Ordering::Relaxed), 3);
+}
+
+#[tokio::test]
+async fn dictionary_collapse_stops_queued_requests_and_keeps_mined_params() {
+    let (target, requests, server) = mining_server().await;
+    let wordlist = candidate_wordlist();
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(vec![Param::new(
+        "saved",
+        "value",
+        Location::Body,
+    )]));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    let count = requests.load(Ordering::Relaxed);
+    sleep(Duration::from_millis(20)).await;
+    server.abort();
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        count,
+        "no detached probes after return"
+    );
+    assert_eq!(count, 16, "one sentinel + fifteen reflection samples");
+    let params = params.lock().await;
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "saved" && p.location == Location::Body)
+    );
+    // The sentinels did not reflect, so "this target echoes arbitrary names" is
+    // disproved: the stop still bounds the fan-out, but the fifteen candidates
+    // it did confirm stay as real injection points instead of being replaced by
+    // an `any` the target answers nothing for.
+    assert!(
+        !params.iter().any(|p| p.name == "any"),
+        "unconfirmed collapse must not fold real params into a stand-in"
+    );
+    let mined: Vec<_> = params
+        .iter()
+        .filter(|p| p.location == Location::Query)
+        .collect();
+    assert_eq!(mined.len(), 15);
+    assert!(mined.iter().all(|p| p.name.starts_with("candidate_")));
+    assert!(
+        mined.iter().all(|p| p.valid_specials.is_some()),
+        "the drained samples must seed metadata"
+    );
+}
+
+#[tokio::test]
+async fn dom_collapse_stops_queued_requests() {
+    let (target, requests, server) = mining_server().await;
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_response_id_params(
+        &target,
+        &default_scan_args(),
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        17,
+        "HTML fetch + sentinel + fifteen samples"
+    );
+    let params = params.lock().await;
+    // Same as the dictionary stage: stop early, keep what was confirmed. The
+    // DOM candidate set comes from a HashSet, so only the shape is asserted.
+    assert_eq!(params.len(), 15);
+    assert!(params.iter().all(|p| p.name.starts_with("candidate_")));
+    assert!(!params.iter().any(|p| p.name == "any"));
+}
+
+#[tokio::test]
+async fn known_query_candidates_are_probed_once_at_most() {
+    let (target, requests, server) = mining_server().await;
+    let wordlist = candidate_wordlist();
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(
+        (0..500)
+            .map(|i| Param::new(format!("candidate_{i}"), "a", Location::Query))
+            .collect(),
+    ));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    // Every wordlist entry is an already-discovered Query slot, so no candidate
+    // probe is sent — only the arbitrary-name pre-probe, whose first sentinel
+    // does not reflect here.
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+    probe_response_id_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    assert_eq!(
+        requests.load(Ordering::Relaxed),
+        3,
+        "DOM needs its HTML fetch and one sentinel"
+    );
+    assert_eq!(params.lock().await.len(), 500);
+}
+
+#[tokio::test]
+async fn existing_body_slot_does_not_suppress_a_query_candidate() {
+    let (target, requests, server) = mining_server().await;
+    let wordlist = TempWordlist::new("location-mining", "hidden\nhidden\n");
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(vec![Param::new("hidden", "a", Location::Body)]));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    assert_eq!(params.len(), 2);
+    assert!(
+        params
+            .iter()
+            .any(|p| p.name == "hidden" && p.location == Location::Query)
+    );
+    assert_eq!(requests.load(Ordering::Relaxed), 1);
+}
+
+#[tokio::test]
+async fn mining_pipeline_preserves_dictionary_findings_through_dom_collapse() {
+    let (mut target, requests, server) = mining_server().await;
+    let wordlist = TempWordlist::new("pipeline-mining", &("selected\n".repeat(500) + "hidden\n"));
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    mine_parameters(
+        &mut target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(1)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    let names: Vec<_> = params.iter().map(|p| p.name.as_str()).collect();
+    assert_eq!(&names[..2], ["selected", "hidden"], "{names:?}");
+    // DOM mining stops on its EWMA sample and keeps those fifteen candidates;
+    // the two dictionary findings are never folded away.
+    assert_eq!(names.len(), 17, "{names:?}");
+    assert!(names[2..].iter().all(|n| n.starts_with("candidate_")));
+    // 1 dictionary sentinel + 2 candidates, then 1 HTML fetch + 1 DOM sentinel
+    // + 15 DOM samples.
+    assert_eq!(requests.load(Ordering::Relaxed), 20);
+}
+
+#[tokio::test]
+async fn nonreflecting_prefix_does_not_skip_a_late_hidden_parameter() {
+    let (target, requests, server) = mining_server().await;
+    let words = (0..30).map(|i| format!("miss_{i}\n")).collect::<String>() + "hidden\n";
+    let wordlist = TempWordlist::new("late-mining", &words);
+    let args = ScanArgs {
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_dictionary_params(
+        &target,
+        &args,
+        params.clone(),
+        Arc::new(Semaphore::new(4)),
+        None,
+    )
+    .await;
+    server.abort();
+    let params = params.lock().await;
+    assert_eq!(params.len(), 1);
+    assert_eq!(params[0].name, "hidden");
+    assert_eq!(requests.load(Ordering::Relaxed), 32);
+}
+
+#[tokio::test]
+async fn concurrent_mining_bounds_overshoot_to_active_workers() {
+    let (mut target, requests, server) = mining_server().await;
+    target.workers = crate::cmd::scan::DEFAULT_WORKERS;
+    let semaphore = Arc::new(Semaphore::new(crate::utils::semaphore_permits(
+        target.workers,
+    )));
+    let wordlist = candidate_wordlist();
+    let args = ScanArgs {
+        workers: target.workers,
+        mining_dict_word: Some(wordlist.as_str()),
+        ..default_scan_args()
+    };
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_dictionary_params(&target, &args, params, semaphore.clone(), None).await;
+    let dictionary_requests = requests.swap(0, Ordering::Relaxed);
+    // Fifteen samples trigger the stop; up to workers-1 other requests may
+    // already be active. Include the failed sentinel (and DOM's HTML fetch).
+    assert!((16..=15 + target.workers).contains(&dictionary_requests));
+    let params = Arc::new(Mutex::new(Vec::new()));
+    probe_response_id_params(&target, &args, params, semaphore, None).await;
+    server.abort();
+    let dom_requests = requests.load(Ordering::Relaxed);
+    assert!((17..=16 + target.workers).contains(&dom_requests));
+}

--- a/src/scanning/mod.rs
+++ b/src/scanning/mod.rs
@@ -43,11 +43,12 @@
 //!   request — so the scan-wide number of *in-flight requests* never exceeds
 //!   `workers`.
 //!
-//! The reflection and DOM phases issue their payloads in chunks of up to
-//! `request_concurrency()` in flight (bounded by `req_budget`) and fold the
-//! responses back **in payload order**, so first-hit-wins dedup and the ordered
-//! #1156 early-exit budgets behave exactly as under the old strictly-serial
-//! loop. This is what makes a single-parameter target actually use `--workers`:
+//! The reflection and DOM phases grow their initial batches (1, 2, 4, ...)
+//! within the existing full-window boundaries, up to `request_concurrency()`
+//! in flight (bounded by `req_budget`). Responses are processed in payload
+//! order. After an R finding or a DOM early-exit signal, the remaining fetched
+//! responses can still supply a V; only future requests are skipped. This is
+//! what makes a single-parameter target actually use `--workers`:
 //! previously one permit was held for the whole parameter, so its entire payload
 //! catalog went out one request at a time regardless of `--workers` (a scan of
 //! one hard-filter parameter took `catalog × latency` wall-time). `--sxss`,
@@ -389,6 +390,19 @@ struct ParamScanState {
     /// DOM XSS already confirmed for this param locally — skip the
     /// remaining DOM payloads.
     dom_found_locally: bool,
+}
+
+/// Grow speculative batches gradually: early catalog hits should not cost a
+/// full worker window. Failed prefixes still ramp up to the existing ceiling.
+/// Keep the old boundaries (1, 1 + concurrency, ...) so reaching a given hit
+/// or early-exit budget never sends more requests than the full-window scheme.
+fn payload_chunk_size(completed: usize, concurrency: usize) -> usize {
+    if completed == 0 {
+        return 1;
+    }
+    let concurrency = concurrency.max(1);
+    let remaining_in_window = concurrency - (completed - 1) % concurrency;
+    completed.saturating_add(1).min(remaining_in_window)
 }
 
 /// Shared, cheaply-clonable context handed to each spawned worker. Every
@@ -740,13 +754,11 @@ impl ScanWorkerCtx {
         // Within-parameter concurrency: the reflection set is issued in chunks
         // of up to `request_concurrency()` requests in flight at once (each
         // bounded by the scan-wide `req_budget`), and the responses are
-        // processed serially in payload order so the first-hit-wins dedup, the
-        // static V upgrade, and the once-per-param AST pass all behave exactly
-        // as they did in the old strictly-sequential loop. The very first
-        // payload is sent alone so a parameter that reflects on payload 0 (the
-        // common case) still costs a single request — the fan-out only pays off
-        // on the non-short-circuiting sanitizing / hard-filter parameters, which
-        // is where a serial catalog used to spend thousands of round-trips.
+        // processed serially in payload order for deterministic dedup, the
+        // static V upgrade, and the once-per-param AST pass. The very first
+        // payload is sent alone, then batches grow 2, 4, 8, ... within the old
+        // full-window boundaries. Early hits avoid a full window of speculation;
+        // hard-filter parameters still reach the configured concurrency.
         let total = reflection_payloads.len();
         let concurrency = self.request_concurrency();
         let mut i = 0usize;
@@ -771,7 +783,7 @@ impl ScanWorkerCtx {
                 self.inc_progress((total - i) as u64);
                 break;
             }
-            let chunk = if i == 0 { 1 } else { concurrency };
+            let chunk = payload_chunk_size(i, concurrency);
             let end = (i + chunk).min(total);
             let fetched = futures::future::join_all(
                 reflection_payloads[i..end]
@@ -783,10 +795,10 @@ impl ScanWorkerCtx {
                 reflection_payloads[i..end].iter().zip(fetched)
             {
                 self.inc_progress(1);
-                // A hit earlier in this same chunk already claimed the slot; the
-                // rest were speculatively fetched (bounded overshoot) — don't
-                // record duplicates for them.
-                if state.reflection_found_locally {
+                // A plain R must not hide a V in responses we already paid for.
+                // Keep checking this chunk until execution is confirmed; the
+                // result processor still deduplicates repeated R findings.
+                if !self.args.deep_scan && state.dom_found_locally {
                     continue;
                 }
                 self.process_reflection_result(
@@ -905,13 +917,10 @@ impl ScanWorkerCtx {
                 } else {
                     let mut found = self.found_params.write().await;
                     let key = found_param_key(param);
-                    if !found.reflection.contains(&key) {
-                        found.reflection.insert(key);
-                        state.reflection_found_locally = true;
-                        true
-                    } else {
-                        false
-                    }
+                    let new_reflection = found.reflection.insert(key.clone());
+                    state.reflection_found_locally = true;
+                    let new_verification = dom_evidence_kind.is_some() && found.dom.insert(key);
+                    new_reflection || new_verification
                 };
 
                 if should_add {
@@ -1119,7 +1128,7 @@ impl ScanWorkerCtx {
                 self.inc_progress((total - done) as u64);
                 break;
             }
-            let chunk = if i == 0 { 1 } else { concurrency };
+            let chunk = payload_chunk_size(i, concurrency);
             let end = (i + chunk).min(total);
             let fetched = futures::future::join_all(
                 dom_payloads[i..end]
@@ -1127,6 +1136,7 @@ impl ScanWorkerCtx {
                     .map(|p| self.fetch_dom(param, p)),
             )
             .await;
+            let mut early_exit = None;
             for (dom_payload, outcome) in dom_payloads[i..end].iter().zip(fetched) {
                 done += 1;
                 self.inc_progress(1);
@@ -1247,22 +1257,29 @@ impl ScanWorkerCtx {
                     blocked_streak = next_blocked_streak(blocked_streak, status, reflected);
                     redirect_streak = next_redirect_streak(redirect_streak, status);
                 }
-                if dom_phase_should_early_exit(
-                    self.args.deep_scan,
-                    inert_echo_count,
-                    blocked_streak,
-                    redirect_streak,
-                ) {
-                    crate::dbg_log!(
-                        "dom phase early-exit (param={}): inert_echo={}, blocked_streak={}, redirect_streak={} — endpoint shows no path to DOM verification, skipping remaining payloads",
-                        param.name,
+                if early_exit.is_none()
+                    && dom_phase_should_early_exit(
+                        self.args.deep_scan,
                         inert_echo_count,
                         blocked_streak,
                         redirect_streak,
-                    );
-                    self.inc_progress((total - done) as u64);
-                    break 'outer;
+                    )
+                {
+                    // Stop future requests, but inspect the rest of this
+                    // already-fetched chunk for a V before abandoning it.
+                    early_exit = Some((inert_echo_count, blocked_streak, redirect_streak));
                 }
+            }
+            if let Some((inert, blocked, redirects)) = early_exit {
+                crate::dbg_log!(
+                    "dom phase early-exit (param={}): inert_echo={}, blocked_streak={}, redirect_streak={} — no verification in fetched responses, skipping remaining payloads",
+                    param.name,
+                    inert,
+                    blocked,
+                    redirects,
+                );
+                self.inc_progress((total - done) as u64);
+                break;
             }
             i = end;
         }

--- a/src/scanning/tests.rs
+++ b/src/scanning/tests.rs
@@ -2,6 +2,8 @@ use super::*;
 use crate::parameter_analysis::{InjectionContext, Location, Param};
 use crate::target_parser::parse_target;
 
+mod request_efficiency;
+
 /// ScanArgs preset for run_scanning integration tests below. Keeps
 /// `skip_xss_scanning` toggleable per-test so the empty/short-circuit
 /// tests can still opt out of real HTTP traffic while the

--- a/src/scanning/tests/request_efficiency.rs
+++ b/src/scanning/tests/request_efficiency.rs
@@ -1,0 +1,195 @@
+use super::*;
+use axum::{Router, extract::Query, response::Html, routing::get};
+use std::collections::HashMap;
+use std::sync::atomic::AtomicUsize;
+
+const VERIFIED: &str = "<svg onload=alert(1)>";
+
+// Exercise the actual HTTP/verification pipeline with a fixed catalog so
+// payload-generator changes cannot silently weaken the request-count checks.
+async fn worker(
+    redirects: bool,
+) -> (
+    ScanWorkerCtx,
+    Param,
+    Arc<AtomicUsize>,
+    tokio::task::JoinHandle<()>,
+) {
+    let requests = Arc::new(AtomicUsize::new(0));
+    let count = requests.clone();
+    let app = Router::new().route(
+        "/",
+        get(move |Query(params): Query<HashMap<String, String>>| {
+            let count = count.clone();
+            async move {
+                count.fetch_add(1, Ordering::Relaxed);
+                let q = params.get("q").map(String::as_str).unwrap_or_default();
+                if redirects && q.starts_with("miss") {
+                    return (axum::http::StatusCode::FOUND, Html(String::new()));
+                }
+                let body = if q == VERIFIED || q == "echo" || q == markers::bracketed_marker() {
+                    format!("<html><body>{q}</body></html>")
+                } else {
+                    "<html><body>filtered</body></html>".to_owned()
+                };
+                (axum::http::StatusCode::OK, Html(body))
+            }
+        }),
+    );
+    let listener = tokio::net::TcpListener::bind("127.0.0.1:0").await.unwrap();
+    let addr = listener.local_addr().unwrap();
+    let server = tokio::spawn(async move { axum::serve(listener, app).await.unwrap() });
+    let mut target = parse_target(&format!("http://{addr}/?q=a")).unwrap();
+    target.workers = crate::cmd::scan::DEFAULT_WORKERS;
+    let param = Param::new("q".to_owned(), "a".to_owned(), Location::Query);
+    let ctx = ScanWorkerCtx {
+        args: Arc::new(integration_scan_args(false)),
+        client: Arc::new(target.build_client_or_default()),
+        target: Arc::new(target),
+        results: Arc::new(Mutex::new(Vec::new())),
+        found_params: Arc::new(RwLock::new(FoundParams {
+            reflection: HashSet::new(),
+            dom: HashSet::new(),
+        })),
+        findings_count: Arc::new(AtomicUsize::new(0)),
+        pb: None,
+        overall_pb: None,
+        limit_result_type: Arc::from("ALL"),
+        cancel: None,
+        finding_tx: None,
+        semaphore: Arc::new(Semaphore::new(1)),
+        req_budget: Arc::new(Semaphore::new(crate::utils::semaphore_permits(
+            crate::cmd::scan::DEFAULT_WORKERS,
+        ))),
+        params_done: None,
+    };
+    (ctx, param, requests, server)
+}
+
+fn catalog() -> Vec<String> {
+    (0..150).map(|i| format!("miss{i}")).collect()
+}
+
+#[tokio::test]
+async fn early_reflection_hit_uses_four_requests_including_probe() {
+    let (ctx, param, requests, server) = worker(false).await;
+    let mut payloads = catalog();
+    payloads[1] = VERIFIED.to_owned();
+    ctx.scan_param(param, payloads, vec![]).await;
+    server.abort();
+    let results = ctx.results.lock().await;
+    assert!(
+        results
+            .iter()
+            .any(|r| r.result_type == FindingType::Verified)
+    );
+    assert_eq!(requests.load(Ordering::Relaxed), 4);
+}
+
+#[tokio::test]
+async fn early_dom_hit_uses_four_requests_including_probe() {
+    let (ctx, param, requests, server) = worker(false).await;
+    let mut payloads = catalog();
+    payloads[1] = VERIFIED.to_owned();
+    ctx.scan_param(param, vec![], payloads).await;
+    server.abort();
+    let results = ctx.results.lock().await;
+    assert!(
+        results
+            .iter()
+            .any(|r| r.result_type == FindingType::Verified)
+    );
+    assert_eq!(requests.load(Ordering::Relaxed), 4);
+}
+
+#[tokio::test]
+async fn prefetched_verification_survives_an_earlier_reflection() {
+    let (ctx, param, requests, server) = worker(false).await;
+    let mut payloads = catalog();
+    payloads[1] = "echo".to_owned();
+    payloads[2] = VERIFIED.to_owned();
+    // No DOM catalog: the V must come from the already-fetched reflection
+    // response. Retrying that payload in a later phase cannot rescue it.
+    ctx.scan_param(param, payloads, vec![]).await;
+    server.abort();
+    let results = ctx.results.lock().await;
+    assert!(
+        results
+            .iter()
+            .any(|r| r.result_type == FindingType::Verified)
+    );
+    assert_eq!(requests.load(Ordering::Relaxed), 4);
+    assert_eq!(
+        results
+            .iter()
+            .filter(|r| r.result_type == FindingType::Verified)
+            .count(),
+        1
+    );
+}
+
+#[tokio::test]
+async fn prefetched_reflections_still_deduplicate() {
+    let (ctx, param, requests, server) = worker(false).await;
+    let mut payloads = catalog();
+    payloads[1] = "echo".to_owned();
+    payloads[2] = "echo".to_owned();
+    ctx.scan_param(param, payloads, vec![]).await;
+    server.abort();
+    let results = ctx.results.lock().await;
+    assert_eq!(results.len(), 1);
+    assert_eq!(results[0].result_type, FindingType::Reflected);
+    assert_eq!(requests.load(Ordering::Relaxed), 4);
+}
+
+#[tokio::test]
+async fn dom_budget_preserves_prefetched_verification() {
+    let (ctx, param, requests, server) = worker(true).await;
+    let mut payloads = catalog();
+    payloads[REDIRECT_STREAK_LIMIT as usize] = VERIFIED.to_owned();
+    ctx.scan_param(param, vec![], payloads).await;
+    server.abort();
+    let results = ctx.results.lock().await;
+    assert!(
+        results
+            .iter()
+            .any(|r| r.result_type == FindingType::Verified)
+    );
+    // 1 probe + batches of 1, 2, 4, 8, 16, 20; no further batch is needed.
+    assert_eq!(requests.load(Ordering::Relaxed), 52);
+}
+
+#[tokio::test]
+async fn dom_budget_still_stops_when_prefetched_responses_do_not_verify() {
+    let (ctx, param, requests, server) = worker(true).await;
+    ctx.scan_param(param, vec![], catalog()).await;
+    server.abort();
+    assert!(ctx.results.lock().await.is_empty());
+    assert_eq!(requests.load(Ordering::Relaxed), 52);
+}
+
+#[tokio::test]
+async fn deep_scan_keeps_the_full_unsuccessful_catalog() {
+    let (mut ctx, param, requests, server) = worker(true).await;
+    Arc::make_mut(&mut ctx.args).deep_scan = true;
+    ctx.scan_param(param, vec![], catalog()).await;
+    server.abort();
+    assert!(ctx.results.lock().await.is_empty());
+    assert_eq!(requests.load(Ordering::Relaxed), 151);
+}
+
+#[test]
+fn growing_batches_never_exceed_previous_request_cost_at_any_stop_position() {
+    for concurrency in 1..=crate::cmd::scan::MAX_PER_PARAM_CONCURRENCY {
+        let mut completed = 0;
+        for stop_after in 1usize..=512 {
+            if completed < stop_after {
+                let chunk = payload_chunk_size(completed, concurrency);
+                assert!((1..=concurrency).contains(&chunk));
+                completed += chunk;
+            }
+            let previous_cost = 1 + (stop_after - 1).div_ceil(concurrency) * concurrency;
+            assert!(completed <= previous_cost);
+        }
+    }
+}


### PR DESCRIPTION
## Why

Two request-efficiency problems in the scan path, plus the two false-negative
paths that fixing the second one opened.

**Payload batching.** The reflection and DOM phases sent the first payload
alone and then jumped straight to a full `--workers` window. A parameter that
reflects on payload 2 therefore cost 52 requests instead of 4. Worse, once one
response in a window produced a hit, the responses that arrived after it were
dropped unread — including ones carrying DOM evidence that would have upgraded
a plain `R` to a `V`.

**Mining.** Dictionary and DOM mining filtered duplicate and already-discovered
candidates *after* spawning a task per wordlist entry, and when the reflection
sample decided to stop the stage, everything already queued behind the
semaphore went out anyway.

## What changed

- Batches grow `1, 2, 4, 8, …` and stay inside the previous full-window
  boundaries, so no stop position costs more requests than before (property
  test over every concurrency and stop position). Hard-filter parameters still
  reach the configured concurrency.
- Responses already fetched are always inspected: a plain `R` no longer hides a
  `V` from the same batch, and the #1156 DOM early-exit stops *future* requests
  instead of the ones in hand.
- Mining filters candidates before probing, and a probe re-checks the collapse
  flag after taking its permit, so a stopped stage sends nothing more.

## The two FNs that filtering introduced

Both were found by running the same tests against `HEAD` and against this
branch in isolated checkouts, and both are now regression-guarded in
`src/parameter_analysis/mining/tests/collapse_recall.rs`.

1. **Sentinel eligibility.** The arbitrary-name pre-probe was gated on the
   *filtered* candidate count, so a wordlist made entirely of already-known
   slots stopped running it — and with it lost the synthetic `any` parameter,
   the only injection point that covers "this target echoes names it does not
   have". Eligibility is measured on the list as loaded again.
2. **EWMA collapse turned destructive.** Dropping duplicate misses raises the
   reflection EWMA, so a target with many genuinely reflecting parameters now
   trips the collapse. The collapse then *deleted* those confirmed parameters
   and reported `any`, which that target answers nothing for — 20 real findings
   became 0. The stop stays (it bounds Stage 3-6 fan-out on an endpoint that
   reflects most of a wordlist), but the destructive fold now requires the
   sentinels to confirm that arbitrary names really do reflect. That also closes
   the same fold for a wordlist under the pre-probe threshold, where no revision
   ever had the evidence — `main` folds there too.

A reflecting response is also kept when a sibling sets the collapse flag while
that request is in flight; it is paid for either way.

## Verification

`cargo fmt`, `clippy` clean, `cargo test` green (2534 lib + all integration).

xssmaze, 1013 scored endpoints, `--skip-mining --workers 20`, run twice in both
orders against a freshly restarted server:

| | recall | V-rate | FP | requests |
|---|---|---|---|---|
| `main` | 99.21% | 88.15% | 16 | 141359 / 145520 |
| this branch | 99.11% | 88.15% | 16 | 142922 / 148586 |

Identical FP set and identical `V` count. 53 endpoints cut ~40% of their
requests (45 → 27 across the filter families); overall requests are **-638**
once the stateful `stored*` family is excluded — that family accumulates server
state, and its counts move by thousands between runs on either revision.

The single recall difference, `storedpat-level1`, is a coin flip on both
revisions: run alone against a fresh server three times each, `main` detected it
once and this branch once, with an identical request count on every miss.

A mining-enabled subset (77 scored endpoints) is identical on recall, `V` and FP,
with slightly fewer requests (26771 vs 26947).

## Trade-off

Reaching the deep end of a catalog now takes a few more round trips for the same
number of requests, so a tight `--scan-timeout` can cut a payload the
full-window batching would have reached. Documented in the CLI reference;
`--scan-timeout` defaults to off.
