### PR TITLE
feat(scan): widen DOM XSS AST coverage and cut its false positives

### DIFF
--- a/skills/dalfox/references/results.md
+++ b/skills/dalfox/references/results.md
@@ -41,6 +41,21 @@ produces. Never tell a user dalfox "watched an alert fire".
 The method field is stable; the `A` tier is being absorbed into the confidence
 axis (issue #1238).
 
+AST analysis follows optional calls/member access (`?.`), statically resolved
+bracket notation, and sinks nested in unary expressions, arrays, objects, and
+constructor arguments. Computed `URLSearchParams.get` and storage `getItem`
+calls retain their parameter/key labels for PoCs. Numeric and comparison
+results do not carry executable string taint; string concatenation still does.
+Function bodies are analyzed wherever the literal is written — including
+options-object callbacks (`$.ajax({success: fn})`) — and a function's
+parameters shadow same-named bindings from the enclosing scope, so a helper
+that only ever touches its own argument is not reported against an outer
+variable.
+HTML extraction skips non-JavaScript script types (including JSON, templates,
+import maps, and speculation rules) and ignores inline text when `src` is
+present. Same-origin external script discovery uses the same type filter.
+These are static flow checks; runtime reachability still needs confirmation.
+
 ### `confidence` — the grade behind the claim
 
 Every XSS finding carries `confidence` (`"high"` / `"low"`) plus a

--- a/src/scanning/ast_dom_analysis/bindings.rs
+++ b/src/scanning/ast_dom_analysis/bindings.rs
@@ -304,36 +304,7 @@ impl<'a> DomXssVisitor<'a> {
         let _guard = self.enter_recursion()?;
         match expr {
             Expression::Identifier(id) => self.var_aliases.get(id.name.as_str()).cloned(),
-            Expression::StaticMemberExpression(member) => {
-                if let Some(source) = self.url_search_params_source_for_member(member) {
-                    return Some(source);
-                }
-                if let Some(source) = self.class_accessor_taint_source(member) {
-                    return Some(source);
-                }
-                if let Some(source) = self.xhr_response_source_for_member(member) {
-                    return Some(source);
-                }
-                if let Some(source) = self.file_reader_source_for_member(member) {
-                    return Some(source);
-                }
-                if let Some(full_path) = self.get_member_string(member) {
-                    if matches!(
-                        full_path.as_str(),
-                        "event.data" | "e.data" | "event.newValue"
-                    ) && let Some(source) = self.field_taints.get(&full_path)
-                    {
-                        return Some(source.clone());
-                    }
-                    if self.sources.contains(full_path.as_str()) {
-                        return Some(full_path);
-                    }
-                    if let Some(source) = self.field_taints.get(&full_path) {
-                        return Some(source.clone());
-                    }
-                }
-                self.find_source_in_expr(&member.object)
-            }
+            Expression::StaticMemberExpression(member) => self.static_member_source(member),
             Expression::ArrayExpression(array) => {
                 // Find first tainted element's source
                 for elem in &array.elements {
@@ -380,9 +351,10 @@ impl<'a> DomXssVisitor<'a> {
                 }
                 None
             }
-            Expression::BinaryExpression(binary) => self
-                .find_source_in_expr(&binary.left)
-                .or_else(|| self.find_source_in_expr(&binary.right)),
+            Expression::BinaryExpression(binary) if binary.operator == BinaryOperator::Addition => {
+                self.find_source_in_expr(&binary.left)
+                    .or_else(|| self.find_source_in_expr(&binary.right))
+            }
             Expression::LogicalExpression(logical) => self
                 .find_source_in_expr(&logical.left)
                 .or_else(|| self.find_source_in_expr(&logical.right)),
@@ -428,14 +400,15 @@ impl<'a> DomXssVisitor<'a> {
                 }
                 None
             }
-            Expression::ComputedMemberExpression(member) => {
-                if let Some(full_path) = self.get_computed_member_string(member)
-                    && self.sources.contains(full_path.as_str())
-                {
-                    return Some(full_path);
+            Expression::ComputedMemberExpression(member) => self.computed_member_source(member),
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::CallExpression(call) => self.call_taint_and_source(call).1,
+                ChainElement::StaticMemberExpression(member) => self.static_member_source(member),
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.computed_member_source(member)
                 }
-                self.find_source_in_expr(&member.object)
-            }
+                _ => None,
+            },
             Expression::ParenthesizedExpression(paren) => {
                 self.find_source_in_expr(&paren.expression)
             }
@@ -523,5 +496,52 @@ impl<'a> DomXssVisitor<'a> {
         for property in properties {
             self.field_taints.remove(&format!("{var_name}.{property}"));
         }
+    }
+    pub(super) fn static_member_source(
+        &self,
+        member: &StaticMemberExpression<'a>,
+    ) -> Option<String> {
+        if let Some(source) = self.url_search_params_source_for_member(member) {
+            return Some(source);
+        }
+        if let Some(source) = self.class_accessor_taint_source(member) {
+            return Some(source);
+        }
+        if let Some(source) = self.xhr_response_source_for_member(member) {
+            return Some(source);
+        }
+        if let Some(source) = self.file_reader_source_for_member(member) {
+            return Some(source);
+        }
+        if let Some(full_path) = self.get_member_string(member) {
+            if matches!(
+                full_path.as_str(),
+                "event.data" | "e.data" | "event.newValue"
+            ) && let Some(source) = self.field_taints.get(&full_path)
+            {
+                return Some(source.clone());
+            }
+            if self.sources.contains(full_path.as_str()) {
+                return Some(full_path);
+            }
+            if let Some(source) = self.field_taints.get(&full_path) {
+                return Some(source.clone());
+            }
+        }
+        self.find_source_in_expr(&member.object)
+    }
+    pub(super) fn computed_member_source(
+        &self,
+        member: &ComputedMemberExpression<'a>,
+    ) -> Option<String> {
+        if let Some(path) = self.get_computed_member_string(member) {
+            if let Some(source) = self.field_taints.get(&path) {
+                return Some(source.clone());
+            }
+            if self.sources.contains(path.as_str()) {
+                return Some(path);
+            }
+        }
+        self.find_source_in_expr(&member.object)
     }
 }

--- a/src/scanning/ast_dom_analysis/resolve.rs
+++ b/src/scanning/ast_dom_analysis/resolve.rs
@@ -16,6 +16,13 @@ impl<'a> DomXssVisitor<'a> {
             Expression::MetaProperty(meta) => {
                 Some(format!("{}.{}", meta.meta.name, meta.property.name))
             }
+            Expression::ChainExpression(chain) => match &chain.expression {
+                ChainElement::StaticMemberExpression(member) => self.get_member_string(member),
+                ChainElement::ComputedMemberExpression(member) => {
+                    self.get_computed_member_string(member)
+                }
+                _ => None,
+            },
             _ => None,
         }
     }
@@ -32,6 +39,9 @@ impl<'a> DomXssVisitor<'a> {
             Expression::Identifier(id) => Some(format!("{}.{}", id.name.as_str(), property)),
             Expression::StaticMemberExpression(inner) => self
                 .get_member_string(inner)
+                .map(|obj| format!("{}.{}", obj, property)),
+            Expression::ComputedMemberExpression(inner) => self
+                .get_computed_member_string(inner)
                 .map(|obj| format!("{}.{}", obj, property)),
             Expression::MetaProperty(meta) => Some(format!(
                 "{}.{}.{}",

--- a/src/scanning/ast_dom_analysis/sinks.rs
+++ b/src/scanning/ast_dom_analysis/sinks.rs
@@ -1194,31 +1194,55 @@ impl<'a> DomXssVisitor<'a> {
     /// Walk function/arrow callbacks passed as call arguments, each with an
     /// isolated taint scope so a callback-local variable (`var q = …` inside
     /// the callback) does not leak taint into the enclosing scope. Only
-    /// function-shaped arguments are descended; data arguments keep their
+    /// callback-shaped arguments are descended; data arguments keep their
     /// existing taint-evaluation-only treatment.
     pub(super) fn walk_callback_argument_bodies(&mut self, call: &CallExpression<'a>) {
         for arg in &call.arguments {
-            let Some(expr) = arg.as_expression() else {
-                continue;
-            };
-            let statements = match expr {
-                Expression::FunctionExpression(func) => {
-                    let Some(body) = &func.body else {
-                        continue;
-                    };
-                    &body.statements
-                }
-                Expression::ArrowFunctionExpression(arrow) => &arrow.body.statements,
-                _ => continue,
-            };
-
-            let saved_tainted = self.tainted_vars.clone();
-            let saved_aliases = self.var_aliases.clone();
-            let saved_field_taints = self.field_taints.clone();
-            self.walk_statements(statements);
-            self.tainted_vars = saved_tainted;
-            self.var_aliases = saved_aliases;
-            self.field_taints = saved_field_taints;
+            if let Some(expr) = arg.as_expression() {
+                self.walk_callback_argument_expression(expr);
+            }
         }
+    }
+    /// A callback reaches a call either directly (`setTimeout(fn)`) or as a
+    /// property of an options object (`$.ajax({ success: fn })`) — the shape
+    /// every jQuery/axios-style API uses. Both defer the body the same way, so
+    /// both are descended; anything else is left to taint evaluation.
+    fn walk_callback_argument_expression(&mut self, expr: &Expression<'a>) {
+        let Some(_guard) = self.enter_recursion() else {
+            return;
+        };
+        match expr {
+            Expression::FunctionExpression(func) => {
+                if let Some(body) = &func.body {
+                    self.walk_isolated_callback_body(&func.params, &body.statements);
+                }
+            }
+            Expression::ArrowFunctionExpression(arrow) => {
+                self.walk_isolated_callback_body(&arrow.params, &arrow.body.statements);
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    if let ObjectPropertyKind::ObjectProperty(property) = property {
+                        self.walk_callback_argument_expression(&property.value);
+                    }
+                }
+            }
+            Expression::ParenthesizedExpression(paren) => {
+                self.walk_callback_argument_expression(&paren.expression);
+            }
+            _ => {}
+        }
+    }
+    /// A callback body additionally isolates `field_taints`: an argument
+    /// callback runs later and elsewhere, so an `obj.x = …` inside it must not
+    /// be read back as a fact about the enclosing scope's `obj`.
+    fn walk_isolated_callback_body(
+        &mut self,
+        params: &FormalParameters<'a>,
+        statements: &[Statement<'a>],
+    ) {
+        let saved_field_taints = self.field_taints.clone();
+        self.walk_function_literal_body(params, statements);
+        self.field_taints = saved_field_taints;
     }
 }

--- a/src/scanning/ast_dom_analysis/taint.rs
+++ b/src/scanning/ast_dom_analysis/taint.rs
@@ -230,6 +230,16 @@ impl<'a> DomXssVisitor<'a> {
             }
         }
         if let Expression::ComputedMemberExpression(member) = &call.callee {
+            if self.get_computed_property_string(member).as_deref() == Some("get")
+                && let Some(source) = self.url_search_params_get_source(call, &member.object)
+            {
+                return (true, Some(source));
+            }
+            if let Some(callee_str) = self.get_computed_member_string(member)
+                && let Some(source) = self.storage_get_source(call, &callee_str)
+            {
+                return (true, Some(source));
+            }
             if let Some(callee_str) = self.get_computed_member_string(member)
                 && self.sources.contains(callee_str.as_str())
             {
@@ -579,6 +589,53 @@ impl<'a> DomXssVisitor<'a> {
         let (tainted, source) = self.argument_taint_and_source(arg);
         tainted.then(|| source.unwrap_or_else(|| "unknown source".to_string()))
     }
+    pub(super) fn static_member_is_tainted(&self, member: &StaticMemberExpression<'a>) -> bool {
+        if self.url_search_params_source_for_member(member).is_some() {
+            return true;
+        }
+        if self.class_accessor_taint_source(member).is_some() {
+            return true;
+        }
+        if self.xhr_response_source_for_member(member).is_some() {
+            return true;
+        }
+        if self.file_reader_source_for_member(member).is_some() {
+            return true;
+        }
+        if let Some(full_path) = self.get_member_string(member) {
+            // Check field-level taint first for precise tracking
+            if self.field_taints.contains_key(&full_path) {
+                return true;
+            }
+            // Check if the full path is a known source
+            if self.sources.contains(full_path.as_str()) {
+                return true;
+            }
+        }
+        // Also check if the base object is a tainted variable
+        // e.g., if 'data' is tainted, then 'data.field' is also tainted
+        self.is_tainted(&member.object)
+    }
+    pub(super) fn computed_member_is_tainted(&self, member: &ComputedMemberExpression<'a>) -> bool {
+        if let Some(path) = self.get_computed_member_string(member)
+            && (self.sources.contains(path.as_str()) || self.field_taints.contains_key(&path))
+        {
+            return true;
+        }
+        self.is_tainted(&member.object)
+    }
+    /// Optional chaining changes whether an expression runs, not the value
+    /// it returns when it does. Reuse the ordinary call/member rules.
+    pub(super) fn chain_is_tainted(&self, chain: &ChainExpression<'a>) -> bool {
+        match &chain.expression {
+            ChainElement::CallExpression(call) => self.call_taint_and_source(call).0,
+            ChainElement::StaticMemberExpression(member) => self.static_member_is_tainted(member),
+            ChainElement::ComputedMemberExpression(member) => {
+                self.computed_member_is_tainted(member)
+            }
+            _ => false,
+        }
+    }
     /// Check if expression is tainted.
     ///
     /// Hostile JavaScript can nest expressions arbitrarily deep (`a.b.c.d…`,
@@ -599,38 +656,15 @@ impl<'a> DomXssVisitor<'a> {
                 self.tainted_vars.contains(id.name.as_str())
                     || self.global_taints.contains(id.name.as_str())
             }
-            Expression::StaticMemberExpression(member) => {
-                if self.url_search_params_source_for_member(member).is_some() {
-                    return true;
-                }
-                if self.class_accessor_taint_source(member).is_some() {
-                    return true;
-                }
-                if self.xhr_response_source_for_member(member).is_some() {
-                    return true;
-                }
-                if self.file_reader_source_for_member(member).is_some() {
-                    return true;
-                }
-                if let Some(full_path) = self.get_member_string(member) {
-                    // Check field-level taint first for precise tracking
-                    if self.field_taints.contains_key(&full_path) {
-                        return true;
-                    }
-                    // Check if the full path is a known source
-                    if self.sources.contains(full_path.as_str()) {
-                        return true;
-                    }
-                }
-                // Also check if the base object is a tainted variable
-                // e.g., if 'data' is tainted, then 'data.field' is also tainted
-                self.is_tainted(&member.object)
-            }
+            Expression::StaticMemberExpression(member) => self.static_member_is_tainted(member),
             Expression::TemplateLiteral(template) => {
                 template.expressions.iter().any(|e| self.is_tainted(e))
             }
             Expression::BinaryExpression(binary) => {
-                self.is_tainted(&binary.left) || self.is_tainted(&binary.right)
+                // Only + can preserve attacker-controlled string content.
+                // Comparisons and arithmetic produce booleans/numbers.
+                binary.operator == BinaryOperator::Addition
+                    && (self.is_tainted(&binary.left) || self.is_tainted(&binary.right))
             }
             Expression::LogicalExpression(logical) => {
                 self.is_tainted(&logical.left) || self.is_tainted(&logical.right)
@@ -670,15 +704,8 @@ impl<'a> DomXssVisitor<'a> {
                     }
                 })
             }
-            Expression::ComputedMemberExpression(member) => {
-                if let Some(full_path) = self.get_computed_member_string(member)
-                    && self.sources.contains(full_path.as_str())
-                {
-                    return true;
-                }
-                // Check if base object is tainted (e.g., arr[0] where arr is tainted)
-                self.is_tainted(&member.object)
-            }
+            Expression::ComputedMemberExpression(member) => self.computed_member_is_tainted(member),
+            Expression::ChainExpression(chain) => self.chain_is_tainted(chain),
             Expression::ParenthesizedExpression(paren) => {
                 // Parentheses don't affect taint
                 self.is_tainted(&paren.expression)

--- a/src/scanning/ast_dom_analysis/tests.rs
+++ b/src/scanning/ast_dom_analysis/tests.rs
@@ -5418,3 +5418,4 @@ open.onsuccess = function (e) {
         "a named object-store variable should still resolve: {vulns:?}"
     );
 }
+mod expression_regressions;

--- a/src/scanning/ast_dom_analysis/tests/expression_regressions.rs
+++ b/src/scanning/ast_dom_analysis/tests/expression_regressions.rs
@@ -1,0 +1,273 @@
+use super::*;
+
+#[test]
+fn optional_chains_preserve_sources_and_sinks() {
+    for js in [
+        "document.write?.(location.hash);",
+        "document?.write(location.hash);",
+        "document.write(window?.location.hash);",
+        "document.write(location?.['hash']);",
+        "document.write(location.hash?.slice(1));",
+        "const x = location?.hash; document.write(x);",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(
+            findings.iter().any(|v| v.source.contains("location.hash")),
+            "{js}: {findings:?}"
+        );
+    }
+    for js in [
+        "document.write?.('safe');",
+        "document.write(DOMPurify.sanitize?.(location.hash));",
+    ] {
+        assert!(
+            AstDomAnalyzer::new().analyze(js).unwrap().is_empty(),
+            "{js}"
+        );
+    }
+}
+
+#[test]
+fn computed_sources_preserve_parameter_and_storage_keys() {
+    for (js, source) in [
+        (
+            "document.write(window['location'].hash);",
+            "window.location.hash",
+        ),
+        (
+            "document.write(new URLSearchParams(location.search)['get']('query'));",
+            "URLSearchParams.get(query)",
+        ),
+        (
+            "document.write(localStorage['getItem']('preview'));",
+            "localStorage.getItem(preview)",
+        ),
+        (
+            "const state = {}; state.html = location.hash; document.write(state['html']);",
+            "location.hash",
+        ),
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(
+            findings.iter().any(|v| v.source == source),
+            "{js}: {findings:?}"
+        );
+    }
+}
+
+#[test]
+fn nested_sink_expressions_are_visited() {
+    for js in [
+        "void document.write(location.hash);",
+        "!function () { document.write(location.hash); }();",
+        "const a = [document.write(location.hash)];",
+        "const a = {value: document.write(location.hash)};",
+        "const a = {[document.write(location.hash)]: 1};",
+        "new Object(document.write(location.hash));",
+        "new Object(...[document.write(location.hash)]);",
+        "const a = [...[document.write(location.hash)]];",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(
+            findings.iter().any(|v| v.source == "location.hash"),
+            "{js}: {findings:?}"
+        );
+    }
+}
+
+#[test]
+fn function_literals_in_containers_are_analyzed() {
+    // A function literal is analyzed wherever it is written. Reaching one
+    // through an array, an object literal, an options-object property, a
+    // constructor argument, or a unary operand does not make the source it
+    // reads any less real — and these container shapes are how every
+    // jQuery/axios-style API takes its callbacks.
+    for js in [
+        "const f = [() => document.write(location.hash)];",
+        "const f = {run() { document.write(location.hash); }};",
+        "void (() => document.write(location.hash));",
+        "new Object(function () { document.write(location.hash); });",
+        "$.ajax({success: function (d) { document.write(location.hash); }});",
+        "new Promise(function (resolve) { document.write(location.hash); });",
+        "grid.render({rows: [], onDraw: () => document.write(location.hash)});",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert_eq!(findings.len(), 1, "{js}: {findings:?}");
+        assert_eq!(findings[0].source, "location.hash", "{js}");
+    }
+}
+
+#[test]
+fn function_parameters_shadow_the_enclosing_scope() {
+    // The body can only ever see the argument it was called with, so an outer
+    // binding of the same name is not a flow. The parameter's own flow is
+    // reported at the call site from the function's summary instead, which is
+    // also why walking the body here cannot double-report it.
+    for js in [
+        "const x = location.hash; const f = function (x) { document.write(x); }; f('safe');",
+        "const x = location.hash; const f = {run(x) { document.write(x); }}; f.run('safe');",
+        "const x = location.hash; const f = function ({x}) { document.write(x); }; f({});",
+        "const x = location.hash; const f = function (...x) { document.write(x); }; f('safe');",
+        "const x = location.hash; function f(x) { document.write(x); } f('safe');",
+        "const d = location.hash; setTimeout(function (d) { document.write(d); }, 0);",
+        "const d = location.hash; $.ajax({success: function (d) { document.write(d); }});",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(findings.is_empty(), "{js}: {findings:?}");
+    }
+}
+
+#[test]
+fn free_variables_in_parameterized_functions_still_flow() {
+    // The summary registered for a declaration only carries parameter flows,
+    // so a source the body reads on its own has to come from the body walk.
+    // Both may fire for the same function without duplicating each other.
+    let findings = AstDomAnalyzer::new()
+        .analyze("function render(el) { el.innerHTML = location.hash; } render(document.body);")
+        .unwrap();
+    assert_eq!(findings.len(), 1, "{findings:?}");
+    assert_eq!(findings[0].source, "location.hash");
+
+    let findings = AstDomAnalyzer::new()
+        .analyze("function show(v) { document.write(v); } show(location.hash);")
+        .unwrap();
+    assert_eq!(
+        findings.len(),
+        1,
+        "parameter flow must not double-report: {findings:?}"
+    );
+}
+
+#[test]
+fn function_bodies_leak_outer_writes_but_not_their_own_locals() {
+    // A write to a binding the body does not own outlives the call.
+    for js in [
+        "const f = function () { g = location.hash; }; f(); document.write(g);",
+        "function f() { g = location.hash; } f(); document.write(g);",
+        "setTimeout(function () { g = location.hash; }, 0); document.write(g);",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert_eq!(findings.len(), 1, "{js}: {findings:?}");
+        assert_eq!(findings[0].source, "location.hash", "{js}");
+    }
+    // A local of the same name is a different variable, in every statement
+    // form that can hold a declaration. Each entry exercises one arm of the
+    // declared-name scan; an arm that stops matching lets that local escape
+    // as a global and taints an unrelated outer `q`.
+    for js in [
+        "const f = function () { var q = location.hash; }; f(); document.write(q);",
+        "const f = function () { { var q = location.hash; } }; f(); document.write(q);",
+        "const f = function () { if (0) 1; else { var q = location.hash; } }; document.write(q);",
+        "const f = function () { for (var q = location.hash;;) break; }; f(); document.write(q);",
+        "const f = function () { for (var q in o) { q = location.hash; } }; document.write(q);",
+        "const f = function () { for (var q of o) { q = location.hash; } }; document.write(q);",
+        "const f = function () { while (0) { var q = location.hash; } }; document.write(q);",
+        "const f = function () { do { var q = location.hash; } while (0); }; document.write(q);",
+        "const f = function () { loop: { var q = location.hash; } }; document.write(q);",
+        "const f = function () { switch (1) { case 1: var q = location.hash; } }; document.write(q);",
+        "const f = function () { try { let q = location.hash; } catch (q) {} }; document.write(q);",
+        "const f = function () { try { 1; } finally { var q = location.hash; } }; document.write(q);",
+        "const f = function () { function q() {} q = location.hash; }; document.write(q);",
+        "const f = function () { class q {} q = location.hash; }; document.write(q);",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(findings.is_empty(), "{js}: {findings:?}");
+    }
+    // Shadowing a parameter must not erase the outer binding's own taint —
+    // including a name the enclosing scope tainted by destructuring, which is
+    // tracked as a global rather than a plain local.
+    for js in [
+        "const x = location.hash; const f = function (x) { return x; }; document.write(x);",
+        "const {x} = location; const f = function (x) { return x; }; document.write(x + location.hash);",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert_eq!(findings.len(), 1, "{js}: {findings:?}");
+    }
+}
+
+#[test]
+fn parameter_shadowing_covers_every_binding_form() {
+    // Destructuring defaults, nested patterns, and rest elements all bind
+    // names the body sees instead of the enclosing scope's.
+    for js in [
+        "const x = location.hash; const f = function (x = 1) { document.write(x); }; f();",
+        "const x = location.hash; const f = function ({x = 1}) { document.write(x); }; f({});",
+        "const x = location.hash; const f = function ({a: {x}}) { document.write(x); }; f({a: {}});",
+        "const x = location.hash; const f = function ({...x}) { document.write(x); }; f({});",
+        "const x = location.hash; const f = function ([, x]) { document.write(x); }; f([]);",
+        "const x = location.hash; const f = function ([...x]) { document.write(x); }; f([]);",
+        // A name the enclosing scope tainted by destructuring is tracked as a
+        // global, which the parameter has to shadow the same way.
+        "const {x} = location.hash; const f = function (x) { document.write(x); }; f('safe');",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(findings.is_empty(), "{js}: {findings:?}");
+    }
+    // …and the outer binding keeps its taint once the function is behind us.
+    let findings = AstDomAnalyzer::new()
+        .analyze("const {x} = location.hash; const f = function (x) {}; document.write(x);")
+        .unwrap();
+    assert_eq!(findings.len(), 1, "{findings:?}");
+}
+
+#[test]
+fn callbacks_and_chains_are_reached_through_wrappers() {
+    // A parenthesized callback argument and a spread-in options object are
+    // still callbacks; an optional computed member is still a member walk.
+    for js in [
+        "setTimeout((function () { document.write(location.hash); }), 0);",
+        "render({...base, draw: function () { document.write(location.hash); }});",
+        "const o = {...{run: () => document.write(location.hash)}};",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert_eq!(findings.len(), 1, "{js}: {findings:?}");
+    }
+    // The chain's own operands are walked, so a sink evaluated to build the
+    // key or the receiver is not lost.
+    for js in [
+        "cache?.[document.write(location.hash)];",
+        "document.write(location.hash)?.trim();",
+    ] {
+        let findings = AstDomAnalyzer::new().analyze(js).unwrap();
+        assert!(
+            findings.iter().any(|v| v.source == "location.hash"),
+            "{js}: {findings:?}"
+        );
+    }
+}
+
+#[test]
+fn numeric_and_boolean_binary_results_do_not_carry_executable_input() {
+    for value in [
+        "location.hash === '#yes'",
+        "location.hash != ''",
+        "location.hash < 'z'",
+        "location.hash - 1",
+        "location.hash * 2",
+        "location.hash | 0",
+    ] {
+        let js = format!("document.write({value});");
+        assert!(
+            AstDomAnalyzer::new().analyze(&js).unwrap().is_empty(),
+            "{js}"
+        );
+    }
+    for value in [
+        "'prefix' + location.hash",
+        "location.hash || ''",
+        "location.hash ?? ''",
+    ] {
+        let js = format!("document.write({value});");
+        assert!(
+            !AstDomAnalyzer::new().analyze(&js).unwrap().is_empty(),
+            "{js}"
+        );
+    }
+    // Coercing the result never makes a sink evaluated inside the operand safe.
+    assert!(
+        !AstDomAnalyzer::new()
+            .analyze("document.write(location.hash) === 0;")
+            .unwrap()
+            .is_empty()
+    );
+}

--- a/src/scanning/ast_dom_analysis/walk.rs
+++ b/src/scanning/ast_dom_analysis/walk.rs
@@ -115,26 +115,15 @@ impl<'a> DomXssVisitor<'a> {
                 self.walk_statement(&labeled.body);
             }
             Statement::FunctionDeclaration(func_decl) => {
-                // Parameterized functions are primarily handled through summaries/call sites.
-                // Walking bodies here can duplicate findings when summaries are also applied.
-                // Keep direct walk only for zero-parameter functions where call-site summaries
-                // cannot currently represent source->sink usage.
-                if func_decl.params.items.is_empty()
-                    && let Some(body) = &func_decl.body
-                {
-                    // Save current tainted vars state
-                    let saved_tainted = self.tainted_vars.clone();
-                    let saved_aliases = self.var_aliases.clone();
-                    let saved_response_vars = self.response_object_vars.clone();
-
-                    self.walk_statements(&body.statements);
-
-                    // Restore state after function (locals don't leak out —
-                    // e.g. a `const r = await fetch()` Response binding must
-                    // not taint an unrelated outer `r.text()`).
-                    self.tainted_vars = saved_tainted;
-                    self.var_aliases = saved_aliases;
-                    self.response_object_vars = saved_response_vars;
+                // Parameter *flows* belong to the summary registered for this
+                // declaration and are reported at each call site. What the
+                // summary cannot represent is a free variable the body reads
+                // on its own (`function render(el) { el.innerHTML =
+                // location.hash; }`), so the body is walked here too — with
+                // its parameters shadowed, which is what keeps the two from
+                // reporting the same flow twice.
+                if let Some(body) = &func_decl.body {
+                    self.walk_function_literal_body(&func_decl.params, &body.statements);
                 }
             }
             Statement::ClassDeclaration(class_decl) => {
@@ -257,6 +246,48 @@ impl<'a> DomXssVisitor<'a> {
             Expression::CallExpression(call) => {
                 self.walk_call_expression(call);
             }
+            Expression::ChainExpression(chain) => {
+                self.branch_depth += 1;
+                match &chain.expression {
+                    ChainElement::CallExpression(call) => self.walk_call_expression(call),
+                    ChainElement::StaticMemberExpression(member) => {
+                        self.walk_expression(&member.object)
+                    }
+                    ChainElement::ComputedMemberExpression(member) => {
+                        self.walk_expression(&member.object);
+                        self.walk_expression(&member.expression);
+                    }
+                    _ => {}
+                }
+                self.branch_depth -= 1;
+            }
+            Expression::UnaryExpression(unary) => self.walk_expression(&unary.argument),
+            Expression::ArrayExpression(array) => {
+                for element in &array.elements {
+                    if let ArrayExpressionElement::SpreadElement(spread) = element {
+                        self.walk_expression(&spread.argument);
+                    } else if let Some(expr) = element.as_expression() {
+                        self.walk_expression(expr);
+                    }
+                }
+            }
+            Expression::ObjectExpression(object) => {
+                for property in &object.properties {
+                    match property {
+                        ObjectPropertyKind::ObjectProperty(property) => {
+                            if property.computed
+                                && let Some(key) = property.key.as_expression()
+                            {
+                                self.walk_expression(key);
+                            }
+                            self.walk_expression(&property.value);
+                        }
+                        ObjectPropertyKind::SpreadProperty(spread) => {
+                            self.walk_expression(&spread.argument)
+                        }
+                    }
+                }
+            }
             Expression::TemplateLiteral(template) => {
                 for e in &template.expressions {
                     self.walk_expression(e);
@@ -283,6 +314,14 @@ impl<'a> DomXssVisitor<'a> {
                 self.walk_expression(&cond.alternate);
             }
             Expression::NewExpression(new_expr) => {
+                self.walk_expression(&new_expr.callee);
+                for arg in &new_expr.arguments {
+                    if let Argument::SpreadElement(spread) = arg {
+                        self.walk_expression(&spread.argument);
+                    } else if let Some(expr) = arg.as_expression() {
+                        self.walk_expression(expr);
+                    }
+                }
                 // Handle new Function(tainted) - constructor calls with tainted arguments
                 if let Expression::Identifier(id) = &new_expr.callee {
                     let callee_name = id.name.as_str();
@@ -327,11 +366,11 @@ impl<'a> DomXssVisitor<'a> {
             // lookup fires the sink finding.
             Expression::FunctionExpression(func) => {
                 if let Some(body) = &func.body {
-                    self.walk_statements(&body.statements);
+                    self.walk_function_literal_body(&func.params, &body.statements);
                 }
             }
             Expression::ArrowFunctionExpression(arrow) => {
-                self.walk_statements(&arrow.body.statements);
+                self.walk_function_literal_body(&arrow.params, &arrow.body.statements);
             }
             // Dynamic `import(tainted)` runs an attacker-controlled module
             // (issue #1022). Detect it here; reached both as a bare statement
@@ -366,6 +405,203 @@ impl<'a> DomXssVisitor<'a> {
             _ => {}
         }
     }
+    /// Walk a function literal's body the way [`Statement::FunctionDeclaration`]
+    /// does — locals must not leak back out — with one addition: the parameter
+    /// names shadow whatever the enclosing scope bound to them.
+    ///
+    /// Without the shadowing step `const f = function (x) { sink(x); }` reports
+    /// the *outer* `x`'s source even though the body can only ever see the
+    /// argument, and the summary registered for `f` already covers the real
+    /// parameter flow at each call site. Free variables read inside the body
+    /// (`function () { sink(location.hash); }`) are genuine flows and stay
+    /// reported, which is the whole reason the body is walked here at all —
+    /// as are writes the body makes to bindings it does not own, which escape
+    /// the rollback as globals.
+    pub(super) fn walk_function_literal_body(
+        &mut self,
+        params: &FormalParameters<'a>,
+        statements: &[Statement<'a>],
+    ) {
+        let saved_tainted = self.tainted_vars.clone();
+        let saved_aliases = self.var_aliases.clone();
+        let saved_response_vars = self.response_object_vars.clone();
+        let param_names = self.function_param_bindings(params);
+        // `global_taints` is deliberately *not* saved wholesale — see the
+        // escape handling below. Only the shadowed parameter names are lifted
+        // out for the walk and put back afterwards.
+        let mut shadowed_globals = Vec::new();
+        for name in &param_names {
+            self.tainted_vars.remove(name.as_str());
+            self.var_aliases.remove(name.as_str());
+            if self.global_taints.remove(name.as_str()) {
+                shadowed_globals.push(name.clone());
+            }
+        }
+
+        self.walk_statements(statements);
+
+        // A name the body tainted that it neither declared nor took as a
+        // parameter is an *outer* binding: `function () { g = location.hash; }`
+        // leaves `g` tainted for every later read. Those escape into
+        // `global_taints`, which is scope-free by design; everything else is
+        // rolled back so a body-local (`const r = await fetch()`) cannot taint
+        // an unrelated outer name of the same spelling.
+        let mut locals: HashSet<String> = param_names.into_iter().collect();
+        Self::collect_declared_names(statements, &mut locals);
+        let escaped: Vec<(String, Option<String>)> = self
+            .tainted_vars
+            .iter()
+            .filter(|name| !saved_tainted.contains(*name) && !locals.contains(*name))
+            .map(|name| (name.clone(), self.var_aliases.get(name).cloned()))
+            .collect();
+
+        self.tainted_vars = saved_tainted;
+        self.var_aliases = saved_aliases;
+        self.response_object_vars = saved_response_vars;
+        self.global_taints.extend(shadowed_globals);
+        for (name, source) in escaped {
+            if let Some(source) = source {
+                self.var_aliases.insert(name.clone(), source);
+            }
+            self.global_taints.insert(name);
+        }
+    }
+
+    /// Names bound by declarations anywhere in a function body, so the escape
+    /// check above can tell a local apart from a write to an outer binding.
+    ///
+    /// Nested function bodies are skipped: their own locals are theirs, and a
+    /// write *they* make to an outer name has already escaped through this
+    /// same path. A statement form missed here just means a local escapes as
+    /// if it were a global — the behaviour function literals had before this
+    /// scoping existed at all.
+    fn collect_declared_names(statements: &[Statement<'a>], out: &mut HashSet<String>) {
+        for stmt in statements {
+            match stmt {
+                Statement::VariableDeclaration(decl) => {
+                    for declarator in &decl.declarations {
+                        Self::collect_binding_pattern_strs(&declarator.id, out);
+                    }
+                }
+                Statement::FunctionDeclaration(func) => {
+                    if let Some(id) = &func.id {
+                        out.insert(id.name.to_string());
+                    }
+                }
+                Statement::ClassDeclaration(class) => {
+                    if let Some(id) = &class.id {
+                        out.insert(id.name.to_string());
+                    }
+                }
+                Statement::BlockStatement(block) => Self::collect_declared_names(&block.body, out),
+                Statement::IfStatement(if_stmt) => {
+                    Self::collect_declared_names(std::slice::from_ref(&if_stmt.consequent), out);
+                    if let Some(alt) = &if_stmt.alternate {
+                        Self::collect_declared_names(std::slice::from_ref(alt), out);
+                    }
+                }
+                Statement::ForStatement(for_stmt) => {
+                    if let Some(ForStatementInit::VariableDeclaration(decl)) = &for_stmt.init {
+                        for declarator in &decl.declarations {
+                            Self::collect_binding_pattern_strs(&declarator.id, out);
+                        }
+                    }
+                    Self::collect_declared_names(std::slice::from_ref(&for_stmt.body), out);
+                }
+                Statement::ForInStatement(for_in) => {
+                    Self::collect_for_loop_left(&for_in.left, out);
+                    Self::collect_declared_names(std::slice::from_ref(&for_in.body), out);
+                }
+                Statement::ForOfStatement(for_of) => {
+                    Self::collect_for_loop_left(&for_of.left, out);
+                    Self::collect_declared_names(std::slice::from_ref(&for_of.body), out);
+                }
+                Statement::WhileStatement(while_stmt) => {
+                    Self::collect_declared_names(std::slice::from_ref(&while_stmt.body), out);
+                }
+                Statement::DoWhileStatement(do_while) => {
+                    Self::collect_declared_names(std::slice::from_ref(&do_while.body), out);
+                }
+                Statement::LabeledStatement(labeled) => {
+                    Self::collect_declared_names(std::slice::from_ref(&labeled.body), out);
+                }
+                Statement::SwitchStatement(switch_stmt) => {
+                    for case in &switch_stmt.cases {
+                        Self::collect_declared_names(&case.consequent, out);
+                    }
+                }
+                Statement::TryStatement(try_stmt) => {
+                    Self::collect_declared_names(&try_stmt.block.body, out);
+                    if let Some(handler) = &try_stmt.handler {
+                        if let Some(param) = &handler.param {
+                            Self::collect_binding_pattern_strs(&param.pattern, out);
+                        }
+                        Self::collect_declared_names(&handler.body.body, out);
+                    }
+                    if let Some(finalizer) = &try_stmt.finalizer {
+                        Self::collect_declared_names(&finalizer.body, out);
+                    }
+                }
+                _ => {}
+            }
+        }
+    }
+
+    fn collect_for_loop_left(left: &ForStatementLeft<'a>, out: &mut HashSet<String>) {
+        if let ForStatementLeft::VariableDeclaration(decl) = left {
+            for declarator in &decl.declarations {
+                Self::collect_binding_pattern_strs(&declarator.id, out);
+            }
+        }
+    }
+
+    fn collect_binding_pattern_strs(pattern: &BindingPattern<'a>, out: &mut HashSet<String>) {
+        let mut names = Vec::new();
+        Self::collect_binding_pattern_names(pattern, &mut names);
+        out.extend(names);
+    }
+
+    /// Every name a parameter list binds, destructuring and rest included.
+    ///
+    /// Unlike [`extract_param_names`](Self::extract_param_names) — which is
+    /// positional, because summaries key sinks by parameter index — this is a
+    /// flat set used only to decide which outer bindings a body cannot see.
+    fn function_param_bindings(&self, params: &FormalParameters<'a>) -> Vec<String> {
+        let mut names = Vec::new();
+        for param in &params.items {
+            Self::collect_binding_pattern_names(&param.pattern, &mut names);
+        }
+        if let Some(rest) = &params.rest {
+            Self::collect_binding_pattern_names(&rest.rest.argument, &mut names);
+        }
+        names
+    }
+
+    fn collect_binding_pattern_names(pattern: &BindingPattern<'a>, names: &mut Vec<String>) {
+        match pattern {
+            BindingPattern::BindingIdentifier(id) => names.push(id.name.to_string()),
+            BindingPattern::ObjectPattern(obj) => {
+                for property in &obj.properties {
+                    Self::collect_binding_pattern_names(&property.value, names);
+                }
+                if let Some(rest) = &obj.rest {
+                    Self::collect_binding_pattern_names(&rest.argument, names);
+                }
+            }
+            BindingPattern::ArrayPattern(array) => {
+                for element in array.elements.iter().flatten() {
+                    Self::collect_binding_pattern_names(element, names);
+                }
+                if let Some(rest) = &array.rest {
+                    Self::collect_binding_pattern_names(&rest.argument, names);
+                }
+            }
+            BindingPattern::AssignmentPattern(assign) => {
+                Self::collect_binding_pattern_names(&assign.left, names);
+            }
+        }
+    }
+
     /// Report `import(tainted)` as a code-execution sink and walk the
     /// specifier for any nested sinks. A tainted module specifier (a
     /// `data:text/javascript,…` URL or a remote/`//host` URL derived from

--- a/src/scanning/ast_integration.rs
+++ b/src/scanning/ast_integration.rs
@@ -68,6 +68,12 @@ fn js_blocks_from_document(document: &Html) -> Vec<String> {
     {
         let selector = selectors::script();
         for element in document.select(selector) {
+            // With src present the browser ignores child text, even when src
+            // is empty or fails to load. Data blocks are not JavaScript.
+            if !script_type_is_javascript(element.value()) || element.value().attr("src").is_some()
+            {
+                continue;
+            }
             let text = element.text().fold(String::new(), |mut acc, t| {
                 acc.push_str(t);
                 acc
@@ -117,6 +123,42 @@ fn js_blocks_from_document(document: &Html) -> Vec<String> {
     js_code
 }
 
+/// HTML's script preparation rules use a MIME *essence match*, not a
+/// Content-Type parser: parameters such as `; charset=utf-8` are invalid here.
+/// https://html.spec.whatwg.org/multipage/scripting.html#prepare-the-script-element
+fn script_type_is_javascript(element: &scraper::node::Element) -> bool {
+    let script_type = match element.attr("type") {
+        Some("") => return true,
+        Some(value) => value
+            .trim_matches(|c| matches!(c, '\t' | '\n' | '\u{000C}' | '\r' | ' '))
+            .to_ascii_lowercase(),
+        None => match element.attr("language") {
+            None | Some("") => return true,
+            Some(language) => format!("text/{}", language.to_ascii_lowercase()),
+        },
+    };
+    matches!(
+        script_type.as_str(),
+        "module"
+            | "application/ecmascript"
+            | "application/javascript"
+            | "application/x-ecmascript"
+            | "application/x-javascript"
+            | "text/ecmascript"
+            | "text/javascript"
+            | "text/javascript1.0"
+            | "text/javascript1.1"
+            | "text/javascript1.2"
+            | "text/javascript1.3"
+            | "text/javascript1.4"
+            | "text/javascript1.5"
+            | "text/jscript"
+            | "text/livescript"
+            | "text/x-ecmascript"
+            | "text/x-javascript"
+    )
+}
+
 /// Collect resolved, deduped, same-origin `<script src>` URLs from `html`,
 /// resolved relative to `base` (the response URL). Cross-origin srcs are dropped.
 pub(crate) fn extract_same_origin_script_srcs(html: &str, base: &url::Url) -> Vec<url::Url> {
@@ -125,6 +167,9 @@ pub(crate) fn extract_same_origin_script_srcs(html: &str, base: &url::Url) -> Ve
     let mut seen = HashSet::new();
     let mut out = Vec::new();
     for element in document.select(selector) {
+        if !script_type_is_javascript(element.value()) {
+            continue;
+        }
         let src = match element.value().attr("src") {
             Some(s) if !s.trim().is_empty() => s.trim(),
             _ => continue,

--- a/src/scanning/ast_integration/tests.rs
+++ b/src/scanning/ast_integration/tests.rs
@@ -1,6 +1,73 @@
 use super::*;
 
 #[test]
+fn inactive_script_bodies_do_not_produce_dom_findings() {
+    for attrs in [
+        "type='application/json'",
+        "type='application/ld+json'",
+        "type='text/template'",
+        "type='importmap'",
+        "type='speculationrules'",
+        "type='text/javascript; charset=utf-8'",
+        "language='vbscript'",
+        "src='/app.js'",
+        "src=''",
+    ] {
+        let html = format!("<script {attrs}>document.write(location.hash);</script>");
+        let results = run_initial_ast_dom_analysis(
+            &html,
+            "https://example.com/",
+            "GET",
+            PageSecurityPosture::default(),
+        );
+        assert!(results.is_empty(), "{attrs}: {results:?}");
+    }
+}
+
+#[test]
+fn executable_script_types_reach_the_result_pipeline() {
+    for attrs in [
+        "",
+        "type=''",
+        "type='module'",
+        "type='text/javascript'",
+        "type='APPLICATION/JAVASCRIPT'",
+        "type='text/javascript1.5'",
+        "language='JavaScript'",
+        "type='' language='vbscript'",
+    ] {
+        let html = format!(
+            "<script {attrs}>document.write?.(new URLSearchParams(location.search)['get']('query'));</script>"
+        );
+        let results = run_initial_ast_dom_analysis(
+            &html,
+            "https://example.com/",
+            "GET",
+            PageSecurityPosture::default(),
+        );
+        assert_eq!(results.len(), 1, "{attrs}: {results:?}");
+        assert_eq!(results[0].param, "query", "{attrs}: {:?}", results[0]);
+        assert!(results[0].data.contains("query="));
+    }
+}
+
+#[test]
+fn external_script_discovery_skips_data_blocks() {
+    let html = r#"
+        <script type="application/json" src="/data.json"></script>
+        <script type="importmap" src="/imports.json"></script>
+        <script type="module" src="/app.mjs"></script>
+        <script src="/app.js"></script>
+    "#;
+    let urls =
+        extract_same_origin_script_srcs(html, &url::Url::parse("https://example.com/").unwrap());
+    assert_eq!(
+        urls.iter().map(|u| u.path()).collect::<Vec<_>>(),
+        ["/app.mjs", "/app.js"]
+    );
+}
+
+#[test]
 fn test_extract_javascript_from_html() {
     let html = r#"
 <html>


### PR DESCRIPTION
The AST DOM analyzer missed whole expression forms and reported a few shapes that cannot carry attacker input. Both directions are addressed here, each with a regression test.

## Coverage

- **Optional chaining (`?.`)** resolves like the ordinary call/member rules — for taint, source lookup, and member-path resolution alike. `eval?.(location.hash)` and `el.innerHTML = window?.name` were previously invisible.
- **Statically resolvable bracket notation** keeps its path, so `window['location'].hash` and `new URLSearchParams(location.search)['get']('q')` carry the same source — and the same PoC parameter / storage-key label — as the dotted form.
- **Sinks nested in unary operands, array/object literals and constructor arguments** are visited.
- **Function bodies are analyzed wherever the literal is written.** That includes the options-object callbacks every jQuery/axios-style API takes (`$.ajax({success: fn})`), array/object elements, constructor arguments, and parameterized function declarations — whose summaries only ever carried *parameter* flows, so a source the body read on its own (`function render(el) { el.innerHTML = location.hash }`) was reported nowhere.

## False positives

- **Only `+` preserves attacker-controlled string content.** Comparisons and arithmetic yield booleans and numbers; `document.write(location.hash - 1)` is no longer a finding.
- **A function's parameters shadow same-named bindings from the enclosing scope**, so a helper that only touches its own argument stops being reported against an outer variable. The parameter's real flow still reports from the call site via the function summary, so the two cannot double-report.
- **Script elements the HTML standard treats as data blocks** (JSON, templates, import maps, speculation rules, a `type` carrying parameters) are skipped, as is inline text on an element that has `src`. External script discovery applies the same filter. Checked against the spec's own `prepare the script element` wording, including the `type=""` → JavaScript and `type=" "` → data block edges.

Body walks keep their existing scope discipline: locals are rolled back, while a write the body makes to a binding it does not own (`function () { g = location.hash }`) still escapes.

## Verification

`cargo test` green (15 binaries), `cargo clippy --all-targets` and `cargo fmt --check` clean. 6 new regression tests in `ast_dom_analysis/tests/expression_regressions.rs` plus 3 in `ast_integration/tests.rs`.

A/B probed against `main` on ~40 hand-written flows. Representative deltas:

| case | before | after |
|---|---|---|
| `document.write(location.hash - 1)` | 1 (FP) | 0 |
| `const x = location.hash; const f = function (x) { document.write(x) }` | 1 (FP) | 0 |
| `eval?.(location.hash)` | 0 (FN) | 1 |
| `new URLSearchParams(...)?.get('q')` | 0 (FN) | 1 |
| `$.ajax({success: function () { document.write(location.hash) }})` | 0 (FN) | 1 |
| `function render(el) { el.innerHTML = location.hash }` | 0 (FN) | 1 |
| `window['loc' + 'ation'].hash` | source `window.location` | `window.location.hash` |

No probe regressed, and no existing test changed verdict except the one that encoded the old container rule, which is rewritten to encode the new one.

Analysis cost, debug build, synthetic 130–500 KB inputs: +60% on a webpack-style module map (20 → 33 ms) and +37% on 2k options-object callbacks (25 → 34 ms), which is the newly walked work; unchanged where nothing new is walked. The AST phase runs once per response and is far below request latency.

## Note for consumers

Some source labels got more specific (`window.location` → `window.location.hash`, computed `localStorage.getItem` → `localStorage.getItem(k)`). That label becomes the finding's `param`, so a `--baseline` file written by an older build may show these DOM findings as new. The `window.location.hash` case also fixes the PoC URL, which now injects into the fragment instead of a query parameter.